### PR TITLE
Make it so the protocol structs `#[derive]` more traits

### DIFF
--- a/generator/src/generator/error_events.rs
+++ b/generator/src/generator/error_events.rs
@@ -41,7 +41,10 @@ fn generate_errors(out: &mut Output, module: &xcbgen::defs::Module) {
     let namespaces = module.sorted_namespaces();
 
     outln!(out, "/// Enumeration of all possible X11 error kinds.");
-    outln!(out, "#[derive(Debug, Clone, Copy, PartialEq, Eq)]");
+    outln!(
+        out,
+        "#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]"
+    );
     outln!(out, "#[non_exhaustive]");
     outln!(out, "pub enum ErrorKind {{");
     out.indented(|out| {

--- a/generator/src/generator/namespace/helpers.rs
+++ b/generator/src/generator/namespace/helpers.rs
@@ -209,8 +209,13 @@ pub(super) struct Derives {
     pub(super) debug: bool,
     pub(super) clone: bool,
     pub(super) copy: bool,
+    /// "default" is a reserved keyword
+    pub(super) default_: bool,
     pub(super) partial_eq: bool,
     pub(super) eq: bool,
+    pub(super) partial_ord: bool,
+    pub(super) ord: bool,
+    pub(super) hash: bool,
 }
 
 impl Derives {
@@ -220,8 +225,12 @@ impl Derives {
             debug: true,
             clone: true,
             copy: true,
+            default_: true,
             partial_eq: true,
             eq: true,
+            partial_ord: true,
+            ord: true,
+            hash: true,
         }
     }
 
@@ -229,8 +238,12 @@ impl Derives {
         self.debug &= other.debug;
         self.clone &= other.clone;
         self.copy &= other.copy;
+        self.default_ &= other.default_;
         self.partial_eq &= other.partial_eq;
         self.eq &= other.eq;
+        self.partial_ord &= other.partial_ord;
+        self.ord &= other.ord;
+        self.hash &= other.hash;
     }
 
     pub(super) fn to_list(self) -> Vec<&'static str> {
@@ -244,11 +257,23 @@ impl Derives {
         if self.copy {
             list.push("Copy");
         }
+        if self.default_ {
+            list.push("Default");
+        }
         if self.partial_eq {
             list.push("PartialEq");
         }
         if self.eq {
             list.push("Eq");
+        }
+        if self.partial_ord {
+            list.push("PartialOrd")
+        }
+        if self.ord {
+            list.push("Ord");
+        }
+        if self.hash {
+            list.push("Hash");
         }
         list
     }

--- a/generator/src/generator/namespace/switch.rs
+++ b/generator/src/generator/namespace/switch.rs
@@ -84,6 +84,7 @@ pub(super) fn emit_switch_type(
             let type_name = format!("{}{}", name, to_rust_type_name(&field_name));
 
             let mut derives = Derives::all();
+            derives.default_ = false;
             let case_fields = case.fields.borrow();
             let ext_params = case.external_params.borrow();
 
@@ -116,6 +117,7 @@ pub(super) fn emit_switch_type(
     }
 
     let mut derives = Derives::all();
+    derives.default_ = false;
     for case in switch.cases.iter() {
         generator.filter_derives_for_fields(&mut derives, &*case.fields.borrow(), false);
     }

--- a/x11rb-protocol/src/protocol/bigreq.rs
+++ b/x11rb-protocol/src/protocol/bigreq.rs
@@ -32,7 +32,7 @@ pub const X11_XML_VERSION: (u32, u32) = (0, 0);
 
 /// Opcode for the Enable request
 pub const ENABLE_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EnableRequest;
 impl EnableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -74,7 +74,7 @@ impl crate::x11_utils::ReplyRequest for EnableRequest {
     type Reply = EnableReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EnableReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/composite.rs
+++ b/x11rb-protocol/src/protocol/composite.rs
@@ -34,7 +34,7 @@ pub const X11_EXTENSION_NAME: &str = "Composite";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (0, 4);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Redirect(u8);
 impl Redirect {
     pub const AUTOMATIC: Self = Self(0);
@@ -94,7 +94,7 @@ impl std::fmt::Debug for Redirect  {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
@@ -153,7 +153,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -183,7 +183,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the RedirectWindow request
 pub const REDIRECT_WINDOW_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RedirectWindowRequest {
     pub window: xproto::Window,
     pub update: Redirect,
@@ -245,7 +245,7 @@ impl crate::x11_utils::VoidRequest for RedirectWindowRequest {
 
 /// Opcode for the RedirectSubwindows request
 pub const REDIRECT_SUBWINDOWS_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RedirectSubwindowsRequest {
     pub window: xproto::Window,
     pub update: Redirect,
@@ -307,7 +307,7 @@ impl crate::x11_utils::VoidRequest for RedirectSubwindowsRequest {
 
 /// Opcode for the UnredirectWindow request
 pub const UNREDIRECT_WINDOW_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UnredirectWindowRequest {
     pub window: xproto::Window,
     pub update: Redirect,
@@ -369,7 +369,7 @@ impl crate::x11_utils::VoidRequest for UnredirectWindowRequest {
 
 /// Opcode for the UnredirectSubwindows request
 pub const UNREDIRECT_SUBWINDOWS_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UnredirectSubwindowsRequest {
     pub window: xproto::Window,
     pub update: Redirect,
@@ -431,7 +431,7 @@ impl crate::x11_utils::VoidRequest for UnredirectSubwindowsRequest {
 
 /// Opcode for the CreateRegionFromBorderClip request
 pub const CREATE_REGION_FROM_BORDER_CLIP_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateRegionFromBorderClipRequest {
     pub region: xfixes::Region,
     pub window: xproto::Window,
@@ -491,7 +491,7 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromBorderClipRequest {
 
 /// Opcode for the NameWindowPixmap request
 pub const NAME_WINDOW_PIXMAP_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NameWindowPixmapRequest {
     pub window: xproto::Window,
     pub pixmap: xproto::Pixmap,
@@ -551,7 +551,7 @@ impl crate::x11_utils::VoidRequest for NameWindowPixmapRequest {
 
 /// Opcode for the GetOverlayWindow request
 pub const GET_OVERLAY_WINDOW_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetOverlayWindowRequest {
     pub window: xproto::Window,
 }
@@ -602,7 +602,7 @@ impl crate::x11_utils::ReplyRequest for GetOverlayWindowRequest {
     type Reply = GetOverlayWindowReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetOverlayWindowReply {
     pub sequence: u16,
     pub length: u32,
@@ -630,7 +630,7 @@ impl TryParse for GetOverlayWindowReply {
 
 /// Opcode for the ReleaseOverlayWindow request
 pub const RELEASE_OVERLAY_WINDOW_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReleaseOverlayWindowRequest {
     pub window: xproto::Window,
 }

--- a/x11rb-protocol/src/protocol/damage.rs
+++ b/x11rb-protocol/src/protocol/damage.rs
@@ -36,7 +36,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
 pub type Damage = u32;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReportLevel(u8);
 impl ReportLevel {
     pub const RAW_RECTANGLES: Self = Self(0);
@@ -103,7 +103,7 @@ pub const BAD_DAMAGE_ERROR: u8 = 0;
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
@@ -162,7 +162,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -192,7 +192,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the Create request
 pub const CREATE_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateRequest {
     pub damage: Damage,
     pub drawable: xproto::Drawable,
@@ -262,7 +262,7 @@ impl crate::x11_utils::VoidRequest for CreateRequest {
 
 /// Opcode for the Destroy request
 pub const DESTROY_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyRequest {
     pub damage: Damage,
 }
@@ -314,7 +314,7 @@ impl crate::x11_utils::VoidRequest for DestroyRequest {
 
 /// Opcode for the Subtract request
 pub const SUBTRACT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubtractRequest {
     pub damage: Damage,
     pub repair: xfixes::Region,
@@ -382,7 +382,7 @@ impl crate::x11_utils::VoidRequest for SubtractRequest {
 
 /// Opcode for the Add request
 pub const ADD_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AddRequest {
     pub drawable: xproto::Drawable,
     pub region: xfixes::Region,
@@ -442,7 +442,7 @@ impl crate::x11_utils::VoidRequest for AddRequest {
 
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotifyEvent {
     pub response_type: u8,
     pub level: ReportLevel,

--- a/x11rb-protocol/src/protocol/dpms.rs
+++ b/x11rb-protocol/src/protocol/dpms.rs
@@ -32,7 +32,7 @@ pub const X11_XML_VERSION: (u32, u32) = (0, 0);
 
 /// Opcode for the GetVersion request
 pub const GET_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
@@ -87,7 +87,7 @@ impl crate::x11_utils::ReplyRequest for GetVersionRequest {
     type Reply = GetVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -116,7 +116,7 @@ impl TryParse for GetVersionReply {
 
 /// Opcode for the Capable request
 pub const CAPABLE_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CapableRequest;
 impl CapableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -158,7 +158,7 @@ impl crate::x11_utils::ReplyRequest for CapableRequest {
     type Reply = CapableReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CapableReply {
     pub sequence: u16,
     pub length: u32,
@@ -186,7 +186,7 @@ impl TryParse for CapableReply {
 
 /// Opcode for the GetTimeouts request
 pub const GET_TIMEOUTS_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTimeoutsRequest;
 impl GetTimeoutsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -228,7 +228,7 @@ impl crate::x11_utils::ReplyRequest for GetTimeoutsRequest {
     type Reply = GetTimeoutsReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTimeoutsReply {
     pub sequence: u16,
     pub length: u32,
@@ -260,7 +260,7 @@ impl TryParse for GetTimeoutsReply {
 
 /// Opcode for the SetTimeouts request
 pub const SET_TIMEOUTS_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetTimeoutsRequest {
     pub standby_timeout: u16,
     pub suspend_timeout: u16,
@@ -324,7 +324,7 @@ impl crate::x11_utils::VoidRequest for SetTimeoutsRequest {
 
 /// Opcode for the Enable request
 pub const ENABLE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EnableRequest;
 impl EnableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -367,7 +367,7 @@ impl crate::x11_utils::VoidRequest for EnableRequest {
 
 /// Opcode for the Disable request
 pub const DISABLE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DisableRequest;
 impl DisableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -408,7 +408,7 @@ impl Request for DisableRequest {
 impl crate::x11_utils::VoidRequest for DisableRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DPMSMode(u16);
 impl DPMSMode {
     pub const ON: Self = Self(0);
@@ -466,7 +466,7 @@ impl std::fmt::Debug for DPMSMode  {
 
 /// Opcode for the ForceLevel request
 pub const FORCE_LEVEL_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ForceLevelRequest {
     pub power_level: DPMSMode,
 }
@@ -519,7 +519,7 @@ impl crate::x11_utils::VoidRequest for ForceLevelRequest {
 
 /// Opcode for the Info request
 pub const INFO_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InfoRequest;
 impl InfoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -561,7 +561,7 @@ impl crate::x11_utils::ReplyRequest for InfoRequest {
     type Reply = InfoReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InfoReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/dri2.rs
+++ b/x11rb-protocol/src/protocol/dri2.rs
@@ -32,7 +32,7 @@ pub const X11_EXTENSION_NAME: &str = "DRI2";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 4);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Attachment(u32);
 impl Attachment {
     pub const BUFFER_FRONT_LEFT: Self = Self(0);
@@ -96,7 +96,7 @@ impl std::fmt::Debug for Attachment  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DriverType(u32);
 impl DriverType {
     pub const DRI: Self = Self(0);
@@ -142,7 +142,7 @@ impl std::fmt::Debug for DriverType  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EventType(u16);
 impl EventType {
     pub const EXCHANGE_COMPLETE: Self = Self(1);
@@ -196,7 +196,7 @@ impl std::fmt::Debug for EventType  {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DRI2Buffer {
     pub attachment: Attachment,
     pub name: u32,
@@ -257,7 +257,7 @@ impl Serialize for DRI2Buffer {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AttachFormat {
     pub attachment: Attachment,
     pub format: u32,
@@ -296,7 +296,7 @@ impl Serialize for AttachFormat {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
@@ -355,7 +355,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -384,7 +384,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the Connect request
 pub const CONNECT_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConnectRequest {
     pub window: xproto::Window,
     pub driver_type: DriverType,
@@ -444,7 +444,7 @@ impl crate::x11_utils::ReplyRequest for ConnectRequest {
     type Reply = ConnectReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConnectReply {
     pub sequence: u16,
     pub length: u32,
@@ -509,7 +509,7 @@ impl ConnectReply {
 
 /// Opcode for the Authenticate request
 pub const AUTHENTICATE_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AuthenticateRequest {
     pub window: xproto::Window,
     pub magic: u32,
@@ -568,7 +568,7 @@ impl crate::x11_utils::ReplyRequest for AuthenticateRequest {
     type Reply = AuthenticateReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AuthenticateReply {
     pub sequence: u16,
     pub length: u32,
@@ -595,7 +595,7 @@ impl TryParse for AuthenticateReply {
 
 /// Opcode for the CreateDrawable request
 pub const CREATE_DRAWABLE_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateDrawableRequest {
     pub drawable: xproto::Drawable,
 }
@@ -647,7 +647,7 @@ impl crate::x11_utils::VoidRequest for CreateDrawableRequest {
 
 /// Opcode for the DestroyDrawable request
 pub const DESTROY_DRAWABLE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyDrawableRequest {
     pub drawable: xproto::Drawable,
 }
@@ -699,7 +699,7 @@ impl crate::x11_utils::VoidRequest for DestroyDrawableRequest {
 
 /// Opcode for the GetBuffers request
 pub const GET_BUFFERS_REQUEST: u8 = 5;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetBuffersRequest<'input> {
     pub drawable: xproto::Drawable,
     pub count: u32,
@@ -780,7 +780,7 @@ impl<'input> crate::x11_utils::ReplyRequest for GetBuffersRequest<'input> {
     type Reply = GetBuffersReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetBuffersReply {
     pub sequence: u16,
     pub length: u32,
@@ -828,7 +828,7 @@ impl GetBuffersReply {
 
 /// Opcode for the CopyRegion request
 pub const COPY_REGION_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CopyRegionRequest {
     pub drawable: xproto::Drawable,
     pub region: u32,
@@ -903,7 +903,7 @@ impl crate::x11_utils::ReplyRequest for CopyRegionRequest {
     type Reply = CopyRegionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CopyRegionReply {
     pub sequence: u16,
     pub length: u32,
@@ -928,7 +928,7 @@ impl TryParse for CopyRegionReply {
 
 /// Opcode for the GetBuffersWithFormat request
 pub const GET_BUFFERS_WITH_FORMAT_REQUEST: u8 = 7;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetBuffersWithFormatRequest<'input> {
     pub drawable: xproto::Drawable,
     pub count: u32,
@@ -1009,7 +1009,7 @@ impl<'input> crate::x11_utils::ReplyRequest for GetBuffersWithFormatRequest<'inp
     type Reply = GetBuffersWithFormatReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetBuffersWithFormatReply {
     pub sequence: u16,
     pub length: u32,
@@ -1057,7 +1057,7 @@ impl GetBuffersWithFormatReply {
 
 /// Opcode for the SwapBuffers request
 pub const SWAP_BUFFERS_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SwapBuffersRequest {
     pub drawable: xproto::Drawable,
     pub target_msc_hi: u32,
@@ -1156,7 +1156,7 @@ impl crate::x11_utils::ReplyRequest for SwapBuffersRequest {
     type Reply = SwapBuffersReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SwapBuffersReply {
     pub sequence: u16,
     pub length: u32,
@@ -1185,7 +1185,7 @@ impl TryParse for SwapBuffersReply {
 
 /// Opcode for the GetMSC request
 pub const GET_MSC_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMSCRequest {
     pub drawable: xproto::Drawable,
 }
@@ -1236,7 +1236,7 @@ impl crate::x11_utils::ReplyRequest for GetMSCRequest {
     type Reply = GetMSCReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMSCReply {
     pub sequence: u16,
     pub length: u32,
@@ -1273,7 +1273,7 @@ impl TryParse for GetMSCReply {
 
 /// Opcode for the WaitMSC request
 pub const WAIT_MSC_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WaitMSCRequest {
     pub drawable: xproto::Drawable,
     pub target_msc_hi: u32,
@@ -1372,7 +1372,7 @@ impl crate::x11_utils::ReplyRequest for WaitMSCRequest {
     type Reply = WaitMSCReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WaitMSCReply {
     pub sequence: u16,
     pub length: u32,
@@ -1409,7 +1409,7 @@ impl TryParse for WaitMSCReply {
 
 /// Opcode for the WaitSBC request
 pub const WAIT_SBC_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WaitSBCRequest {
     pub drawable: xproto::Drawable,
     pub target_sbc_hi: u32,
@@ -1476,7 +1476,7 @@ impl crate::x11_utils::ReplyRequest for WaitSBCRequest {
     type Reply = WaitSBCReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WaitSBCReply {
     pub sequence: u16,
     pub length: u32,
@@ -1513,7 +1513,7 @@ impl TryParse for WaitSBCReply {
 
 /// Opcode for the SwapInterval request
 pub const SWAP_INTERVAL_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SwapIntervalRequest {
     pub drawable: xproto::Drawable,
     pub interval: u32,
@@ -1573,7 +1573,7 @@ impl crate::x11_utils::VoidRequest for SwapIntervalRequest {
 
 /// Opcode for the GetParam request
 pub const GET_PARAM_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetParamRequest {
     pub drawable: xproto::Drawable,
     pub param: u32,
@@ -1632,7 +1632,7 @@ impl crate::x11_utils::ReplyRequest for GetParamRequest {
     type Reply = GetParamReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetParamReply {
     pub is_param_recognized: bool,
     pub sequence: u16,
@@ -1662,7 +1662,7 @@ impl TryParse for GetParamReply {
 
 /// Opcode for the BufferSwapComplete event
 pub const BUFFER_SWAP_COMPLETE_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BufferSwapCompleteEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -1751,7 +1751,7 @@ impl From<BufferSwapCompleteEvent> for [u8; 32] {
 
 /// Opcode for the InvalidateBuffers event
 pub const INVALIDATE_BUFFERS_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InvalidateBuffersEvent {
     pub response_type: u8,
     pub sequence: u16,

--- a/x11rb-protocol/src/protocol/dri3.rs
+++ b/x11rb-protocol/src/protocol/dri3.rs
@@ -34,7 +34,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
@@ -93,7 +93,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -122,7 +122,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the Open request
 pub const OPEN_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OpenRequest {
     pub drawable: xproto::Drawable,
     pub provider: u32,
@@ -311,7 +311,7 @@ impl crate::x11_utils::VoidRequest for PixmapFromBufferRequest {
 
 /// Opcode for the BufferFromPixmap request
 pub const BUFFER_FROM_PIXMAP_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BufferFromPixmapRequest {
     pub pixmap: xproto::Pixmap,
 }
@@ -477,7 +477,7 @@ impl crate::x11_utils::VoidRequest for FenceFromFDRequest {
 
 /// Opcode for the FDFromFence request
 pub const FD_FROM_FENCE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FDFromFenceRequest {
     pub drawable: xproto::Drawable,
     pub fence: u32,
@@ -566,7 +566,7 @@ impl TryParseFd for FDFromFenceReply {
 
 /// Opcode for the GetSupportedModifiers request
 pub const GET_SUPPORTED_MODIFIERS_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSupportedModifiersRequest {
     pub window: u32,
     pub depth: u8,
@@ -630,7 +630,7 @@ impl crate::x11_utils::ReplyRequest for GetSupportedModifiersRequest {
     type Reply = GetSupportedModifiersReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSupportedModifiersReply {
     pub sequence: u16,
     pub length: u32,
@@ -865,7 +865,7 @@ impl crate::x11_utils::VoidRequest for PixmapFromBuffersRequest {
 
 /// Opcode for the BuffersFromPixmap request
 pub const BUFFERS_FROM_PIXMAP_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BuffersFromPixmapRequest {
     pub pixmap: xproto::Pixmap,
 }

--- a/x11rb-protocol/src/protocol/ge.rs
+++ b/x11rb-protocol/src/protocol/ge.rs
@@ -32,7 +32,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
@@ -87,7 +87,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/glx.rs
+++ b/x11rb-protocol/src/protocol/glx.rs
@@ -97,7 +97,7 @@ pub const GLX_BAD_PROFILE_ARB_ERROR: u8 = 13;
 
 /// Opcode for the PbufferClobber event
 pub const PBUFFER_CLOBBER_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PbufferClobberEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -194,7 +194,7 @@ impl From<PbufferClobberEvent> for [u8; 32] {
 
 /// Opcode for the BufferSwapComplete event
 pub const BUFFER_SWAP_COMPLETE_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BufferSwapCompleteEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -280,7 +280,7 @@ impl From<BufferSwapCompleteEvent> for [u8; 32] {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PBCET(u16);
 impl PBCET {
     pub const DAMAGED: Self = Self(32791);
@@ -332,7 +332,7 @@ impl std::fmt::Debug for PBCET  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PBCDT(u16);
 impl PBCDT {
     pub const WINDOW: Self = Self(32793);
@@ -386,7 +386,7 @@ impl std::fmt::Debug for PBCDT  {
 
 /// Opcode for the Render request
 pub const RENDER_REQUEST: u8 = 1;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RenderRequest<'input> {
     pub context_tag: ContextTag,
     pub data: Cow<'input, [u8]>,
@@ -451,7 +451,7 @@ impl<'input> crate::x11_utils::VoidRequest for RenderRequest<'input> {
 
 /// Opcode for the RenderLarge request
 pub const RENDER_LARGE_REQUEST: u8 = 2;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RenderLargeRequest<'input> {
     pub context_tag: ContextTag,
     pub request_num: u16,
@@ -537,7 +537,7 @@ impl<'input> crate::x11_utils::VoidRequest for RenderLargeRequest<'input> {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateContextRequest {
     pub context: Context,
     pub visual: xproto::Visualid,
@@ -622,7 +622,7 @@ impl crate::x11_utils::VoidRequest for CreateContextRequest {
 
 /// Opcode for the DestroyContext request
 pub const DESTROY_CONTEXT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyContextRequest {
     pub context: Context,
 }
@@ -674,7 +674,7 @@ impl crate::x11_utils::VoidRequest for DestroyContextRequest {
 
 /// Opcode for the MakeCurrent request
 pub const MAKE_CURRENT_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MakeCurrentRequest {
     pub drawable: Drawable,
     pub context: Context,
@@ -741,7 +741,7 @@ impl crate::x11_utils::ReplyRequest for MakeCurrentRequest {
     type Reply = MakeCurrentReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MakeCurrentReply {
     pub sequence: u16,
     pub length: u32,
@@ -769,7 +769,7 @@ impl TryParse for MakeCurrentReply {
 
 /// Opcode for the IsDirect request
 pub const IS_DIRECT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IsDirectRequest {
     pub context: Context,
 }
@@ -820,7 +820,7 @@ impl crate::x11_utils::ReplyRequest for IsDirectRequest {
     type Reply = IsDirectReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IsDirectReply {
     pub sequence: u16,
     pub length: u32,
@@ -848,7 +848,7 @@ impl TryParse for IsDirectReply {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
@@ -907,7 +907,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -937,7 +937,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the WaitGL request
 pub const WAIT_GL_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WaitGLRequest {
     pub context_tag: ContextTag,
 }
@@ -989,7 +989,7 @@ impl crate::x11_utils::VoidRequest for WaitGLRequest {
 
 /// Opcode for the WaitX request
 pub const WAIT_X_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WaitXRequest {
     pub context_tag: ContextTag,
 }
@@ -1041,7 +1041,7 @@ impl crate::x11_utils::VoidRequest for WaitXRequest {
 
 /// Opcode for the CopyContext request
 pub const COPY_CONTEXT_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CopyContextRequest {
     pub src: Context,
     pub dest: Context,
@@ -1115,7 +1115,7 @@ impl Request for CopyContextRequest {
 impl crate::x11_utils::VoidRequest for CopyContextRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GC(u32);
 impl GC {
     pub const GL_CURRENT_BIT: Self = Self(1 << 0);
@@ -1201,7 +1201,7 @@ impl std::fmt::Debug for GC  {
 
 /// Opcode for the SwapBuffers request
 pub const SWAP_BUFFERS_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SwapBuffersRequest {
     pub context_tag: ContextTag,
     pub drawable: Drawable,
@@ -1261,7 +1261,7 @@ impl crate::x11_utils::VoidRequest for SwapBuffersRequest {
 
 /// Opcode for the UseXFont request
 pub const USE_X_FONT_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UseXFontRequest {
     pub context_tag: ContextTag,
     pub font: xproto::Font,
@@ -1345,7 +1345,7 @@ impl crate::x11_utils::VoidRequest for UseXFontRequest {
 
 /// Opcode for the CreateGLXPixmap request
 pub const CREATE_GLX_PIXMAP_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateGLXPixmapRequest {
     pub screen: u32,
     pub visual: xproto::Visualid,
@@ -1421,7 +1421,7 @@ impl crate::x11_utils::VoidRequest for CreateGLXPixmapRequest {
 
 /// Opcode for the GetVisualConfigs request
 pub const GET_VISUAL_CONFIGS_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetVisualConfigsRequest {
     pub screen: u32,
 }
@@ -1472,7 +1472,7 @@ impl crate::x11_utils::ReplyRequest for GetVisualConfigsRequest {
     type Reply = GetVisualConfigsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetVisualConfigsReply {
     pub sequence: u16,
     pub num_visuals: u32,
@@ -1518,7 +1518,7 @@ impl GetVisualConfigsReply {
 
 /// Opcode for the DestroyGLXPixmap request
 pub const DESTROY_GLX_PIXMAP_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyGLXPixmapRequest {
     pub glx_pixmap: Pixmap,
 }
@@ -1570,7 +1570,7 @@ impl crate::x11_utils::VoidRequest for DestroyGLXPixmapRequest {
 
 /// Opcode for the VendorPrivate request
 pub const VENDOR_PRIVATE_REQUEST: u8 = 16;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VendorPrivateRequest<'input> {
     pub vendor_code: u32,
     pub context_tag: ContextTag,
@@ -1644,7 +1644,7 @@ impl<'input> crate::x11_utils::VoidRequest for VendorPrivateRequest<'input> {
 
 /// Opcode for the VendorPrivateWithReply request
 pub const VENDOR_PRIVATE_WITH_REPLY_REQUEST: u8 = 17;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VendorPrivateWithReplyRequest<'input> {
     pub vendor_code: u32,
     pub context_tag: ContextTag,
@@ -1717,7 +1717,7 @@ impl<'input> crate::x11_utils::ReplyRequest for VendorPrivateWithReplyRequest<'i
     type Reply = VendorPrivateWithReplyReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VendorPrivateWithReplyReply {
     pub sequence: u16,
     pub retval: u32,
@@ -1765,7 +1765,7 @@ impl VendorPrivateWithReplyReply {
 
 /// Opcode for the QueryExtensionsString request
 pub const QUERY_EXTENSIONS_STRING_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryExtensionsStringRequest {
     pub screen: u32,
 }
@@ -1816,7 +1816,7 @@ impl crate::x11_utils::ReplyRequest for QueryExtensionsStringRequest {
     type Reply = QueryExtensionsStringReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryExtensionsStringReply {
     pub sequence: u16,
     pub length: u32,
@@ -1845,7 +1845,7 @@ impl TryParse for QueryExtensionsStringReply {
 
 /// Opcode for the QueryServerString request
 pub const QUERY_SERVER_STRING_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryServerStringRequest {
     pub screen: u32,
     pub name: u32,
@@ -1904,7 +1904,7 @@ impl crate::x11_utils::ReplyRequest for QueryServerStringRequest {
     type Reply = QueryServerStringReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryServerStringReply {
     pub sequence: u16,
     pub length: u32,
@@ -1950,7 +1950,7 @@ impl QueryServerStringReply {
 
 /// Opcode for the ClientInfo request
 pub const CLIENT_INFO_REQUEST: u8 = 20;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClientInfoRequest<'input> {
     pub major_version: u32,
     pub minor_version: u32,
@@ -2031,7 +2031,7 @@ impl<'input> crate::x11_utils::VoidRequest for ClientInfoRequest<'input> {
 
 /// Opcode for the GetFBConfigs request
 pub const GET_FB_CONFIGS_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetFBConfigsRequest {
     pub screen: u32,
 }
@@ -2082,7 +2082,7 @@ impl crate::x11_utils::ReplyRequest for GetFBConfigsRequest {
     type Reply = GetFBConfigsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetFBConfigsReply {
     pub sequence: u16,
     pub num_fb_configs: u32,
@@ -2128,7 +2128,7 @@ impl GetFBConfigsReply {
 
 /// Opcode for the CreatePixmap request
 pub const CREATE_PIXMAP_REQUEST: u8 = 22;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreatePixmapRequest<'input> {
     pub screen: u32,
     pub fbconfig: Fbconfig,
@@ -2229,7 +2229,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreatePixmapRequest<'input> {
 
 /// Opcode for the DestroyPixmap request
 pub const DESTROY_PIXMAP_REQUEST: u8 = 23;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyPixmapRequest {
     pub glx_pixmap: Pixmap,
 }
@@ -2281,7 +2281,7 @@ impl crate::x11_utils::VoidRequest for DestroyPixmapRequest {
 
 /// Opcode for the CreateNewContext request
 pub const CREATE_NEW_CONTEXT_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateNewContextRequest {
     pub context: Context,
     pub fbconfig: Fbconfig,
@@ -2374,7 +2374,7 @@ impl crate::x11_utils::VoidRequest for CreateNewContextRequest {
 
 /// Opcode for the QueryContext request
 pub const QUERY_CONTEXT_REQUEST: u8 = 25;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryContextRequest {
     pub context: Context,
 }
@@ -2425,7 +2425,7 @@ impl crate::x11_utils::ReplyRequest for QueryContextRequest {
     type Reply = QueryContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -2470,7 +2470,7 @@ impl QueryContextReply {
 
 /// Opcode for the MakeContextCurrent request
 pub const MAKE_CONTEXT_CURRENT_REQUEST: u8 = 26;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MakeContextCurrentRequest {
     pub old_context_tag: ContextTag,
     pub drawable: Drawable,
@@ -2545,7 +2545,7 @@ impl crate::x11_utils::ReplyRequest for MakeContextCurrentRequest {
     type Reply = MakeContextCurrentReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MakeContextCurrentReply {
     pub sequence: u16,
     pub length: u32,
@@ -2573,7 +2573,7 @@ impl TryParse for MakeContextCurrentReply {
 
 /// Opcode for the CreatePbuffer request
 pub const CREATE_PBUFFER_REQUEST: u8 = 27;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreatePbufferRequest<'input> {
     pub screen: u32,
     pub fbconfig: Fbconfig,
@@ -2665,7 +2665,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreatePbufferRequest<'input> {
 
 /// Opcode for the DestroyPbuffer request
 pub const DESTROY_PBUFFER_REQUEST: u8 = 28;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyPbufferRequest {
     pub pbuffer: Pbuffer,
 }
@@ -2717,7 +2717,7 @@ impl crate::x11_utils::VoidRequest for DestroyPbufferRequest {
 
 /// Opcode for the GetDrawableAttributes request
 pub const GET_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 29;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDrawableAttributesRequest {
     pub drawable: Drawable,
 }
@@ -2768,7 +2768,7 @@ impl crate::x11_utils::ReplyRequest for GetDrawableAttributesRequest {
     type Reply = GetDrawableAttributesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDrawableAttributesReply {
     pub sequence: u16,
     pub length: u32,
@@ -2813,7 +2813,7 @@ impl GetDrawableAttributesReply {
 
 /// Opcode for the ChangeDrawableAttributes request
 pub const CHANGE_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 30;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeDrawableAttributesRequest<'input> {
     pub drawable: Drawable,
     pub attribs: Cow<'input, [u32]>,
@@ -2887,7 +2887,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeDrawableAttributesRequest<'
 
 /// Opcode for the CreateWindow request
 pub const CREATE_WINDOW_REQUEST: u8 = 31;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateWindowRequest<'input> {
     pub screen: u32,
     pub fbconfig: Fbconfig,
@@ -2988,7 +2988,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateWindowRequest<'input> {
 
 /// Opcode for the DeleteWindow request
 pub const DELETE_WINDOW_REQUEST: u8 = 32;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeleteWindowRequest {
     pub glxwindow: Window,
 }
@@ -3040,7 +3040,7 @@ impl crate::x11_utils::VoidRequest for DeleteWindowRequest {
 
 /// Opcode for the SetClientInfoARB request
 pub const SET_CLIENT_INFO_ARB_REQUEST: u8 = 33;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetClientInfoARBRequest<'input> {
     pub major_version: u32,
     pub minor_version: u32,
@@ -3147,7 +3147,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetClientInfoARBRequest<'input> {
 
 /// Opcode for the CreateContextAttribsARB request
 pub const CREATE_CONTEXT_ATTRIBS_ARB_REQUEST: u8 = 34;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateContextAttribsARBRequest<'input> {
     pub context: Context,
     pub fbconfig: Fbconfig,
@@ -3258,7 +3258,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateContextAttribsARBRequest<'i
 
 /// Opcode for the SetClientInfo2ARB request
 pub const SET_CLIENT_INFO2_ARB_REQUEST: u8 = 35;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetClientInfo2ARBRequest<'input> {
     pub major_version: u32,
     pub minor_version: u32,
@@ -3365,7 +3365,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetClientInfo2ARBRequest<'input> 
 
 /// Opcode for the NewList request
 pub const NEW_LIST_REQUEST: u8 = 101;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NewListRequest {
     pub context_tag: ContextTag,
     pub list: u32,
@@ -3433,7 +3433,7 @@ impl crate::x11_utils::VoidRequest for NewListRequest {
 
 /// Opcode for the EndList request
 pub const END_LIST_REQUEST: u8 = 102;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EndListRequest {
     pub context_tag: ContextTag,
 }
@@ -3485,7 +3485,7 @@ impl crate::x11_utils::VoidRequest for EndListRequest {
 
 /// Opcode for the DeleteLists request
 pub const DELETE_LISTS_REQUEST: u8 = 103;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeleteListsRequest {
     pub context_tag: ContextTag,
     pub list: u32,
@@ -3553,7 +3553,7 @@ impl crate::x11_utils::VoidRequest for DeleteListsRequest {
 
 /// Opcode for the GenLists request
 pub const GEN_LISTS_REQUEST: u8 = 104;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GenListsRequest {
     pub context_tag: ContextTag,
     pub range: i32,
@@ -3612,7 +3612,7 @@ impl crate::x11_utils::ReplyRequest for GenListsRequest {
     type Reply = GenListsReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GenListsReply {
     pub sequence: u16,
     pub length: u32,
@@ -3639,7 +3639,7 @@ impl TryParse for GenListsReply {
 
 /// Opcode for the FeedbackBuffer request
 pub const FEEDBACK_BUFFER_REQUEST: u8 = 105;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackBufferRequest {
     pub context_tag: ContextTag,
     pub size: i32,
@@ -3707,7 +3707,7 @@ impl crate::x11_utils::VoidRequest for FeedbackBufferRequest {
 
 /// Opcode for the SelectBuffer request
 pub const SELECT_BUFFER_REQUEST: u8 = 106;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectBufferRequest {
     pub context_tag: ContextTag,
     pub size: i32,
@@ -3767,7 +3767,7 @@ impl crate::x11_utils::VoidRequest for SelectBufferRequest {
 
 /// Opcode for the RenderMode request
 pub const RENDER_MODE_REQUEST: u8 = 107;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RenderModeRequest {
     pub context_tag: ContextTag,
     pub mode: u32,
@@ -3826,7 +3826,7 @@ impl crate::x11_utils::ReplyRequest for RenderModeRequest {
     type Reply = RenderModeReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RenderModeReply {
     pub sequence: u16,
     pub length: u32,
@@ -3872,7 +3872,7 @@ impl RenderModeReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RM(u16);
 impl RM {
     pub const GL_RENDER: Self = Self(7168);
@@ -3928,7 +3928,7 @@ impl std::fmt::Debug for RM  {
 
 /// Opcode for the Finish request
 pub const FINISH_REQUEST: u8 = 108;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FinishRequest {
     pub context_tag: ContextTag,
 }
@@ -3979,7 +3979,7 @@ impl crate::x11_utils::ReplyRequest for FinishRequest {
     type Reply = FinishReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FinishReply {
     pub sequence: u16,
     pub length: u32,
@@ -4004,7 +4004,7 @@ impl TryParse for FinishReply {
 
 /// Opcode for the PixelStoref request
 pub const PIXEL_STOREF_REQUEST: u8 = 109;
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
 pub struct PixelStorefRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
@@ -4072,7 +4072,7 @@ impl crate::x11_utils::VoidRequest for PixelStorefRequest {
 
 /// Opcode for the PixelStorei request
 pub const PIXEL_STOREI_REQUEST: u8 = 110;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PixelStoreiRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
@@ -4140,7 +4140,7 @@ impl crate::x11_utils::VoidRequest for PixelStoreiRequest {
 
 /// Opcode for the ReadPixels request
 pub const READ_PIXELS_REQUEST: u8 = 111;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReadPixelsRequest {
     pub context_tag: ContextTag,
     pub x: i32,
@@ -4251,7 +4251,7 @@ impl crate::x11_utils::ReplyRequest for ReadPixelsRequest {
     type Reply = ReadPixelsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReadPixelsReply {
     pub sequence: u16,
     pub data: Vec<u8>,
@@ -4295,7 +4295,7 @@ impl ReadPixelsReply {
 
 /// Opcode for the GetBooleanv request
 pub const GET_BOOLEANV_REQUEST: u8 = 112;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetBooleanvRequest {
     pub context_tag: ContextTag,
     pub pname: i32,
@@ -4354,7 +4354,7 @@ impl crate::x11_utils::ReplyRequest for GetBooleanvRequest {
     type Reply = GetBooleanvReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetBooleanvReply {
     pub sequence: u16,
     pub length: u32,
@@ -4401,7 +4401,7 @@ impl GetBooleanvReply {
 
 /// Opcode for the GetClipPlane request
 pub const GET_CLIP_PLANE_REQUEST: u8 = 113;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetClipPlaneRequest {
     pub context_tag: ContextTag,
     pub plane: i32,
@@ -4460,7 +4460,7 @@ impl crate::x11_utils::ReplyRequest for GetClipPlaneRequest {
     type Reply = GetClipPlaneReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetClipPlaneReply {
     pub sequence: u16,
     pub data: Vec<Float64>,
@@ -4503,7 +4503,7 @@ impl GetClipPlaneReply {
 
 /// Opcode for the GetDoublev request
 pub const GET_DOUBLEV_REQUEST: u8 = 114;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDoublevRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
@@ -4562,7 +4562,7 @@ impl crate::x11_utils::ReplyRequest for GetDoublevRequest {
     type Reply = GetDoublevReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetDoublevReply {
     pub sequence: u16,
     pub length: u32,
@@ -4609,7 +4609,7 @@ impl GetDoublevReply {
 
 /// Opcode for the GetError request
 pub const GET_ERROR_REQUEST: u8 = 115;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetErrorRequest {
     pub context_tag: ContextTag,
 }
@@ -4660,7 +4660,7 @@ impl crate::x11_utils::ReplyRequest for GetErrorRequest {
     type Reply = GetErrorReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetErrorReply {
     pub sequence: u16,
     pub length: u32,
@@ -4687,7 +4687,7 @@ impl TryParse for GetErrorReply {
 
 /// Opcode for the GetFloatv request
 pub const GET_FLOATV_REQUEST: u8 = 116;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetFloatvRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
@@ -4746,7 +4746,7 @@ impl crate::x11_utils::ReplyRequest for GetFloatvRequest {
     type Reply = GetFloatvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetFloatvReply {
     pub sequence: u16,
     pub length: u32,
@@ -4793,7 +4793,7 @@ impl GetFloatvReply {
 
 /// Opcode for the GetIntegerv request
 pub const GET_INTEGERV_REQUEST: u8 = 117;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetIntegervRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
@@ -4852,7 +4852,7 @@ impl crate::x11_utils::ReplyRequest for GetIntegervRequest {
     type Reply = GetIntegervReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetIntegervReply {
     pub sequence: u16,
     pub length: u32,
@@ -4899,7 +4899,7 @@ impl GetIntegervReply {
 
 /// Opcode for the GetLightfv request
 pub const GET_LIGHTFV_REQUEST: u8 = 118;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetLightfvRequest {
     pub context_tag: ContextTag,
     pub light: u32,
@@ -4966,7 +4966,7 @@ impl crate::x11_utils::ReplyRequest for GetLightfvRequest {
     type Reply = GetLightfvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetLightfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -5013,7 +5013,7 @@ impl GetLightfvReply {
 
 /// Opcode for the GetLightiv request
 pub const GET_LIGHTIV_REQUEST: u8 = 119;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetLightivRequest {
     pub context_tag: ContextTag,
     pub light: u32,
@@ -5080,7 +5080,7 @@ impl crate::x11_utils::ReplyRequest for GetLightivRequest {
     type Reply = GetLightivReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetLightivReply {
     pub sequence: u16,
     pub length: u32,
@@ -5127,7 +5127,7 @@ impl GetLightivReply {
 
 /// Opcode for the GetMapdv request
 pub const GET_MAPDV_REQUEST: u8 = 120;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMapdvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -5194,7 +5194,7 @@ impl crate::x11_utils::ReplyRequest for GetMapdvRequest {
     type Reply = GetMapdvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetMapdvReply {
     pub sequence: u16,
     pub length: u32,
@@ -5241,7 +5241,7 @@ impl GetMapdvReply {
 
 /// Opcode for the GetMapfv request
 pub const GET_MAPFV_REQUEST: u8 = 121;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMapfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -5308,7 +5308,7 @@ impl crate::x11_utils::ReplyRequest for GetMapfvRequest {
     type Reply = GetMapfvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetMapfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -5355,7 +5355,7 @@ impl GetMapfvReply {
 
 /// Opcode for the GetMapiv request
 pub const GET_MAPIV_REQUEST: u8 = 122;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMapivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -5422,7 +5422,7 @@ impl crate::x11_utils::ReplyRequest for GetMapivRequest {
     type Reply = GetMapivReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMapivReply {
     pub sequence: u16,
     pub length: u32,
@@ -5469,7 +5469,7 @@ impl GetMapivReply {
 
 /// Opcode for the GetMaterialfv request
 pub const GET_MATERIALFV_REQUEST: u8 = 123;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMaterialfvRequest {
     pub context_tag: ContextTag,
     pub face: u32,
@@ -5536,7 +5536,7 @@ impl crate::x11_utils::ReplyRequest for GetMaterialfvRequest {
     type Reply = GetMaterialfvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetMaterialfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -5583,7 +5583,7 @@ impl GetMaterialfvReply {
 
 /// Opcode for the GetMaterialiv request
 pub const GET_MATERIALIV_REQUEST: u8 = 124;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMaterialivRequest {
     pub context_tag: ContextTag,
     pub face: u32,
@@ -5650,7 +5650,7 @@ impl crate::x11_utils::ReplyRequest for GetMaterialivRequest {
     type Reply = GetMaterialivReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMaterialivReply {
     pub sequence: u16,
     pub length: u32,
@@ -5697,7 +5697,7 @@ impl GetMaterialivReply {
 
 /// Opcode for the GetPixelMapfv request
 pub const GET_PIXEL_MAPFV_REQUEST: u8 = 125;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPixelMapfvRequest {
     pub context_tag: ContextTag,
     pub map: u32,
@@ -5756,7 +5756,7 @@ impl crate::x11_utils::ReplyRequest for GetPixelMapfvRequest {
     type Reply = GetPixelMapfvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetPixelMapfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -5803,7 +5803,7 @@ impl GetPixelMapfvReply {
 
 /// Opcode for the GetPixelMapuiv request
 pub const GET_PIXEL_MAPUIV_REQUEST: u8 = 126;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPixelMapuivRequest {
     pub context_tag: ContextTag,
     pub map: u32,
@@ -5862,7 +5862,7 @@ impl crate::x11_utils::ReplyRequest for GetPixelMapuivRequest {
     type Reply = GetPixelMapuivReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPixelMapuivReply {
     pub sequence: u16,
     pub length: u32,
@@ -5909,7 +5909,7 @@ impl GetPixelMapuivReply {
 
 /// Opcode for the GetPixelMapusv request
 pub const GET_PIXEL_MAPUSV_REQUEST: u8 = 127;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPixelMapusvRequest {
     pub context_tag: ContextTag,
     pub map: u32,
@@ -5968,7 +5968,7 @@ impl crate::x11_utils::ReplyRequest for GetPixelMapusvRequest {
     type Reply = GetPixelMapusvReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPixelMapusvReply {
     pub sequence: u16,
     pub length: u32,
@@ -6015,7 +6015,7 @@ impl GetPixelMapusvReply {
 
 /// Opcode for the GetPolygonStipple request
 pub const GET_POLYGON_STIPPLE_REQUEST: u8 = 128;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPolygonStippleRequest {
     pub context_tag: ContextTag,
     pub lsb_first: bool,
@@ -6074,7 +6074,7 @@ impl crate::x11_utils::ReplyRequest for GetPolygonStippleRequest {
     type Reply = GetPolygonStippleReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPolygonStippleReply {
     pub sequence: u16,
     pub data: Vec<u8>,
@@ -6118,7 +6118,7 @@ impl GetPolygonStippleReply {
 
 /// Opcode for the GetString request
 pub const GET_STRING_REQUEST: u8 = 129;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetStringRequest {
     pub context_tag: ContextTag,
     pub name: u32,
@@ -6177,7 +6177,7 @@ impl crate::x11_utils::ReplyRequest for GetStringRequest {
     type Reply = GetStringReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetStringReply {
     pub sequence: u16,
     pub length: u32,
@@ -6223,7 +6223,7 @@ impl GetStringReply {
 
 /// Opcode for the GetTexEnvfv request
 pub const GET_TEX_ENVFV_REQUEST: u8 = 130;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexEnvfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -6290,7 +6290,7 @@ impl crate::x11_utils::ReplyRequest for GetTexEnvfvRequest {
     type Reply = GetTexEnvfvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetTexEnvfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -6337,7 +6337,7 @@ impl GetTexEnvfvReply {
 
 /// Opcode for the GetTexEnviv request
 pub const GET_TEX_ENVIV_REQUEST: u8 = 131;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexEnvivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -6404,7 +6404,7 @@ impl crate::x11_utils::ReplyRequest for GetTexEnvivRequest {
     type Reply = GetTexEnvivReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexEnvivReply {
     pub sequence: u16,
     pub length: u32,
@@ -6451,7 +6451,7 @@ impl GetTexEnvivReply {
 
 /// Opcode for the GetTexGendv request
 pub const GET_TEX_GENDV_REQUEST: u8 = 132;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexGendvRequest {
     pub context_tag: ContextTag,
     pub coord: u32,
@@ -6518,7 +6518,7 @@ impl crate::x11_utils::ReplyRequest for GetTexGendvRequest {
     type Reply = GetTexGendvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetTexGendvReply {
     pub sequence: u16,
     pub length: u32,
@@ -6565,7 +6565,7 @@ impl GetTexGendvReply {
 
 /// Opcode for the GetTexGenfv request
 pub const GET_TEX_GENFV_REQUEST: u8 = 133;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexGenfvRequest {
     pub context_tag: ContextTag,
     pub coord: u32,
@@ -6632,7 +6632,7 @@ impl crate::x11_utils::ReplyRequest for GetTexGenfvRequest {
     type Reply = GetTexGenfvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetTexGenfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -6679,7 +6679,7 @@ impl GetTexGenfvReply {
 
 /// Opcode for the GetTexGeniv request
 pub const GET_TEX_GENIV_REQUEST: u8 = 134;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexGenivRequest {
     pub context_tag: ContextTag,
     pub coord: u32,
@@ -6746,7 +6746,7 @@ impl crate::x11_utils::ReplyRequest for GetTexGenivRequest {
     type Reply = GetTexGenivReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexGenivReply {
     pub sequence: u16,
     pub length: u32,
@@ -6793,7 +6793,7 @@ impl GetTexGenivReply {
 
 /// Opcode for the GetTexImage request
 pub const GET_TEX_IMAGE_REQUEST: u8 = 135;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexImageRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -6884,7 +6884,7 @@ impl crate::x11_utils::ReplyRequest for GetTexImageRequest {
     type Reply = GetTexImageReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexImageReply {
     pub sequence: u16,
     pub width: i32,
@@ -6935,7 +6935,7 @@ impl GetTexImageReply {
 
 /// Opcode for the GetTexParameterfv request
 pub const GET_TEX_PARAMETERFV_REQUEST: u8 = 136;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -7002,7 +7002,7 @@ impl crate::x11_utils::ReplyRequest for GetTexParameterfvRequest {
     type Reply = GetTexParameterfvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetTexParameterfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -7049,7 +7049,7 @@ impl GetTexParameterfvReply {
 
 /// Opcode for the GetTexParameteriv request
 pub const GET_TEX_PARAMETERIV_REQUEST: u8 = 137;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -7116,7 +7116,7 @@ impl crate::x11_utils::ReplyRequest for GetTexParameterivRequest {
     type Reply = GetTexParameterivReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexParameterivReply {
     pub sequence: u16,
     pub length: u32,
@@ -7163,7 +7163,7 @@ impl GetTexParameterivReply {
 
 /// Opcode for the GetTexLevelParameterfv request
 pub const GET_TEX_LEVEL_PARAMETERFV_REQUEST: u8 = 138;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexLevelParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -7238,7 +7238,7 @@ impl crate::x11_utils::ReplyRequest for GetTexLevelParameterfvRequest {
     type Reply = GetTexLevelParameterfvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetTexLevelParameterfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -7285,7 +7285,7 @@ impl GetTexLevelParameterfvReply {
 
 /// Opcode for the GetTexLevelParameteriv request
 pub const GET_TEX_LEVEL_PARAMETERIV_REQUEST: u8 = 139;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexLevelParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -7360,7 +7360,7 @@ impl crate::x11_utils::ReplyRequest for GetTexLevelParameterivRequest {
     type Reply = GetTexLevelParameterivReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetTexLevelParameterivReply {
     pub sequence: u16,
     pub length: u32,
@@ -7407,7 +7407,7 @@ impl GetTexLevelParameterivReply {
 
 /// Opcode for the IsEnabled request
 pub const IS_ENABLED_REQUEST: u8 = 140;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IsEnabledRequest {
     pub context_tag: ContextTag,
     pub capability: u32,
@@ -7466,7 +7466,7 @@ impl crate::x11_utils::ReplyRequest for IsEnabledRequest {
     type Reply = IsEnabledReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IsEnabledReply {
     pub sequence: u16,
     pub length: u32,
@@ -7493,7 +7493,7 @@ impl TryParse for IsEnabledReply {
 
 /// Opcode for the IsList request
 pub const IS_LIST_REQUEST: u8 = 141;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IsListRequest {
     pub context_tag: ContextTag,
     pub list: u32,
@@ -7552,7 +7552,7 @@ impl crate::x11_utils::ReplyRequest for IsListRequest {
     type Reply = IsListReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IsListReply {
     pub sequence: u16,
     pub length: u32,
@@ -7579,7 +7579,7 @@ impl TryParse for IsListReply {
 
 /// Opcode for the Flush request
 pub const FLUSH_REQUEST: u8 = 142;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FlushRequest {
     pub context_tag: ContextTag,
 }
@@ -7631,7 +7631,7 @@ impl crate::x11_utils::VoidRequest for FlushRequest {
 
 /// Opcode for the AreTexturesResident request
 pub const ARE_TEXTURES_RESIDENT_REQUEST: u8 = 143;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AreTexturesResidentRequest<'input> {
     pub context_tag: ContextTag,
     pub textures: Cow<'input, [u32]>,
@@ -7703,7 +7703,7 @@ impl<'input> crate::x11_utils::ReplyRequest for AreTexturesResidentRequest<'inpu
     type Reply = AreTexturesResidentReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AreTexturesResidentReply {
     pub sequence: u16,
     pub ret_val: Bool32,
@@ -7748,7 +7748,7 @@ impl AreTexturesResidentReply {
 
 /// Opcode for the DeleteTextures request
 pub const DELETE_TEXTURES_REQUEST: u8 = 144;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeleteTexturesRequest<'input> {
     pub context_tag: ContextTag,
     pub textures: Cow<'input, [u32]>,
@@ -7821,7 +7821,7 @@ impl<'input> crate::x11_utils::VoidRequest for DeleteTexturesRequest<'input> {
 
 /// Opcode for the GenTextures request
 pub const GEN_TEXTURES_REQUEST: u8 = 145;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GenTexturesRequest {
     pub context_tag: ContextTag,
     pub n: i32,
@@ -7880,7 +7880,7 @@ impl crate::x11_utils::ReplyRequest for GenTexturesRequest {
     type Reply = GenTexturesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GenTexturesReply {
     pub sequence: u16,
     pub data: Vec<u32>,
@@ -7922,7 +7922,7 @@ impl GenTexturesReply {
 
 /// Opcode for the IsTexture request
 pub const IS_TEXTURE_REQUEST: u8 = 146;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IsTextureRequest {
     pub context_tag: ContextTag,
     pub texture: u32,
@@ -7981,7 +7981,7 @@ impl crate::x11_utils::ReplyRequest for IsTextureRequest {
     type Reply = IsTextureReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IsTextureReply {
     pub sequence: u16,
     pub length: u32,
@@ -8008,7 +8008,7 @@ impl TryParse for IsTextureReply {
 
 /// Opcode for the GetColorTable request
 pub const GET_COLOR_TABLE_REQUEST: u8 = 147;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetColorTableRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8091,7 +8091,7 @@ impl crate::x11_utils::ReplyRequest for GetColorTableRequest {
     type Reply = GetColorTableReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetColorTableReply {
     pub sequence: u16,
     pub width: i32,
@@ -8138,7 +8138,7 @@ impl GetColorTableReply {
 
 /// Opcode for the GetColorTableParameterfv request
 pub const GET_COLOR_TABLE_PARAMETERFV_REQUEST: u8 = 148;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetColorTableParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8205,7 +8205,7 @@ impl crate::x11_utils::ReplyRequest for GetColorTableParameterfvRequest {
     type Reply = GetColorTableParameterfvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetColorTableParameterfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -8252,7 +8252,7 @@ impl GetColorTableParameterfvReply {
 
 /// Opcode for the GetColorTableParameteriv request
 pub const GET_COLOR_TABLE_PARAMETERIV_REQUEST: u8 = 149;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetColorTableParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8319,7 +8319,7 @@ impl crate::x11_utils::ReplyRequest for GetColorTableParameterivRequest {
     type Reply = GetColorTableParameterivReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetColorTableParameterivReply {
     pub sequence: u16,
     pub length: u32,
@@ -8366,7 +8366,7 @@ impl GetColorTableParameterivReply {
 
 /// Opcode for the GetConvolutionFilter request
 pub const GET_CONVOLUTION_FILTER_REQUEST: u8 = 150;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetConvolutionFilterRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8449,7 +8449,7 @@ impl crate::x11_utils::ReplyRequest for GetConvolutionFilterRequest {
     type Reply = GetConvolutionFilterReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetConvolutionFilterReply {
     pub sequence: u16,
     pub width: i32,
@@ -8498,7 +8498,7 @@ impl GetConvolutionFilterReply {
 
 /// Opcode for the GetConvolutionParameterfv request
 pub const GET_CONVOLUTION_PARAMETERFV_REQUEST: u8 = 151;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetConvolutionParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8565,7 +8565,7 @@ impl crate::x11_utils::ReplyRequest for GetConvolutionParameterfvRequest {
     type Reply = GetConvolutionParameterfvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetConvolutionParameterfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -8612,7 +8612,7 @@ impl GetConvolutionParameterfvReply {
 
 /// Opcode for the GetConvolutionParameteriv request
 pub const GET_CONVOLUTION_PARAMETERIV_REQUEST: u8 = 152;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetConvolutionParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8679,7 +8679,7 @@ impl crate::x11_utils::ReplyRequest for GetConvolutionParameterivRequest {
     type Reply = GetConvolutionParameterivReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetConvolutionParameterivReply {
     pub sequence: u16,
     pub length: u32,
@@ -8726,7 +8726,7 @@ impl GetConvolutionParameterivReply {
 
 /// Opcode for the GetSeparableFilter request
 pub const GET_SEPARABLE_FILTER_REQUEST: u8 = 153;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSeparableFilterRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8809,7 +8809,7 @@ impl crate::x11_utils::ReplyRequest for GetSeparableFilterRequest {
     type Reply = GetSeparableFilterReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSeparableFilterReply {
     pub sequence: u16,
     pub row_w: i32,
@@ -8858,7 +8858,7 @@ impl GetSeparableFilterReply {
 
 /// Opcode for the GetHistogram request
 pub const GET_HISTOGRAM_REQUEST: u8 = 154;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetHistogramRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8945,7 +8945,7 @@ impl crate::x11_utils::ReplyRequest for GetHistogramRequest {
     type Reply = GetHistogramReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetHistogramReply {
     pub sequence: u16,
     pub width: i32,
@@ -8992,7 +8992,7 @@ impl GetHistogramReply {
 
 /// Opcode for the GetHistogramParameterfv request
 pub const GET_HISTOGRAM_PARAMETERFV_REQUEST: u8 = 155;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetHistogramParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -9059,7 +9059,7 @@ impl crate::x11_utils::ReplyRequest for GetHistogramParameterfvRequest {
     type Reply = GetHistogramParameterfvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetHistogramParameterfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -9106,7 +9106,7 @@ impl GetHistogramParameterfvReply {
 
 /// Opcode for the GetHistogramParameteriv request
 pub const GET_HISTOGRAM_PARAMETERIV_REQUEST: u8 = 156;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetHistogramParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -9173,7 +9173,7 @@ impl crate::x11_utils::ReplyRequest for GetHistogramParameterivRequest {
     type Reply = GetHistogramParameterivReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetHistogramParameterivReply {
     pub sequence: u16,
     pub length: u32,
@@ -9220,7 +9220,7 @@ impl GetHistogramParameterivReply {
 
 /// Opcode for the GetMinmax request
 pub const GET_MINMAX_REQUEST: u8 = 157;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMinmaxRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -9307,7 +9307,7 @@ impl crate::x11_utils::ReplyRequest for GetMinmaxRequest {
     type Reply = GetMinmaxReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMinmaxReply {
     pub sequence: u16,
     pub data: Vec<u8>,
@@ -9351,7 +9351,7 @@ impl GetMinmaxReply {
 
 /// Opcode for the GetMinmaxParameterfv request
 pub const GET_MINMAX_PARAMETERFV_REQUEST: u8 = 158;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMinmaxParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -9418,7 +9418,7 @@ impl crate::x11_utils::ReplyRequest for GetMinmaxParameterfvRequest {
     type Reply = GetMinmaxParameterfvReply;
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
 pub struct GetMinmaxParameterfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -9465,7 +9465,7 @@ impl GetMinmaxParameterfvReply {
 
 /// Opcode for the GetMinmaxParameteriv request
 pub const GET_MINMAX_PARAMETERIV_REQUEST: u8 = 159;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMinmaxParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -9532,7 +9532,7 @@ impl crate::x11_utils::ReplyRequest for GetMinmaxParameterivRequest {
     type Reply = GetMinmaxParameterivReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMinmaxParameterivReply {
     pub sequence: u16,
     pub length: u32,
@@ -9579,7 +9579,7 @@ impl GetMinmaxParameterivReply {
 
 /// Opcode for the GetCompressedTexImageARB request
 pub const GET_COMPRESSED_TEX_IMAGE_ARB_REQUEST: u8 = 160;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCompressedTexImageARBRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -9646,7 +9646,7 @@ impl crate::x11_utils::ReplyRequest for GetCompressedTexImageARBRequest {
     type Reply = GetCompressedTexImageARBReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCompressedTexImageARBReply {
     pub sequence: u16,
     pub size: i32,
@@ -9693,7 +9693,7 @@ impl GetCompressedTexImageARBReply {
 
 /// Opcode for the DeleteQueriesARB request
 pub const DELETE_QUERIES_ARB_REQUEST: u8 = 161;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeleteQueriesARBRequest<'input> {
     pub context_tag: ContextTag,
     pub ids: Cow<'input, [u32]>,
@@ -9766,7 +9766,7 @@ impl<'input> crate::x11_utils::VoidRequest for DeleteQueriesARBRequest<'input> {
 
 /// Opcode for the GenQueriesARB request
 pub const GEN_QUERIES_ARB_REQUEST: u8 = 162;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GenQueriesARBRequest {
     pub context_tag: ContextTag,
     pub n: i32,
@@ -9825,7 +9825,7 @@ impl crate::x11_utils::ReplyRequest for GenQueriesARBRequest {
     type Reply = GenQueriesARBReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GenQueriesARBReply {
     pub sequence: u16,
     pub data: Vec<u32>,
@@ -9867,7 +9867,7 @@ impl GenQueriesARBReply {
 
 /// Opcode for the IsQueryARB request
 pub const IS_QUERY_ARB_REQUEST: u8 = 163;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IsQueryARBRequest {
     pub context_tag: ContextTag,
     pub id: u32,
@@ -9926,7 +9926,7 @@ impl crate::x11_utils::ReplyRequest for IsQueryARBRequest {
     type Reply = IsQueryARBReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IsQueryARBReply {
     pub sequence: u16,
     pub length: u32,
@@ -9953,7 +9953,7 @@ impl TryParse for IsQueryARBReply {
 
 /// Opcode for the GetQueryivARB request
 pub const GET_QUERYIV_ARB_REQUEST: u8 = 164;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetQueryivARBRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -10020,7 +10020,7 @@ impl crate::x11_utils::ReplyRequest for GetQueryivARBRequest {
     type Reply = GetQueryivARBReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetQueryivARBReply {
     pub sequence: u16,
     pub length: u32,
@@ -10067,7 +10067,7 @@ impl GetQueryivARBReply {
 
 /// Opcode for the GetQueryObjectivARB request
 pub const GET_QUERY_OBJECTIV_ARB_REQUEST: u8 = 165;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetQueryObjectivARBRequest {
     pub context_tag: ContextTag,
     pub id: u32,
@@ -10134,7 +10134,7 @@ impl crate::x11_utils::ReplyRequest for GetQueryObjectivARBRequest {
     type Reply = GetQueryObjectivARBReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetQueryObjectivARBReply {
     pub sequence: u16,
     pub length: u32,
@@ -10181,7 +10181,7 @@ impl GetQueryObjectivARBReply {
 
 /// Opcode for the GetQueryObjectuivARB request
 pub const GET_QUERY_OBJECTUIV_ARB_REQUEST: u8 = 166;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetQueryObjectuivARBRequest {
     pub context_tag: ContextTag,
     pub id: u32,
@@ -10248,7 +10248,7 @@ impl crate::x11_utils::ReplyRequest for GetQueryObjectuivARBRequest {
     type Reply = GetQueryObjectuivARBReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetQueryObjectuivARBReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/mod.rs
+++ b/x11rb-protocol/src/protocol/mod.rs
@@ -8174,7 +8174,7 @@ pub(crate) fn request_name(extension: Option<&str>, major_opcode: u8, minor_opco
 }
 
 /// Enumeration of all possible X11 error kinds.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum ErrorKind {
     Unknown(u8),

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -38,7 +38,7 @@ pub const X11_EXTENSION_NAME: &str = "Present";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EventEnum(u8);
 impl EventEnum {
     pub const CONFIGURE_NOTIFY: Self = Self(0);
@@ -100,7 +100,7 @@ impl std::fmt::Debug for EventEnum  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EventMask(u8);
 impl EventMask {
     pub const NO_EVENT: Self = Self(0);
@@ -165,7 +165,7 @@ impl std::fmt::Debug for EventMask  {
 }
 bitmask_binop!(EventMask, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Option(u8);
 impl Option {
     pub const NONE: Self = Self(0);
@@ -230,7 +230,7 @@ impl std::fmt::Debug for Option  {
 }
 bitmask_binop!(Option, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Capability(u8);
 impl Capability {
     pub const NONE: Self = Self(0);
@@ -293,7 +293,7 @@ impl std::fmt::Debug for Capability  {
 }
 bitmask_binop!(Capability, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompleteKind(u8);
 impl CompleteKind {
     pub const PIXMAP: Self = Self(0);
@@ -351,7 +351,7 @@ impl std::fmt::Debug for CompleteKind  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompleteMode(u8);
 impl CompleteMode {
     pub const COPY: Self = Self(0);
@@ -413,7 +413,7 @@ impl std::fmt::Debug for CompleteMode  {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Notify {
     pub window: xproto::Window,
     pub serial: u32,
@@ -451,7 +451,7 @@ impl Serialize for Notify {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
@@ -510,7 +510,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -539,7 +539,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the Pixmap request
 pub const PIXMAP_REQUEST: u8 = 1;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PixmapRequest<'input> {
     pub window: xproto::Window,
     pub pixmap: xproto::Pixmap,
@@ -742,7 +742,7 @@ impl<'input> crate::x11_utils::VoidRequest for PixmapRequest<'input> {
 
 /// Opcode for the NotifyMSC request
 pub const NOTIFY_MSC_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotifyMSCRequest {
     pub window: xproto::Window,
     pub serial: u32,
@@ -845,7 +845,7 @@ pub type Event = u32;
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectInputRequest {
     pub eid: Event,
     pub window: xproto::Window,
@@ -913,7 +913,7 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 
 /// Opcode for the QueryCapabilities request
 pub const QUERY_CAPABILITIES_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryCapabilitiesRequest {
     pub target: u32,
 }
@@ -964,7 +964,7 @@ impl crate::x11_utils::ReplyRequest for QueryCapabilitiesRequest {
     type Reply = QueryCapabilitiesReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryCapabilitiesReply {
     pub sequence: u16,
     pub length: u32,
@@ -991,7 +991,7 @@ impl TryParse for QueryCapabilitiesReply {
 
 /// Opcode for the Generic event
 pub const GENERIC_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GenericEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -1070,7 +1070,7 @@ impl From<GenericEvent> for [u8; 32] {
 
 /// Opcode for the ConfigureNotify event
 pub const CONFIGURE_NOTIFY_EVENT: u16 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConfigureNotifyEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -1119,7 +1119,7 @@ impl TryParse for ConfigureNotifyEvent {
 
 /// Opcode for the CompleteNotify event
 pub const COMPLETE_NOTIFY_EVENT: u16 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompleteNotifyEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -1161,7 +1161,7 @@ impl TryParse for CompleteNotifyEvent {
 
 /// Opcode for the IdleNotify event
 pub const IDLE_NOTIFY_EVENT: u16 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IdleNotifyEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -1198,7 +1198,7 @@ impl TryParse for IdleNotifyEvent {
 
 /// Opcode for the RedirectNotify event
 pub const REDIRECT_NOTIFY_EVENT: u16 = 3;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RedirectNotifyEvent {
     pub response_type: u8,
     pub extension: u8,

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -56,7 +56,7 @@ pub const BAD_MODE_ERROR: u8 = 2;
 /// Opcode for the BadProvider error
 pub const BAD_PROVIDER_ERROR: u8 = 3;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Rotation(u8);
 impl Rotation {
     pub const ROTATE0: Self = Self(1 << 0);
@@ -123,7 +123,7 @@ impl std::fmt::Debug for Rotation  {
 }
 bitmask_binop!(Rotation, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScreenSize {
     pub width: u16,
     pub height: u16,
@@ -167,7 +167,7 @@ impl Serialize for ScreenSize {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RefreshRates {
     pub rates: Vec<u16>,
 }
@@ -210,7 +210,7 @@ impl RefreshRates {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
@@ -269,7 +269,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -297,7 +297,7 @@ impl TryParse for QueryVersionReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetConfig(u8);
 impl SetConfig {
     pub const SUCCESS: Self = Self(0);
@@ -361,7 +361,7 @@ impl std::fmt::Debug for SetConfig  {
 
 /// Opcode for the SetScreenConfig request
 pub const SET_SCREEN_CONFIG_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetScreenConfigRequest {
     pub window: xproto::Window,
     pub timestamp: xproto::Timestamp,
@@ -449,7 +449,7 @@ impl crate::x11_utils::ReplyRequest for SetScreenConfigRequest {
     type Reply = SetScreenConfigReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetScreenConfigReply {
     pub status: SetConfig,
     pub sequence: u16,
@@ -484,7 +484,7 @@ impl TryParse for SetScreenConfigReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotifyMask(u8);
 impl NotifyMask {
     pub const SCREEN_CHANGE: Self = Self(1 << 0);
@@ -557,7 +557,7 @@ bitmask_binop!(NotifyMask, u8);
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectInputRequest {
     pub window: xproto::Window,
     pub enable: u16,
@@ -618,7 +618,7 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 
 /// Opcode for the GetScreenInfo request
 pub const GET_SCREEN_INFO_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenInfoRequest {
     pub window: xproto::Window,
 }
@@ -669,7 +669,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenInfoRequest {
     type Reply = GetScreenInfoReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenInfoReply {
     pub rotations: u8,
     pub sequence: u16,
@@ -730,7 +730,7 @@ impl GetScreenInfoReply {
 
 /// Opcode for the GetScreenSizeRange request
 pub const GET_SCREEN_SIZE_RANGE_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenSizeRangeRequest {
     pub window: xproto::Window,
 }
@@ -781,7 +781,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenSizeRangeRequest {
     type Reply = GetScreenSizeRangeReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenSizeRangeReply {
     pub sequence: u16,
     pub length: u32,
@@ -815,7 +815,7 @@ impl TryParse for GetScreenSizeRangeReply {
 
 /// Opcode for the SetScreenSize request
 pub const SET_SCREEN_SIZE_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetScreenSizeRequest {
     pub window: xproto::Window,
     pub width: u16,
@@ -893,7 +893,7 @@ impl Request for SetScreenSizeRequest {
 impl crate::x11_utils::VoidRequest for SetScreenSizeRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModeFlag(u16);
 impl ModeFlag {
     pub const HSYNC_POSITIVE: Self = Self(1 << 0);
@@ -970,7 +970,7 @@ impl std::fmt::Debug for ModeFlag  {
 }
 bitmask_binop!(ModeFlag, u16);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModeInfo {
     pub id: u32,
     pub width: u16,
@@ -1076,7 +1076,7 @@ impl Serialize for ModeInfo {
 
 /// Opcode for the GetScreenResources request
 pub const GET_SCREEN_RESOURCES_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenResourcesRequest {
     pub window: xproto::Window,
 }
@@ -1127,7 +1127,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenResourcesRequest {
     type Reply = GetScreenResourcesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenResourcesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1222,7 +1222,7 @@ impl GetScreenResourcesReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Connection(u8);
 impl Connection {
     pub const CONNECTED: Self = Self(0);
@@ -1284,7 +1284,7 @@ impl std::fmt::Debug for Connection  {
 
 /// Opcode for the GetOutputInfo request
 pub const GET_OUTPUT_INFO_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetOutputInfoRequest {
     pub output: Output,
     pub config_timestamp: xproto::Timestamp,
@@ -1343,7 +1343,7 @@ impl crate::x11_utils::ReplyRequest for GetOutputInfoRequest {
     type Reply = GetOutputInfoReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetOutputInfoReply {
     pub status: SetConfig,
     pub sequence: u16,
@@ -1453,7 +1453,7 @@ impl GetOutputInfoReply {
 
 /// Opcode for the ListOutputProperties request
 pub const LIST_OUTPUT_PROPERTIES_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListOutputPropertiesRequest {
     pub output: Output,
 }
@@ -1504,7 +1504,7 @@ impl crate::x11_utils::ReplyRequest for ListOutputPropertiesRequest {
     type Reply = ListOutputPropertiesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListOutputPropertiesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1548,7 +1548,7 @@ impl ListOutputPropertiesReply {
 
 /// Opcode for the QueryOutputProperty request
 pub const QUERY_OUTPUT_PROPERTY_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryOutputPropertyRequest {
     pub output: Output,
     pub property: xproto::Atom,
@@ -1607,7 +1607,7 @@ impl crate::x11_utils::ReplyRequest for QueryOutputPropertyRequest {
     type Reply = QueryOutputPropertyReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryOutputPropertyReply {
     pub sequence: u16,
     pub pending: bool,
@@ -1655,7 +1655,7 @@ impl QueryOutputPropertyReply {
 
 /// Opcode for the ConfigureOutputProperty request
 pub const CONFIGURE_OUTPUT_PROPERTY_REQUEST: u8 = 12;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConfigureOutputPropertyRequest<'input> {
     pub output: Output,
     pub property: xproto::Atom,
@@ -1752,7 +1752,7 @@ impl<'input> crate::x11_utils::VoidRequest for ConfigureOutputPropertyRequest<'i
 
 /// Opcode for the ChangeOutputProperty request
 pub const CHANGE_OUTPUT_PROPERTY_REQUEST: u8 = 13;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeOutputPropertyRequest<'input> {
     pub output: Output,
     pub property: xproto::Atom,
@@ -1861,7 +1861,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeOutputPropertyRequest<'inpu
 
 /// Opcode for the DeleteOutputProperty request
 pub const DELETE_OUTPUT_PROPERTY_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeleteOutputPropertyRequest {
     pub output: Output,
     pub property: xproto::Atom,
@@ -1921,7 +1921,7 @@ impl crate::x11_utils::VoidRequest for DeleteOutputPropertyRequest {
 
 /// Opcode for the GetOutputProperty request
 pub const GET_OUTPUT_PROPERTY_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetOutputPropertyRequest {
     pub output: Output,
     pub property: xproto::Atom,
@@ -2017,7 +2017,7 @@ impl crate::x11_utils::ReplyRequest for GetOutputPropertyRequest {
     type Reply = GetOutputPropertyReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetOutputPropertyReply {
     pub format: u8,
     pub sequence: u16,
@@ -2053,7 +2053,7 @@ impl TryParse for GetOutputPropertyReply {
 
 /// Opcode for the CreateMode request
 pub const CREATE_MODE_REQUEST: u8 = 16;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateModeRequest<'input> {
     pub window: xproto::Window,
     pub mode_info: ModeInfo,
@@ -2154,7 +2154,7 @@ impl<'input> crate::x11_utils::ReplyRequest for CreateModeRequest<'input> {
     type Reply = CreateModeReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateModeReply {
     pub sequence: u16,
     pub length: u32,
@@ -2182,7 +2182,7 @@ impl TryParse for CreateModeReply {
 
 /// Opcode for the DestroyMode request
 pub const DESTROY_MODE_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyModeRequest {
     pub mode: Mode,
 }
@@ -2234,7 +2234,7 @@ impl crate::x11_utils::VoidRequest for DestroyModeRequest {
 
 /// Opcode for the AddOutputMode request
 pub const ADD_OUTPUT_MODE_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AddOutputModeRequest {
     pub output: Output,
     pub mode: Mode,
@@ -2294,7 +2294,7 @@ impl crate::x11_utils::VoidRequest for AddOutputModeRequest {
 
 /// Opcode for the DeleteOutputMode request
 pub const DELETE_OUTPUT_MODE_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeleteOutputModeRequest {
     pub output: Output,
     pub mode: Mode,
@@ -2354,7 +2354,7 @@ impl crate::x11_utils::VoidRequest for DeleteOutputModeRequest {
 
 /// Opcode for the GetCrtcInfo request
 pub const GET_CRTC_INFO_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCrtcInfoRequest {
     pub crtc: Crtc,
     pub config_timestamp: xproto::Timestamp,
@@ -2413,7 +2413,7 @@ impl crate::x11_utils::ReplyRequest for GetCrtcInfoRequest {
     type Reply = GetCrtcInfoReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCrtcInfoReply {
     pub status: SetConfig,
     pub sequence: u16,
@@ -2490,7 +2490,7 @@ impl GetCrtcInfoReply {
 
 /// Opcode for the SetCrtcConfig request
 pub const SET_CRTC_CONFIG_REQUEST: u8 = 21;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetCrtcConfigRequest<'input> {
     pub crtc: Crtc,
     pub timestamp: xproto::Timestamp,
@@ -2613,7 +2613,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetCrtcConfigRequest<'input> {
     type Reply = SetCrtcConfigReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetCrtcConfigReply {
     pub status: SetConfig,
     pub sequence: u16,
@@ -2643,7 +2643,7 @@ impl TryParse for SetCrtcConfigReply {
 
 /// Opcode for the GetCrtcGammaSize request
 pub const GET_CRTC_GAMMA_SIZE_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCrtcGammaSizeRequest {
     pub crtc: Crtc,
 }
@@ -2694,7 +2694,7 @@ impl crate::x11_utils::ReplyRequest for GetCrtcGammaSizeRequest {
     type Reply = GetCrtcGammaSizeReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCrtcGammaSizeReply {
     pub sequence: u16,
     pub length: u32,
@@ -2722,7 +2722,7 @@ impl TryParse for GetCrtcGammaSizeReply {
 
 /// Opcode for the GetCrtcGamma request
 pub const GET_CRTC_GAMMA_REQUEST: u8 = 23;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCrtcGammaRequest {
     pub crtc: Crtc,
 }
@@ -2773,7 +2773,7 @@ impl crate::x11_utils::ReplyRequest for GetCrtcGammaRequest {
     type Reply = GetCrtcGammaReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCrtcGammaReply {
     pub sequence: u16,
     pub length: u32,
@@ -2821,7 +2821,7 @@ impl GetCrtcGammaReply {
 
 /// Opcode for the SetCrtcGamma request
 pub const SET_CRTC_GAMMA_REQUEST: u8 = 24;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetCrtcGammaRequest<'input> {
     pub crtc: Crtc,
     pub red: Cow<'input, [u16]>,
@@ -2909,7 +2909,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetCrtcGammaRequest<'input> {
 
 /// Opcode for the GetScreenResourcesCurrent request
 pub const GET_SCREEN_RESOURCES_CURRENT_REQUEST: u8 = 25;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenResourcesCurrentRequest {
     pub window: xproto::Window,
 }
@@ -2960,7 +2960,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenResourcesCurrentRequest {
     type Reply = GetScreenResourcesCurrentReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenResourcesCurrentReply {
     pub sequence: u16,
     pub length: u32,
@@ -3055,7 +3055,7 @@ impl GetScreenResourcesCurrentReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Transform(u8);
 impl Transform {
     pub const UNIT: Self = Self(1 << 0);
@@ -3120,7 +3120,7 @@ bitmask_binop!(Transform, u8);
 
 /// Opcode for the SetCrtcTransform request
 pub const SET_CRTC_TRANSFORM_REQUEST: u8 = 26;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetCrtcTransformRequest<'input> {
     pub crtc: Crtc,
     pub transform: render::Transform,
@@ -3253,7 +3253,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetCrtcTransformRequest<'input> {
 
 /// Opcode for the GetCrtcTransform request
 pub const GET_CRTC_TRANSFORM_REQUEST: u8 = 27;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCrtcTransformRequest {
     pub crtc: Crtc,
 }
@@ -3304,7 +3304,7 @@ impl crate::x11_utils::ReplyRequest for GetCrtcTransformRequest {
     type Reply = GetCrtcTransformReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCrtcTransformReply {
     pub sequence: u16,
     pub length: u32,
@@ -3414,7 +3414,7 @@ impl GetCrtcTransformReply {
 
 /// Opcode for the GetPanning request
 pub const GET_PANNING_REQUEST: u8 = 28;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPanningRequest {
     pub crtc: Crtc,
 }
@@ -3465,7 +3465,7 @@ impl crate::x11_utils::ReplyRequest for GetPanningRequest {
     type Reply = GetPanningReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPanningReply {
     pub status: SetConfig,
     pub sequence: u16,
@@ -3518,7 +3518,7 @@ impl TryParse for GetPanningReply {
 
 /// Opcode for the SetPanning request
 pub const SET_PANNING_REQUEST: u8 = 29;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetPanningRequest {
     pub crtc: Crtc,
     pub timestamp: xproto::Timestamp,
@@ -3649,7 +3649,7 @@ impl crate::x11_utils::ReplyRequest for SetPanningRequest {
     type Reply = SetPanningReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetPanningReply {
     pub status: SetConfig,
     pub sequence: u16,
@@ -3678,7 +3678,7 @@ impl TryParse for SetPanningReply {
 
 /// Opcode for the SetOutputPrimary request
 pub const SET_OUTPUT_PRIMARY_REQUEST: u8 = 30;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetOutputPrimaryRequest {
     pub window: xproto::Window,
     pub output: Output,
@@ -3738,7 +3738,7 @@ impl crate::x11_utils::VoidRequest for SetOutputPrimaryRequest {
 
 /// Opcode for the GetOutputPrimary request
 pub const GET_OUTPUT_PRIMARY_REQUEST: u8 = 31;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetOutputPrimaryRequest {
     pub window: xproto::Window,
 }
@@ -3789,7 +3789,7 @@ impl crate::x11_utils::ReplyRequest for GetOutputPrimaryRequest {
     type Reply = GetOutputPrimaryReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetOutputPrimaryReply {
     pub sequence: u16,
     pub length: u32,
@@ -3816,7 +3816,7 @@ impl TryParse for GetOutputPrimaryReply {
 
 /// Opcode for the GetProviders request
 pub const GET_PROVIDERS_REQUEST: u8 = 32;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetProvidersRequest {
     pub window: xproto::Window,
 }
@@ -3867,7 +3867,7 @@ impl crate::x11_utils::ReplyRequest for GetProvidersRequest {
     type Reply = GetProvidersReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetProvidersReply {
     pub sequence: u16,
     pub length: u32,
@@ -3911,7 +3911,7 @@ impl GetProvidersReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProviderCapability(u8);
 impl ProviderCapability {
     pub const SOURCE_OUTPUT: Self = Self(1 << 0);
@@ -3976,7 +3976,7 @@ bitmask_binop!(ProviderCapability, u8);
 
 /// Opcode for the GetProviderInfo request
 pub const GET_PROVIDER_INFO_REQUEST: u8 = 33;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetProviderInfoRequest {
     pub provider: Provider,
     pub config_timestamp: xproto::Timestamp,
@@ -4035,7 +4035,7 @@ impl crate::x11_utils::ReplyRequest for GetProviderInfoRequest {
     type Reply = GetProviderInfoReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetProviderInfoReply {
     pub status: u8,
     pub sequence: u16,
@@ -4135,7 +4135,7 @@ impl GetProviderInfoReply {
 
 /// Opcode for the SetProviderOffloadSink request
 pub const SET_PROVIDER_OFFLOAD_SINK_REQUEST: u8 = 34;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetProviderOffloadSinkRequest {
     pub provider: Provider,
     pub sink_provider: Provider,
@@ -4203,7 +4203,7 @@ impl crate::x11_utils::VoidRequest for SetProviderOffloadSinkRequest {
 
 /// Opcode for the SetProviderOutputSource request
 pub const SET_PROVIDER_OUTPUT_SOURCE_REQUEST: u8 = 35;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetProviderOutputSourceRequest {
     pub provider: Provider,
     pub source_provider: Provider,
@@ -4271,7 +4271,7 @@ impl crate::x11_utils::VoidRequest for SetProviderOutputSourceRequest {
 
 /// Opcode for the ListProviderProperties request
 pub const LIST_PROVIDER_PROPERTIES_REQUEST: u8 = 36;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListProviderPropertiesRequest {
     pub provider: Provider,
 }
@@ -4322,7 +4322,7 @@ impl crate::x11_utils::ReplyRequest for ListProviderPropertiesRequest {
     type Reply = ListProviderPropertiesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListProviderPropertiesReply {
     pub sequence: u16,
     pub length: u32,
@@ -4366,7 +4366,7 @@ impl ListProviderPropertiesReply {
 
 /// Opcode for the QueryProviderProperty request
 pub const QUERY_PROVIDER_PROPERTY_REQUEST: u8 = 37;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryProviderPropertyRequest {
     pub provider: Provider,
     pub property: xproto::Atom,
@@ -4425,7 +4425,7 @@ impl crate::x11_utils::ReplyRequest for QueryProviderPropertyRequest {
     type Reply = QueryProviderPropertyReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryProviderPropertyReply {
     pub sequence: u16,
     pub pending: bool,
@@ -4473,7 +4473,7 @@ impl QueryProviderPropertyReply {
 
 /// Opcode for the ConfigureProviderProperty request
 pub const CONFIGURE_PROVIDER_PROPERTY_REQUEST: u8 = 38;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConfigureProviderPropertyRequest<'input> {
     pub provider: Provider,
     pub property: xproto::Atom,
@@ -4570,7 +4570,7 @@ impl<'input> crate::x11_utils::VoidRequest for ConfigureProviderPropertyRequest<
 
 /// Opcode for the ChangeProviderProperty request
 pub const CHANGE_PROVIDER_PROPERTY_REQUEST: u8 = 39;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeProviderPropertyRequest<'input> {
     pub provider: Provider,
     pub property: xproto::Atom,
@@ -4678,7 +4678,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeProviderPropertyRequest<'in
 
 /// Opcode for the DeleteProviderProperty request
 pub const DELETE_PROVIDER_PROPERTY_REQUEST: u8 = 40;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeleteProviderPropertyRequest {
     pub provider: Provider,
     pub property: xproto::Atom,
@@ -4738,7 +4738,7 @@ impl crate::x11_utils::VoidRequest for DeleteProviderPropertyRequest {
 
 /// Opcode for the GetProviderProperty request
 pub const GET_PROVIDER_PROPERTY_REQUEST: u8 = 41;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetProviderPropertyRequest {
     pub provider: Provider,
     pub property: xproto::Atom,
@@ -4834,7 +4834,7 @@ impl crate::x11_utils::ReplyRequest for GetProviderPropertyRequest {
     type Reply = GetProviderPropertyReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetProviderPropertyReply {
     pub format: u8,
     pub sequence: u16,
@@ -4870,7 +4870,7 @@ impl TryParse for GetProviderPropertyReply {
 
 /// Opcode for the ScreenChangeNotify event
 pub const SCREEN_CHANGE_NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScreenChangeNotifyEvent {
     pub response_type: u8,
     pub rotation: u8,
@@ -4967,7 +4967,7 @@ impl From<ScreenChangeNotifyEvent> for [u8; 32] {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Notify(u8);
 impl Notify {
     pub const CRTC_CHANGE: Self = Self(0);
@@ -5035,7 +5035,7 @@ impl std::fmt::Debug for Notify  {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CrtcChange {
     pub timestamp: xproto::Timestamp,
     pub window: xproto::Window,
@@ -5121,7 +5121,7 @@ impl Serialize for CrtcChange {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OutputChange {
     pub timestamp: xproto::Timestamp,
     pub config_timestamp: xproto::Timestamp,
@@ -5207,7 +5207,7 @@ impl Serialize for OutputChange {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OutputProperty {
     pub window: xproto::Window,
     pub output: Output,
@@ -5278,7 +5278,7 @@ impl Serialize for OutputProperty {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProviderChange {
     pub timestamp: xproto::Timestamp,
     pub window: xproto::Window,
@@ -5340,7 +5340,7 @@ impl Serialize for ProviderChange {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProviderProperty {
     pub window: xproto::Window,
     pub provider: Provider,
@@ -5410,7 +5410,7 @@ impl Serialize for ProviderProperty {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ResourceChange {
     pub timestamp: xproto::Timestamp,
     pub window: xproto::Window,
@@ -5468,7 +5468,7 @@ impl Serialize for ResourceChange {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MonitorInfo {
     pub name: xproto::Atom,
     pub primary: bool,
@@ -5539,7 +5539,7 @@ impl MonitorInfo {
 
 /// Opcode for the GetMonitors request
 pub const GET_MONITORS_REQUEST: u8 = 42;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMonitorsRequest {
     pub window: xproto::Window,
     pub get_active: bool,
@@ -5598,7 +5598,7 @@ impl crate::x11_utils::ReplyRequest for GetMonitorsRequest {
     type Reply = GetMonitorsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMonitorsReply {
     pub sequence: u16,
     pub length: u32,
@@ -5646,7 +5646,7 @@ impl GetMonitorsReply {
 
 /// Opcode for the SetMonitor request
 pub const SET_MONITOR_REQUEST: u8 = 43;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetMonitorRequest {
     pub window: xproto::Window,
     pub monitorinfo: MonitorInfo,
@@ -5705,7 +5705,7 @@ impl crate::x11_utils::VoidRequest for SetMonitorRequest {
 
 /// Opcode for the DeleteMonitor request
 pub const DELETE_MONITOR_REQUEST: u8 = 44;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeleteMonitorRequest {
     pub window: xproto::Window,
     pub name: xproto::Atom,
@@ -5765,7 +5765,7 @@ impl crate::x11_utils::VoidRequest for DeleteMonitorRequest {
 
 /// Opcode for the CreateLease request
 pub const CREATE_LEASE_REQUEST: u8 = 45;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateLeaseRequest<'input> {
     pub window: xproto::Window,
     pub lid: Lease,
@@ -5885,7 +5885,7 @@ impl TryParseFd for CreateLeaseReply {
 
 /// Opcode for the FreeLease request
 pub const FREE_LEASE_REQUEST: u8 = 46;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FreeLeaseRequest {
     pub lid: Lease,
     pub terminate: u8,
@@ -5943,7 +5943,7 @@ impl Request for FreeLeaseRequest {
 impl crate::x11_utils::VoidRequest for FreeLeaseRequest {
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LeaseNotify {
     pub timestamp: xproto::Timestamp,
     pub window: xproto::Window,

--- a/x11rb-protocol/src/protocol/record.rs
+++ b/x11rb-protocol/src/protocol/record.rs
@@ -32,7 +32,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 13);
 
 pub type Context = u32;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Range8 {
     pub first: u8,
     pub last: u8,
@@ -62,7 +62,7 @@ impl Serialize for Range8 {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Range16 {
     pub first: u16,
     pub last: u16,
@@ -94,7 +94,7 @@ impl Serialize for Range16 {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExtRange {
     pub major: Range8,
     pub minor: Range16,
@@ -128,7 +128,7 @@ impl Serialize for ExtRange {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Range {
     pub core_requests: Range8,
     pub core_replies: Range8,
@@ -210,7 +210,7 @@ impl Serialize for Range {
 
 pub type ElementHeader = u8;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HType(u8);
 impl HType {
     pub const FROM_SERVER_TIME: Self = Self(1 << 0);
@@ -273,7 +273,7 @@ bitmask_binop!(HType, u8);
 
 pub type ClientSpec = u32;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CS(u8);
 impl CS {
     pub const CURRENT_CLIENTS: Self = Self(1);
@@ -333,7 +333,7 @@ impl std::fmt::Debug for CS  {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClientInfo {
     pub client_resource: ClientSpec,
     pub ranges: Vec<Range>,
@@ -383,7 +383,7 @@ pub const BAD_CONTEXT_ERROR: u8 = 0;
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub major_version: u16,
     pub minor_version: u16,
@@ -438,7 +438,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -467,7 +467,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 1;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateContextRequest<'input> {
     pub context: Context,
     pub element_header: ElementHeader,
@@ -563,7 +563,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateContextRequest<'input> {
 
 /// Opcode for the RegisterClients request
 pub const REGISTER_CLIENTS_REQUEST: u8 = 2;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RegisterClientsRequest<'input> {
     pub context: Context,
     pub element_header: ElementHeader,
@@ -659,7 +659,7 @@ impl<'input> crate::x11_utils::VoidRequest for RegisterClientsRequest<'input> {
 
 /// Opcode for the UnregisterClients request
 pub const UNREGISTER_CLIENTS_REQUEST: u8 = 3;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UnregisterClientsRequest<'input> {
     pub context: Context,
     pub client_specs: Cow<'input, [ClientSpec]>,
@@ -732,7 +732,7 @@ impl<'input> crate::x11_utils::VoidRequest for UnregisterClientsRequest<'input> 
 
 /// Opcode for the GetContext request
 pub const GET_CONTEXT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetContextRequest {
     pub context: Context,
 }
@@ -783,7 +783,7 @@ impl crate::x11_utils::ReplyRequest for GetContextRequest {
     type Reply = GetContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetContextReply {
     pub enabled: bool,
     pub sequence: u16,
@@ -831,7 +831,7 @@ impl GetContextReply {
 
 /// Opcode for the EnableContext request
 pub const ENABLE_CONTEXT_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EnableContextRequest {
     pub context: Context,
 }
@@ -882,7 +882,7 @@ impl crate::x11_utils::ReplyRequest for EnableContextRequest {
     type Reply = EnableContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EnableContextReply {
     pub category: u8,
     pub sequence: u16,
@@ -938,7 +938,7 @@ impl EnableContextReply {
 
 /// Opcode for the DisableContext request
 pub const DISABLE_CONTEXT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DisableContextRequest {
     pub context: Context,
 }
@@ -990,7 +990,7 @@ impl crate::x11_utils::VoidRequest for DisableContextRequest {
 
 /// Opcode for the FreeContext request
 pub const FREE_CONTEXT_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FreeContextRequest {
     pub context: Context,
 }

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -32,7 +32,7 @@ pub const X11_EXTENSION_NAME: &str = "RENDER";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (0, 11);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PictType(u8);
 impl PictType {
     pub const INDEXED: Self = Self(0);
@@ -90,7 +90,7 @@ impl std::fmt::Debug for PictType  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PictureEnum(u8);
 impl PictureEnum {
     pub const NONE: Self = Self(0);
@@ -146,7 +146,7 @@ impl std::fmt::Debug for PictureEnum  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PictOp(u8);
 impl PictOp {
     pub const CLEAR: Self = Self(0);
@@ -306,7 +306,7 @@ impl std::fmt::Debug for PictOp  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PolyEdge(u32);
 impl PolyEdge {
     pub const SHARP: Self = Self(0);
@@ -352,7 +352,7 @@ impl std::fmt::Debug for PolyEdge  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PolyMode(u32);
 impl PolyMode {
     pub const PRECISE: Self = Self(0);
@@ -398,7 +398,7 @@ impl std::fmt::Debug for PolyMode  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CP(u16);
 impl CP {
     pub const REPEAT: Self = Self(1 << 0);
@@ -473,7 +473,7 @@ impl std::fmt::Debug for CP  {
 }
 bitmask_binop!(CP, u16);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubPixel(u32);
 impl SubPixel {
     pub const UNKNOWN: Self = Self(0);
@@ -527,7 +527,7 @@ impl std::fmt::Debug for SubPixel  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Repeat(u32);
 impl Repeat {
     pub const NONE: Self = Self(0);
@@ -602,7 +602,7 @@ pub const GLYPH_SET_ERROR: u8 = 3;
 /// Opcode for the Glyph error
 pub const GLYPH_ERROR: u8 = 4;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Directformat {
     pub red_shift: u16,
     pub red_mask: u16,
@@ -670,7 +670,7 @@ impl Serialize for Directformat {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Pictforminfo {
     pub id: Pictformat,
     pub type_: PictType,
@@ -741,7 +741,7 @@ impl Serialize for Pictforminfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Pictvisual {
     pub visual: xproto::Visualid,
     pub format: Pictformat,
@@ -777,7 +777,7 @@ impl Serialize for Pictvisual {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Pictdepth {
     pub depth: u8,
     pub visuals: Vec<Pictvisual>,
@@ -826,7 +826,7 @@ impl Pictdepth {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Pictscreen {
     pub fallback: Pictformat,
     pub depths: Vec<Pictdepth>,
@@ -871,7 +871,7 @@ impl Pictscreen {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Indexvalue {
     pub pixel: u32,
     pub red: u16,
@@ -923,7 +923,7 @@ impl Serialize for Indexvalue {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Color {
     pub red: u16,
     pub green: u16,
@@ -967,7 +967,7 @@ impl Serialize for Color {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Pointfix {
     pub x: Fixed,
     pub y: Fixed,
@@ -1003,7 +1003,7 @@ impl Serialize for Pointfix {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Linefix {
     pub p1: Pointfix,
     pub p2: Pointfix,
@@ -1047,7 +1047,7 @@ impl Serialize for Linefix {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Triangle {
     pub p1: Pointfix,
     pub p2: Pointfix,
@@ -1103,7 +1103,7 @@ impl Serialize for Triangle {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Trapezoid {
     pub top: Fixed,
     pub bottom: Fixed,
@@ -1179,7 +1179,7 @@ impl Serialize for Trapezoid {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Glyphinfo {
     pub width: u16,
     pub height: u16,
@@ -1237,7 +1237,7 @@ impl Serialize for Glyphinfo {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
@@ -1296,7 +1296,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -1326,7 +1326,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the QueryPictFormats request
 pub const QUERY_PICT_FORMATS_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryPictFormatsRequest;
 impl QueryPictFormatsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1368,7 +1368,7 @@ impl crate::x11_utils::ReplyRequest for QueryPictFormatsRequest {
     type Reply = QueryPictFormatsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryPictFormatsReply {
     pub sequence: u16,
     pub length: u32,
@@ -1456,7 +1456,7 @@ impl QueryPictFormatsReply {
 
 /// Opcode for the QueryPictIndexValues request
 pub const QUERY_PICT_INDEX_VALUES_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryPictIndexValuesRequest {
     pub format: Pictformat,
 }
@@ -1507,7 +1507,7 @@ impl crate::x11_utils::ReplyRequest for QueryPictIndexValuesRequest {
     type Reply = QueryPictIndexValuesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryPictIndexValuesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1550,7 +1550,7 @@ impl QueryPictIndexValuesReply {
 }
 
 /// Auxiliary and optional information for the `create_picture` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct CreatePictureAux {
     pub repeat: Option<Repeat>,
     pub alphamap: Option<Picture>,
@@ -1864,7 +1864,7 @@ impl CreatePictureAux {
 
 /// Opcode for the CreatePicture request
 pub const CREATE_PICTURE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreatePictureRequest<'input> {
     pub pid: Picture,
     pub drawable: xproto::Drawable,
@@ -1954,7 +1954,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreatePictureRequest<'input> {
 }
 
 /// Auxiliary and optional information for the `change_picture` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ChangePictureAux {
     pub repeat: Option<Repeat>,
     pub alphamap: Option<Picture>,
@@ -2268,7 +2268,7 @@ impl ChangePictureAux {
 
 /// Opcode for the ChangePicture request
 pub const CHANGE_PICTURE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangePictureRequest<'input> {
     pub picture: Picture,
     pub value_list: Cow<'input, ChangePictureAux>,
@@ -2341,7 +2341,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangePictureRequest<'input> {
 
 /// Opcode for the SetPictureClipRectangles request
 pub const SET_PICTURE_CLIP_RECTANGLES_REQUEST: u8 = 6;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetPictureClipRectanglesRequest<'input> {
     pub picture: Picture,
     pub clip_x_origin: i16,
@@ -2428,7 +2428,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetPictureClipRectanglesRequest<'
 
 /// Opcode for the FreePicture request
 pub const FREE_PICTURE_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FreePictureRequest {
     pub picture: Picture,
 }
@@ -2480,7 +2480,7 @@ impl crate::x11_utils::VoidRequest for FreePictureRequest {
 
 /// Opcode for the Composite request
 pub const COMPOSITE_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompositeRequest {
     pub op: PictOp,
     pub src: Picture,
@@ -2606,7 +2606,7 @@ impl crate::x11_utils::VoidRequest for CompositeRequest {
 
 /// Opcode for the Trapezoids request
 pub const TRAPEZOIDS_REQUEST: u8 = 10;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TrapezoidsRequest<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -2722,7 +2722,7 @@ impl<'input> crate::x11_utils::VoidRequest for TrapezoidsRequest<'input> {
 
 /// Opcode for the Triangles request
 pub const TRIANGLES_REQUEST: u8 = 11;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TrianglesRequest<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -2838,7 +2838,7 @@ impl<'input> crate::x11_utils::VoidRequest for TrianglesRequest<'input> {
 
 /// Opcode for the TriStrip request
 pub const TRI_STRIP_REQUEST: u8 = 12;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TriStripRequest<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -2954,7 +2954,7 @@ impl<'input> crate::x11_utils::VoidRequest for TriStripRequest<'input> {
 
 /// Opcode for the TriFan request
 pub const TRI_FAN_REQUEST: u8 = 13;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TriFanRequest<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -3070,7 +3070,7 @@ impl<'input> crate::x11_utils::VoidRequest for TriFanRequest<'input> {
 
 /// Opcode for the CreateGlyphSet request
 pub const CREATE_GLYPH_SET_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateGlyphSetRequest {
     pub gsid: Glyphset,
     pub format: Pictformat,
@@ -3130,7 +3130,7 @@ impl crate::x11_utils::VoidRequest for CreateGlyphSetRequest {
 
 /// Opcode for the ReferenceGlyphSet request
 pub const REFERENCE_GLYPH_SET_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReferenceGlyphSetRequest {
     pub gsid: Glyphset,
     pub existing: Glyphset,
@@ -3190,7 +3190,7 @@ impl crate::x11_utils::VoidRequest for ReferenceGlyphSetRequest {
 
 /// Opcode for the FreeGlyphSet request
 pub const FREE_GLYPH_SET_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FreeGlyphSetRequest {
     pub glyphset: Glyphset,
 }
@@ -3242,7 +3242,7 @@ impl crate::x11_utils::VoidRequest for FreeGlyphSetRequest {
 
 /// Opcode for the AddGlyphs request
 pub const ADD_GLYPHS_REQUEST: u8 = 20;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AddGlyphsRequest<'input> {
     pub glyphset: Glyphset,
     pub glyphids: Cow<'input, [u32]>,
@@ -3327,7 +3327,7 @@ impl<'input> crate::x11_utils::VoidRequest for AddGlyphsRequest<'input> {
 
 /// Opcode for the FreeGlyphs request
 pub const FREE_GLYPHS_REQUEST: u8 = 22;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FreeGlyphsRequest<'input> {
     pub glyphset: Glyphset,
     pub glyphs: Cow<'input, [Glyph]>,
@@ -3400,7 +3400,7 @@ impl<'input> crate::x11_utils::VoidRequest for FreeGlyphsRequest<'input> {
 
 /// Opcode for the CompositeGlyphs8 request
 pub const COMPOSITE_GLYPHS8_REQUEST: u8 = 23;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompositeGlyphs8Request<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -3517,7 +3517,7 @@ impl<'input> crate::x11_utils::VoidRequest for CompositeGlyphs8Request<'input> {
 
 /// Opcode for the CompositeGlyphs16 request
 pub const COMPOSITE_GLYPHS16_REQUEST: u8 = 24;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompositeGlyphs16Request<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -3634,7 +3634,7 @@ impl<'input> crate::x11_utils::VoidRequest for CompositeGlyphs16Request<'input> 
 
 /// Opcode for the CompositeGlyphs32 request
 pub const COMPOSITE_GLYPHS32_REQUEST: u8 = 25;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompositeGlyphs32Request<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -3751,7 +3751,7 @@ impl<'input> crate::x11_utils::VoidRequest for CompositeGlyphs32Request<'input> 
 
 /// Opcode for the FillRectangles request
 pub const FILL_RECTANGLES_REQUEST: u8 = 26;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FillRectanglesRequest<'input> {
     pub op: PictOp,
     pub dst: Picture,
@@ -3848,7 +3848,7 @@ impl<'input> crate::x11_utils::VoidRequest for FillRectanglesRequest<'input> {
 
 /// Opcode for the CreateCursor request
 pub const CREATE_CURSOR_REQUEST: u8 = 27;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateCursorRequest {
     pub cid: xproto::Cursor,
     pub source: Picture,
@@ -3918,7 +3918,7 @@ impl Request for CreateCursorRequest {
 impl crate::x11_utils::VoidRequest for CreateCursorRequest {
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Transform {
     pub matrix11: Fixed,
     pub matrix12: Fixed,
@@ -4012,7 +4012,7 @@ impl Serialize for Transform {
 
 /// Opcode for the SetPictureTransform request
 pub const SET_PICTURE_TRANSFORM_REQUEST: u8 = 28;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetPictureTransformRequest {
     pub picture: Picture,
     pub transform: Transform,
@@ -4104,7 +4104,7 @@ impl crate::x11_utils::VoidRequest for SetPictureTransformRequest {
 
 /// Opcode for the QueryFilters request
 pub const QUERY_FILTERS_REQUEST: u8 = 29;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryFiltersRequest {
     pub drawable: xproto::Drawable,
 }
@@ -4155,7 +4155,7 @@ impl crate::x11_utils::ReplyRequest for QueryFiltersRequest {
     type Reply = QueryFiltersReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryFiltersReply {
     pub sequence: u16,
     pub length: u32,
@@ -4215,7 +4215,7 @@ impl QueryFiltersReply {
 
 /// Opcode for the SetPictureFilter request
 pub const SET_PICTURE_FILTER_REQUEST: u8 = 30;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetPictureFilterRequest<'input> {
     pub picture: Picture,
     pub filter: Cow<'input, [u8]>,
@@ -4305,7 +4305,7 @@ impl<'input> Request for SetPictureFilterRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for SetPictureFilterRequest<'input> {
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Animcursorelt {
     pub cursor: xproto::Cursor,
     pub delay: u32,
@@ -4343,7 +4343,7 @@ impl Serialize for Animcursorelt {
 
 /// Opcode for the CreateAnimCursor request
 pub const CREATE_ANIM_CURSOR_REQUEST: u8 = 31;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateAnimCursorRequest<'input> {
     pub cid: xproto::Cursor,
     pub cursors: Cow<'input, [Animcursorelt]>,
@@ -4414,7 +4414,7 @@ impl<'input> Request for CreateAnimCursorRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for CreateAnimCursorRequest<'input> {
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Spanfix {
     pub l: Fixed,
     pub r: Fixed,
@@ -4458,7 +4458,7 @@ impl Serialize for Spanfix {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Trap {
     pub top: Spanfix,
     pub bot: Spanfix,
@@ -4512,7 +4512,7 @@ impl Serialize for Trap {
 
 /// Opcode for the AddTraps request
 pub const ADD_TRAPS_REQUEST: u8 = 32;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AddTrapsRequest<'input> {
     pub picture: Picture,
     pub x_off: i16,
@@ -4599,7 +4599,7 @@ impl<'input> crate::x11_utils::VoidRequest for AddTrapsRequest<'input> {
 
 /// Opcode for the CreateSolidFill request
 pub const CREATE_SOLID_FILL_REQUEST: u8 = 33;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateSolidFillRequest {
     pub picture: Picture,
     pub color: Color,
@@ -4663,7 +4663,7 @@ impl crate::x11_utils::VoidRequest for CreateSolidFillRequest {
 
 /// Opcode for the CreateLinearGradient request
 pub const CREATE_LINEAR_GRADIENT_REQUEST: u8 = 34;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateLinearGradientRequest<'input> {
     pub picture: Picture,
     pub p1: Pointfix,
@@ -4769,7 +4769,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateLinearGradientRequest<'inpu
 
 /// Opcode for the CreateRadialGradient request
 pub const CREATE_RADIAL_GRADIENT_REQUEST: u8 = 35;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateRadialGradientRequest<'input> {
     pub picture: Picture,
     pub inner: Pointfix,
@@ -4893,7 +4893,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateRadialGradientRequest<'inpu
 
 /// Opcode for the CreateConicalGradient request
 pub const CREATE_CONICAL_GRADIENT_REQUEST: u8 = 36;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateConicalGradientRequest<'input> {
     pub picture: Picture,
     pub center: Pointfix,

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -32,7 +32,7 @@ pub const X11_EXTENSION_NAME: &str = "X-Resource";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Client {
     pub resource_base: u32,
     pub resource_mask: u32,
@@ -68,7 +68,7 @@ impl Serialize for Client {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Type {
     pub resource_type: xproto::Atom,
     pub count: u32,
@@ -104,7 +104,7 @@ impl Serialize for Type {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClientIdMask(u8);
 impl ClientIdMask {
     pub const CLIENT_XID: Self = Self(1 << 0);
@@ -163,7 +163,7 @@ impl std::fmt::Debug for ClientIdMask  {
 }
 bitmask_binop!(ClientIdMask, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClientIdSpec {
     pub client: u32,
     pub mask: u32,
@@ -199,7 +199,7 @@ impl Serialize for ClientIdSpec {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClientIdValue {
     pub spec: ClientIdSpec,
     pub value: Vec<u32>,
@@ -245,7 +245,7 @@ impl ClientIdValue {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ResourceIdSpec {
     pub resource: u32,
     pub type_: u32,
@@ -281,7 +281,7 @@ impl Serialize for ResourceIdSpec {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ResourceSizeSpec {
     pub spec: ResourceIdSpec,
     pub bytes: u32,
@@ -337,7 +337,7 @@ impl Serialize for ResourceSizeSpec {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ResourceSizeValue {
     pub size: ResourceSizeSpec,
     pub cross_references: Vec<ResourceSizeSpec>,
@@ -384,7 +384,7 @@ impl ResourceSizeValue {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub client_major: u8,
     pub client_minor: u8,
@@ -439,7 +439,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -468,7 +468,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the QueryClients request
 pub const QUERY_CLIENTS_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryClientsRequest;
 impl QueryClientsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -510,7 +510,7 @@ impl crate::x11_utils::ReplyRequest for QueryClientsRequest {
     type Reply = QueryClientsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryClientsReply {
     pub sequence: u16,
     pub length: u32,
@@ -554,7 +554,7 @@ impl QueryClientsReply {
 
 /// Opcode for the QueryClientResources request
 pub const QUERY_CLIENT_RESOURCES_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryClientResourcesRequest {
     pub xid: u32,
 }
@@ -605,7 +605,7 @@ impl crate::x11_utils::ReplyRequest for QueryClientResourcesRequest {
     type Reply = QueryClientResourcesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryClientResourcesReply {
     pub sequence: u16,
     pub length: u32,
@@ -649,7 +649,7 @@ impl QueryClientResourcesReply {
 
 /// Opcode for the QueryClientPixmapBytes request
 pub const QUERY_CLIENT_PIXMAP_BYTES_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryClientPixmapBytesRequest {
     pub xid: u32,
 }
@@ -700,7 +700,7 @@ impl crate::x11_utils::ReplyRequest for QueryClientPixmapBytesRequest {
     type Reply = QueryClientPixmapBytesReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryClientPixmapBytesReply {
     pub sequence: u16,
     pub length: u32,
@@ -729,7 +729,7 @@ impl TryParse for QueryClientPixmapBytesReply {
 
 /// Opcode for the QueryClientIds request
 pub const QUERY_CLIENT_IDS_REQUEST: u8 = 4;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryClientIdsRequest<'input> {
     pub specs: Cow<'input, [ClientIdSpec]>,
 }
@@ -792,7 +792,7 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryClientIdsRequest<'input> {
     type Reply = QueryClientIdsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryClientIdsReply {
     pub sequence: u16,
     pub length: u32,
@@ -836,7 +836,7 @@ impl QueryClientIdsReply {
 
 /// Opcode for the QueryResourceBytes request
 pub const QUERY_RESOURCE_BYTES_REQUEST: u8 = 5;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryResourceBytesRequest<'input> {
     pub client: u32,
     pub specs: Cow<'input, [ResourceIdSpec]>,
@@ -908,7 +908,7 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryResourceBytesRequest<'input
     type Reply = QueryResourceBytesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryResourceBytesReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -32,7 +32,7 @@ pub const X11_EXTENSION_NAME: &str = "MIT-SCREEN-SAVER";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Kind(u8);
 impl Kind {
     pub const BLANKED: Self = Self(0);
@@ -92,7 +92,7 @@ impl std::fmt::Debug for Kind  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Event(u8);
 impl Event {
     pub const NOTIFY_MASK: Self = Self(1 << 0);
@@ -151,7 +151,7 @@ impl std::fmt::Debug for Event  {
 }
 bitmask_binop!(Event, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct State(u8);
 impl State {
     pub const OFF: Self = Self(0);
@@ -215,7 +215,7 @@ impl std::fmt::Debug for State  {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub client_major_version: u8,
     pub client_minor_version: u8,
@@ -271,7 +271,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -301,7 +301,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the QueryInfo request
 pub const QUERY_INFO_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryInfoRequest {
     pub drawable: xproto::Drawable,
 }
@@ -352,7 +352,7 @@ impl crate::x11_utils::ReplyRequest for QueryInfoRequest {
     type Reply = QueryInfoReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryInfoReply {
     pub state: u8,
     pub sequence: u16,
@@ -390,7 +390,7 @@ impl TryParse for QueryInfoReply {
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectInputRequest {
     pub drawable: xproto::Drawable,
     pub event_mask: u32,
@@ -449,7 +449,7 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 }
 
 /// Auxiliary and optional information for the `set_attributes` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct SetAttributesAux {
     pub background_pixmap: Option<xproto::Pixmap>,
     pub background_pixel: Option<u32>,
@@ -804,7 +804,7 @@ impl SetAttributesAux {
 
 /// Opcode for the SetAttributes request
 pub const SET_ATTRIBUTES_REQUEST: u8 = 3;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetAttributesRequest<'input> {
     pub drawable: xproto::Drawable,
     pub x: i16,
@@ -934,7 +934,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetAttributesRequest<'input> {
 
 /// Opcode for the UnsetAttributes request
 pub const UNSET_ATTRIBUTES_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UnsetAttributesRequest {
     pub drawable: xproto::Drawable,
 }
@@ -986,7 +986,7 @@ impl crate::x11_utils::VoidRequest for UnsetAttributesRequest {
 
 /// Opcode for the Suspend request
 pub const SUSPEND_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SuspendRequest {
     pub suspend: u32,
 }
@@ -1038,7 +1038,7 @@ impl crate::x11_utils::VoidRequest for SuspendRequest {
 
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotifyEvent {
     pub response_type: u8,
     pub state: State,

--- a/x11rb-protocol/src/protocol/shape.rs
+++ b/x11rb-protocol/src/protocol/shape.rs
@@ -36,7 +36,7 @@ pub type Op = u8;
 
 pub type Kind = u8;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SO(u8);
 impl SO {
     pub const SET: Self = Self(0);
@@ -100,7 +100,7 @@ impl std::fmt::Debug for SO  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SK(u8);
 impl SK {
     pub const BOUNDING: Self = Self(0);
@@ -162,7 +162,7 @@ impl std::fmt::Debug for SK  {
 
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotifyEvent {
     pub response_type: u8,
     pub shape_kind: SK,
@@ -253,7 +253,7 @@ impl From<NotifyEvent> for [u8; 32] {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -295,7 +295,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -324,7 +324,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the Rectangles request
 pub const RECTANGLES_REQUEST: u8 = 1;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RectanglesRequest<'input> {
     pub operation: SO,
     pub destination_kind: SK,
@@ -434,7 +434,7 @@ impl<'input> crate::x11_utils::VoidRequest for RectanglesRequest<'input> {
 
 /// Opcode for the Mask request
 pub const MASK_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MaskRequest {
     pub operation: SO,
     pub destination_kind: SK,
@@ -521,7 +521,7 @@ impl crate::x11_utils::VoidRequest for MaskRequest {
 
 /// Opcode for the Combine request
 pub const COMBINE_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CombineRequest {
     pub operation: SO,
     pub destination_kind: SK,
@@ -613,7 +613,7 @@ impl crate::x11_utils::VoidRequest for CombineRequest {
 
 /// Opcode for the Offset request
 pub const OFFSET_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OffsetRequest {
     pub destination_kind: SK,
     pub destination_window: xproto::Window,
@@ -687,7 +687,7 @@ impl crate::x11_utils::VoidRequest for OffsetRequest {
 
 /// Opcode for the QueryExtents request
 pub const QUERY_EXTENTS_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryExtentsRequest {
     pub destination_window: xproto::Window,
 }
@@ -738,7 +738,7 @@ impl crate::x11_utils::ReplyRequest for QueryExtentsRequest {
     type Reply = QueryExtentsReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryExtentsReply {
     pub sequence: u16,
     pub length: u32,
@@ -784,7 +784,7 @@ impl TryParse for QueryExtentsReply {
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectInputRequest {
     pub destination_window: xproto::Window,
     pub enable: bool,
@@ -845,7 +845,7 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 
 /// Opcode for the InputSelected request
 pub const INPUT_SELECTED_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputSelectedRequest {
     pub destination_window: xproto::Window,
 }
@@ -896,7 +896,7 @@ impl crate::x11_utils::ReplyRequest for InputSelectedRequest {
     type Reply = InputSelectedReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputSelectedReply {
     pub enabled: bool,
     pub sequence: u16,
@@ -922,7 +922,7 @@ impl TryParse for InputSelectedReply {
 
 /// Opcode for the GetRectangles request
 pub const GET_RECTANGLES_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetRectanglesRequest {
     pub window: xproto::Window,
     pub source_kind: SK,
@@ -983,7 +983,7 @@ impl crate::x11_utils::ReplyRequest for GetRectanglesRequest {
     type Reply = GetRectanglesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetRectanglesReply {
     pub ordering: xproto::ClipOrdering,
     pub sequence: u16,

--- a/x11rb-protocol/src/protocol/shm.rs
+++ b/x11rb-protocol/src/protocol/shm.rs
@@ -36,7 +36,7 @@ pub type Seg = u32;
 
 /// Opcode for the Completion event
 pub const COMPLETION_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompletionEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -122,7 +122,7 @@ pub const BAD_SEG_ERROR: u8 = 0;
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -164,7 +164,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub shared_pixmaps: bool,
     pub sequence: u16,
@@ -201,7 +201,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the Attach request
 pub const ATTACH_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AttachRequest {
     pub shmseg: Seg,
     pub shmid: u32,
@@ -270,7 +270,7 @@ impl crate::x11_utils::VoidRequest for AttachRequest {
 
 /// Opcode for the Detach request
 pub const DETACH_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DetachRequest {
     pub shmseg: Seg,
 }
@@ -322,7 +322,7 @@ impl crate::x11_utils::VoidRequest for DetachRequest {
 
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PutImageRequest {
     pub drawable: xproto::Drawable,
     pub gc: xproto::Gcontext,
@@ -463,7 +463,7 @@ impl crate::x11_utils::VoidRequest for PutImageRequest {
 
 /// Opcode for the GetImage request
 pub const GET_IMAGE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetImageRequest {
     pub drawable: xproto::Drawable,
     pub x: i16,
@@ -571,7 +571,7 @@ impl crate::x11_utils::ReplyRequest for GetImageRequest {
     type Reply = GetImageReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetImageReply {
     pub depth: u8,
     pub sequence: u16,
@@ -601,7 +601,7 @@ impl TryParse for GetImageReply {
 
 /// Opcode for the CreatePixmap request
 pub const CREATE_PIXMAP_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreatePixmapRequest {
     pub pid: xproto::Pixmap,
     pub drawable: xproto::Drawable,
@@ -763,7 +763,7 @@ impl crate::x11_utils::VoidRequest for AttachFdRequest {
 
 /// Opcode for the CreateSegment request
 pub const CREATE_SEGMENT_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateSegmentRequest {
     pub shmseg: Seg,
     pub size: u32,

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -34,7 +34,7 @@ pub const X11_XML_VERSION: (u32, u32) = (3, 1);
 
 pub type Alarm = u32;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ALARMSTATE(u8);
 impl ALARMSTATE {
     pub const ACTIVE: Self = Self(0);
@@ -98,7 +98,7 @@ pub type Counter = u32;
 
 pub type Fence = u32;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TESTTYPE(u32);
 impl TESTTYPE {
     pub const POSITIVE_TRANSITION: Self = Self(0);
@@ -148,7 +148,7 @@ impl std::fmt::Debug for TESTTYPE  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VALUETYPE(u32);
 impl VALUETYPE {
     pub const ABSOLUTE: Self = Self(0);
@@ -194,7 +194,7 @@ impl std::fmt::Debug for VALUETYPE  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CA(u8);
 impl CA {
     pub const COUNTER: Self = Self(1 << 0);
@@ -261,7 +261,7 @@ impl std::fmt::Debug for CA  {
 }
 bitmask_binop!(CA, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Int64 {
     pub hi: i32,
     pub lo: u32,
@@ -297,7 +297,7 @@ impl Serialize for Int64 {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Systemcounter {
     pub counter: Counter,
     pub resolution: Int64,
@@ -352,7 +352,7 @@ impl Systemcounter {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Trigger {
     pub counter: Counter,
     pub wait_type: VALUETYPE,
@@ -410,7 +410,7 @@ impl Serialize for Trigger {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Waitcondition {
     pub trigger: Trigger,
     pub event_threshold: Int64,
@@ -474,7 +474,7 @@ pub const ALARM_ERROR: u8 = 1;
 
 /// Opcode for the Initialize request
 pub const INITIALIZE_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InitializeRequest {
     pub desired_major_version: u8,
     pub desired_minor_version: u8,
@@ -529,7 +529,7 @@ impl crate::x11_utils::ReplyRequest for InitializeRequest {
     type Reply = InitializeReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InitializeReply {
     pub sequence: u16,
     pub length: u32,
@@ -559,7 +559,7 @@ impl TryParse for InitializeReply {
 
 /// Opcode for the ListSystemCounters request
 pub const LIST_SYSTEM_COUNTERS_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListSystemCountersRequest;
 impl ListSystemCountersRequest {
     /// Serialize this request into bytes for the provided connection
@@ -601,7 +601,7 @@ impl crate::x11_utils::ReplyRequest for ListSystemCountersRequest {
     type Reply = ListSystemCountersReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListSystemCountersReply {
     pub sequence: u16,
     pub length: u32,
@@ -645,7 +645,7 @@ impl ListSystemCountersReply {
 
 /// Opcode for the CreateCounter request
 pub const CREATE_COUNTER_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateCounterRequest {
     pub id: Counter,
     pub initial_value: Int64,
@@ -709,7 +709,7 @@ impl crate::x11_utils::VoidRequest for CreateCounterRequest {
 
 /// Opcode for the DestroyCounter request
 pub const DESTROY_COUNTER_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyCounterRequest {
     pub counter: Counter,
 }
@@ -761,7 +761,7 @@ impl crate::x11_utils::VoidRequest for DestroyCounterRequest {
 
 /// Opcode for the QueryCounter request
 pub const QUERY_COUNTER_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryCounterRequest {
     pub counter: Counter,
 }
@@ -812,7 +812,7 @@ impl crate::x11_utils::ReplyRequest for QueryCounterRequest {
     type Reply = QueryCounterReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryCounterReply {
     pub sequence: u16,
     pub length: u32,
@@ -839,7 +839,7 @@ impl TryParse for QueryCounterReply {
 
 /// Opcode for the Await request
 pub const AWAIT_REQUEST: u8 = 7;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AwaitRequest<'input> {
     pub wait_list: Cow<'input, [Waitcondition]>,
 }
@@ -903,7 +903,7 @@ impl<'input> crate::x11_utils::VoidRequest for AwaitRequest<'input> {
 
 /// Opcode for the ChangeCounter request
 pub const CHANGE_COUNTER_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeCounterRequest {
     pub counter: Counter,
     pub amount: Int64,
@@ -967,7 +967,7 @@ impl crate::x11_utils::VoidRequest for ChangeCounterRequest {
 
 /// Opcode for the SetCounter request
 pub const SET_COUNTER_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetCounterRequest {
     pub counter: Counter,
     pub value: Int64,
@@ -1030,7 +1030,7 @@ impl crate::x11_utils::VoidRequest for SetCounterRequest {
 }
 
 /// Auxiliary and optional information for the `create_alarm` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct CreateAlarmAux {
     pub counter: Option<Counter>,
     pub value_type: Option<VALUETYPE>,
@@ -1195,7 +1195,7 @@ impl CreateAlarmAux {
 
 /// Opcode for the CreateAlarm request
 pub const CREATE_ALARM_REQUEST: u8 = 8;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateAlarmRequest<'input> {
     pub id: Alarm,
     pub value_list: Cow<'input, CreateAlarmAux>,
@@ -1267,7 +1267,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateAlarmRequest<'input> {
 }
 
 /// Auxiliary and optional information for the `change_alarm` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ChangeAlarmAux {
     pub counter: Option<Counter>,
     pub value_type: Option<VALUETYPE>,
@@ -1432,7 +1432,7 @@ impl ChangeAlarmAux {
 
 /// Opcode for the ChangeAlarm request
 pub const CHANGE_ALARM_REQUEST: u8 = 9;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeAlarmRequest<'input> {
     pub id: Alarm,
     pub value_list: Cow<'input, ChangeAlarmAux>,
@@ -1505,7 +1505,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeAlarmRequest<'input> {
 
 /// Opcode for the DestroyAlarm request
 pub const DESTROY_ALARM_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyAlarmRequest {
     pub alarm: Alarm,
 }
@@ -1557,7 +1557,7 @@ impl crate::x11_utils::VoidRequest for DestroyAlarmRequest {
 
 /// Opcode for the QueryAlarm request
 pub const QUERY_ALARM_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryAlarmRequest {
     pub alarm: Alarm,
 }
@@ -1608,7 +1608,7 @@ impl crate::x11_utils::ReplyRequest for QueryAlarmRequest {
     type Reply = QueryAlarmReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryAlarmReply {
     pub sequence: u16,
     pub length: u32,
@@ -1643,7 +1643,7 @@ impl TryParse for QueryAlarmReply {
 
 /// Opcode for the SetPriority request
 pub const SET_PRIORITY_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetPriorityRequest {
     pub id: u32,
     pub priority: i32,
@@ -1703,7 +1703,7 @@ impl crate::x11_utils::VoidRequest for SetPriorityRequest {
 
 /// Opcode for the GetPriority request
 pub const GET_PRIORITY_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPriorityRequest {
     pub id: u32,
 }
@@ -1754,7 +1754,7 @@ impl crate::x11_utils::ReplyRequest for GetPriorityRequest {
     type Reply = GetPriorityReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPriorityReply {
     pub sequence: u16,
     pub length: u32,
@@ -1781,7 +1781,7 @@ impl TryParse for GetPriorityReply {
 
 /// Opcode for the CreateFence request
 pub const CREATE_FENCE_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateFenceRequest {
     pub drawable: xproto::Drawable,
     pub fence: Fence,
@@ -1849,7 +1849,7 @@ impl crate::x11_utils::VoidRequest for CreateFenceRequest {
 
 /// Opcode for the TriggerFence request
 pub const TRIGGER_FENCE_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TriggerFenceRequest {
     pub fence: Fence,
 }
@@ -1901,7 +1901,7 @@ impl crate::x11_utils::VoidRequest for TriggerFenceRequest {
 
 /// Opcode for the ResetFence request
 pub const RESET_FENCE_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ResetFenceRequest {
     pub fence: Fence,
 }
@@ -1953,7 +1953,7 @@ impl crate::x11_utils::VoidRequest for ResetFenceRequest {
 
 /// Opcode for the DestroyFence request
 pub const DESTROY_FENCE_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyFenceRequest {
     pub fence: Fence,
 }
@@ -2005,7 +2005,7 @@ impl crate::x11_utils::VoidRequest for DestroyFenceRequest {
 
 /// Opcode for the QueryFence request
 pub const QUERY_FENCE_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryFenceRequest {
     pub fence: Fence,
 }
@@ -2056,7 +2056,7 @@ impl crate::x11_utils::ReplyRequest for QueryFenceRequest {
     type Reply = QueryFenceReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryFenceReply {
     pub sequence: u16,
     pub length: u32,
@@ -2084,7 +2084,7 @@ impl TryParse for QueryFenceReply {
 
 /// Opcode for the AwaitFence request
 pub const AWAIT_FENCE_REQUEST: u8 = 19;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AwaitFenceRequest<'input> {
     pub fence_list: Cow<'input, [Fence]>,
 }
@@ -2148,7 +2148,7 @@ impl<'input> crate::x11_utils::VoidRequest for AwaitFenceRequest<'input> {
 
 /// Opcode for the CounterNotify event
 pub const COUNTER_NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CounterNotifyEvent {
     pub response_type: u8,
     pub kind: u8,
@@ -2235,7 +2235,7 @@ impl From<CounterNotifyEvent> for [u8; 32] {
 
 /// Opcode for the AlarmNotify event
 pub const ALARM_NOTIFY_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AlarmNotifyEvent {
     pub response_type: u8,
     pub kind: u8,

--- a/x11rb-protocol/src/protocol/xc_misc.rs
+++ b/x11rb-protocol/src/protocol/xc_misc.rs
@@ -32,7 +32,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
 /// Opcode for the GetVersion request
 pub const GET_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
@@ -87,7 +87,7 @@ impl crate::x11_utils::ReplyRequest for GetVersionRequest {
     type Reply = GetVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -116,7 +116,7 @@ impl TryParse for GetVersionReply {
 
 /// Opcode for the GetXIDRange request
 pub const GET_XID_RANGE_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetXIDRangeRequest;
 impl GetXIDRangeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -158,7 +158,7 @@ impl crate::x11_utils::ReplyRequest for GetXIDRangeRequest {
     type Reply = GetXIDRangeReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetXIDRangeReply {
     pub sequence: u16,
     pub length: u32,
@@ -187,7 +187,7 @@ impl TryParse for GetXIDRangeReply {
 
 /// Opcode for the GetXIDList request
 pub const GET_XID_LIST_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetXIDListRequest {
     pub count: u32,
 }
@@ -238,7 +238,7 @@ impl crate::x11_utils::ReplyRequest for GetXIDListRequest {
     type Reply = GetXIDListReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetXIDListReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/xevie.rs
+++ b/x11rb-protocol/src/protocol/xevie.rs
@@ -32,7 +32,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
@@ -87,7 +87,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -117,7 +117,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the Start request
 pub const START_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StartRequest {
     pub screen: u32,
 }
@@ -168,7 +168,7 @@ impl crate::x11_utils::ReplyRequest for StartRequest {
     type Reply = StartReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StartReply {
     pub sequence: u16,
     pub length: u32,
@@ -194,7 +194,7 @@ impl TryParse for StartReply {
 
 /// Opcode for the End request
 pub const END_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EndRequest {
     pub cmap: u32,
 }
@@ -245,7 +245,7 @@ impl crate::x11_utils::ReplyRequest for EndRequest {
     type Reply = EndReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EndReply {
     pub sequence: u16,
     pub length: u32,
@@ -269,7 +269,7 @@ impl TryParse for EndReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Datatype(bool);
 impl Datatype {
     pub const UNMODIFIED: Self = Self(false);
@@ -339,7 +339,7 @@ impl std::fmt::Debug for Datatype  {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Event {
 }
 impl TryParse for Event {
@@ -395,7 +395,7 @@ impl Serialize for Event {
 
 /// Opcode for the Send request
 pub const SEND_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SendRequest {
     pub event: Event,
     pub data_type: u32,
@@ -547,7 +547,7 @@ impl crate::x11_utils::ReplyRequest for SendRequest {
     type Reply = SendReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SendReply {
     pub sequence: u16,
     pub length: u32,
@@ -573,7 +573,7 @@ impl TryParse for SendReply {
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectInputRequest {
     pub event_mask: u32,
 }
@@ -624,7 +624,7 @@ impl crate::x11_utils::ReplyRequest for SelectInputRequest {
     type Reply = SelectInputReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectInputReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/xf86dri.rs
+++ b/x11rb-protocol/src/protocol/xf86dri.rs
@@ -30,7 +30,7 @@ pub const X11_EXTENSION_NAME: &str = "XFree86-DRI";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (4, 1);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DrmClipRect {
     pub x1: i16,
     pub y1: i16,
@@ -76,7 +76,7 @@ impl Serialize for DrmClipRect {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -118,7 +118,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -149,7 +149,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the QueryDirectRenderingCapable request
 pub const QUERY_DIRECT_RENDERING_CAPABLE_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryDirectRenderingCapableRequest {
     pub screen: u32,
 }
@@ -200,7 +200,7 @@ impl crate::x11_utils::ReplyRequest for QueryDirectRenderingCapableRequest {
     type Reply = QueryDirectRenderingCapableReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryDirectRenderingCapableReply {
     pub sequence: u16,
     pub length: u32,
@@ -227,7 +227,7 @@ impl TryParse for QueryDirectRenderingCapableReply {
 
 /// Opcode for the OpenConnection request
 pub const OPEN_CONNECTION_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OpenConnectionRequest {
     pub screen: u32,
 }
@@ -278,7 +278,7 @@ impl crate::x11_utils::ReplyRequest for OpenConnectionRequest {
     type Reply = OpenConnectionReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OpenConnectionReply {
     pub sequence: u16,
     pub length: u32,
@@ -327,7 +327,7 @@ impl OpenConnectionReply {
 
 /// Opcode for the CloseConnection request
 pub const CLOSE_CONNECTION_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CloseConnectionRequest {
     pub screen: u32,
 }
@@ -379,7 +379,7 @@ impl crate::x11_utils::VoidRequest for CloseConnectionRequest {
 
 /// Opcode for the GetClientDriverName request
 pub const GET_CLIENT_DRIVER_NAME_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetClientDriverNameRequest {
     pub screen: u32,
 }
@@ -430,7 +430,7 @@ impl crate::x11_utils::ReplyRequest for GetClientDriverNameRequest {
     type Reply = GetClientDriverNameReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetClientDriverNameReply {
     pub sequence: u16,
     pub length: u32,
@@ -481,7 +481,7 @@ impl GetClientDriverNameReply {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateContextRequest {
     pub screen: u32,
     pub visual: u32,
@@ -548,7 +548,7 @@ impl crate::x11_utils::ReplyRequest for CreateContextRequest {
     type Reply = CreateContextReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -575,7 +575,7 @@ impl TryParse for CreateContextReply {
 
 /// Opcode for the DestroyContext request
 pub const DESTROY_CONTEXT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyContextRequest {
     pub screen: u32,
     pub context: u32,
@@ -635,7 +635,7 @@ impl crate::x11_utils::VoidRequest for DestroyContextRequest {
 
 /// Opcode for the CreateDrawable request
 pub const CREATE_DRAWABLE_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateDrawableRequest {
     pub screen: u32,
     pub drawable: u32,
@@ -694,7 +694,7 @@ impl crate::x11_utils::ReplyRequest for CreateDrawableRequest {
     type Reply = CreateDrawableReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateDrawableReply {
     pub sequence: u16,
     pub length: u32,
@@ -721,7 +721,7 @@ impl TryParse for CreateDrawableReply {
 
 /// Opcode for the DestroyDrawable request
 pub const DESTROY_DRAWABLE_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyDrawableRequest {
     pub screen: u32,
     pub drawable: u32,
@@ -781,7 +781,7 @@ impl crate::x11_utils::VoidRequest for DestroyDrawableRequest {
 
 /// Opcode for the GetDrawableInfo request
 pub const GET_DRAWABLE_INFO_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDrawableInfoRequest {
     pub screen: u32,
     pub drawable: u32,
@@ -840,7 +840,7 @@ impl crate::x11_utils::ReplyRequest for GetDrawableInfoRequest {
     type Reply = GetDrawableInfoReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDrawableInfoReply {
     pub sequence: u16,
     pub length: u32,
@@ -915,7 +915,7 @@ impl GetDrawableInfoReply {
 
 /// Opcode for the GetDeviceInfo request
 pub const GET_DEVICE_INFO_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceInfoRequest {
     pub screen: u32,
 }
@@ -966,7 +966,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceInfoRequest {
     type Reply = GetDeviceInfoReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceInfoReply {
     pub sequence: u16,
     pub length: u32,
@@ -1019,7 +1019,7 @@ impl GetDeviceInfoReply {
 
 /// Opcode for the AuthConnection request
 pub const AUTH_CONNECTION_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AuthConnectionRequest {
     pub screen: u32,
     pub magic: u32,
@@ -1078,7 +1078,7 @@ impl crate::x11_utils::ReplyRequest for AuthConnectionRequest {
     type Reply = AuthConnectionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AuthConnectionReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -34,7 +34,7 @@ pub type Syncrange = u32;
 
 pub type Dotclock = u32;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModeFlag(u16);
 impl ModeFlag {
     pub const POSITIVE_H_SYNC: Self = Self(1 << 0);
@@ -109,7 +109,7 @@ impl std::fmt::Debug for ModeFlag  {
 }
 bitmask_binop!(ModeFlag, u16);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClockFlag(u8);
 impl ClockFlag {
     pub const PROGRAMABLE: Self = Self(1 << 0);
@@ -166,7 +166,7 @@ impl std::fmt::Debug for ClockFlag  {
 }
 bitmask_binop!(ClockFlag, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Permission(u8);
 impl Permission {
     pub const READ: Self = Self(1 << 0);
@@ -225,7 +225,7 @@ impl std::fmt::Debug for Permission  {
 }
 bitmask_binop!(Permission, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModeInfo {
     pub dotclock: Dotclock,
     pub hdisplay: u16,
@@ -347,7 +347,7 @@ impl Serialize for ModeInfo {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -389,7 +389,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -418,7 +418,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the GetModeLine request
 pub const GET_MODE_LINE_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetModeLineRequest {
     pub screen: u16,
 }
@@ -470,7 +470,7 @@ impl crate::x11_utils::ReplyRequest for GetModeLineRequest {
     type Reply = GetModeLineReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetModeLineReply {
     pub sequence: u16,
     pub length: u32,
@@ -538,7 +538,7 @@ impl GetModeLineReply {
 
 /// Opcode for the ModModeLine request
 pub const MOD_MODE_LINE_REQUEST: u8 = 2;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModModeLineRequest<'input> {
     pub screen: u32,
     pub hdisplay: u16,
@@ -698,7 +698,7 @@ impl<'input> crate::x11_utils::VoidRequest for ModModeLineRequest<'input> {
 
 /// Opcode for the SwitchMode request
 pub const SWITCH_MODE_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SwitchModeRequest {
     pub screen: u16,
     pub zoom: u16,
@@ -754,7 +754,7 @@ impl crate::x11_utils::VoidRequest for SwitchModeRequest {
 
 /// Opcode for the GetMonitor request
 pub const GET_MONITOR_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMonitorRequest {
     pub screen: u16,
 }
@@ -806,7 +806,7 @@ impl crate::x11_utils::ReplyRequest for GetMonitorRequest {
     type Reply = GetMonitorReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMonitorReply {
     pub sequence: u16,
     pub length: u32,
@@ -903,7 +903,7 @@ impl GetMonitorReply {
 
 /// Opcode for the LockModeSwitch request
 pub const LOCK_MODE_SWITCH_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LockModeSwitchRequest {
     pub screen: u16,
     pub lock: u16,
@@ -959,7 +959,7 @@ impl crate::x11_utils::VoidRequest for LockModeSwitchRequest {
 
 /// Opcode for the GetAllModeLines request
 pub const GET_ALL_MODE_LINES_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetAllModeLinesRequest {
     pub screen: u16,
 }
@@ -1011,7 +1011,7 @@ impl crate::x11_utils::ReplyRequest for GetAllModeLinesRequest {
     type Reply = GetAllModeLinesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetAllModeLinesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1055,7 +1055,7 @@ impl GetAllModeLinesReply {
 
 /// Opcode for the AddModeLine request
 pub const ADD_MODE_LINE_REQUEST: u8 = 7;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AddModeLineRequest<'input> {
     pub screen: u32,
     pub dotclock: Dotclock,
@@ -1321,7 +1321,7 @@ impl<'input> crate::x11_utils::VoidRequest for AddModeLineRequest<'input> {
 
 /// Opcode for the DeleteModeLine request
 pub const DELETE_MODE_LINE_REQUEST: u8 = 8;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeleteModeLineRequest<'input> {
     pub screen: u32,
     pub dotclock: Dotclock,
@@ -1490,7 +1490,7 @@ impl<'input> crate::x11_utils::VoidRequest for DeleteModeLineRequest<'input> {
 
 /// Opcode for the ValidateModeLine request
 pub const VALIDATE_MODE_LINE_REQUEST: u8 = 9;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ValidateModeLineRequest<'input> {
     pub screen: u32,
     pub dotclock: Dotclock,
@@ -1658,7 +1658,7 @@ impl<'input> crate::x11_utils::ReplyRequest for ValidateModeLineRequest<'input> 
     type Reply = ValidateModeLineReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ValidateModeLineReply {
     pub sequence: u16,
     pub length: u32,
@@ -1686,7 +1686,7 @@ impl TryParse for ValidateModeLineReply {
 
 /// Opcode for the SwitchToMode request
 pub const SWITCH_TO_MODE_REQUEST: u8 = 10;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SwitchToModeRequest<'input> {
     pub screen: u32,
     pub dotclock: Dotclock,
@@ -1855,7 +1855,7 @@ impl<'input> crate::x11_utils::VoidRequest for SwitchToModeRequest<'input> {
 
 /// Opcode for the GetViewPort request
 pub const GET_VIEW_PORT_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetViewPortRequest {
     pub screen: u16,
 }
@@ -1907,7 +1907,7 @@ impl crate::x11_utils::ReplyRequest for GetViewPortRequest {
     type Reply = GetViewPortReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetViewPortReply {
     pub sequence: u16,
     pub length: u32,
@@ -1937,7 +1937,7 @@ impl TryParse for GetViewPortReply {
 
 /// Opcode for the SetViewPort request
 pub const SET_VIEW_PORT_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetViewPortRequest {
     pub screen: u16,
     pub x: u32,
@@ -2006,7 +2006,7 @@ impl crate::x11_utils::VoidRequest for SetViewPortRequest {
 
 /// Opcode for the GetDotClocks request
 pub const GET_DOT_CLOCKS_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDotClocksRequest {
     pub screen: u16,
 }
@@ -2058,7 +2058,7 @@ impl crate::x11_utils::ReplyRequest for GetDotClocksRequest {
     type Reply = GetDotClocksReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDotClocksReply {
     pub sequence: u16,
     pub length: u32,
@@ -2092,7 +2092,7 @@ impl TryParse for GetDotClocksReply {
 
 /// Opcode for the SetClientVersion request
 pub const SET_CLIENT_VERSION_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetClientVersionRequest {
     pub major: u16,
     pub minor: u16,
@@ -2148,7 +2148,7 @@ impl crate::x11_utils::VoidRequest for SetClientVersionRequest {
 
 /// Opcode for the SetGamma request
 pub const SET_GAMMA_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetGammaRequest {
     pub screen: u16,
     pub red: u32,
@@ -2238,7 +2238,7 @@ impl crate::x11_utils::VoidRequest for SetGammaRequest {
 
 /// Opcode for the GetGamma request
 pub const GET_GAMMA_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetGammaRequest {
     pub screen: u16,
 }
@@ -2314,7 +2314,7 @@ impl crate::x11_utils::ReplyRequest for GetGammaRequest {
     type Reply = GetGammaReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetGammaReply {
     pub sequence: u16,
     pub length: u32,
@@ -2346,7 +2346,7 @@ impl TryParse for GetGammaReply {
 
 /// Opcode for the GetGammaRamp request
 pub const GET_GAMMA_RAMP_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetGammaRampRequest {
     pub screen: u16,
     pub size: u16,
@@ -2401,7 +2401,7 @@ impl crate::x11_utils::ReplyRequest for GetGammaRampRequest {
     type Reply = GetGammaRampReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetGammaRampReply {
     pub sequence: u16,
     pub length: u32,
@@ -2435,7 +2435,7 @@ impl TryParse for GetGammaRampReply {
 
 /// Opcode for the SetGammaRamp request
 pub const SET_GAMMA_RAMP_REQUEST: u8 = 18;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetGammaRampRequest<'input> {
     pub screen: u16,
     pub size: u16,
@@ -2521,7 +2521,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetGammaRampRequest<'input> {
 
 /// Opcode for the GetGammaRampSize request
 pub const GET_GAMMA_RAMP_SIZE_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetGammaRampSizeRequest {
     pub screen: u16,
 }
@@ -2573,7 +2573,7 @@ impl crate::x11_utils::ReplyRequest for GetGammaRampSizeRequest {
     type Reply = GetGammaRampSizeReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetGammaRampSizeReply {
     pub sequence: u16,
     pub length: u32,
@@ -2601,7 +2601,7 @@ impl TryParse for GetGammaRampSizeReply {
 
 /// Opcode for the GetPermissions request
 pub const GET_PERMISSIONS_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPermissionsRequest {
     pub screen: u16,
 }
@@ -2653,7 +2653,7 @@ impl crate::x11_utils::ReplyRequest for GetPermissionsRequest {
     type Reply = GetPermissionsReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPermissionsReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -38,7 +38,7 @@ pub const X11_XML_VERSION: (u32, u32) = (5, 0);
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
@@ -97,7 +97,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -125,7 +125,7 @@ impl TryParse for QueryVersionReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SaveSetMode(u8);
 impl SaveSetMode {
     pub const INSERT: Self = Self(0);
@@ -183,7 +183,7 @@ impl std::fmt::Debug for SaveSetMode  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SaveSetTarget(u8);
 impl SaveSetTarget {
     pub const NEAREST: Self = Self(0);
@@ -241,7 +241,7 @@ impl std::fmt::Debug for SaveSetTarget  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SaveSetMapping(u8);
 impl SaveSetMapping {
     pub const MAP: Self = Self(0);
@@ -301,7 +301,7 @@ impl std::fmt::Debug for SaveSetMapping  {
 
 /// Opcode for the ChangeSaveSet request
 pub const CHANGE_SAVE_SET_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeSaveSetRequest {
     pub mode: SaveSetMode,
     pub target: SaveSetTarget,
@@ -371,7 +371,7 @@ impl Request for ChangeSaveSetRequest {
 impl crate::x11_utils::VoidRequest for ChangeSaveSetRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectionEvent(u8);
 impl SelectionEvent {
     pub const SET_SELECTION_OWNER: Self = Self(0);
@@ -431,7 +431,7 @@ impl std::fmt::Debug for SelectionEvent  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectionEventMask(u8);
 impl SelectionEventMask {
     pub const SET_SELECTION_OWNER: Self = Self(1 << 0);
@@ -494,7 +494,7 @@ bitmask_binop!(SelectionEventMask, u8);
 
 /// Opcode for the SelectionNotify event
 pub const SELECTION_NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectionNotifyEvent {
     pub response_type: u8,
     pub subtype: SelectionEvent,
@@ -579,7 +579,7 @@ impl From<SelectionNotifyEvent> for [u8; 32] {
 
 /// Opcode for the SelectSelectionInput request
 pub const SELECT_SELECTION_INPUT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectSelectionInputRequest {
     pub window: xproto::Window,
     pub selection: xproto::Atom,
@@ -645,7 +645,7 @@ impl Request for SelectSelectionInputRequest {
 impl crate::x11_utils::VoidRequest for SelectSelectionInputRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CursorNotify(u8);
 impl CursorNotify {
     pub const DISPLAY_CURSOR: Self = Self(0);
@@ -701,7 +701,7 @@ impl std::fmt::Debug for CursorNotify  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CursorNotifyMask(u8);
 impl CursorNotifyMask {
     pub const DISPLAY_CURSOR: Self = Self(1 << 0);
@@ -760,7 +760,7 @@ bitmask_binop!(CursorNotifyMask, u8);
 
 /// Opcode for the CursorNotify event
 pub const CURSOR_NOTIFY_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CursorNotifyEvent {
     pub response_type: u8,
     pub subtype: CursorNotify,
@@ -842,7 +842,7 @@ impl From<CursorNotifyEvent> for [u8; 32] {
 
 /// Opcode for the SelectCursorInput request
 pub const SELECT_CURSOR_INPUT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectCursorInputRequest {
     pub window: xproto::Window,
     pub event_mask: u32,
@@ -902,7 +902,7 @@ impl crate::x11_utils::VoidRequest for SelectCursorInputRequest {
 
 /// Opcode for the GetCursorImage request
 pub const GET_CURSOR_IMAGE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCursorImageRequest;
 impl GetCursorImageRequest {
     /// Serialize this request into bytes for the provided connection
@@ -944,7 +944,7 @@ impl crate::x11_utils::ReplyRequest for GetCursorImageRequest {
     type Reply = GetCursorImageReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCursorImageReply {
     pub sequence: u16,
     pub length: u32,
@@ -989,7 +989,7 @@ pub type Region = u32;
 /// Opcode for the BadRegion error
 pub const BAD_REGION_ERROR: u8 = 0;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RegionEnum(u8);
 impl RegionEnum {
     pub const NONE: Self = Self(0);
@@ -1047,7 +1047,7 @@ impl std::fmt::Debug for RegionEnum  {
 
 /// Opcode for the CreateRegion request
 pub const CREATE_REGION_REQUEST: u8 = 5;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateRegionRequest<'input> {
     pub region: Region,
     pub rectangles: Cow<'input, [xproto::Rectangle]>,
@@ -1120,7 +1120,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateRegionRequest<'input> {
 
 /// Opcode for the CreateRegionFromBitmap request
 pub const CREATE_REGION_FROM_BITMAP_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateRegionFromBitmapRequest {
     pub region: Region,
     pub bitmap: xproto::Pixmap,
@@ -1180,7 +1180,7 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromBitmapRequest {
 
 /// Opcode for the CreateRegionFromWindow request
 pub const CREATE_REGION_FROM_WINDOW_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateRegionFromWindowRequest {
     pub region: Region,
     pub window: xproto::Window,
@@ -1250,7 +1250,7 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromWindowRequest {
 
 /// Opcode for the CreateRegionFromGC request
 pub const CREATE_REGION_FROM_GC_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateRegionFromGCRequest {
     pub region: Region,
     pub gc: xproto::Gcontext,
@@ -1310,7 +1310,7 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromGCRequest {
 
 /// Opcode for the CreateRegionFromPicture request
 pub const CREATE_REGION_FROM_PICTURE_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateRegionFromPictureRequest {
     pub region: Region,
     pub picture: render::Picture,
@@ -1370,7 +1370,7 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromPictureRequest {
 
 /// Opcode for the DestroyRegion request
 pub const DESTROY_REGION_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyRegionRequest {
     pub region: Region,
 }
@@ -1422,7 +1422,7 @@ impl crate::x11_utils::VoidRequest for DestroyRegionRequest {
 
 /// Opcode for the SetRegion request
 pub const SET_REGION_REQUEST: u8 = 11;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetRegionRequest<'input> {
     pub region: Region,
     pub rectangles: Cow<'input, [xproto::Rectangle]>,
@@ -1495,7 +1495,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetRegionRequest<'input> {
 
 /// Opcode for the CopyRegion request
 pub const COPY_REGION_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CopyRegionRequest {
     pub source: Region,
     pub destination: Region,
@@ -1555,7 +1555,7 @@ impl crate::x11_utils::VoidRequest for CopyRegionRequest {
 
 /// Opcode for the UnionRegion request
 pub const UNION_REGION_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UnionRegionRequest {
     pub source1: Region,
     pub source2: Region,
@@ -1623,7 +1623,7 @@ impl crate::x11_utils::VoidRequest for UnionRegionRequest {
 
 /// Opcode for the IntersectRegion request
 pub const INTERSECT_REGION_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IntersectRegionRequest {
     pub source1: Region,
     pub source2: Region,
@@ -1691,7 +1691,7 @@ impl crate::x11_utils::VoidRequest for IntersectRegionRequest {
 
 /// Opcode for the SubtractRegion request
 pub const SUBTRACT_REGION_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubtractRegionRequest {
     pub source1: Region,
     pub source2: Region,
@@ -1759,7 +1759,7 @@ impl crate::x11_utils::VoidRequest for SubtractRegionRequest {
 
 /// Opcode for the InvertRegion request
 pub const INVERT_REGION_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InvertRegionRequest {
     pub source: Region,
     pub bounds: xproto::Rectangle,
@@ -1831,7 +1831,7 @@ impl crate::x11_utils::VoidRequest for InvertRegionRequest {
 
 /// Opcode for the TranslateRegion request
 pub const TRANSLATE_REGION_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TranslateRegionRequest {
     pub region: Region,
     pub dx: i16,
@@ -1895,7 +1895,7 @@ impl crate::x11_utils::VoidRequest for TranslateRegionRequest {
 
 /// Opcode for the RegionExtents request
 pub const REGION_EXTENTS_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RegionExtentsRequest {
     pub source: Region,
     pub destination: Region,
@@ -1955,7 +1955,7 @@ impl crate::x11_utils::VoidRequest for RegionExtentsRequest {
 
 /// Opcode for the FetchRegion request
 pub const FETCH_REGION_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FetchRegionRequest {
     pub region: Region,
 }
@@ -2006,7 +2006,7 @@ impl crate::x11_utils::ReplyRequest for FetchRegionRequest {
     type Reply = FetchRegionReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FetchRegionReply {
     pub sequence: u16,
     pub extents: xproto::Rectangle,
@@ -2051,7 +2051,7 @@ impl FetchRegionReply {
 
 /// Opcode for the SetGCClipRegion request
 pub const SET_GC_CLIP_REGION_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetGCClipRegionRequest {
     pub gc: xproto::Gcontext,
     pub region: Region,
@@ -2123,7 +2123,7 @@ impl crate::x11_utils::VoidRequest for SetGCClipRegionRequest {
 
 /// Opcode for the SetWindowShapeRegion request
 pub const SET_WINDOW_SHAPE_REGION_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetWindowShapeRegionRequest {
     pub dest: xproto::Window,
     pub dest_kind: shape::SK,
@@ -2205,7 +2205,7 @@ impl crate::x11_utils::VoidRequest for SetWindowShapeRegionRequest {
 
 /// Opcode for the SetPictureClipRegion request
 pub const SET_PICTURE_CLIP_REGION_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetPictureClipRegionRequest {
     pub picture: render::Picture,
     pub region: Region,
@@ -2277,7 +2277,7 @@ impl crate::x11_utils::VoidRequest for SetPictureClipRegionRequest {
 
 /// Opcode for the SetCursorName request
 pub const SET_CURSOR_NAME_REQUEST: u8 = 23;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetCursorNameRequest<'input> {
     pub cursor: xproto::Cursor,
     pub name: Cow<'input, [u8]>,
@@ -2350,7 +2350,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetCursorNameRequest<'input> {
 
 /// Opcode for the GetCursorName request
 pub const GET_CURSOR_NAME_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCursorNameRequest {
     pub cursor: xproto::Cursor,
 }
@@ -2401,7 +2401,7 @@ impl crate::x11_utils::ReplyRequest for GetCursorNameRequest {
     type Reply = GetCursorNameReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCursorNameReply {
     pub sequence: u16,
     pub length: u32,
@@ -2448,7 +2448,7 @@ impl GetCursorNameReply {
 
 /// Opcode for the GetCursorImageAndName request
 pub const GET_CURSOR_IMAGE_AND_NAME_REQUEST: u8 = 25;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCursorImageAndNameRequest;
 impl GetCursorImageAndNameRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2490,7 +2490,7 @@ impl crate::x11_utils::ReplyRequest for GetCursorImageAndNameRequest {
     type Reply = GetCursorImageAndNameReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCursorImageAndNameReply {
     pub sequence: u16,
     pub length: u32,
@@ -2553,7 +2553,7 @@ impl GetCursorImageAndNameReply {
 
 /// Opcode for the ChangeCursor request
 pub const CHANGE_CURSOR_REQUEST: u8 = 26;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeCursorRequest {
     pub source: xproto::Cursor,
     pub destination: xproto::Cursor,
@@ -2613,7 +2613,7 @@ impl crate::x11_utils::VoidRequest for ChangeCursorRequest {
 
 /// Opcode for the ChangeCursorByName request
 pub const CHANGE_CURSOR_BY_NAME_REQUEST: u8 = 27;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeCursorByNameRequest<'input> {
     pub src: xproto::Cursor,
     pub name: Cow<'input, [u8]>,
@@ -2686,7 +2686,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeCursorByNameRequest<'input>
 
 /// Opcode for the ExpandRegion request
 pub const EXPAND_REGION_REQUEST: u8 = 28;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExpandRegionRequest {
     pub source: Region,
     pub destination: Region,
@@ -2770,7 +2770,7 @@ impl crate::x11_utils::VoidRequest for ExpandRegionRequest {
 
 /// Opcode for the HideCursor request
 pub const HIDE_CURSOR_REQUEST: u8 = 29;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HideCursorRequest {
     pub window: xproto::Window,
 }
@@ -2822,7 +2822,7 @@ impl crate::x11_utils::VoidRequest for HideCursorRequest {
 
 /// Opcode for the ShowCursor request
 pub const SHOW_CURSOR_REQUEST: u8 = 30;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ShowCursorRequest {
     pub window: xproto::Window,
 }
@@ -2874,7 +2874,7 @@ impl crate::x11_utils::VoidRequest for ShowCursorRequest {
 
 pub type Barrier = u32;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BarrierDirections(u8);
 impl BarrierDirections {
     pub const POSITIVE_X: Self = Self(1 << 0);
@@ -2939,7 +2939,7 @@ bitmask_binop!(BarrierDirections, u8);
 
 /// Opcode for the CreatePointerBarrier request
 pub const CREATE_POINTER_BARRIER_REQUEST: u8 = 31;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreatePointerBarrierRequest<'input> {
     pub barrier: Barrier,
     pub window: xproto::Window,
@@ -3059,7 +3059,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreatePointerBarrierRequest<'inpu
 
 /// Opcode for the DeletePointerBarrier request
 pub const DELETE_POINTER_BARRIER_REQUEST: u8 = 32;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeletePointerBarrierRequest {
     pub barrier: Barrier,
 }

--- a/x11rb-protocol/src/protocol/xinerama.rs
+++ b/x11rb-protocol/src/protocol/xinerama.rs
@@ -32,7 +32,7 @@ pub const X11_EXTENSION_NAME: &str = "XINERAMA";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScreenInfo {
     pub x_org: i16,
     pub y_org: i16,
@@ -78,7 +78,7 @@ impl Serialize for ScreenInfo {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub major: u8,
     pub minor: u8,
@@ -133,7 +133,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -162,7 +162,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the GetState request
 pub const GET_STATE_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetStateRequest {
     pub window: xproto::Window,
 }
@@ -213,7 +213,7 @@ impl crate::x11_utils::ReplyRequest for GetStateRequest {
     type Reply = GetStateReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetStateReply {
     pub state: u8,
     pub sequence: u16,
@@ -241,7 +241,7 @@ impl TryParse for GetStateReply {
 
 /// Opcode for the GetScreenCount request
 pub const GET_SCREEN_COUNT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenCountRequest {
     pub window: xproto::Window,
 }
@@ -292,7 +292,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenCountRequest {
     type Reply = GetScreenCountReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenCountReply {
     pub screen_count: u8,
     pub sequence: u16,
@@ -320,7 +320,7 @@ impl TryParse for GetScreenCountReply {
 
 /// Opcode for the GetScreenSize request
 pub const GET_SCREEN_SIZE_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenSizeRequest {
     pub window: xproto::Window,
     pub screen: u32,
@@ -379,7 +379,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenSizeRequest {
     type Reply = GetScreenSizeReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenSizeReply {
     pub sequence: u16,
     pub length: u32,
@@ -412,7 +412,7 @@ impl TryParse for GetScreenSizeReply {
 
 /// Opcode for the IsActive request
 pub const IS_ACTIVE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IsActiveRequest;
 impl IsActiveRequest {
     /// Serialize this request into bytes for the provided connection
@@ -454,7 +454,7 @@ impl crate::x11_utils::ReplyRequest for IsActiveRequest {
     type Reply = IsActiveReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IsActiveReply {
     pub sequence: u16,
     pub length: u32,
@@ -481,7 +481,7 @@ impl TryParse for IsActiveReply {
 
 /// Opcode for the QueryScreens request
 pub const QUERY_SCREENS_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryScreensRequest;
 impl QueryScreensRequest {
     /// Serialize this request into bytes for the provided connection
@@ -523,7 +523,7 @@ impl crate::x11_utils::ReplyRequest for QueryScreensRequest {
     type Reply = QueryScreensReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryScreensReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -42,7 +42,7 @@ pub type DeviceId = u16;
 
 pub type Fp1616 = i32;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Fp3232 {
     pub integral: i32,
     pub frac: u32,
@@ -80,7 +80,7 @@ impl Serialize for Fp3232 {
 
 /// Opcode for the GetExtensionVersion request
 pub const GET_EXTENSION_VERSION_REQUEST: u8 = 1;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetExtensionVersionRequest<'input> {
     pub name: Cow<'input, [u8]>,
 }
@@ -143,7 +143,7 @@ impl<'input> crate::x11_utils::ReplyRequest for GetExtensionVersionRequest<'inpu
     type Reply = GetExtensionVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetExtensionVersionReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -174,7 +174,7 @@ impl TryParse for GetExtensionVersionReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceUse(u8);
 impl DeviceUse {
     pub const IS_X_POINTER: Self = Self(0);
@@ -238,7 +238,7 @@ impl std::fmt::Debug for DeviceUse  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputClass(u8);
 impl InputClass {
     pub const KEY: Self = Self(0);
@@ -306,7 +306,7 @@ impl std::fmt::Debug for InputClass  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ValuatorMode(u8);
 impl ValuatorMode {
     pub const RELATIVE: Self = Self(0);
@@ -364,7 +364,7 @@ impl std::fmt::Debug for ValuatorMode  {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceInfo {
     pub device_type: xproto::Atom,
     pub device_id: u8,
@@ -411,7 +411,7 @@ impl Serialize for DeviceInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyInfo {
     pub class_id: InputClass,
     pub len: u8,
@@ -462,7 +462,7 @@ impl Serialize for KeyInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ButtonInfo {
     pub class_id: InputClass,
     pub len: u8,
@@ -499,7 +499,7 @@ impl Serialize for ButtonInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AxisInfo {
     pub resolution: u32,
     pub minimum: i32,
@@ -543,7 +543,7 @@ impl Serialize for AxisInfo {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ValuatorInfo {
     pub class_id: InputClass,
     pub len: u8,
@@ -599,7 +599,7 @@ impl ValuatorInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputInfoInfoKey {
     pub min_keycode: KeyCode,
     pub max_keycode: KeyCode,
@@ -638,7 +638,7 @@ impl Serialize for InputInfoInfoKey {
         bytes.extend_from_slice(&[0; 2]);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputInfoInfoButton {
     pub num_buttons: u16,
 }
@@ -663,7 +663,7 @@ impl Serialize for InputInfoInfoButton {
         self.num_buttons.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputInfoInfoValuator {
     pub mode: ValuatorMode,
     pub motion_size: u32,
@@ -711,7 +711,7 @@ impl InputInfoInfoValuator {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum InputInfoInfo {
     Key(InputInfoInfoKey),
     Button(InputInfoInfoButton),
@@ -803,7 +803,7 @@ impl InputInfoInfo {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputInfo {
     pub len: u8,
     pub info: InputInfoInfo,
@@ -833,7 +833,7 @@ impl Serialize for InputInfo {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceName {
     pub string: Vec<u8>,
 }
@@ -878,7 +878,7 @@ impl DeviceName {
 
 /// Opcode for the ListInputDevices request
 pub const LIST_INPUT_DEVICES_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListInputDevicesRequest;
 impl ListInputDevicesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -920,7 +920,7 @@ impl crate::x11_utils::ReplyRequest for ListInputDevicesRequest {
     type Reply = ListInputDevicesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListInputDevicesReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -974,7 +974,7 @@ impl ListInputDevicesReply {
 
 pub type EventTypeBase = u8;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputClassInfo {
     pub class_id: InputClass,
     pub event_type_base: EventTypeBase,
@@ -1007,7 +1007,7 @@ impl Serialize for InputClassInfo {
 
 /// Opcode for the OpenDevice request
 pub const OPEN_DEVICE_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OpenDeviceRequest {
     pub device_id: u8,
 }
@@ -1059,7 +1059,7 @@ impl crate::x11_utils::ReplyRequest for OpenDeviceRequest {
     type Reply = OpenDeviceReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OpenDeviceReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1109,7 +1109,7 @@ impl OpenDeviceReply {
 
 /// Opcode for the CloseDevice request
 pub const CLOSE_DEVICE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CloseDeviceRequest {
     pub device_id: u8,
 }
@@ -1162,7 +1162,7 @@ impl crate::x11_utils::VoidRequest for CloseDeviceRequest {
 
 /// Opcode for the SetDeviceMode request
 pub const SET_DEVICE_MODE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDeviceModeRequest {
     pub device_id: u8,
     pub mode: ValuatorMode,
@@ -1219,7 +1219,7 @@ impl crate::x11_utils::ReplyRequest for SetDeviceModeRequest {
     type Reply = SetDeviceModeReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDeviceModeReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1249,7 +1249,7 @@ impl TryParse for SetDeviceModeReply {
 
 /// Opcode for the SelectExtensionEvent request
 pub const SELECT_EXTENSION_EVENT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectExtensionEventRequest<'input> {
     pub window: xproto::Window,
     pub classes: Cow<'input, [EventClass]>,
@@ -1323,7 +1323,7 @@ impl<'input> crate::x11_utils::VoidRequest for SelectExtensionEventRequest<'inpu
 
 /// Opcode for the GetSelectedExtensionEvents request
 pub const GET_SELECTED_EXTENSION_EVENTS_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSelectedExtensionEventsRequest {
     pub window: xproto::Window,
 }
@@ -1374,7 +1374,7 @@ impl crate::x11_utils::ReplyRequest for GetSelectedExtensionEventsRequest {
     type Reply = GetSelectedExtensionEventsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSelectedExtensionEventsReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1433,7 +1433,7 @@ impl GetSelectedExtensionEventsReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PropagateMode(u8);
 impl PropagateMode {
     pub const ADD_TO_LIST: Self = Self(0);
@@ -1493,7 +1493,7 @@ impl std::fmt::Debug for PropagateMode  {
 
 /// Opcode for the ChangeDeviceDontPropagateList request
 pub const CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 8;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeDeviceDontPropagateListRequest<'input> {
     pub window: xproto::Window,
     pub mode: PropagateMode,
@@ -1573,7 +1573,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeDeviceDontPropagateListRequ
 
 /// Opcode for the GetDeviceDontPropagateList request
 pub const GET_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceDontPropagateListRequest {
     pub window: xproto::Window,
 }
@@ -1624,7 +1624,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceDontPropagateListRequest {
     type Reply = GetDeviceDontPropagateListReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceDontPropagateListReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1667,7 +1667,7 @@ impl GetDeviceDontPropagateListReply {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceTimeCoord {
     pub time: xproto::Timestamp,
     pub axisvalues: Vec<i32>,
@@ -1696,7 +1696,7 @@ impl DeviceTimeCoord {
 
 /// Opcode for the GetDeviceMotionEvents request
 pub const GET_DEVICE_MOTION_EVENTS_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceMotionEventsRequest {
     pub start: xproto::Timestamp,
     pub stop: xproto::Timestamp,
@@ -1764,7 +1764,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceMotionEventsRequest {
     type Reply = GetDeviceMotionEventsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceMotionEventsReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1821,7 +1821,7 @@ impl GetDeviceMotionEventsReply {
 
 /// Opcode for the ChangeKeyboardDevice request
 pub const CHANGE_KEYBOARD_DEVICE_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeKeyboardDeviceRequest {
     pub device_id: u8,
 }
@@ -1873,7 +1873,7 @@ impl crate::x11_utils::ReplyRequest for ChangeKeyboardDeviceRequest {
     type Reply = ChangeKeyboardDeviceReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeKeyboardDeviceReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1903,7 +1903,7 @@ impl TryParse for ChangeKeyboardDeviceReply {
 
 /// Opcode for the ChangePointerDevice request
 pub const CHANGE_POINTER_DEVICE_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangePointerDeviceRequest {
     pub x_axis: u8,
     pub y_axis: u8,
@@ -1963,7 +1963,7 @@ impl crate::x11_utils::ReplyRequest for ChangePointerDeviceRequest {
     type Reply = ChangePointerDeviceReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangePointerDeviceReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1993,7 +1993,7 @@ impl TryParse for ChangePointerDeviceReply {
 
 /// Opcode for the GrabDevice request
 pub const GRAB_DEVICE_REQUEST: u8 = 13;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabDeviceRequest<'input> {
     pub grab_window: xproto::Window,
     pub time: xproto::Timestamp,
@@ -2101,7 +2101,7 @@ impl<'input> crate::x11_utils::ReplyRequest for GrabDeviceRequest<'input> {
     type Reply = GrabDeviceReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabDeviceReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -2131,7 +2131,7 @@ impl TryParse for GrabDeviceReply {
 
 /// Opcode for the UngrabDevice request
 pub const UNGRAB_DEVICE_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UngrabDeviceRequest {
     pub time: xproto::Timestamp,
     pub device_id: u8,
@@ -2190,7 +2190,7 @@ impl Request for UngrabDeviceRequest {
 impl crate::x11_utils::VoidRequest for UngrabDeviceRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModifierDevice(u8);
 impl ModifierDevice {
     pub const USE_X_KEYBOARD: Self = Self(255);
@@ -2248,7 +2248,7 @@ impl std::fmt::Debug for ModifierDevice  {
 
 /// Opcode for the GrabDeviceKey request
 pub const GRAB_DEVICE_KEY_REQUEST: u8 = 15;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabDeviceKeyRequest<'input> {
     pub grab_window: xproto::Window,
     pub modifiers: u16,
@@ -2367,7 +2367,7 @@ impl<'input> crate::x11_utils::VoidRequest for GrabDeviceKeyRequest<'input> {
 
 /// Opcode for the UngrabDeviceKey request
 pub const UNGRAB_DEVICE_KEY_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UngrabDeviceKeyRequest {
     pub grab_window: xproto::Window,
     pub modifiers: u16,
@@ -2443,7 +2443,7 @@ impl crate::x11_utils::VoidRequest for UngrabDeviceKeyRequest {
 
 /// Opcode for the GrabDeviceButton request
 pub const GRAB_DEVICE_BUTTON_REQUEST: u8 = 17;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabDeviceButtonRequest<'input> {
     pub grab_window: xproto::Window,
     pub grabbed_device: u8,
@@ -2562,7 +2562,7 @@ impl<'input> crate::x11_utils::VoidRequest for GrabDeviceButtonRequest<'input> {
 
 /// Opcode for the UngrabDeviceButton request
 pub const UNGRAB_DEVICE_BUTTON_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UngrabDeviceButtonRequest {
     pub grab_window: xproto::Window,
     pub modifiers: u16,
@@ -2637,7 +2637,7 @@ impl Request for UngrabDeviceButtonRequest {
 impl crate::x11_utils::VoidRequest for UngrabDeviceButtonRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceInputMode(u8);
 impl DeviceInputMode {
     pub const ASYNC_THIS_DEVICE: Self = Self(0);
@@ -2705,7 +2705,7 @@ impl std::fmt::Debug for DeviceInputMode  {
 
 /// Opcode for the AllowDeviceEvents request
 pub const ALLOW_DEVICE_EVENTS_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AllowDeviceEventsRequest {
     pub time: xproto::Timestamp,
     pub mode: DeviceInputMode,
@@ -2771,7 +2771,7 @@ impl crate::x11_utils::VoidRequest for AllowDeviceEventsRequest {
 
 /// Opcode for the GetDeviceFocus request
 pub const GET_DEVICE_FOCUS_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceFocusRequest {
     pub device_id: u8,
 }
@@ -2823,7 +2823,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceFocusRequest {
     type Reply = GetDeviceFocusReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceFocusReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -2857,7 +2857,7 @@ impl TryParse for GetDeviceFocusReply {
 
 /// Opcode for the SetDeviceFocus request
 pub const SET_DEVICE_FOCUS_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDeviceFocusRequest {
     pub focus: xproto::Window,
     pub time: xproto::Timestamp,
@@ -2929,7 +2929,7 @@ impl Request for SetDeviceFocusRequest {
 impl crate::x11_utils::VoidRequest for SetDeviceFocusRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackClass(u8);
 impl FeedbackClass {
     pub const KEYBOARD: Self = Self(0);
@@ -2995,7 +2995,7 @@ impl std::fmt::Debug for FeedbackClass  {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KbdFeedbackState {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -3114,7 +3114,7 @@ impl Serialize for KbdFeedbackState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PtrFeedbackState {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -3173,7 +3173,7 @@ impl Serialize for PtrFeedbackState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IntegerFeedbackState {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -3234,7 +3234,7 @@ impl Serialize for IntegerFeedbackState {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StringFeedbackState {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -3289,7 +3289,7 @@ impl StringFeedbackState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BellFeedbackState {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -3348,7 +3348,7 @@ impl Serialize for BellFeedbackState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LedFeedbackState {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -3401,7 +3401,7 @@ impl Serialize for LedFeedbackState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackStateDataKeyboard {
     pub pitch: u16,
     pub duration: u16,
@@ -3502,7 +3502,7 @@ impl Serialize for FeedbackStateDataKeyboard {
         bytes.extend_from_slice(&self.auto_repeats);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackStateDataPointer {
     pub accel_num: u16,
     pub accel_denom: u16,
@@ -3543,7 +3543,7 @@ impl Serialize for FeedbackStateDataPointer {
         self.threshold.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackStateDataString {
     pub max_symbols: u16,
     pub keysyms: Vec<xproto::Keysym>,
@@ -3587,7 +3587,7 @@ impl FeedbackStateDataString {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackStateDataInteger {
     pub resolution: u32,
     pub min_value: i32,
@@ -3630,7 +3630,7 @@ impl Serialize for FeedbackStateDataInteger {
         self.max_value.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackStateDataLed {
     pub led_mask: u32,
     pub led_values: u32,
@@ -3665,7 +3665,7 @@ impl Serialize for FeedbackStateDataLed {
         self.led_values.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackStateDataBell {
     pub percent: u8,
     pub pitch: u16,
@@ -3706,7 +3706,7 @@ impl Serialize for FeedbackStateDataBell {
         self.duration.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum FeedbackStateData {
     Keyboard(FeedbackStateDataKeyboard),
     Pointer(FeedbackStateDataPointer),
@@ -3843,7 +3843,7 @@ impl FeedbackStateData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackState {
     pub feedback_id: u8,
     pub len: u16,
@@ -3878,7 +3878,7 @@ impl Serialize for FeedbackState {
 
 /// Opcode for the GetFeedbackControl request
 pub const GET_FEEDBACK_CONTROL_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetFeedbackControlRequest {
     pub device_id: u8,
 }
@@ -3930,7 +3930,7 @@ impl crate::x11_utils::ReplyRequest for GetFeedbackControlRequest {
     type Reply = GetFeedbackControlReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetFeedbackControlReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -3973,7 +3973,7 @@ impl GetFeedbackControlReply {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KbdFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -4058,7 +4058,7 @@ impl Serialize for KbdFeedbackCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PtrFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -4117,7 +4117,7 @@ impl Serialize for PtrFeedbackCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IntegerFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -4162,7 +4162,7 @@ impl Serialize for IntegerFeedbackCtl {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StringFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -4216,7 +4216,7 @@ impl StringFeedbackCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BellFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -4275,7 +4275,7 @@ impl Serialize for BellFeedbackCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LedFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -4328,7 +4328,7 @@ impl Serialize for LedFeedbackCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackCtlDataKeyboard {
     pub key: KeyCode,
     pub auto_repeat_mode: u8,
@@ -4395,7 +4395,7 @@ impl Serialize for FeedbackCtlDataKeyboard {
         self.led_values.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackCtlDataPointer {
     pub num: i16,
     pub denom: i16,
@@ -4436,7 +4436,7 @@ impl Serialize for FeedbackCtlDataPointer {
         self.threshold.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackCtlDataString {
     pub keysyms: Vec<xproto::Keysym>,
 }
@@ -4479,7 +4479,7 @@ impl FeedbackCtlDataString {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackCtlDataInteger {
     pub int_to_display: i32,
 }
@@ -4506,7 +4506,7 @@ impl Serialize for FeedbackCtlDataInteger {
         self.int_to_display.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackCtlDataLed {
     pub led_mask: u32,
     pub led_values: u32,
@@ -4541,7 +4541,7 @@ impl Serialize for FeedbackCtlDataLed {
         self.led_values.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackCtlDataBell {
     pub percent: i8,
     pub pitch: i16,
@@ -4582,7 +4582,7 @@ impl Serialize for FeedbackCtlDataBell {
         self.duration.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum FeedbackCtlData {
     Keyboard(FeedbackCtlDataKeyboard),
     Pointer(FeedbackCtlDataPointer),
@@ -4719,7 +4719,7 @@ impl FeedbackCtlData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FeedbackCtl {
     pub feedback_id: u8,
     pub len: u16,
@@ -4752,7 +4752,7 @@ impl Serialize for FeedbackCtl {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeFeedbackControlMask(u8);
 impl ChangeFeedbackControlMask {
     pub const KEY_CLICK_PERCENT: Self = Self(1 << 0);
@@ -4835,7 +4835,7 @@ bitmask_binop!(ChangeFeedbackControlMask, u8);
 
 /// Opcode for the ChangeFeedbackControl request
 pub const CHANGE_FEEDBACK_CONTROL_REQUEST: u8 = 23;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeFeedbackControlRequest {
     pub mask: u32,
     pub device_id: u8,
@@ -4907,7 +4907,7 @@ impl crate::x11_utils::VoidRequest for ChangeFeedbackControlRequest {
 
 /// Opcode for the GetDeviceKeyMapping request
 pub const GET_DEVICE_KEY_MAPPING_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceKeyMappingRequest {
     pub device_id: u8,
     pub first_keycode: KeyCode,
@@ -4967,7 +4967,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceKeyMappingRequest {
     type Reply = GetDeviceKeyMappingReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceKeyMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -5012,7 +5012,7 @@ impl GetDeviceKeyMappingReply {
 
 /// Opcode for the ChangeDeviceKeyMapping request
 pub const CHANGE_DEVICE_KEY_MAPPING_REQUEST: u8 = 25;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeDeviceKeyMappingRequest<'input> {
     pub device_id: u8,
     pub first_keycode: KeyCode,
@@ -5094,7 +5094,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeDeviceKeyMappingRequest<'in
 
 /// Opcode for the GetDeviceModifierMapping request
 pub const GET_DEVICE_MODIFIER_MAPPING_REQUEST: u8 = 26;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceModifierMappingRequest {
     pub device_id: u8,
 }
@@ -5146,7 +5146,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceModifierMappingRequest {
     type Reply = GetDeviceModifierMappingReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceModifierMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -5193,7 +5193,7 @@ impl GetDeviceModifierMappingReply {
 
 /// Opcode for the SetDeviceModifierMapping request
 pub const SET_DEVICE_MODIFIER_MAPPING_REQUEST: u8 = 27;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDeviceModifierMappingRequest<'input> {
     pub device_id: u8,
     pub keymaps: Cow<'input, [u8]>,
@@ -5262,7 +5262,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetDeviceModifierMappingRequest<
     type Reply = SetDeviceModifierMappingReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDeviceModifierMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -5292,7 +5292,7 @@ impl TryParse for SetDeviceModifierMappingReply {
 
 /// Opcode for the GetDeviceButtonMapping request
 pub const GET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 28;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceButtonMappingRequest {
     pub device_id: u8,
 }
@@ -5344,7 +5344,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceButtonMappingRequest {
     type Reply = GetDeviceButtonMappingReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceButtonMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -5395,7 +5395,7 @@ impl GetDeviceButtonMappingReply {
 
 /// Opcode for the SetDeviceButtonMapping request
 pub const SET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 29;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDeviceButtonMappingRequest<'input> {
     pub device_id: u8,
     pub map: Cow<'input, [u8]>,
@@ -5463,7 +5463,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetDeviceButtonMappingRequest<'i
     type Reply = SetDeviceButtonMappingReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDeviceButtonMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -5491,7 +5491,7 @@ impl TryParse for SetDeviceButtonMappingReply {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyState {
     pub class_id: InputClass,
     pub len: u8,
@@ -5566,7 +5566,7 @@ impl Serialize for KeyState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ButtonState {
     pub class_id: InputClass,
     pub len: u8,
@@ -5641,7 +5641,7 @@ impl Serialize for ButtonState {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ValuatorStateModeMask(u8);
 impl ValuatorStateModeMask {
     pub const DEVICE_MODE_ABSOLUTE: Self = Self(1 << 0);
@@ -5700,7 +5700,7 @@ impl std::fmt::Debug for ValuatorStateModeMask  {
 }
 bitmask_binop!(ValuatorStateModeMask, u8);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ValuatorState {
     pub class_id: InputClass,
     pub len: u8,
@@ -5752,7 +5752,7 @@ impl ValuatorState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputStateDataKey {
     pub num_keys: u8,
     pub keys: [u8; 32],
@@ -5815,7 +5815,7 @@ impl Serialize for InputStateDataKey {
         bytes.extend_from_slice(&self.keys);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputStateDataButton {
     pub num_buttons: u8,
     pub buttons: [u8; 32],
@@ -5878,7 +5878,7 @@ impl Serialize for InputStateDataButton {
         bytes.extend_from_slice(&self.buttons);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputStateDataValuator {
     pub mode: u8,
     pub valuators: Vec<i32>,
@@ -5922,7 +5922,7 @@ impl InputStateDataValuator {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum InputStateData {
     Key(InputStateDataKey),
     Button(InputStateDataButton),
@@ -6014,7 +6014,7 @@ impl InputStateData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputState {
     pub len: u8,
     pub data: InputStateData,
@@ -6046,7 +6046,7 @@ impl Serialize for InputState {
 
 /// Opcode for the QueryDeviceState request
 pub const QUERY_DEVICE_STATE_REQUEST: u8 = 30;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryDeviceStateRequest {
     pub device_id: u8,
 }
@@ -6098,7 +6098,7 @@ impl crate::x11_utils::ReplyRequest for QueryDeviceStateRequest {
     type Reply = QueryDeviceStateReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryDeviceStateReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -6143,7 +6143,7 @@ impl QueryDeviceStateReply {
 
 /// Opcode for the DeviceBell request
 pub const DEVICE_BELL_REQUEST: u8 = 32;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceBellRequest {
     pub device_id: u8,
     pub feedback_id: u8,
@@ -6207,7 +6207,7 @@ impl crate::x11_utils::VoidRequest for DeviceBellRequest {
 
 /// Opcode for the SetDeviceValuators request
 pub const SET_DEVICE_VALUATORS_REQUEST: u8 = 33;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDeviceValuatorsRequest<'input> {
     pub device_id: u8,
     pub first_valuator: u8,
@@ -6281,7 +6281,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetDeviceValuatorsRequest<'input
     type Reply = SetDeviceValuatorsReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDeviceValuatorsReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -6309,7 +6309,7 @@ impl TryParse for SetDeviceValuatorsReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceControl(u16);
 impl DeviceControl {
     pub const RESOLUTION: Self = Self(1);
@@ -6367,7 +6367,7 @@ impl std::fmt::Debug for DeviceControl  {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceResolutionState {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -6424,7 +6424,7 @@ impl DeviceResolutionState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceAbsCalibState {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -6521,7 +6521,7 @@ impl Serialize for DeviceAbsCalibState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceAbsAreaState {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -6602,7 +6602,7 @@ impl Serialize for DeviceAbsAreaState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceCoreState {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -6649,7 +6649,7 @@ impl Serialize for DeviceCoreState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceEnableState {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -6692,7 +6692,7 @@ impl Serialize for DeviceEnableState {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceStateDataResolution {
     pub resolution_values: Vec<u32>,
     pub resolution_min: Vec<u32>,
@@ -6740,7 +6740,7 @@ impl DeviceStateDataResolution {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceStateDataAbsCalib {
     pub min_x: i32,
     pub max_x: i32,
@@ -6823,7 +6823,7 @@ impl Serialize for DeviceStateDataAbsCalib {
         self.button_threshold.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceStateDataCore {
     pub status: u8,
     pub iscore: u8,
@@ -6856,7 +6856,7 @@ impl Serialize for DeviceStateDataCore {
         bytes.extend_from_slice(&[0; 2]);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceStateDataAbsArea {
     pub offset_x: u32,
     pub offset_y: u32,
@@ -6923,7 +6923,7 @@ impl Serialize for DeviceStateDataAbsArea {
         self.following.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DeviceStateData {
     Resolution(DeviceStateDataResolution),
     AbsCalib(DeviceStateDataAbsCalib),
@@ -7051,7 +7051,7 @@ impl DeviceStateData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceState {
     pub len: u16,
     pub data: DeviceStateData,
@@ -7083,7 +7083,7 @@ impl Serialize for DeviceState {
 
 /// Opcode for the GetDeviceControl request
 pub const GET_DEVICE_CONTROL_REQUEST: u8 = 34;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceControlRequest {
     pub control_id: DeviceControl,
     pub device_id: u8,
@@ -7140,7 +7140,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceControlRequest {
     type Reply = GetDeviceControlReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceControlReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -7169,7 +7169,7 @@ impl TryParse for GetDeviceControlReply {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceResolutionCtl {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -7223,7 +7223,7 @@ impl DeviceResolutionCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceAbsCalibCtl {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -7320,7 +7320,7 @@ impl Serialize for DeviceAbsCalibCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceAbsAreaCtrl {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -7401,7 +7401,7 @@ impl Serialize for DeviceAbsAreaCtrl {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceCoreCtrl {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -7444,7 +7444,7 @@ impl Serialize for DeviceCoreCtrl {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceEnableCtrl {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -7487,7 +7487,7 @@ impl Serialize for DeviceEnableCtrl {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceCtlDataResolution {
     pub first_valuator: u8,
     pub resolution_values: Vec<u32>,
@@ -7533,7 +7533,7 @@ impl DeviceCtlDataResolution {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceCtlDataAbsCalib {
     pub min_x: i32,
     pub max_x: i32,
@@ -7616,7 +7616,7 @@ impl Serialize for DeviceCtlDataAbsCalib {
         self.button_threshold.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceCtlDataCore {
     pub status: u8,
 }
@@ -7645,7 +7645,7 @@ impl Serialize for DeviceCtlDataCore {
         bytes.extend_from_slice(&[0; 3]);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceCtlDataAbsArea {
     pub offset_x: u32,
     pub offset_y: u32,
@@ -7712,7 +7712,7 @@ impl Serialize for DeviceCtlDataAbsArea {
         self.following.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DeviceCtlData {
     Resolution(DeviceCtlDataResolution),
     AbsCalib(DeviceCtlDataAbsCalib),
@@ -7840,7 +7840,7 @@ impl DeviceCtlData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceCtl {
     pub len: u16,
     pub data: DeviceCtlData,
@@ -7872,7 +7872,7 @@ impl Serialize for DeviceCtl {
 
 /// Opcode for the ChangeDeviceControl request
 pub const CHANGE_DEVICE_CONTROL_REQUEST: u8 = 35;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeDeviceControlRequest {
     pub control_id: DeviceControl,
     pub device_id: u8,
@@ -7936,7 +7936,7 @@ impl crate::x11_utils::ReplyRequest for ChangeDeviceControlRequest {
     type Reply = ChangeDeviceControlReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeDeviceControlReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -7965,7 +7965,7 @@ impl TryParse for ChangeDeviceControlReply {
 
 /// Opcode for the ListDeviceProperties request
 pub const LIST_DEVICE_PROPERTIES_REQUEST: u8 = 36;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListDevicePropertiesRequest {
     pub device_id: u8,
 }
@@ -8017,7 +8017,7 @@ impl crate::x11_utils::ReplyRequest for ListDevicePropertiesRequest {
     type Reply = ListDevicePropertiesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListDevicePropertiesReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -8060,7 +8060,7 @@ impl ListDevicePropertiesReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PropertyFormat(u8);
 impl PropertyFormat {
     pub const M8_BITS: Self = Self(8);
@@ -8120,7 +8120,7 @@ impl std::fmt::Debug for PropertyFormat  {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ChangeDevicePropertyAux {
     Data8(Vec<u8>),
     Data16(Vec<u16>),
@@ -8239,7 +8239,7 @@ impl ChangeDevicePropertyAux {
 
 /// Opcode for the ChangeDeviceProperty request
 pub const CHANGE_DEVICE_PROPERTY_REQUEST: u8 = 37;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeDevicePropertyRequest<'input> {
     pub property: xproto::Atom,
     pub type_: xproto::Atom,
@@ -8342,7 +8342,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeDevicePropertyRequest<'inpu
 
 /// Opcode for the DeleteDeviceProperty request
 pub const DELETE_DEVICE_PROPERTY_REQUEST: u8 = 38;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeleteDevicePropertyRequest {
     pub property: xproto::Atom,
     pub device_id: u8,
@@ -8403,7 +8403,7 @@ impl crate::x11_utils::VoidRequest for DeleteDevicePropertyRequest {
 
 /// Opcode for the GetDeviceProperty request
 pub const GET_DEVICE_PROPERTY_REQUEST: u8 = 39;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDevicePropertyRequest {
     pub property: xproto::Atom,
     pub type_: xproto::Atom,
@@ -8491,7 +8491,7 @@ impl crate::x11_utils::ReplyRequest for GetDevicePropertyRequest {
     type Reply = GetDevicePropertyReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum GetDevicePropertyItems {
     Data8(Vec<u8>),
     Data16(Vec<u16>),
@@ -8570,7 +8570,7 @@ impl GetDevicePropertyItems {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDevicePropertyReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -8606,7 +8606,7 @@ impl TryParse for GetDevicePropertyReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Device(bool);
 impl Device {
     pub const ALL: Self = Self(false);
@@ -8676,7 +8676,7 @@ impl std::fmt::Debug for Device  {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GroupInfo {
     pub base: u8,
     pub latched: u8,
@@ -8716,7 +8716,7 @@ impl Serialize for GroupInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModifierInfo {
     pub base: u32,
     pub latched: u32,
@@ -8770,7 +8770,7 @@ impl Serialize for ModifierInfo {
 
 /// Opcode for the XIQueryPointer request
 pub const XI_QUERY_POINTER_REQUEST: u8 = 40;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIQueryPointerRequest {
     pub window: xproto::Window,
     pub deviceid: DeviceId,
@@ -8830,7 +8830,7 @@ impl crate::x11_utils::ReplyRequest for XIQueryPointerRequest {
     type Reply = XIQueryPointerReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIQueryPointerReply {
     pub sequence: u16,
     pub length: u32,
@@ -8892,7 +8892,7 @@ impl XIQueryPointerReply {
 
 /// Opcode for the XIWarpPointer request
 pub const XI_WARP_POINTER_REQUEST: u8 = 41;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIWarpPointerRequest {
     pub src_win: xproto::Window,
     pub dst_win: xproto::Window,
@@ -9005,7 +9005,7 @@ impl crate::x11_utils::VoidRequest for XIWarpPointerRequest {
 
 /// Opcode for the XIChangeCursor request
 pub const XI_CHANGE_CURSOR_REQUEST: u8 = 42;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIChangeCursorRequest {
     pub window: xproto::Window,
     pub cursor: xproto::Cursor,
@@ -9072,7 +9072,7 @@ impl Request for XIChangeCursorRequest {
 impl crate::x11_utils::VoidRequest for XIChangeCursorRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HierarchyChangeType(u16);
 impl HierarchyChangeType {
     pub const ADD_MASTER: Self = Self(1);
@@ -9128,7 +9128,7 @@ impl std::fmt::Debug for HierarchyChangeType  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeMode(u8);
 impl ChangeMode {
     pub const ATTACH: Self = Self(1);
@@ -9186,7 +9186,7 @@ impl std::fmt::Debug for ChangeMode  {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AddMaster {
     pub type_: HierarchyChangeType,
     pub len: u16,
@@ -9248,7 +9248,7 @@ impl AddMaster {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RemoveMaster {
     pub type_: HierarchyChangeType,
     pub len: u16,
@@ -9308,7 +9308,7 @@ impl Serialize for RemoveMaster {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AttachSlave {
     pub type_: HierarchyChangeType,
     pub len: u16,
@@ -9353,7 +9353,7 @@ impl Serialize for AttachSlave {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DetachSlave {
     pub type_: HierarchyChangeType,
     pub len: u16,
@@ -9396,7 +9396,7 @@ impl Serialize for DetachSlave {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HierarchyChangeDataAddMaster {
     pub send_core: bool,
     pub enable: bool,
@@ -9450,7 +9450,7 @@ impl HierarchyChangeDataAddMaster {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HierarchyChangeDataRemoveMaster {
     pub deviceid: DeviceId,
     pub return_mode: ChangeMode,
@@ -9496,7 +9496,7 @@ impl Serialize for HierarchyChangeDataRemoveMaster {
         self.return_keyboard.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HierarchyChangeDataAttachSlave {
     pub deviceid: DeviceId,
     pub master: DeviceId,
@@ -9527,7 +9527,7 @@ impl Serialize for HierarchyChangeDataAttachSlave {
         self.master.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HierarchyChangeDataDetachSlave {
     pub deviceid: DeviceId,
 }
@@ -9556,7 +9556,7 @@ impl Serialize for HierarchyChangeDataDetachSlave {
         bytes.extend_from_slice(&[0; 2]);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum HierarchyChangeData {
     AddMaster(HierarchyChangeDataAddMaster),
     RemoveMaster(HierarchyChangeDataRemoveMaster),
@@ -9663,7 +9663,7 @@ impl HierarchyChangeData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HierarchyChange {
     pub len: u16,
     pub data: HierarchyChangeData,
@@ -9695,7 +9695,7 @@ impl Serialize for HierarchyChange {
 
 /// Opcode for the XIChangeHierarchy request
 pub const XI_CHANGE_HIERARCHY_REQUEST: u8 = 43;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIChangeHierarchyRequest<'input> {
     pub changes: Cow<'input, [HierarchyChange]>,
 }
@@ -9760,7 +9760,7 @@ impl<'input> crate::x11_utils::VoidRequest for XIChangeHierarchyRequest<'input> 
 
 /// Opcode for the XISetClientPointer request
 pub const XI_SET_CLIENT_POINTER_REQUEST: u8 = 44;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XISetClientPointerRequest {
     pub window: xproto::Window,
     pub deviceid: DeviceId,
@@ -9821,7 +9821,7 @@ impl crate::x11_utils::VoidRequest for XISetClientPointerRequest {
 
 /// Opcode for the XIGetClientPointer request
 pub const XI_GET_CLIENT_POINTER_REQUEST: u8 = 45;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIGetClientPointerRequest {
     pub window: xproto::Window,
 }
@@ -9872,7 +9872,7 @@ impl crate::x11_utils::ReplyRequest for XIGetClientPointerRequest {
     type Reply = XIGetClientPointerReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIGetClientPointerReply {
     pub sequence: u16,
     pub length: u32,
@@ -9901,7 +9901,7 @@ impl TryParse for XIGetClientPointerReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIEventMask(u32);
 impl XIEventMask {
     pub const DEVICE_CHANGED: Self = Self(1 << 1);
@@ -9996,7 +9996,7 @@ impl std::fmt::Debug for XIEventMask  {
 }
 bitmask_binop!(XIEventMask, u32);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EventMask {
     pub deviceid: DeviceId,
     pub mask: Vec<u32>,
@@ -10043,7 +10043,7 @@ impl EventMask {
 
 /// Opcode for the XISelectEvents request
 pub const XI_SELECT_EVENTS_REQUEST: u8 = 46;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XISelectEventsRequest<'input> {
     pub window: xproto::Window,
     pub masks: Cow<'input, [EventMask]>,
@@ -10117,7 +10117,7 @@ impl<'input> crate::x11_utils::VoidRequest for XISelectEventsRequest<'input> {
 
 /// Opcode for the XIQueryVersion request
 pub const XI_QUERY_VERSION_REQUEST: u8 = 47;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIQueryVersionRequest {
     pub major_version: u16,
     pub minor_version: u16,
@@ -10172,7 +10172,7 @@ impl crate::x11_utils::ReplyRequest for XIQueryVersionRequest {
     type Reply = XIQueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIQueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -10200,7 +10200,7 @@ impl TryParse for XIQueryVersionReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceClassType(u16);
 impl DeviceClassType {
     pub const KEY: Self = Self(0);
@@ -10258,7 +10258,7 @@ impl std::fmt::Debug for DeviceClassType  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceType(u16);
 impl DeviceType {
     pub const MASTER_POINTER: Self = Self(1);
@@ -10316,7 +10316,7 @@ impl std::fmt::Debug for DeviceType  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScrollFlags(u8);
 impl ScrollFlags {
     pub const NO_EMULATION: Self = Self(1 << 0);
@@ -10375,7 +10375,7 @@ impl std::fmt::Debug for ScrollFlags  {
 }
 bitmask_binop!(ScrollFlags, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScrollType(u16);
 impl ScrollType {
     pub const VERTICAL: Self = Self(1);
@@ -10427,7 +10427,7 @@ impl std::fmt::Debug for ScrollType  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TouchMode(u8);
 impl TouchMode {
     pub const DIRECT: Self = Self(1);
@@ -10485,7 +10485,7 @@ impl std::fmt::Debug for TouchMode  {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ButtonClass {
     pub type_: DeviceClassType,
     pub len: u16,
@@ -10541,7 +10541,7 @@ impl ButtonClass {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyClass {
     pub type_: DeviceClassType,
     pub len: u16,
@@ -10593,7 +10593,7 @@ impl KeyClass {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScrollClass {
     pub type_: DeviceClassType,
     pub len: u16,
@@ -10669,7 +10669,7 @@ impl Serialize for ScrollClass {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TouchClass {
     pub type_: DeviceClassType,
     pub len: u16,
@@ -10719,7 +10719,7 @@ impl Serialize for TouchClass {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ValuatorClass {
     pub type_: DeviceClassType,
     pub len: u16,
@@ -10827,7 +10827,7 @@ impl Serialize for ValuatorClass {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceClassDataKey {
     pub keys: Vec<u32>,
 }
@@ -10867,7 +10867,7 @@ impl DeviceClassDataKey {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceClassDataButton {
     pub state: Vec<u32>,
     pub labels: Vec<xproto::Atom>,
@@ -10911,7 +10911,7 @@ impl DeviceClassDataButton {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceClassDataValuator {
     pub number: u16,
     pub label: xproto::Atom,
@@ -10999,7 +10999,7 @@ impl Serialize for DeviceClassDataValuator {
         bytes.extend_from_slice(&[0; 3]);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceClassDataScroll {
     pub number: u16,
     pub scroll_type: ScrollType,
@@ -11055,7 +11055,7 @@ impl Serialize for DeviceClassDataScroll {
         self.increment.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceClassDataTouch {
     pub mode: TouchMode,
     pub num_touches: u8,
@@ -11085,7 +11085,7 @@ impl Serialize for DeviceClassDataTouch {
         self.num_touches.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DeviceClassData {
     Key(DeviceClassDataKey),
     Button(DeviceClassDataButton),
@@ -11207,7 +11207,7 @@ impl DeviceClassData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceClass {
     pub len: u16,
     pub sourceid: DeviceId,
@@ -11240,7 +11240,7 @@ impl Serialize for DeviceClass {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIDeviceInfo {
     pub deviceid: DeviceId,
     pub type_: DeviceType,
@@ -11325,7 +11325,7 @@ impl XIDeviceInfo {
 
 /// Opcode for the XIQueryDevice request
 pub const XI_QUERY_DEVICE_REQUEST: u8 = 48;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIQueryDeviceRequest {
     pub deviceid: DeviceId,
 }
@@ -11377,7 +11377,7 @@ impl crate::x11_utils::ReplyRequest for XIQueryDeviceRequest {
     type Reply = XIQueryDeviceReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIQueryDeviceReply {
     pub sequence: u16,
     pub length: u32,
@@ -11421,7 +11421,7 @@ impl XIQueryDeviceReply {
 
 /// Opcode for the XISetFocus request
 pub const XI_SET_FOCUS_REQUEST: u8 = 49;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XISetFocusRequest {
     pub window: xproto::Window,
     pub time: xproto::Timestamp,
@@ -11490,7 +11490,7 @@ impl crate::x11_utils::VoidRequest for XISetFocusRequest {
 
 /// Opcode for the XIGetFocus request
 pub const XI_GET_FOCUS_REQUEST: u8 = 50;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIGetFocusRequest {
     pub deviceid: DeviceId,
 }
@@ -11542,7 +11542,7 @@ impl crate::x11_utils::ReplyRequest for XIGetFocusRequest {
     type Reply = XIGetFocusReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIGetFocusReply {
     pub sequence: u16,
     pub length: u32,
@@ -11568,7 +11568,7 @@ impl TryParse for XIGetFocusReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabOwner(bool);
 impl GrabOwner {
     pub const NO_OWNER: Self = Self(false);
@@ -11640,7 +11640,7 @@ impl std::fmt::Debug for GrabOwner  {
 
 /// Opcode for the XIGrabDevice request
 pub const XI_GRAB_DEVICE_REQUEST: u8 = 51;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIGrabDeviceRequest<'input> {
     pub window: xproto::Window,
     pub time: xproto::Timestamp,
@@ -11758,7 +11758,7 @@ impl<'input> crate::x11_utils::ReplyRequest for XIGrabDeviceRequest<'input> {
     type Reply = XIGrabDeviceReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIGrabDeviceReply {
     pub sequence: u16,
     pub length: u32,
@@ -11787,7 +11787,7 @@ impl TryParse for XIGrabDeviceReply {
 
 /// Opcode for the XIUngrabDevice request
 pub const XI_UNGRAB_DEVICE_REQUEST: u8 = 52;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIUngrabDeviceRequest {
     pub time: xproto::Timestamp,
     pub deviceid: DeviceId,
@@ -11846,7 +11846,7 @@ impl Request for XIUngrabDeviceRequest {
 impl crate::x11_utils::VoidRequest for XIUngrabDeviceRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EventMode(u8);
 impl EventMode {
     pub const ASYNC_DEVICE: Self = Self(0);
@@ -11918,7 +11918,7 @@ impl std::fmt::Debug for EventMode  {
 
 /// Opcode for the XIAllowEvents request
 pub const XI_ALLOW_EVENTS_REQUEST: u8 = 53;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIAllowEventsRequest {
     pub time: xproto::Timestamp,
     pub deviceid: DeviceId,
@@ -11998,7 +11998,7 @@ impl Request for XIAllowEventsRequest {
 impl crate::x11_utils::VoidRequest for XIAllowEventsRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabMode22(u8);
 impl GrabMode22 {
     pub const SYNC: Self = Self(0);
@@ -12058,7 +12058,7 @@ impl std::fmt::Debug for GrabMode22  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabType(u8);
 impl GrabType {
     pub const BUTTON: Self = Self(0);
@@ -12122,7 +12122,7 @@ impl std::fmt::Debug for GrabType  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModifierMask(u32);
 impl ModifierMask {
     pub const ANY: Self = Self(1 << 31);
@@ -12167,7 +12167,7 @@ impl std::fmt::Debug for ModifierMask  {
 }
 bitmask_binop!(ModifierMask, u32);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabModifierInfo {
     pub modifiers: u32,
     pub status: xproto::GrabStatus,
@@ -12208,7 +12208,7 @@ impl Serialize for GrabModifierInfo {
 
 /// Opcode for the XIPassiveGrabDevice request
 pub const XI_PASSIVE_GRAB_DEVICE_REQUEST: u8 = 54;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIPassiveGrabDeviceRequest<'input> {
     pub time: xproto::Timestamp,
     pub grab_window: xproto::Window,
@@ -12354,7 +12354,7 @@ impl<'input> crate::x11_utils::ReplyRequest for XIPassiveGrabDeviceRequest<'inpu
     type Reply = XIPassiveGrabDeviceReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIPassiveGrabDeviceReply {
     pub sequence: u16,
     pub length: u32,
@@ -12398,7 +12398,7 @@ impl XIPassiveGrabDeviceReply {
 
 /// Opcode for the XIPassiveUngrabDevice request
 pub const XI_PASSIVE_UNGRAB_DEVICE_REQUEST: u8 = 55;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIPassiveUngrabDeviceRequest<'input> {
     pub grab_window: xproto::Window,
     pub detail: u32,
@@ -12496,7 +12496,7 @@ impl<'input> crate::x11_utils::VoidRequest for XIPassiveUngrabDeviceRequest<'inp
 
 /// Opcode for the XIListProperties request
 pub const XI_LIST_PROPERTIES_REQUEST: u8 = 56;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIListPropertiesRequest {
     pub deviceid: DeviceId,
 }
@@ -12548,7 +12548,7 @@ impl crate::x11_utils::ReplyRequest for XIListPropertiesRequest {
     type Reply = XIListPropertiesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIListPropertiesReply {
     pub sequence: u16,
     pub length: u32,
@@ -12590,7 +12590,7 @@ impl XIListPropertiesReply {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum XIChangePropertyAux {
     Data8(Vec<u8>),
     Data16(Vec<u16>),
@@ -12709,7 +12709,7 @@ impl XIChangePropertyAux {
 
 /// Opcode for the XIChangeProperty request
 pub const XI_CHANGE_PROPERTY_REQUEST: u8 = 57;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIChangePropertyRequest<'input> {
     pub deviceid: DeviceId,
     pub mode: xproto::PropMode,
@@ -12811,7 +12811,7 @@ impl<'input> crate::x11_utils::VoidRequest for XIChangePropertyRequest<'input> {
 
 /// Opcode for the XIDeleteProperty request
 pub const XI_DELETE_PROPERTY_REQUEST: u8 = 58;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIDeletePropertyRequest {
     pub deviceid: DeviceId,
     pub property: xproto::Atom,
@@ -12872,7 +12872,7 @@ impl crate::x11_utils::VoidRequest for XIDeletePropertyRequest {
 
 /// Opcode for the XIGetProperty request
 pub const XI_GET_PROPERTY_REQUEST: u8 = 59;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIGetPropertyRequest {
     pub deviceid: DeviceId,
     pub delete: bool,
@@ -12960,7 +12960,7 @@ impl crate::x11_utils::ReplyRequest for XIGetPropertyRequest {
     type Reply = XIGetPropertyReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum XIGetPropertyItems {
     Data8(Vec<u8>),
     Data16(Vec<u16>),
@@ -13039,7 +13039,7 @@ impl XIGetPropertyItems {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIGetPropertyReply {
     pub sequence: u16,
     pub length: u32,
@@ -13074,7 +13074,7 @@ impl TryParse for XIGetPropertyReply {
 
 /// Opcode for the XIGetSelectedEvents request
 pub const XI_GET_SELECTED_EVENTS_REQUEST: u8 = 60;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIGetSelectedEventsRequest {
     pub window: xproto::Window,
 }
@@ -13125,7 +13125,7 @@ impl crate::x11_utils::ReplyRequest for XIGetSelectedEventsRequest {
     type Reply = XIGetSelectedEventsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIGetSelectedEventsReply {
     pub sequence: u16,
     pub length: u32,
@@ -13167,7 +13167,7 @@ impl XIGetSelectedEventsReply {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BarrierReleasePointerInfo {
     pub deviceid: DeviceId,
     pub barrier: xfixes::Barrier,
@@ -13215,7 +13215,7 @@ impl Serialize for BarrierReleasePointerInfo {
 
 /// Opcode for the XIBarrierReleasePointer request
 pub const XI_BARRIER_RELEASE_POINTER_REQUEST: u8 = 61;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIBarrierReleasePointerRequest<'input> {
     pub barriers: Cow<'input, [BarrierReleasePointerInfo]>,
 }
@@ -13279,7 +13279,7 @@ impl<'input> crate::x11_utils::VoidRequest for XIBarrierReleasePointerRequest<'i
 
 /// Opcode for the DeviceValuator event
 pub const DEVICE_VALUATOR_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceValuatorEvent {
     pub response_type: u8,
     pub device_id: u8,
@@ -13375,7 +13375,7 @@ impl From<DeviceValuatorEvent> for [u8; 32] {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MoreEventsMask(u8);
 impl MoreEventsMask {
     pub const MORE_EVENTS: Self = Self(1 << 7);
@@ -13434,7 +13434,7 @@ bitmask_binop!(MoreEventsMask, u8);
 
 /// Opcode for the DeviceKeyPress event
 pub const DEVICE_KEY_PRESS_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceKeyPressEvent {
     pub response_type: u8,
     pub detail: u8,
@@ -13551,7 +13551,7 @@ pub type DeviceMotionNotifyEvent = DeviceKeyPressEvent;
 
 /// Opcode for the DeviceFocusIn event
 pub const DEVICE_FOCUS_IN_EVENT: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceFocusInEvent {
     pub response_type: u8,
     pub detail: xproto::NotifyDetail,
@@ -13644,7 +13644,7 @@ pub type ProximityInEvent = DeviceKeyPressEvent;
 pub const PROXIMITY_OUT_EVENT: u8 = 9;
 pub type ProximityOutEvent = DeviceKeyPressEvent;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClassesReportedMask(u8);
 impl ClassesReportedMask {
     pub const OUT_OF_PROXIMITY: Self = Self(1 << 7);
@@ -13711,7 +13711,7 @@ bitmask_binop!(ClassesReportedMask, u8);
 
 /// Opcode for the DeviceStateNotify event
 pub const DEVICE_STATE_NOTIFY_EVENT: u8 = 10;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceStateNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
@@ -13812,7 +13812,7 @@ impl From<DeviceStateNotifyEvent> for [u8; 32] {
 
 /// Opcode for the DeviceMappingNotify event
 pub const DEVICE_MAPPING_NOTIFY_EVENT: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceMappingNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
@@ -13893,7 +13893,7 @@ impl From<DeviceMappingNotifyEvent> for [u8; 32] {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeDevice(u8);
 impl ChangeDevice {
     pub const NEW_POINTER: Self = Self(0);
@@ -13953,7 +13953,7 @@ impl std::fmt::Debug for ChangeDevice  {
 
 /// Opcode for the ChangeDeviceNotify event
 pub const CHANGE_DEVICE_NOTIFY_EVENT: u8 = 12;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeDeviceNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
@@ -14029,7 +14029,7 @@ impl From<ChangeDeviceNotifyEvent> for [u8; 32] {
 
 /// Opcode for the DeviceKeyStateNotify event
 pub const DEVICE_KEY_STATE_NOTIFY_EVENT: u8 = 13;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceKeyStateNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
@@ -14100,7 +14100,7 @@ impl From<DeviceKeyStateNotifyEvent> for [u8; 32] {
 
 /// Opcode for the DeviceButtonStateNotify event
 pub const DEVICE_BUTTON_STATE_NOTIFY_EVENT: u8 = 14;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceButtonStateNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
@@ -14169,7 +14169,7 @@ impl From<DeviceButtonStateNotifyEvent> for [u8; 32] {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceChange(u8);
 impl DeviceChange {
     pub const ADDED: Self = Self(0);
@@ -14237,7 +14237,7 @@ impl std::fmt::Debug for DeviceChange  {
 
 /// Opcode for the DevicePresenceNotify event
 pub const DEVICE_PRESENCE_NOTIFY_EVENT: u8 = 15;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DevicePresenceNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -14317,7 +14317,7 @@ impl From<DevicePresenceNotifyEvent> for [u8; 32] {
 
 /// Opcode for the DevicePropertyNotify event
 pub const DEVICE_PROPERTY_NOTIFY_EVENT: u8 = 16;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DevicePropertyNotifyEvent {
     pub response_type: u8,
     pub state: xproto::Property,
@@ -14394,7 +14394,7 @@ impl From<DevicePropertyNotifyEvent> for [u8; 32] {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeReason(u8);
 impl ChangeReason {
     pub const SLAVE_SWITCH: Self = Self(1);
@@ -14454,7 +14454,7 @@ impl std::fmt::Debug for ChangeReason  {
 
 /// Opcode for the DeviceChanged event
 pub const DEVICE_CHANGED_EVENT: u16 = 1;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceChangedEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -14506,7 +14506,7 @@ impl DeviceChangedEvent {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyEventFlags(u32);
 impl KeyEventFlags {
     pub const KEY_REPEAT: Self = Self(1 << 16);
@@ -14553,7 +14553,7 @@ bitmask_binop!(KeyEventFlags, u32);
 
 /// Opcode for the KeyPress event
 pub const KEY_PRESS_EVENT: u16 = 2;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyPressEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -14646,7 +14646,7 @@ impl KeyPressEvent {
 pub const KEY_RELEASE_EVENT: u16 = 3;
 pub type KeyReleaseEvent = KeyPressEvent;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PointerEventFlags(u32);
 impl PointerEventFlags {
     pub const POINTER_EMULATED: Self = Self(1 << 16);
@@ -14693,7 +14693,7 @@ bitmask_binop!(PointerEventFlags, u32);
 
 /// Opcode for the ButtonPress event
 pub const BUTTON_PRESS_EVENT: u16 = 4;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ButtonPressEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -14790,7 +14790,7 @@ pub type ButtonReleaseEvent = ButtonPressEvent;
 pub const MOTION_EVENT: u16 = 6;
 pub type MotionEvent = ButtonPressEvent;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotifyMode(u8);
 impl NotifyMode {
     pub const NORMAL: Self = Self(0);
@@ -14856,7 +14856,7 @@ impl std::fmt::Debug for NotifyMode  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotifyDetail(u8);
 impl NotifyDetail {
     pub const ANCESTOR: Self = Self(0);
@@ -14928,7 +14928,7 @@ impl std::fmt::Debug for NotifyDetail  {
 
 /// Opcode for the Enter event
 pub const ENTER_EVENT: u16 = 7;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EnterEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15016,7 +15016,7 @@ pub type FocusInEvent = EnterEvent;
 pub const FOCUS_OUT_EVENT: u16 = 10;
 pub type FocusOutEvent = EnterEvent;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HierarchyMask(u8);
 impl HierarchyMask {
     pub const MASTER_ADDED: Self = Self(1 << 0);
@@ -15087,7 +15087,7 @@ impl std::fmt::Debug for HierarchyMask  {
 }
 bitmask_binop!(HierarchyMask, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HierarchyInfo {
     pub deviceid: DeviceId,
     pub attachment: DeviceId,
@@ -15144,7 +15144,7 @@ impl Serialize for HierarchyInfo {
 
 /// Opcode for the Hierarchy event
 pub const HIERARCHY_EVENT: u16 = 11;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HierarchyEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15193,7 +15193,7 @@ impl HierarchyEvent {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PropertyFlag(u8);
 impl PropertyFlag {
     pub const DELETED: Self = Self(0);
@@ -15255,7 +15255,7 @@ impl std::fmt::Debug for PropertyFlag  {
 
 /// Opcode for the Property event
 pub const PROPERTY_EVENT: u16 = 12;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PropertyEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15291,7 +15291,7 @@ impl TryParse for PropertyEvent {
 
 /// Opcode for the RawKeyPress event
 pub const RAW_KEY_PRESS_EVENT: u16 = 13;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RawKeyPressEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15354,7 +15354,7 @@ pub type RawKeyReleaseEvent = RawKeyPressEvent;
 
 /// Opcode for the RawButtonPress event
 pub const RAW_BUTTON_PRESS_EVENT: u16 = 15;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RawButtonPressEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15419,7 +15419,7 @@ pub type RawButtonReleaseEvent = RawButtonPressEvent;
 pub const RAW_MOTION_EVENT: u16 = 17;
 pub type RawMotionEvent = RawButtonPressEvent;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TouchEventFlags(u32);
 impl TouchEventFlags {
     pub const TOUCH_PENDING_END: Self = Self(1 << 16);
@@ -15468,7 +15468,7 @@ bitmask_binop!(TouchEventFlags, u32);
 
 /// Opcode for the TouchBegin event
 pub const TOUCH_BEGIN_EVENT: u16 = 18;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TouchBeginEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15565,7 +15565,7 @@ pub type TouchUpdateEvent = TouchBeginEvent;
 pub const TOUCH_END_EVENT: u16 = 20;
 pub type TouchEndEvent = TouchBeginEvent;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TouchOwnershipFlags(u32);
 impl TouchOwnershipFlags {
     pub const NONE: Self = Self(0);
@@ -15611,7 +15611,7 @@ impl std::fmt::Debug for TouchOwnershipFlags  {
 
 /// Opcode for the TouchOwnership event
 pub const TOUCH_OWNERSHIP_EVENT: u16 = 21;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TouchOwnershipEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15656,7 +15656,7 @@ impl TryParse for TouchOwnershipEvent {
 
 /// Opcode for the RawTouchBegin event
 pub const RAW_TOUCH_BEGIN_EVENT: u16 = 22;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RawTouchBeginEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15721,7 +15721,7 @@ pub type RawTouchUpdateEvent = RawTouchBeginEvent;
 pub const RAW_TOUCH_END_EVENT: u16 = 24;
 pub type RawTouchEndEvent = RawTouchBeginEvent;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BarrierFlags(u8);
 impl BarrierFlags {
     pub const POINTER_RELEASED: Self = Self(1 << 0);
@@ -15782,7 +15782,7 @@ bitmask_binop!(BarrierFlags, u8);
 
 /// Opcode for the BarrierHit event
 pub const BARRIER_HIT_EVENT: u16 = 25;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BarrierHitEvent {
     pub response_type: u8,
     pub extension: u8,

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -32,7 +32,7 @@ pub const X11_EXTENSION_NAME: &str = "XKEYBOARD";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Const(u8);
 impl Const {
     pub const MAX_LEGAL_KEY_CODE: Self = Self(255);
@@ -92,7 +92,7 @@ impl std::fmt::Debug for Const  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EventType(u16);
 impl EventType {
     pub const NEW_KEYBOARD_NOTIFY: Self = Self(1 << 0);
@@ -165,7 +165,7 @@ impl std::fmt::Debug for EventType  {
 }
 bitmask_binop!(EventType, u16);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NKNDetail(u8);
 impl NKNDetail {
     pub const KEYCODES: Self = Self(1 << 0);
@@ -226,7 +226,7 @@ impl std::fmt::Debug for NKNDetail  {
 }
 bitmask_binop!(NKNDetail, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AXNDetail(u8);
 impl AXNDetail {
     pub const SK_PRESS: Self = Self(1 << 0);
@@ -295,7 +295,7 @@ impl std::fmt::Debug for AXNDetail  {
 }
 bitmask_binop!(AXNDetail, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MapPart(u8);
 impl MapPart {
     pub const KEY_TYPES: Self = Self(1 << 0);
@@ -366,7 +366,7 @@ impl std::fmt::Debug for MapPart  {
 }
 bitmask_binop!(MapPart, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetMapFlags(u8);
 impl SetMapFlags {
     pub const RESIZE_TYPES: Self = Self(1 << 0);
@@ -425,7 +425,7 @@ impl std::fmt::Debug for SetMapFlags  {
 }
 bitmask_binop!(SetMapFlags, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StatePart(u16);
 impl StatePart {
     pub const MODIFIER_STATE: Self = Self(1 << 0);
@@ -502,7 +502,7 @@ impl std::fmt::Debug for StatePart  {
 }
 bitmask_binop!(StatePart, u16);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BoolCtrl(u16);
 impl BoolCtrl {
     pub const REPEAT_KEYS: Self = Self(1 << 0);
@@ -577,7 +577,7 @@ impl std::fmt::Debug for BoolCtrl  {
 }
 bitmask_binop!(BoolCtrl, u16);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Control(u32);
 impl Control {
     pub const GROUPS_WRAP: Self = Self(1 << 27);
@@ -630,7 +630,7 @@ impl std::fmt::Debug for Control  {
 }
 bitmask_binop!(Control, u32);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AXOption(u16);
 impl AXOption {
     pub const SK_PRESS_FB: Self = Self(1 << 0);
@@ -705,7 +705,7 @@ bitmask_binop!(AXOption, u16);
 
 pub type DeviceSpec = u16;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LedClassResult(u16);
 impl LedClassResult {
     pub const KBD_FEEDBACK_CLASS: Self = Self(0);
@@ -757,7 +757,7 @@ impl std::fmt::Debug for LedClassResult  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LedClass(u16);
 impl LedClass {
     pub const KBD_FEEDBACK_CLASS: Self = Self(0);
@@ -815,7 +815,7 @@ impl std::fmt::Debug for LedClass  {
 
 pub type LedClassSpec = u16;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BellClassResult(u8);
 impl BellClassResult {
     pub const KBD_FEEDBACK_CLASS: Self = Self(0);
@@ -873,7 +873,7 @@ impl std::fmt::Debug for BellClassResult  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BellClass(u16);
 impl BellClass {
     pub const KBD_FEEDBACK_CLASS: Self = Self(0);
@@ -929,7 +929,7 @@ impl std::fmt::Debug for BellClass  {
 
 pub type BellClassSpec = u16;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ID(u16);
 impl ID {
     pub const USE_CORE_KBD: Self = Self(256);
@@ -993,7 +993,7 @@ impl std::fmt::Debug for ID  {
 
 pub type IDSpec = u16;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Group(u8);
 impl Group {
     pub const M1: Self = Self(0);
@@ -1055,7 +1055,7 @@ impl std::fmt::Debug for Group  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Groups(u8);
 impl Groups {
     pub const ANY: Self = Self(254);
@@ -1113,7 +1113,7 @@ impl std::fmt::Debug for Groups  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetOfGroup(u8);
 impl SetOfGroup {
     pub const GROUP1: Self = Self(1 << 0);
@@ -1176,7 +1176,7 @@ impl std::fmt::Debug for SetOfGroup  {
 }
 bitmask_binop!(SetOfGroup, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetOfGroups(u8);
 impl SetOfGroups {
     pub const ANY: Self = Self(1 << 7);
@@ -1233,7 +1233,7 @@ impl std::fmt::Debug for SetOfGroups  {
 }
 bitmask_binop!(SetOfGroups, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GroupsWrap(u8);
 impl GroupsWrap {
     pub const WRAP_INTO_RANGE: Self = Self(0);
@@ -1294,7 +1294,7 @@ impl std::fmt::Debug for GroupsWrap  {
 }
 bitmask_binop!(GroupsWrap, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VModsHigh(u8);
 impl VModsHigh {
     pub const M15: Self = Self(1 << 7);
@@ -1365,7 +1365,7 @@ impl std::fmt::Debug for VModsHigh  {
 }
 bitmask_binop!(VModsHigh, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VModsLow(u8);
 impl VModsLow {
     pub const M7: Self = Self(1 << 7);
@@ -1436,7 +1436,7 @@ impl std::fmt::Debug for VModsLow  {
 }
 bitmask_binop!(VModsLow, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VMod(u16);
 impl VMod {
     pub const M15: Self = Self(1 << 15);
@@ -1517,7 +1517,7 @@ impl std::fmt::Debug for VMod  {
 }
 bitmask_binop!(VMod, u16);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Explicit(u8);
 impl Explicit {
     pub const V_MOD_MAP: Self = Self(1 << 7);
@@ -1588,7 +1588,7 @@ impl std::fmt::Debug for Explicit  {
 }
 bitmask_binop!(Explicit, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SymInterpretMatch(u8);
 impl SymInterpretMatch {
     pub const NONE_OF: Self = Self(0);
@@ -1652,7 +1652,7 @@ impl std::fmt::Debug for SymInterpretMatch  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SymInterpMatch(u8);
 impl SymInterpMatch {
     pub const LEVEL_ONE_ONLY: Self = Self(1 << 7);
@@ -1710,7 +1710,7 @@ impl std::fmt::Debug for SymInterpMatch  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IMFlag(u8);
 impl IMFlag {
     pub const NO_EXPLICIT: Self = Self(1 << 7);
@@ -1771,7 +1771,7 @@ impl std::fmt::Debug for IMFlag  {
 }
 bitmask_binop!(IMFlag, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IMModsWhich(u8);
 impl IMModsWhich {
     pub const USE_COMPAT: Self = Self(1 << 4);
@@ -1836,7 +1836,7 @@ impl std::fmt::Debug for IMModsWhich  {
 }
 bitmask_binop!(IMModsWhich, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IMGroupsWhich(u8);
 impl IMGroupsWhich {
     pub const USE_COMPAT: Self = Self(1 << 4);
@@ -1901,7 +1901,7 @@ impl std::fmt::Debug for IMGroupsWhich  {
 }
 bitmask_binop!(IMGroupsWhich, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IndicatorMap {
     pub flags: IMFlag,
     pub which_groups: IMGroupsWhich,
@@ -1969,7 +1969,7 @@ impl Serialize for IndicatorMap {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CMDetail(u8);
 impl CMDetail {
     pub const SYM_INTERP: Self = Self(1 << 0);
@@ -2028,7 +2028,7 @@ impl std::fmt::Debug for CMDetail  {
 }
 bitmask_binop!(CMDetail, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NameDetail(u16);
 impl NameDetail {
     pub const KEYCODES: Self = Self(1 << 0);
@@ -2105,7 +2105,7 @@ impl std::fmt::Debug for NameDetail  {
 }
 bitmask_binop!(NameDetail, u16);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GBNDetail(u8);
 impl GBNDetail {
     pub const TYPES: Self = Self(1 << 0);
@@ -2176,7 +2176,7 @@ impl std::fmt::Debug for GBNDetail  {
 }
 bitmask_binop!(GBNDetail, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct XIFeature(u8);
 impl XIFeature {
     pub const KEYBOARDS: Self = Self(1 << 0);
@@ -2241,7 +2241,7 @@ impl std::fmt::Debug for XIFeature  {
 }
 bitmask_binop!(XIFeature, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PerClientFlag(u8);
 impl PerClientFlag {
     pub const DETECTABLE_AUTO_REPEAT: Self = Self(1 << 0);
@@ -2306,7 +2306,7 @@ impl std::fmt::Debug for PerClientFlag  {
 }
 bitmask_binop!(PerClientFlag, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModDef {
     pub mask: u8,
     pub real_mods: u8,
@@ -2342,7 +2342,7 @@ impl Serialize for ModDef {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyName {
     pub name: [u8; 4],
 }
@@ -2370,7 +2370,7 @@ impl Serialize for KeyName {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyAlias {
     pub real: [u8; 4],
     pub alias: [u8; 4],
@@ -2406,7 +2406,7 @@ impl Serialize for KeyAlias {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CountedString16 {
     pub string: Vec<u8>,
     pub alignment_pad: Vec<u8>,
@@ -2453,7 +2453,7 @@ impl CountedString16 {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KTMapEntry {
     pub active: bool,
     pub mods_mask: u8,
@@ -2503,7 +2503,7 @@ impl Serialize for KTMapEntry {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyType {
     pub mods_mask: u8,
     pub mods_mods: u8,
@@ -2566,7 +2566,7 @@ impl KeyType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeySymMap {
     pub kt_index: [u8; 4],
     pub group_info: u8,
@@ -2618,7 +2618,7 @@ impl KeySymMap {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CommonBehavior {
     pub type_: u8,
     pub data: u8,
@@ -2648,7 +2648,7 @@ impl Serialize for CommonBehavior {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DefaultBehavior {
     pub type_: u8,
 }
@@ -2678,7 +2678,7 @@ impl Serialize for DefaultBehavior {
 
 pub type LockBehavior = DefaultBehavior;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RadioGroupBehavior {
     pub type_: u8,
     pub group: u8,
@@ -2708,7 +2708,7 @@ impl Serialize for RadioGroupBehavior {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OverlayBehavior {
     pub type_: u8,
     pub key: xproto::Keycode,
@@ -2890,7 +2890,7 @@ impl From<u8> for Behavior {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BehaviorType(u8);
 impl BehaviorType {
     pub const DEFAULT: Self = Self(0);
@@ -2996,7 +2996,7 @@ impl Serialize for SetBehavior {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetExplicit {
     pub keycode: xproto::Keycode,
     pub explicit: u8,
@@ -3026,7 +3026,7 @@ impl Serialize for SetExplicit {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyModMap {
     pub keycode: xproto::Keycode,
     pub mods: u8,
@@ -3056,7 +3056,7 @@ impl Serialize for KeyModMap {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyVModMap {
     pub keycode: xproto::Keycode,
     pub vmods: u16,
@@ -3090,7 +3090,7 @@ impl Serialize for KeyVModMap {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KTSetMapEntry {
     pub level: u8,
     pub real_mods: u8,
@@ -3126,7 +3126,7 @@ impl Serialize for KTSetMapEntry {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetKeyType {
     pub mask: u8,
     pub real_mods: u8,
@@ -3191,7 +3191,7 @@ impl SetKeyType {
 
 pub type String8 = u8;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Outline {
     pub corner_radius: u8,
     pub points: Vec<xproto::Point>,
@@ -3238,7 +3238,7 @@ impl Outline {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Shape {
     pub name: xproto::Atom,
     pub primary_ndx: u8,
@@ -3291,7 +3291,7 @@ impl Shape {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Key {
     pub name: [String8; 4],
     pub gap: i16,
@@ -3335,7 +3335,7 @@ impl Serialize for Key {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OverlayKey {
     pub over: [String8; 4],
     pub under: [String8; 4],
@@ -3371,7 +3371,7 @@ impl Serialize for OverlayKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OverlayRow {
     pub row_under: u8,
     pub keys: Vec<OverlayKey>,
@@ -3418,7 +3418,7 @@ impl OverlayRow {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Overlay {
     pub name: xproto::Atom,
     pub rows: Vec<OverlayRow>,
@@ -3465,7 +3465,7 @@ impl Overlay {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Row {
     pub top: i16,
     pub left: i16,
@@ -3518,7 +3518,7 @@ impl Row {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DoodadType(u8);
 impl DoodadType {
     pub const OUTLINE: Self = Self(1);
@@ -3582,7 +3582,7 @@ impl std::fmt::Debug for DoodadType  {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Listing {
     pub flags: u16,
     pub string: Vec<String8>,
@@ -3634,7 +3634,7 @@ impl Listing {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceLedInfo {
     pub led_class: LedClass,
     pub led_id: IDSpec,
@@ -3682,7 +3682,7 @@ impl Serialize for DeviceLedInfo {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Error(u8);
 impl Error {
     pub const BAD_DEVICE: Self = Self(255);
@@ -3745,7 +3745,7 @@ impl std::fmt::Debug for Error  {
 /// Opcode for the Keyboard error
 pub const KEYBOARD_ERROR: u8 = 0;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SA(u8);
 impl SA {
     pub const CLEAR_LOCKS: Self = Self(1 << 0);
@@ -3808,7 +3808,7 @@ impl std::fmt::Debug for SA  {
 }
 bitmask_binop!(SA, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SAType(u8);
 impl SAType {
     pub const NO_ACTION: Self = Self(0);
@@ -3904,7 +3904,7 @@ impl std::fmt::Debug for SAType  {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SANoAction {
     pub type_: SAType,
 }
@@ -3939,7 +3939,7 @@ impl Serialize for SANoAction {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SASetMods {
     pub type_: SAType,
     pub flags: u8,
@@ -3998,7 +3998,7 @@ pub type SALatchMods = SASetMods;
 
 pub type SALockMods = SASetMods;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SASetGroup {
     pub type_: SAType,
     pub flags: u8,
@@ -4045,7 +4045,7 @@ pub type SALatchGroup = SASetGroup;
 
 pub type SALockGroup = SASetGroup;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SAMovePtrFlag(u8);
 impl SAMovePtrFlag {
     pub const NO_ACCELERATION: Self = Self(1 << 0);
@@ -4106,7 +4106,7 @@ impl std::fmt::Debug for SAMovePtrFlag  {
 }
 bitmask_binop!(SAMovePtrFlag, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SAMovePtr {
     pub type_: SAType,
     pub flags: u8,
@@ -4161,7 +4161,7 @@ impl Serialize for SAMovePtr {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SAPtrBtn {
     pub type_: SAType,
     pub flags: u8,
@@ -4208,7 +4208,7 @@ impl Serialize for SAPtrBtn {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SALockPtrBtn {
     pub type_: SAType,
     pub flags: u8,
@@ -4253,7 +4253,7 @@ impl Serialize for SALockPtrBtn {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SASetPtrDfltFlag(u8);
 impl SASetPtrDfltFlag {
     pub const DFLT_BTN_ABSOLUTE: Self = Self(1 << 2);
@@ -4312,7 +4312,7 @@ impl std::fmt::Debug for SASetPtrDfltFlag  {
 }
 bitmask_binop!(SASetPtrDfltFlag, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SASetPtrDflt {
     pub type_: SAType,
     pub flags: u8,
@@ -4359,7 +4359,7 @@ impl Serialize for SASetPtrDflt {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SAIsoLockFlag(u8);
 impl SAIsoLockFlag {
     pub const NO_LOCK: Self = Self(1 << 0);
@@ -4424,7 +4424,7 @@ impl std::fmt::Debug for SAIsoLockFlag  {
 }
 bitmask_binop!(SAIsoLockFlag, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SAIsoLockNoAffect(u8);
 impl SAIsoLockNoAffect {
     pub const CTRLS: Self = Self(1 << 3);
@@ -4487,7 +4487,7 @@ impl std::fmt::Debug for SAIsoLockNoAffect  {
 }
 bitmask_binop!(SAIsoLockNoAffect, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SAIsoLock {
     pub type_: SAType,
     pub flags: u8,
@@ -4548,7 +4548,7 @@ impl Serialize for SAIsoLock {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SATerminate {
     pub type_: SAType,
 }
@@ -4583,7 +4583,7 @@ impl Serialize for SATerminate {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SwitchScreenFlag(u8);
 impl SwitchScreenFlag {
     pub const APPLICATION: Self = Self(1 << 0);
@@ -4642,7 +4642,7 @@ impl std::fmt::Debug for SwitchScreenFlag  {
 }
 bitmask_binop!(SwitchScreenFlag, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SASwitchScreen {
     pub type_: SAType,
     pub flags: u8,
@@ -4685,7 +4685,7 @@ impl Serialize for SASwitchScreen {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BoolCtrlsHigh(u8);
 impl BoolCtrlsHigh {
     pub const ACCESS_X_FEEDBACK: Self = Self(1 << 0);
@@ -4750,7 +4750,7 @@ impl std::fmt::Debug for BoolCtrlsHigh  {
 }
 bitmask_binop!(BoolCtrlsHigh, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BoolCtrlsLow(u8);
 impl BoolCtrlsLow {
     pub const REPEAT_KEYS: Self = Self(1 << 0);
@@ -4821,7 +4821,7 @@ impl std::fmt::Debug for BoolCtrlsLow  {
 }
 bitmask_binop!(BoolCtrlsLow, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SASetControls {
     pub type_: SAType,
     pub bool_ctrls_high: u8,
@@ -4868,7 +4868,7 @@ impl Serialize for SASetControls {
 
 pub type SALockControls = SASetControls;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ActionMessageFlag(u8);
 impl ActionMessageFlag {
     pub const ON_PRESS: Self = Self(1 << 0);
@@ -4929,7 +4929,7 @@ impl std::fmt::Debug for ActionMessageFlag  {
 }
 bitmask_binop!(ActionMessageFlag, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SAActionMessage {
     pub type_: SAType,
     pub flags: u8,
@@ -4970,7 +4970,7 @@ impl Serialize for SAActionMessage {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SARedirectKey {
     pub type_: SAType,
     pub newkey: xproto::Keycode,
@@ -5031,7 +5031,7 @@ impl Serialize for SARedirectKey {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SADeviceBtn {
     pub type_: SAType,
     pub flags: u8,
@@ -5082,7 +5082,7 @@ impl Serialize for SADeviceBtn {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LockDeviceFlags(u8);
 impl LockDeviceFlags {
     pub const NO_LOCK: Self = Self(1 << 0);
@@ -5141,7 +5141,7 @@ impl std::fmt::Debug for LockDeviceFlags  {
 }
 bitmask_binop!(LockDeviceFlags, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SALockDeviceBtn {
     pub type_: SAType,
     pub flags: u8,
@@ -5190,7 +5190,7 @@ impl Serialize for SALockDeviceBtn {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SAValWhat(u8);
 impl SAValWhat {
     pub const IGNORE_VAL: Self = Self(0);
@@ -5256,7 +5256,7 @@ impl std::fmt::Debug for SAValWhat  {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SADeviceValuator {
     pub type_: SAType,
     pub device: u8,
@@ -5319,7 +5319,7 @@ impl Serialize for SADeviceValuator {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SIAction {
     pub type_: SAType,
     pub data: [u8; 7],
@@ -5356,7 +5356,7 @@ impl Serialize for SIAction {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SymInterpret {
     pub sym: xproto::Keysym,
     pub mods: u8,
@@ -5731,7 +5731,7 @@ impl From<SAType> for Action {
 
 /// Opcode for the UseExtension request
 pub const USE_EXTENSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UseExtensionRequest {
     pub wanted_major: u16,
     pub wanted_minor: u16,
@@ -5786,7 +5786,7 @@ impl crate::x11_utils::ReplyRequest for UseExtensionRequest {
     type Reply = UseExtensionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UseExtensionReply {
     pub supported: bool,
     pub sequence: u16,
@@ -5815,7 +5815,7 @@ impl TryParse for UseExtensionReply {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectEventsAuxBitcase1 {
     pub affect_new_keyboard: u16,
     pub new_keyboard_details: u16,
@@ -5846,7 +5846,7 @@ impl Serialize for SelectEventsAuxBitcase1 {
         self.new_keyboard_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectEventsAuxBitcase2 {
     pub affect_state: u16,
     pub state_details: u16,
@@ -5877,7 +5877,7 @@ impl Serialize for SelectEventsAuxBitcase2 {
         self.state_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectEventsAuxBitcase3 {
     pub affect_ctrls: u32,
     pub ctrl_details: u32,
@@ -5912,7 +5912,7 @@ impl Serialize for SelectEventsAuxBitcase3 {
         self.ctrl_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectEventsAuxBitcase4 {
     pub affect_indicator_state: u32,
     pub indicator_state_details: u32,
@@ -5947,7 +5947,7 @@ impl Serialize for SelectEventsAuxBitcase4 {
         self.indicator_state_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectEventsAuxBitcase5 {
     pub affect_indicator_map: u32,
     pub indicator_map_details: u32,
@@ -5982,7 +5982,7 @@ impl Serialize for SelectEventsAuxBitcase5 {
         self.indicator_map_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectEventsAuxBitcase6 {
     pub affect_names: u16,
     pub names_details: u16,
@@ -6013,7 +6013,7 @@ impl Serialize for SelectEventsAuxBitcase6 {
         self.names_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectEventsAuxBitcase7 {
     pub affect_compat: u8,
     pub compat_details: u8,
@@ -6042,7 +6042,7 @@ impl Serialize for SelectEventsAuxBitcase7 {
         self.compat_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectEventsAuxBitcase8 {
     pub affect_bell: u8,
     pub bell_details: u8,
@@ -6071,7 +6071,7 @@ impl Serialize for SelectEventsAuxBitcase8 {
         self.bell_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectEventsAuxBitcase9 {
     pub affect_msg_details: u8,
     pub msg_details: u8,
@@ -6100,7 +6100,7 @@ impl Serialize for SelectEventsAuxBitcase9 {
         self.msg_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectEventsAuxBitcase10 {
     pub affect_access_x: u16,
     pub access_x_details: u16,
@@ -6131,7 +6131,7 @@ impl Serialize for SelectEventsAuxBitcase10 {
         self.access_x_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectEventsAuxBitcase11 {
     pub affect_ext_dev: u16,
     pub extdev_details: u16,
@@ -6163,7 +6163,7 @@ impl Serialize for SelectEventsAuxBitcase11 {
     }
 }
 /// Auxiliary and optional information for the `select_events` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct SelectEventsAux {
     pub bitcase1: Option<SelectEventsAuxBitcase1>,
     pub bitcase2: Option<SelectEventsAuxBitcase2>,
@@ -6420,7 +6420,7 @@ impl SelectEventsAux {
 
 /// Opcode for the SelectEvents request
 pub const SELECT_EVENTS_REQUEST: u8 = 1;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectEventsRequest<'input> {
     pub device_spec: DeviceSpec,
     pub clear: u16,
@@ -6517,7 +6517,7 @@ impl<'input> crate::x11_utils::VoidRequest for SelectEventsRequest<'input> {
 
 /// Opcode for the Bell request
 pub const BELL_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BellRequest {
     pub device_spec: DeviceSpec,
     pub bell_class: BellClassSpec,
@@ -6627,7 +6627,7 @@ impl crate::x11_utils::VoidRequest for BellRequest {
 
 /// Opcode for the GetState request
 pub const GET_STATE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetStateRequest {
     pub device_spec: DeviceSpec,
 }
@@ -6679,7 +6679,7 @@ impl crate::x11_utils::ReplyRequest for GetStateRequest {
     type Reply = GetStateReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetStateReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -6737,7 +6737,7 @@ impl TryParse for GetStateReply {
 
 /// Opcode for the LatchLockState request
 pub const LATCH_LOCK_STATE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LatchLockStateRequest {
     pub device_spec: DeviceSpec,
     pub affect_mod_locks: u8,
@@ -6828,7 +6828,7 @@ impl crate::x11_utils::VoidRequest for LatchLockStateRequest {
 
 /// Opcode for the GetControls request
 pub const GET_CONTROLS_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetControlsRequest {
     pub device_spec: DeviceSpec,
 }
@@ -6880,7 +6880,7 @@ impl crate::x11_utils::ReplyRequest for GetControlsRequest {
     type Reply = GetControlsReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetControlsReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -6961,7 +6961,7 @@ impl TryParse for GetControlsReply {
 
 /// Opcode for the SetControls request
 pub const SET_CONTROLS_REQUEST: u8 = 7;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetControlsRequest<'input> {
     pub device_spec: DeviceSpec,
     pub affect_internal_real_mods: u8,
@@ -7226,7 +7226,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetControlsRequest<'input> {
 
 /// Opcode for the GetMap request
 pub const GET_MAP_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMapRequest {
     pub device_spec: DeviceSpec,
     pub full: u16,
@@ -8031,7 +8031,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetMapRequest<'input> {
 
 /// Opcode for the GetCompatMap request
 pub const GET_COMPAT_MAP_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCompatMapRequest {
     pub device_spec: DeviceSpec,
     pub groups: u8,
@@ -8102,7 +8102,7 @@ impl crate::x11_utils::ReplyRequest for GetCompatMapRequest {
     type Reply = GetCompatMapReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetCompatMapReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -8156,7 +8156,7 @@ impl GetCompatMapReply {
 
 /// Opcode for the SetCompatMap request
 pub const SET_COMPAT_MAP_REQUEST: u8 = 11;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetCompatMapRequest<'input> {
     pub device_spec: DeviceSpec,
     pub recompute_actions: bool,
@@ -8262,7 +8262,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetCompatMapRequest<'input> {
 
 /// Opcode for the GetIndicatorState request
 pub const GET_INDICATOR_STATE_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetIndicatorStateRequest {
     pub device_spec: DeviceSpec,
 }
@@ -8314,7 +8314,7 @@ impl crate::x11_utils::ReplyRequest for GetIndicatorStateRequest {
     type Reply = GetIndicatorStateReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetIndicatorStateReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -8343,7 +8343,7 @@ impl TryParse for GetIndicatorStateReply {
 
 /// Opcode for the GetIndicatorMap request
 pub const GET_INDICATOR_MAP_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetIndicatorMapRequest {
     pub device_spec: DeviceSpec,
     pub which: u32,
@@ -8403,7 +8403,7 @@ impl crate::x11_utils::ReplyRequest for GetIndicatorMapRequest {
     type Reply = GetIndicatorMapReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetIndicatorMapReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -8438,7 +8438,7 @@ impl TryParse for GetIndicatorMapReply {
 
 /// Opcode for the SetIndicatorMap request
 pub const SET_INDICATOR_MAP_REQUEST: u8 = 14;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetIndicatorMapRequest<'input> {
     pub device_spec: DeviceSpec,
     pub which: u32,
@@ -8515,7 +8515,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetIndicatorMapRequest<'input> {
 
 /// Opcode for the GetNamedIndicator request
 pub const GET_NAMED_INDICATOR_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetNamedIndicatorRequest {
     pub device_spec: DeviceSpec,
     pub led_class: LedClass,
@@ -8588,7 +8588,7 @@ impl crate::x11_utils::ReplyRequest for GetNamedIndicatorRequest {
     type Reply = GetNamedIndicatorReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetNamedIndicatorReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -8643,7 +8643,7 @@ impl TryParse for GetNamedIndicatorReply {
 
 /// Opcode for the SetNamedIndicator request
 pub const SET_NAMED_INDICATOR_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetNamedIndicatorRequest {
     pub device_spec: DeviceSpec,
     pub led_class: LedClass,
@@ -8778,7 +8778,7 @@ impl crate::x11_utils::VoidRequest for SetNamedIndicatorRequest {
 
 /// Opcode for the GetNames request
 pub const GET_NAMES_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetNamesRequest {
     pub device_spec: DeviceSpec,
     pub which: u32,
@@ -8838,7 +8838,7 @@ impl crate::x11_utils::ReplyRequest for GetNamesRequest {
     type Reply = GetNamesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetNamesValueListBitcase8 {
     pub n_levels_per_type: Vec<u8>,
     pub kt_level_names: Vec<xproto::Atom>,
@@ -8857,7 +8857,7 @@ impl GetNamesValueListBitcase8 {
         Ok((result, remaining))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct GetNamesValueList {
     pub keycodes_name: Option<xproto::Atom>,
     pub geometry_name: Option<xproto::Atom>,
@@ -8994,7 +8994,7 @@ impl GetNamesValueList {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetNamesReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -9044,7 +9044,7 @@ impl TryParse for GetNamesReply {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetNamesAuxBitcase8 {
     pub n_levels_per_type: Vec<u8>,
     pub kt_level_names: Vec<xproto::Atom>,
@@ -9079,7 +9079,7 @@ impl SetNamesAuxBitcase8 {
     }
 }
 /// Auxiliary and optional information for the `set_names` function
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct SetNamesAux {
     pub keycodes_name: Option<xproto::Atom>,
     pub geometry_name: Option<xproto::Atom>,
@@ -9416,7 +9416,7 @@ impl SetNamesAux {
 
 /// Opcode for the SetNames request
 pub const SET_NAMES_REQUEST: u8 = 18;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetNamesRequest<'input> {
     pub device_spec: DeviceSpec,
     pub virtual_mods: u16,
@@ -9566,7 +9566,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetNamesRequest<'input> {
 
 /// Opcode for the PerClientFlags request
 pub const PER_CLIENT_FLAGS_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PerClientFlagsRequest {
     pub device_spec: DeviceSpec,
     pub change: u32,
@@ -9658,7 +9658,7 @@ impl crate::x11_utils::ReplyRequest for PerClientFlagsRequest {
     type Reply = PerClientFlagsReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PerClientFlagsReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -9693,7 +9693,7 @@ impl TryParse for PerClientFlagsReply {
 
 /// Opcode for the ListComponents request
 pub const LIST_COMPONENTS_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListComponentsRequest {
     pub device_spec: DeviceSpec,
     pub max_names: u16,
@@ -9748,7 +9748,7 @@ impl crate::x11_utils::ReplyRequest for ListComponentsRequest {
     type Reply = ListComponentsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListComponentsReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -9875,7 +9875,7 @@ impl ListComponentsReply {
 
 /// Opcode for the GetKbdByName request
 pub const GET_KBD_BY_NAME_REQUEST: u8 = 23;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetKbdByNameRequest {
     pub device_spec: DeviceSpec,
     pub need: u16,
@@ -10131,7 +10131,7 @@ impl TryParse for GetKbdByNameRepliesTypes {
         Ok((result, remaining))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetKbdByNameRepliesCompatMap {
     pub compatmap_type: u8,
     pub compat_device_id: u8,
@@ -10176,7 +10176,7 @@ impl GetKbdByNameRepliesCompatMap {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetKbdByNameRepliesIndicatorMaps {
     pub indicatormap_type: u8,
     pub indicator_device_id: u8,
@@ -10216,7 +10216,7 @@ impl GetKbdByNameRepliesIndicatorMaps {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetKbdByNameRepliesKeyNamesValueListBitcase8 {
     pub n_levels_per_type: Vec<u8>,
     pub kt_level_names: Vec<xproto::Atom>,
@@ -10235,7 +10235,7 @@ impl GetKbdByNameRepliesKeyNamesValueListBitcase8 {
         Ok((result, remaining))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct GetKbdByNameRepliesKeyNamesValueList {
     pub keycodes_name: Option<xproto::Atom>,
     pub geometry_name: Option<xproto::Atom>,
@@ -10372,7 +10372,7 @@ impl GetKbdByNameRepliesKeyNamesValueList {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetKbdByNameRepliesKeyNames {
     pub keyname_type: u8,
     pub key_device_id: u8,
@@ -10415,7 +10415,7 @@ impl TryParse for GetKbdByNameRepliesKeyNames {
         Ok((result, remaining))
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetKbdByNameRepliesGeometry {
     pub geometry_type: u8,
     pub geometry_device_id: u8,
@@ -10552,7 +10552,7 @@ impl TryParse for GetKbdByNameReply {
 
 /// Opcode for the GetDeviceInfo request
 pub const GET_DEVICE_INFO_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceInfoRequest {
     pub device_spec: DeviceSpec,
     pub wanted: u16,
@@ -10834,7 +10834,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetDeviceInfoRequest<'input> {
 
 /// Opcode for the SetDebuggingFlags request
 pub const SET_DEBUGGING_FLAGS_REQUEST: u8 = 101;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDebuggingFlagsRequest<'input> {
     pub affect_flags: u32,
     pub flags: u32,
@@ -10933,7 +10933,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetDebuggingFlagsRequest<'input>
     type Reply = SetDebuggingFlagsReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDebuggingFlagsReply {
     pub sequence: u16,
     pub length: u32,
@@ -10967,7 +10967,7 @@ impl TryParse for SetDebuggingFlagsReply {
 
 /// Opcode for the NewKeyboardNotify event
 pub const NEW_KEYBOARD_NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NewKeyboardNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11066,7 +11066,7 @@ impl From<NewKeyboardNotifyEvent> for [u8; 32] {
 
 /// Opcode for the MapNotify event
 pub const MAP_NOTIFY_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MapNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11198,7 +11198,7 @@ impl From<MapNotifyEvent> for [u8; 32] {
 
 /// Opcode for the StateNotify event
 pub const STATE_NOTIFY_EVENT: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StateNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11331,7 +11331,7 @@ impl From<StateNotifyEvent> for [u8; 32] {
 
 /// Opcode for the ControlsNotify event
 pub const CONTROLS_NOTIFY_EVENT: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ControlsNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11431,7 +11431,7 @@ impl From<ControlsNotifyEvent> for [u8; 32] {
 
 /// Opcode for the IndicatorStateNotify event
 pub const INDICATOR_STATE_NOTIFY_EVENT: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IndicatorStateNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11513,7 +11513,7 @@ impl From<IndicatorStateNotifyEvent> for [u8; 32] {
 
 /// Opcode for the IndicatorMapNotify event
 pub const INDICATOR_MAP_NOTIFY_EVENT: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IndicatorMapNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11595,7 +11595,7 @@ impl From<IndicatorMapNotifyEvent> for [u8; 32] {
 
 /// Opcode for the NamesNotify event
 pub const NAMES_NOTIFY_EVENT: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NamesNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11708,7 +11708,7 @@ impl From<NamesNotifyEvent> for [u8; 32] {
 
 /// Opcode for the CompatMapNotify event
 pub const COMPAT_MAP_NOTIFY_EVENT: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompatMapNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11795,7 +11795,7 @@ impl From<CompatMapNotifyEvent> for [u8; 32] {
 
 /// Opcode for the BellNotify event
 pub const BELL_NOTIFY_EVENT: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BellNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11895,7 +11895,7 @@ impl From<BellNotifyEvent> for [u8; 32] {
 
 /// Opcode for the ActionMessage event
 pub const ACTION_MESSAGE_EVENT: u8 = 9;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ActionMessageEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11989,7 +11989,7 @@ impl From<ActionMessageEvent> for [u8; 32] {
 
 /// Opcode for the AccessXNotify event
 pub const ACCESS_X_NOTIFY_EVENT: u8 = 10;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AccessXNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -12076,7 +12076,7 @@ impl From<AccessXNotifyEvent> for [u8; 32] {
 
 /// Opcode for the ExtensionDeviceNotify event
 pub const EXTENSION_DEVICE_NOTIFY_EVENT: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExtensionDeviceNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,

--- a/x11rb-protocol/src/protocol/xprint.rs
+++ b/x11rb-protocol/src/protocol/xprint.rs
@@ -34,7 +34,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
 pub type String8 = u8;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Printer {
     pub name: Vec<String8>,
     pub description: Vec<String8>,
@@ -109,7 +109,7 @@ impl Printer {
 
 pub type Pcontext = u32;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDoc(bool);
 impl GetDoc {
     pub const FINISHED: Self = Self(false);
@@ -179,7 +179,7 @@ impl std::fmt::Debug for GetDoc  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EvMask(u8);
 impl EvMask {
     pub const NO_EVENT_MASK: Self = Self(0);
@@ -240,7 +240,7 @@ impl std::fmt::Debug for EvMask  {
 }
 bitmask_binop!(EvMask, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Detail(u8);
 impl Detail {
     pub const START_JOB_NOTIFY: Self = Self(1);
@@ -306,7 +306,7 @@ impl std::fmt::Debug for Detail  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Attr(u8);
 impl Attr {
     pub const JOB_ATTR: Self = Self(1);
@@ -376,7 +376,7 @@ impl std::fmt::Debug for Attr  {
 
 /// Opcode for the PrintQueryVersion request
 pub const PRINT_QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintQueryVersionRequest;
 impl PrintQueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -418,7 +418,7 @@ impl crate::x11_utils::ReplyRequest for PrintQueryVersionRequest {
     type Reply = PrintQueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintQueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -447,7 +447,7 @@ impl TryParse for PrintQueryVersionReply {
 
 /// Opcode for the PrintGetPrinterList request
 pub const PRINT_GET_PRINTER_LIST_REQUEST: u8 = 1;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetPrinterListRequest<'input> {
     pub printer_name: Cow<'input, [String8]>,
     pub locale: Cow<'input, [String8]>,
@@ -521,7 +521,7 @@ impl<'input> crate::x11_utils::ReplyRequest for PrintGetPrinterListRequest<'inpu
     type Reply = PrintGetPrinterListReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetPrinterListReply {
     pub sequence: u16,
     pub length: u32,
@@ -565,7 +565,7 @@ impl PrintGetPrinterListReply {
 
 /// Opcode for the PrintRehashPrinterList request
 pub const PRINT_REHASH_PRINTER_LIST_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintRehashPrinterListRequest;
 impl PrintRehashPrinterListRequest {
     /// Serialize this request into bytes for the provided connection
@@ -608,7 +608,7 @@ impl crate::x11_utils::VoidRequest for PrintRehashPrinterListRequest {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateContextRequest<'input> {
     pub context_id: u32,
     pub printer_name: Cow<'input, [String8]>,
@@ -692,7 +692,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateContextRequest<'input> {
 
 /// Opcode for the PrintSetContext request
 pub const PRINT_SET_CONTEXT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintSetContextRequest {
     pub context: u32,
 }
@@ -744,7 +744,7 @@ impl crate::x11_utils::VoidRequest for PrintSetContextRequest {
 
 /// Opcode for the PrintGetContext request
 pub const PRINT_GET_CONTEXT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetContextRequest;
 impl PrintGetContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -786,7 +786,7 @@ impl crate::x11_utils::ReplyRequest for PrintGetContextRequest {
     type Reply = PrintGetContextReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -813,7 +813,7 @@ impl TryParse for PrintGetContextReply {
 
 /// Opcode for the PrintDestroyContext request
 pub const PRINT_DESTROY_CONTEXT_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintDestroyContextRequest {
     pub context: u32,
 }
@@ -865,7 +865,7 @@ impl crate::x11_utils::VoidRequest for PrintDestroyContextRequest {
 
 /// Opcode for the PrintGetScreenOfContext request
 pub const PRINT_GET_SCREEN_OF_CONTEXT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetScreenOfContextRequest;
 impl PrintGetScreenOfContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -907,7 +907,7 @@ impl crate::x11_utils::ReplyRequest for PrintGetScreenOfContextRequest {
     type Reply = PrintGetScreenOfContextReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetScreenOfContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -934,7 +934,7 @@ impl TryParse for PrintGetScreenOfContextReply {
 
 /// Opcode for the PrintStartJob request
 pub const PRINT_START_JOB_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintStartJobRequest {
     pub output_mode: u8,
 }
@@ -986,7 +986,7 @@ impl crate::x11_utils::VoidRequest for PrintStartJobRequest {
 
 /// Opcode for the PrintEndJob request
 pub const PRINT_END_JOB_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintEndJobRequest {
     pub cancel: bool,
 }
@@ -1038,7 +1038,7 @@ impl crate::x11_utils::VoidRequest for PrintEndJobRequest {
 
 /// Opcode for the PrintStartDoc request
 pub const PRINT_START_DOC_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintStartDocRequest {
     pub driver_mode: u8,
 }
@@ -1090,7 +1090,7 @@ impl crate::x11_utils::VoidRequest for PrintStartDocRequest {
 
 /// Opcode for the PrintEndDoc request
 pub const PRINT_END_DOC_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintEndDocRequest {
     pub cancel: bool,
 }
@@ -1142,7 +1142,7 @@ impl crate::x11_utils::VoidRequest for PrintEndDocRequest {
 
 /// Opcode for the PrintPutDocumentData request
 pub const PRINT_PUT_DOCUMENT_DATA_REQUEST: u8 = 11;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintPutDocumentDataRequest<'input> {
     pub drawable: xproto::Drawable,
     pub data: Cow<'input, [u8]>,
@@ -1234,7 +1234,7 @@ impl<'input> crate::x11_utils::VoidRequest for PrintPutDocumentDataRequest<'inpu
 
 /// Opcode for the PrintGetDocumentData request
 pub const PRINT_GET_DOCUMENT_DATA_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetDocumentDataRequest {
     pub context: Pcontext,
     pub max_bytes: u32,
@@ -1293,7 +1293,7 @@ impl crate::x11_utils::ReplyRequest for PrintGetDocumentDataRequest {
     type Reply = PrintGetDocumentDataReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetDocumentDataReply {
     pub sequence: u16,
     pub length: u32,
@@ -1342,7 +1342,7 @@ impl PrintGetDocumentDataReply {
 
 /// Opcode for the PrintStartPage request
 pub const PRINT_START_PAGE_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintStartPageRequest {
     pub window: xproto::Window,
 }
@@ -1394,7 +1394,7 @@ impl crate::x11_utils::VoidRequest for PrintStartPageRequest {
 
 /// Opcode for the PrintEndPage request
 pub const PRINT_END_PAGE_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintEndPageRequest {
     pub cancel: bool,
 }
@@ -1447,7 +1447,7 @@ impl crate::x11_utils::VoidRequest for PrintEndPageRequest {
 
 /// Opcode for the PrintSelectInput request
 pub const PRINT_SELECT_INPUT_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintSelectInputRequest {
     pub context: Pcontext,
     pub event_mask: u32,
@@ -1507,7 +1507,7 @@ impl crate::x11_utils::VoidRequest for PrintSelectInputRequest {
 
 /// Opcode for the PrintInputSelected request
 pub const PRINT_INPUT_SELECTED_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintInputSelectedRequest {
     pub context: Pcontext,
 }
@@ -1558,7 +1558,7 @@ impl crate::x11_utils::ReplyRequest for PrintInputSelectedRequest {
     type Reply = PrintInputSelectedReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintInputSelectedReply {
     pub sequence: u16,
     pub length: u32,
@@ -1587,7 +1587,7 @@ impl TryParse for PrintInputSelectedReply {
 
 /// Opcode for the PrintGetAttributes request
 pub const PRINT_GET_ATTRIBUTES_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetAttributesRequest {
     pub context: Pcontext,
     pub pool: u8,
@@ -1647,7 +1647,7 @@ impl crate::x11_utils::ReplyRequest for PrintGetAttributesRequest {
     type Reply = PrintGetAttributesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetAttributesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1692,7 +1692,7 @@ impl PrintGetAttributesReply {
 
 /// Opcode for the PrintGetOneAttributes request
 pub const PRINT_GET_ONE_ATTRIBUTES_REQUEST: u8 = 19;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetOneAttributesRequest<'input> {
     pub context: Pcontext,
     pub pool: u8,
@@ -1773,7 +1773,7 @@ impl<'input> crate::x11_utils::ReplyRequest for PrintGetOneAttributesRequest<'in
     type Reply = PrintGetOneAttributesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetOneAttributesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1818,7 +1818,7 @@ impl PrintGetOneAttributesReply {
 
 /// Opcode for the PrintSetAttributes request
 pub const PRINT_SET_ATTRIBUTES_REQUEST: u8 = 18;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintSetAttributesRequest<'input> {
     pub context: Pcontext,
     pub string_len: u32,
@@ -1907,7 +1907,7 @@ impl<'input> crate::x11_utils::VoidRequest for PrintSetAttributesRequest<'input>
 
 /// Opcode for the PrintGetPageDimensions request
 pub const PRINT_GET_PAGE_DIMENSIONS_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetPageDimensionsRequest {
     pub context: Pcontext,
 }
@@ -1958,7 +1958,7 @@ impl crate::x11_utils::ReplyRequest for PrintGetPageDimensionsRequest {
     type Reply = PrintGetPageDimensionsReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetPageDimensionsReply {
     pub sequence: u16,
     pub length: u32,
@@ -1995,7 +1995,7 @@ impl TryParse for PrintGetPageDimensionsReply {
 
 /// Opcode for the PrintQueryScreens request
 pub const PRINT_QUERY_SCREENS_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintQueryScreensRequest;
 impl PrintQueryScreensRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2037,7 +2037,7 @@ impl crate::x11_utils::ReplyRequest for PrintQueryScreensRequest {
     type Reply = PrintQueryScreensReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintQueryScreensReply {
     pub sequence: u16,
     pub length: u32,
@@ -2081,7 +2081,7 @@ impl PrintQueryScreensReply {
 
 /// Opcode for the PrintSetImageResolution request
 pub const PRINT_SET_IMAGE_RESOLUTION_REQUEST: u8 = 23;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintSetImageResolutionRequest {
     pub context: Pcontext,
     pub image_resolution: u16,
@@ -2140,7 +2140,7 @@ impl crate::x11_utils::ReplyRequest for PrintSetImageResolutionRequest {
     type Reply = PrintSetImageResolutionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintSetImageResolutionReply {
     pub status: bool,
     pub sequence: u16,
@@ -2168,7 +2168,7 @@ impl TryParse for PrintSetImageResolutionReply {
 
 /// Opcode for the PrintGetImageResolution request
 pub const PRINT_GET_IMAGE_RESOLUTION_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetImageResolutionRequest {
     pub context: Pcontext,
 }
@@ -2219,7 +2219,7 @@ impl crate::x11_utils::ReplyRequest for PrintGetImageResolutionRequest {
     type Reply = PrintGetImageResolutionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PrintGetImageResolutionReply {
     pub sequence: u16,
     pub length: u32,
@@ -2246,7 +2246,7 @@ impl TryParse for PrintGetImageResolutionReply {
 
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotifyEvent {
     pub response_type: u8,
     pub detail: u8,
@@ -2321,7 +2321,7 @@ impl From<NotifyEvent> for [u8; 32] {
 
 /// Opcode for the AttributNotify event
 pub const ATTRIBUT_NOTIFY_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AttributNotifyEvent {
     pub response_type: u8,
     pub detail: u8,

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -24,7 +24,7 @@ use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
 use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Char2b {
     pub byte1: u8,
     pub byte2: u8,
@@ -86,7 +86,7 @@ pub type Keycode32 = u32;
 
 pub type Button = u8;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Point {
     pub x: i16,
     pub y: i16,
@@ -118,7 +118,7 @@ impl Serialize for Point {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Rectangle {
     pub x: i16,
     pub y: i16,
@@ -162,7 +162,7 @@ impl Serialize for Rectangle {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Arc {
     pub x: i16,
     pub y: i16,
@@ -218,7 +218,7 @@ impl Serialize for Arc {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Format {
     pub depth: u8,
     pub bits_per_pixel: u8,
@@ -260,7 +260,7 @@ impl Serialize for Format {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VisualClass(u8);
 impl VisualClass {
     pub const STATIC_GRAY: Self = Self(0);
@@ -326,7 +326,7 @@ impl std::fmt::Debug for VisualClass  {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Visualtype {
     pub visual_id: Visualid,
     pub class: VisualClass,
@@ -401,7 +401,7 @@ impl Serialize for Visualtype {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Depth {
     pub depth: u8,
     pub visuals: Vec<Visualtype>,
@@ -450,7 +450,7 @@ impl Depth {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EventMask(u32);
 impl EventMask {
     pub const NO_EVENT: Self = Self(0);
@@ -545,7 +545,7 @@ impl std::fmt::Debug for EventMask  {
 }
 bitmask_binop!(EventMask, u32);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BackingStore(u32);
 impl BackingStore {
     pub const NOT_USEFUL: Self = Self(0);
@@ -593,7 +593,7 @@ impl std::fmt::Debug for BackingStore  {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Screen {
     pub root: Window,
     pub default_colormap: Colormap,
@@ -681,7 +681,7 @@ impl Screen {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetupRequest {
     pub byte_order: u8,
     pub protocol_major_version: u16,
@@ -768,7 +768,7 @@ impl SetupRequest {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetupFailed {
     pub status: u8,
     pub protocol_major_version: u16,
@@ -823,7 +823,7 @@ impl SetupFailed {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetupAuthenticate {
     pub status: u8,
     pub reason: Vec<u8>,
@@ -873,7 +873,7 @@ impl SetupAuthenticate {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ImageOrder(u8);
 impl ImageOrder {
     pub const LSB_FIRST: Self = Self(0);
@@ -931,7 +931,7 @@ impl std::fmt::Debug for ImageOrder  {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Setup {
     pub status: u8,
     pub protocol_major_version: u16,
@@ -1069,7 +1069,7 @@ impl Setup {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModMask(u16);
 impl ModMask {
     pub const SHIFT: Self = Self(1 << 0);
@@ -1136,7 +1136,7 @@ impl std::fmt::Debug for ModMask  {
 }
 bitmask_binop!(ModMask, u16);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyButMask(u16);
 impl KeyButMask {
     pub const SHIFT: Self = Self(1 << 0);
@@ -1211,7 +1211,7 @@ impl std::fmt::Debug for KeyButMask  {
 }
 bitmask_binop!(KeyButMask, u16);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowEnum(u8);
 impl WindowEnum {
     pub const NONE: Self = Self(0);
@@ -1293,7 +1293,7 @@ pub const KEY_PRESS_EVENT: u8 = 2;
 ///
 /// * `GrabKey`: request
 /// * `GrabKeyboard`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeyPressEvent {
     pub response_type: u8,
     pub detail: Keycode,
@@ -1394,7 +1394,7 @@ impl From<KeyPressEvent> for [u8; 32] {
 pub const KEY_RELEASE_EVENT: u8 = 3;
 pub type KeyReleaseEvent = KeyPressEvent;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ButtonMask(u16);
 impl ButtonMask {
     pub const M1: Self = Self(1 << 8);
@@ -1481,7 +1481,7 @@ pub const BUTTON_PRESS_EVENT: u8 = 4;
 ///
 /// * `GrabButton`: request
 /// * `GrabPointer`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ButtonPressEvent {
     pub response_type: u8,
     pub detail: Button,
@@ -1582,7 +1582,7 @@ impl From<ButtonPressEvent> for [u8; 32] {
 pub const BUTTON_RELEASE_EVENT: u8 = 5;
 pub type ButtonReleaseEvent = ButtonPressEvent;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Motion(u8);
 impl Motion {
     pub const NORMAL: Self = Self(0);
@@ -1666,7 +1666,7 @@ pub const MOTION_NOTIFY_EVENT: u8 = 6;
 ///
 /// * `GrabKey`: request
 /// * `GrabKeyboard`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MotionNotifyEvent {
     pub response_type: u8,
     pub detail: Motion,
@@ -1764,7 +1764,7 @@ impl From<MotionNotifyEvent> for [u8; 32] {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotifyDetail(u8);
 impl NotifyDetail {
     pub const ANCESTOR: Self = Self(0);
@@ -1834,7 +1834,7 @@ impl std::fmt::Debug for NotifyDetail  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NotifyMode(u8);
 impl NotifyMode {
     pub const NORMAL: Self = Self(0);
@@ -1913,7 +1913,7 @@ pub const ENTER_NOTIFY_EVENT: u8 = 7;
 /// * `event_y` - If `event` is on the same screen as `root`, this is the pointer Y coordinate
 /// relative to the event window's origin.
 /// * `mode` -
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EnterNotifyEvent {
     pub response_type: u8,
     pub detail: NotifyDetail,
@@ -2028,7 +2028,7 @@ pub const FOCUS_IN_EVENT: u8 = 9;
 /// the X server to report the event.
 /// * `detail` -
 /// * `mode` -
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FocusInEvent {
     pub response_type: u8,
     pub detail: NotifyDetail,
@@ -2110,7 +2110,7 @@ pub type FocusOutEvent = FocusInEvent;
 
 /// Opcode for the KeymapNotify event
 pub const KEYMAP_NOTIFY_EVENT: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KeymapNotifyEvent {
     pub response_type: u8,
     pub keys: [u8; 31],
@@ -2190,7 +2190,7 @@ pub const EXPOSE_EVENT: u8 = 12;
 /// not want to optimize redisplay by distinguishing between subareas of its window
 /// can just ignore all Expose events with nonzero counts and perform full
 /// redisplays on events with zero counts.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ExposeEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2276,7 +2276,7 @@ impl From<ExposeEvent> for [u8; 32] {
 
 /// Opcode for the GraphicsExposure event
 pub const GRAPHICS_EXPOSURE_EVENT: u8 = 13;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GraphicsExposureEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2368,7 +2368,7 @@ impl From<GraphicsExposureEvent> for [u8; 32] {
 
 /// Opcode for the NoExposure event
 pub const NO_EXPOSURE_EVENT: u8 = 14;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NoExposureEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2443,7 +2443,7 @@ impl From<NoExposureEvent> for [u8; 32] {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Visibility(u8);
 impl Visibility {
     pub const UNOBSCURED: Self = Self(0);
@@ -2505,7 +2505,7 @@ impl std::fmt::Debug for Visibility  {
 
 /// Opcode for the VisibilityNotify event
 pub const VISIBILITY_NOTIFY_EVENT: u8 = 15;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VisibilityNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2580,7 +2580,7 @@ impl From<VisibilityNotifyEvent> for [u8; 32] {
 
 /// Opcode for the CreateNotify event
 pub const CREATE_NOTIFY_EVENT: u8 = 16;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2683,7 +2683,7 @@ pub const DESTROY_NOTIFY_EVENT: u8 = 17;
 /// # See
 ///
 /// * `DestroyWindow`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2769,7 +2769,7 @@ pub const UNMAP_NOTIFY_EVENT: u8 = 18;
 /// # See
 ///
 /// * `UnmapWindow`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UnmapNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2858,7 +2858,7 @@ pub const MAP_NOTIFY_EVENT: u8 = 19;
 /// # See
 ///
 /// * `MapWindow`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MapNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2945,7 +2945,7 @@ pub const MAP_REQUEST_EVENT: u8 = 20;
 /// # See
 ///
 /// * `MapWindow`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MapRequestEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3018,7 +3018,7 @@ impl From<MapRequestEvent> for [u8; 32] {
 
 /// Opcode for the ReparentNotify event
 pub const REPARENT_NOTIFY_EVENT: u8 = 21;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReparentNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3126,7 +3126,7 @@ pub const CONFIGURE_NOTIFY_EVENT: u8 = 22;
 /// # See
 ///
 /// * `FreeColormap`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConfigureNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3221,7 +3221,7 @@ impl From<ConfigureNotifyEvent> for [u8; 32] {
 
 /// Opcode for the ConfigureRequest event
 pub const CONFIGURE_REQUEST_EVENT: u8 = 23;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConfigureRequestEvent {
     pub response_type: u8,
     pub stack_mode: StackMode,
@@ -3318,7 +3318,7 @@ impl From<ConfigureRequestEvent> for [u8; 32] {
 
 /// Opcode for the GravityNotify event
 pub const GRAVITY_NOTIFY_EVENT: u8 = 24;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GravityNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3397,7 +3397,7 @@ impl From<GravityNotifyEvent> for [u8; 32] {
 
 /// Opcode for the ResizeRequest event
 pub const RESIZE_REQUEST_EVENT: u8 = 25;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ResizeRequestEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3475,7 +3475,7 @@ impl From<ResizeRequestEvent> for [u8; 32] {
 ///
 /// * `OnTop` - The window is now on top of all siblings.
 /// * `OnBottom` - The window is now below all siblings.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Place(u8);
 impl Place {
     pub const ON_TOP: Self = Self(0);
@@ -3547,7 +3547,7 @@ pub const CIRCULATE_NOTIFY_EVENT: u8 = 26;
 /// # See
 ///
 /// * `CirculateWindow`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CirculateNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3628,7 +3628,7 @@ impl From<CirculateNotifyEvent> for [u8; 32] {
 pub const CIRCULATE_REQUEST_EVENT: u8 = 27;
 pub type CirculateRequestEvent = CirculateNotifyEvent;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Property(u8);
 impl Property {
     pub const NEW_VALUE: Self = Self(0);
@@ -3700,7 +3700,7 @@ pub const PROPERTY_NOTIFY_EVENT: u8 = 28;
 /// # See
 ///
 /// * `ChangeProperty`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PropertyNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3781,7 +3781,7 @@ impl From<PropertyNotifyEvent> for [u8; 32] {
 
 /// Opcode for the SelectionClear event
 pub const SELECTION_CLEAR_EVENT: u8 = 29;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectionClearEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3855,7 +3855,7 @@ impl From<SelectionClearEvent> for [u8; 32] {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Time(u8);
 impl Time {
     pub const CURRENT_TIME: Self = Self(0);
@@ -3911,7 +3911,7 @@ impl std::fmt::Debug for Time  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AtomEnum(u8);
 impl AtomEnum {
     pub const NONE: Self = Self(0);
@@ -4107,7 +4107,7 @@ impl std::fmt::Debug for AtomEnum  {
 
 /// Opcode for the SelectionRequest event
 pub const SELECTION_REQUEST_EVENT: u8 = 30;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectionRequestEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -4192,7 +4192,7 @@ impl From<SelectionRequestEvent> for [u8; 32] {
 
 /// Opcode for the SelectionNotify event
 pub const SELECTION_NOTIFY_EVENT: u8 = 31;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectionNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -4276,7 +4276,7 @@ impl From<SelectionNotifyEvent> for [u8; 32] {
 ///
 /// * `Uninstalled` - The colormap was uninstalled.
 /// * `Installed` - The colormap was installed.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ColormapState(u8);
 impl ColormapState {
     pub const UNINSTALLED: Self = Self(0);
@@ -4334,7 +4334,7 @@ impl std::fmt::Debug for ColormapState  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ColormapEnum(u8);
 impl ColormapEnum {
     pub const NONE: Self = Self(0);
@@ -4405,7 +4405,7 @@ pub const COLORMAP_NOTIFY_EVENT: u8 = 32;
 /// # See
 ///
 /// * `FreeColormap`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ColormapNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -4753,7 +4753,7 @@ impl ClientMessageEvent {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Mapping(u8);
 impl Mapping {
     pub const MODIFIER: Self = Self(0);
@@ -4822,7 +4822,7 @@ pub const MAPPING_NOTIFY_EVENT: u8 = 34;
 /// * `request` -
 /// * `first_keycode` - The first number in the range of the altered mapping.
 /// * `count` - The number of keycodes altered.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MappingNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -4907,7 +4907,7 @@ pub const GE_GENERIC_EVENT: u8 = 35;
 /// * `extension` - The major opcode of the extension creating this event
 /// * `length` - The amount (in 4-byte units) of data beyond 32 bytes
 /// * `evtype` - The extension-specific event type
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GeGenericEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -4983,7 +4983,7 @@ pub const LENGTH_ERROR: u8 = 16;
 /// Opcode for the Implementation error
 pub const IMPLEMENTATION_ERROR: u8 = 17;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowClass(u16);
 impl WindowClass {
     pub const COPY_FROM_PARENT: Self = Self(0);
@@ -5107,7 +5107,7 @@ impl std::fmt::Debug for WindowClass  {
 /// * `Cursor` - If a cursor is specified, it will be used whenever the pointer is in the window. If None is speci-
 /// fied, the parent's cursor will be used when the pointer is in the window, and any change in the
 /// parent's cursor will cause an immediate change in the displayed cursor.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CW(u16);
 impl CW {
     pub const BACK_PIXMAP: Self = Self(1 << 0);
@@ -5186,7 +5186,7 @@ impl std::fmt::Debug for CW  {
 }
 bitmask_binop!(CW, u16);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BackPixmap(bool);
 impl BackPixmap {
     pub const NONE: Self = Self(false);
@@ -5256,7 +5256,7 @@ impl std::fmt::Debug for BackPixmap  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Gravity(u32);
 impl Gravity {
     pub const BIT_FORGET: Self = Self(0);
@@ -5323,7 +5323,7 @@ impl std::fmt::Debug for Gravity  {
 }
 
 /// Auxiliary and optional information for the `create_window` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct CreateWindowAux {
     pub background_pixmap: Option<Pixmap>,
     pub background_pixel: Option<u32>,
@@ -5732,7 +5732,7 @@ pub const CREATE_WINDOW_REQUEST: u8 = 1;
 /// * `xcb_generate_id`: function
 /// * `MapWindow`: request
 /// * `CreateNotify`: event
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateWindowRequest<'input> {
     pub depth: u8,
     pub wid: Window,
@@ -5872,7 +5872,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateWindowRequest<'input> {
 }
 
 /// Auxiliary and optional information for the `change_window_attributes` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ChangeWindowAttributesAux {
     pub background_pixmap: Option<Pixmap>,
     pub background_pixel: Option<u32>,
@@ -6247,7 +6247,7 @@ pub const CHANGE_WINDOW_ATTRIBUTES_REQUEST: u8 = 2;
 /// * `Pixmap` - TODO: reasons?
 /// * `Value` - TODO: reasons?
 /// * `Window` - The specified `window` does not exist.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeWindowAttributesRequest<'input> {
     pub window: Window,
     pub value_list: Cow<'input, ChangeWindowAttributesAux>,
@@ -6321,7 +6321,7 @@ impl<'input> Request for ChangeWindowAttributesRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for ChangeWindowAttributesRequest<'input> {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MapState(u8);
 impl MapState {
     pub const UNMAPPED: Self = Self(0);
@@ -6395,7 +6395,7 @@ pub const GET_WINDOW_ATTRIBUTES_REQUEST: u8 = 3;
 ///
 /// * `Window` - The specified `window` does not exist.
 /// * `Drawable` - TODO: reasons?
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetWindowAttributesRequest {
     pub window: Window,
 }
@@ -6465,7 +6465,7 @@ impl crate::x11_utils::ReplyRequest for GetWindowAttributesRequest {
 /// * `bit_gravity` -
 /// * `win_gravity` -
 /// * `map_state` -
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetWindowAttributesReply {
     pub backing_store: BackingStore,
     pub sequence: u16,
@@ -6547,7 +6547,7 @@ pub const DESTROY_WINDOW_REQUEST: u8 = 4;
 /// * `DestroyNotify`: event
 /// * `MapWindow`: request
 /// * `UnmapWindow`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyWindowRequest {
     pub window: Window,
 }
@@ -6602,7 +6602,7 @@ impl crate::x11_utils::VoidRequest for DestroyWindowRequest {
 
 /// Opcode for the DestroySubwindows request
 pub const DESTROY_SUBWINDOWS_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroySubwindowsRequest {
     pub window: Window,
 }
@@ -6655,7 +6655,7 @@ impl Request for DestroySubwindowsRequest {
 impl crate::x11_utils::VoidRequest for DestroySubwindowsRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetMode(u8);
 impl SetMode {
     pub const INSERT: Self = Self(0);
@@ -6737,7 +6737,7 @@ pub const CHANGE_SAVE_SET_REQUEST: u8 = 6;
 /// # See
 ///
 /// * `ReparentWindow`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeSaveSetRequest {
     pub mode: SetMode,
     pub window: Window,
@@ -6828,7 +6828,7 @@ pub const REPARENT_WINDOW_REQUEST: u8 = 7;
 /// * `ReparentNotify`: event
 /// * `MapWindow`: request
 /// * `UnmapWindow`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ReparentWindowRequest {
     pub window: Window,
     pub parent: Window,
@@ -6938,7 +6938,7 @@ pub const MAP_WINDOW_REQUEST: u8 = 8;
 /// * `MapNotify`: event
 /// * `Expose`: event
 /// * `UnmapWindow`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MapWindowRequest {
     pub window: Window,
 }
@@ -6993,7 +6993,7 @@ impl crate::x11_utils::VoidRequest for MapWindowRequest {
 
 /// Opcode for the MapSubwindows request
 pub const MAP_SUBWINDOWS_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MapSubwindowsRequest {
     pub window: Window,
 }
@@ -7069,7 +7069,7 @@ pub const UNMAP_WINDOW_REQUEST: u8 = 10;
 /// * `UnmapNotify`: event
 /// * `Expose`: event
 /// * `MapWindow`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UnmapWindowRequest {
     pub window: Window,
 }
@@ -7124,7 +7124,7 @@ impl crate::x11_utils::VoidRequest for UnmapWindowRequest {
 
 /// Opcode for the UnmapSubwindows request
 pub const UNMAP_SUBWINDOWS_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UnmapSubwindowsRequest {
     pub window: Window,
 }
@@ -7177,7 +7177,7 @@ impl Request for UnmapSubwindowsRequest {
 impl crate::x11_utils::VoidRequest for UnmapSubwindowsRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConfigWindow(u8);
 impl ConfigWindow {
     pub const X: Self = Self(1 << 0);
@@ -7246,7 +7246,7 @@ impl std::fmt::Debug for ConfigWindow  {
 }
 bitmask_binop!(ConfigWindow, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StackMode(u32);
 impl StackMode {
     pub const ABOVE: Self = Self(0);
@@ -7299,7 +7299,7 @@ impl std::fmt::Debug for StackMode  {
 }
 
 /// Auxiliary and optional information for the `configure_window` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ConfigureWindowAux {
     pub x: Option<i32>,
     pub y: Option<i32>,
@@ -7565,7 +7565,7 @@ pub const CONFIGURE_WINDOW_REQUEST: u8 = 12;
 ///     xcb_flush(c);
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConfigureWindowRequest<'input> {
     pub window: Window,
     pub value_list: Cow<'input, ConfigureWindowAux>,
@@ -7640,7 +7640,7 @@ impl<'input> Request for ConfigureWindowRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for ConfigureWindowRequest<'input> {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Circulate(u8);
 impl Circulate {
     pub const RAISE_LOWEST: Self = Self(0);
@@ -7717,7 +7717,7 @@ pub const CIRCULATE_WINDOW_REQUEST: u8 = 13;
 ///
 /// * `Window` - The specified `window` does not exist.
 /// * `Value` - The specified `direction` is invalid.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CirculateWindowRequest {
     pub direction: Circulate,
     pub window: Window,
@@ -7812,7 +7812,7 @@ pub const GET_GEOMETRY_REQUEST: u8 = 14;
 ///     free(reply);
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetGeometryRequest {
     pub drawable: Drawable,
 }
@@ -7879,7 +7879,7 @@ impl crate::x11_utils::ReplyRequest for GetGeometryRequest {
 /// * `height` - The height of `drawable`.
 /// * `border_width` - The border width (in pixels).
 /// * `depth` - The depth of the drawable (bits per pixel for the object).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetGeometryReply {
     pub depth: u8,
     pub sequence: u16,
@@ -7955,7 +7955,7 @@ pub const QUERY_TREE_REQUEST: u8 = 15;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryTreeRequest {
     pub window: Window,
 }
@@ -8013,7 +8013,7 @@ impl crate::x11_utils::ReplyRequest for QueryTreeRequest {
 ///
 /// * `root` - The root window of `window`.
 /// * `parent` - The parent window of `window`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryTreeReply {
     pub sequence: u16,
     pub length: u32,
@@ -8105,7 +8105,7 @@ pub const INTERN_ATOM_REQUEST: u8 = 16;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InternAtomRequest<'input> {
     pub only_if_exists: bool,
     pub name: Cow<'input, [u8]>,
@@ -8175,7 +8175,7 @@ impl<'input> crate::x11_utils::ReplyRequest for InternAtomRequest<'input> {
     type Reply = InternAtomReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InternAtomReply {
     pub sequence: u16,
     pub length: u32,
@@ -8202,7 +8202,7 @@ impl TryParse for InternAtomReply {
 
 /// Opcode for the GetAtomName request
 pub const GET_ATOM_NAME_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetAtomNameRequest {
     pub atom: Atom,
 }
@@ -8256,7 +8256,7 @@ impl crate::x11_utils::ReplyRequest for GetAtomNameRequest {
     type Reply = GetAtomNameReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetAtomNameReply {
     pub sequence: u16,
     pub length: u32,
@@ -8308,7 +8308,7 @@ impl GetAtomNameReply {
 /// * `Append` - Insert the new data after the beginning of existing data. The `format` must
 /// match existing property value. If the property is undefined, it is treated as
 /// defined with the correct type and format with zero-length data.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PropMode(u8);
 impl PropMode {
     pub const REPLACE: Self = Self(0);
@@ -8421,7 +8421,7 @@ pub const CHANGE_PROPERTY_REQUEST: u8 = 18;
 ///     xcb_flush(conn);
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangePropertyRequest<'input> {
     pub mode: PropMode,
     pub window: Window,
@@ -8532,7 +8532,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangePropertyRequest<'input> {
 
 /// Opcode for the DeleteProperty request
 pub const DELETE_PROPERTY_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeletePropertyRequest {
     pub window: Window,
     pub property: Atom,
@@ -8593,7 +8593,7 @@ impl Request for DeletePropertyRequest {
 impl crate::x11_utils::VoidRequest for DeletePropertyRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPropertyType(u8);
 impl GetPropertyType {
     pub const ANY: Self = Self(0);
@@ -8719,7 +8719,7 @@ pub const GET_PROPERTY_REQUEST: u8 = 20;
 ///     free(reply);
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPropertyRequest {
     pub delete: bool,
     pub window: Window,
@@ -8975,7 +8975,7 @@ impl GetPropertyReply {
 /// performed.
 /// * `value_len` - The length of value. You should use the corresponding accessor instead of this
 /// field.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPropertyReply {
     pub format: u8,
     pub sequence: u16,
@@ -9011,7 +9011,7 @@ impl TryParse for GetPropertyReply {
 
 /// Opcode for the ListProperties request
 pub const LIST_PROPERTIES_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListPropertiesRequest {
     pub window: Window,
 }
@@ -9065,7 +9065,7 @@ impl crate::x11_utils::ReplyRequest for ListPropertiesRequest {
     type Reply = ListPropertiesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListPropertiesReply {
     pub sequence: u16,
     pub length: u32,
@@ -9138,7 +9138,7 @@ pub const SET_SELECTION_OWNER_REQUEST: u8 = 22;
 /// # See
 ///
 /// * `SetSelectionOwner`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetSelectionOwnerRequest {
     pub owner: Window,
     pub selection: Atom,
@@ -9226,7 +9226,7 @@ pub const GET_SELECTION_OWNER_REQUEST: u8 = 23;
 /// # See
 ///
 /// * `SetSelectionOwner`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSelectionOwnerRequest {
     pub selection: Atom,
 }
@@ -9283,7 +9283,7 @@ impl crate::x11_utils::ReplyRequest for GetSelectionOwnerRequest {
 /// # Fields
 ///
 /// * `owner` - The current selection owner window.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSelectionOwnerReply {
     pub sequence: u16,
     pub length: u32,
@@ -9310,7 +9310,7 @@ impl TryParse for GetSelectionOwnerReply {
 
 /// Opcode for the ConvertSelection request
 pub const CONVERT_SELECTION_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ConvertSelectionRequest {
     pub requestor: Window,
     pub selection: Atom,
@@ -9395,7 +9395,7 @@ impl Request for ConvertSelectionRequest {
 impl crate::x11_utils::VoidRequest for ConvertSelectionRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SendEventDest(bool);
 impl SendEventDest {
     pub const POINTER_WINDOW: Self = Self(false);
@@ -9540,7 +9540,7 @@ pub const SEND_EVENT_REQUEST: u8 = 25;
 ///     free(event);
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SendEventRequest<'input> {
     pub propagate: bool,
     pub destination: Window,
@@ -9624,7 +9624,7 @@ impl<'input> crate::x11_utils::VoidRequest for SendEventRequest<'input> {
 /// generated by the server until the grabbing client issues a releasing
 /// `AllowEvents` request or until the keyboard grab is released.
 /// * `Async` - Keyboard event processing continues normally.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabMode(u8);
 impl GrabMode {
     pub const SYNC: Self = Self(0);
@@ -9682,7 +9682,7 @@ impl std::fmt::Debug for GrabMode  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabStatus(u8);
 impl GrabStatus {
     pub const SUCCESS: Self = Self(0);
@@ -9746,7 +9746,7 @@ impl std::fmt::Debug for GrabStatus  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CursorEnum(u8);
 impl CursorEnum {
     pub const NONE: Self = Self(0);
@@ -9875,7 +9875,7 @@ pub const GRAB_POINTER_REQUEST: u8 = 26;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabPointerRequest {
     pub owner_events: bool,
     pub grab_window: Window,
@@ -9974,7 +9974,7 @@ impl crate::x11_utils::ReplyRequest for GrabPointerRequest {
     type Reply = GrabPointerReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabPointerReply {
     pub status: GrabStatus,
     pub sequence: u16,
@@ -10024,7 +10024,7 @@ pub const UNGRAB_POINTER_REQUEST: u8 = 27;
 /// * `GrabButton`: request
 /// * `EnterNotify`: event
 /// * `LeaveNotify`: event
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UngrabPointerRequest {
     pub time: Timestamp,
 }
@@ -10085,7 +10085,7 @@ impl crate::x11_utils::VoidRequest for UngrabPointerRequest {
 /// * `3` - The middle mouse button.
 /// * `4` - Scroll wheel. TODO: direction?
 /// * `5` - Scroll wheel. TODO: direction?
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ButtonIndex(u8);
 impl ButtonIndex {
     pub const ANY: Self = Self(0);
@@ -10220,7 +10220,7 @@ pub const GRAB_BUTTON_REQUEST: u8 = 28;
 /// * `Value` - TODO: reasons?
 /// * `Cursor` - The specified `cursor` does not exist.
 /// * `Window` - The specified `window` does not exist.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabButtonRequest {
     pub owner_events: bool,
     pub grab_window: Window,
@@ -10326,7 +10326,7 @@ impl crate::x11_utils::VoidRequest for GrabButtonRequest {
 
 /// Opcode for the UngrabButton request
 pub const UNGRAB_BUTTON_REQUEST: u8 = 29;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UngrabButtonRequest {
     pub button: ButtonIndex,
     pub grab_window: Window,
@@ -10394,7 +10394,7 @@ impl crate::x11_utils::VoidRequest for UngrabButtonRequest {
 
 /// Opcode for the ChangeActivePointerGrab request
 pub const CHANGE_ACTIVE_POINTER_GRAB_REQUEST: u8 = 30;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeActivePointerGrabRequest {
     pub cursor: Cursor,
     pub time: Timestamp,
@@ -10528,7 +10528,7 @@ pub const GRAB_KEYBOARD_REQUEST: u8 = 31;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabKeyboardRequest {
     pub owner_events: bool,
     pub grab_window: Window,
@@ -10608,7 +10608,7 @@ impl crate::x11_utils::ReplyRequest for GrabKeyboardRequest {
     type Reply = GrabKeyboardReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabKeyboardReply {
     pub status: GrabStatus,
     pub sequence: u16,
@@ -10635,7 +10635,7 @@ impl TryParse for GrabKeyboardReply {
 
 /// Opcode for the UngrabKeyboard request
 pub const UNGRAB_KEYBOARD_REQUEST: u8 = 32;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UngrabKeyboardRequest {
     pub time: Timestamp,
 }
@@ -10688,7 +10688,7 @@ impl Request for UngrabKeyboardRequest {
 impl crate::x11_utils::VoidRequest for UngrabKeyboardRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Grab(u8);
 impl Grab {
     pub const ANY: Self = Self(0);
@@ -10806,7 +10806,7 @@ pub const GRAB_KEY_REQUEST: u8 = 33;
 /// # See
 ///
 /// * `GrabKeyboard`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabKeyRequest {
     pub owner_events: bool,
     pub grab_window: Window,
@@ -10916,7 +10916,7 @@ pub const UNGRAB_KEY_REQUEST: u8 = 34;
 ///
 /// * `GrabKey`: request
 /// * `xev`: program
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UngrabKeyRequest {
     pub key: Keycode,
     pub grab_window: Window,
@@ -11040,7 +11040,7 @@ impl crate::x11_utils::VoidRequest for UngrabKeyRequest {
 /// processing for both devices continues normally. If a device is frozen twice by
 /// the client on behalf of two separate grabs, AsyncBoth thaws for both. AsyncBoth
 /// has no effect unless both pointer and keyboard are frozen by the client.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Allow(u8);
 impl Allow {
     pub const ASYNC_POINTER: Self = Self(0);
@@ -11130,7 +11130,7 @@ pub const ALLOW_EVENTS_REQUEST: u8 = 35;
 /// # Errors
 ///
 /// * `Value` - You specified an invalid `mode`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AllowEventsRequest {
     pub mode: Allow,
     pub time: Timestamp,
@@ -11189,7 +11189,7 @@ impl crate::x11_utils::VoidRequest for AllowEventsRequest {
 
 /// Opcode for the GrabServer request
 pub const GRAB_SERVER_REQUEST: u8 = 36;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabServerRequest;
 impl GrabServerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11235,7 +11235,7 @@ impl crate::x11_utils::VoidRequest for GrabServerRequest {
 
 /// Opcode for the UngrabServer request
 pub const UNGRAB_SERVER_REQUEST: u8 = 37;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UngrabServerRequest;
 impl UngrabServerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11294,7 +11294,7 @@ pub const QUERY_POINTER_REQUEST: u8 = 38;
 /// # Errors
 ///
 /// * `Window` - The specified `window` does not exist.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryPointerRequest {
     pub window: Window,
 }
@@ -11367,7 +11367,7 @@ impl crate::x11_utils::ReplyRequest for QueryPointerRequest {
 /// * `mask` - The current logical state of the modifier keys and the buttons. Note that the
 /// logical state of a device (as seen by means of the protocol) may lag the
 /// physical state if device event processing is frozen.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryPointerReply {
     pub same_screen: bool,
     pub sequence: u16,
@@ -11406,7 +11406,7 @@ impl TryParse for QueryPointerReply {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Timecoord {
     pub time: Timestamp,
     pub x: i16,
@@ -11448,7 +11448,7 @@ impl Serialize for Timecoord {
 
 /// Opcode for the GetMotionEvents request
 pub const GET_MOTION_EVENTS_REQUEST: u8 = 39;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMotionEventsRequest {
     pub window: Window,
     pub start: Timestamp,
@@ -11518,7 +11518,7 @@ impl crate::x11_utils::ReplyRequest for GetMotionEventsRequest {
     type Reply = GetMotionEventsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetMotionEventsReply {
     pub sequence: u16,
     pub length: u32,
@@ -11562,7 +11562,7 @@ impl GetMotionEventsReply {
 
 /// Opcode for the TranslateCoordinates request
 pub const TRANSLATE_COORDINATES_REQUEST: u8 = 40;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TranslateCoordinatesRequest {
     pub src_window: Window,
     pub dst_window: Window,
@@ -11636,7 +11636,7 @@ impl crate::x11_utils::ReplyRequest for TranslateCoordinatesRequest {
     type Reply = TranslateCoordinatesReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TranslateCoordinatesReply {
     pub same_screen: bool,
     pub sequence: u16,
@@ -11700,7 +11700,7 @@ pub const WARP_POINTER_REQUEST: u8 = 41;
 /// # See
 ///
 /// * `SetInputFocus`: request
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WarpPointerRequest {
     pub src_window: Window,
     pub dst_window: Window,
@@ -11806,7 +11806,7 @@ impl crate::x11_utils::VoidRequest for WarpPointerRequest {
 /// * `Parent` - The focus reverts to the parent (or closest viewable ancestor) and the new
 /// revert_to value is `XCB_INPUT_FOCUS_NONE`.
 /// * `FollowKeyboard` - NOT YET DOCUMENTED. Only relevant for the xinput extension.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InputFocus(u8);
 impl InputFocus {
     pub const NONE: Self = Self(0);
@@ -11905,7 +11905,7 @@ pub const SET_INPUT_FOCUS_REQUEST: u8 = 42;
 ///
 /// * `FocusIn`: event
 /// * `FocusOut`: event
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetInputFocusRequest {
     pub revert_to: InputFocus,
     pub focus: Window,
@@ -11972,7 +11972,7 @@ impl crate::x11_utils::VoidRequest for SetInputFocusRequest {
 
 /// Opcode for the GetInputFocus request
 pub const GET_INPUT_FOCUS_REQUEST: u8 = 43;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetInputFocusRequest;
 impl GetInputFocusRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12017,7 +12017,7 @@ impl crate::x11_utils::ReplyRequest for GetInputFocusRequest {
     type Reply = GetInputFocusReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetInputFocusReply {
     pub revert_to: InputFocus,
     pub sequence: u16,
@@ -12046,7 +12046,7 @@ impl TryParse for GetInputFocusReply {
 
 /// Opcode for the QueryKeymap request
 pub const QUERY_KEYMAP_REQUEST: u8 = 44;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryKeymapRequest;
 impl QueryKeymapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12091,7 +12091,7 @@ impl crate::x11_utils::ReplyRequest for QueryKeymapRequest {
     type Reply = QueryKeymapReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryKeymapReply {
     pub sequence: u16,
     pub length: u32,
@@ -12138,7 +12138,7 @@ pub const OPEN_FONT_REQUEST: u8 = 45;
 /// # See
 ///
 /// * `xcb_generate_id`: function
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OpenFontRequest<'input> {
     pub fid: Font,
     pub name: Cow<'input, [u8]>,
@@ -12214,7 +12214,7 @@ impl<'input> crate::x11_utils::VoidRequest for OpenFontRequest<'input> {
 
 /// Opcode for the CloseFont request
 pub const CLOSE_FONT_REQUEST: u8 = 46;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CloseFontRequest {
     pub font: Font,
 }
@@ -12267,7 +12267,7 @@ impl Request for CloseFontRequest {
 impl crate::x11_utils::VoidRequest for CloseFontRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FontDraw(u8);
 impl FontDraw {
     pub const LEFT_TO_RIGHT: Self = Self(0);
@@ -12325,7 +12325,7 @@ impl std::fmt::Debug for FontDraw  {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Fontprop {
     pub name: Atom,
     pub value: u32,
@@ -12361,7 +12361,7 @@ impl Serialize for Fontprop {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Charinfo {
     pub left_side_bearing: i16,
     pub right_side_bearing: i16,
@@ -12426,7 +12426,7 @@ pub const QUERY_FONT_REQUEST: u8 = 47;
 /// # Fields
 ///
 /// * `font` - The fontable (Font or Graphics Context) to query.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryFontRequest {
     pub font: Fontable,
 }
@@ -12491,7 +12491,7 @@ impl crate::x11_utils::ReplyRequest for QueryFontRequest {
 /// * `font_ascent` - baseline to top edge of raster
 /// * `font_descent` - baseline to bottom edge of raster
 /// * `draw_direction` -
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryFontReply {
     pub sequence: u16,
     pub length: u32,
@@ -12609,7 +12609,7 @@ pub const QUERY_TEXT_EXTENTS_REQUEST: u8 = 48;
 ///
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Font` - The specified `font` does not exist.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryTextExtentsRequest<'input> {
     pub font: Fontable,
     pub string: Cow<'input, [Char2b]>,
@@ -12693,7 +12693,7 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryTextExtentsRequest<'input> 
     type Reply = QueryTextExtentsReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryTextExtentsReply {
     pub draw_direction: FontDraw,
     pub sequence: u16,
@@ -12732,7 +12732,7 @@ impl TryParse for QueryTextExtentsReply {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Str {
     pub name: Vec<u8>,
 }
@@ -12788,7 +12788,7 @@ pub const LIST_FONTS_REQUEST: u8 = 49;
 /// (?) is a wildcard for a single character. Use of uppercase or lowercase does
 /// not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListFontsRequest<'input> {
     pub max_names: u16,
     pub pattern: Cow<'input, [u8]>,
@@ -12860,7 +12860,7 @@ impl<'input> crate::x11_utils::ReplyRequest for ListFontsRequest<'input> {
 
 /// # Fields
 ///
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListFontsReply {
     pub sequence: u16,
     pub length: u32,
@@ -12916,7 +12916,7 @@ pub const LIST_FONTS_WITH_INFO_REQUEST: u8 = 50;
 /// (?) is a wildcard for a single character. Use of uppercase or lowercase does
 /// not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListFontsWithInfoRequest<'input> {
     pub max_names: u16,
     pub pattern: Cow<'input, [u8]>,
@@ -13000,7 +13000,7 @@ impl<'input> crate::x11_utils::ReplyRequest for ListFontsWithInfoRequest<'input>
 /// may be larger or smaller than the number of fonts actually returned. A zero
 /// value does not guarantee that no more fonts will be returned.
 /// * `draw_direction` -
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListFontsWithInfoReply {
     pub sequence: u16,
     pub length: u32,
@@ -13086,7 +13086,7 @@ impl ListFontsWithInfoReply {
 
 /// Opcode for the SetFontPath request
 pub const SET_FONT_PATH_REQUEST: u8 = 51;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetFontPathRequest<'input> {
     pub font: Cow<'input, [Str]>,
 }
@@ -13154,7 +13154,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetFontPathRequest<'input> {
 
 /// Opcode for the GetFontPath request
 pub const GET_FONT_PATH_REQUEST: u8 = 52;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetFontPathRequest;
 impl GetFontPathRequest {
     /// Serialize this request into bytes for the provided connection
@@ -13199,7 +13199,7 @@ impl crate::x11_utils::ReplyRequest for GetFontPathRequest {
     type Reply = GetFontPathReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetFontPathReply {
     pub sequence: u16,
     pub length: u32,
@@ -13266,7 +13266,7 @@ pub const CREATE_PIXMAP_REQUEST: u8 = 53;
 /// # See
 ///
 /// * `xcb_generate_id`: function
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreatePixmapRequest {
     pub depth: u8,
     pub pid: Pixmap,
@@ -13356,7 +13356,7 @@ pub const FREE_PIXMAP_REQUEST: u8 = 54;
 /// # Errors
 ///
 /// * `Pixmap` - The specified pixmap does not exist.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FreePixmapRequest {
     pub pixmap: Pixmap,
 }
@@ -13511,7 +13511,7 @@ impl crate::x11_utils::VoidRequest for FreePixmapRequest {
 /// * `DashOffset` - TODO
 /// * `DashList` - TODO
 /// * `ArcMode` - TODO
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GC(u32);
 impl GC {
     pub const FUNCTION: Self = Self(1 << 0);
@@ -13600,7 +13600,7 @@ impl std::fmt::Debug for GC  {
 }
 bitmask_binop!(GC, u32);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GX(u32);
 impl GX {
     pub const CLEAR: Self = Self(0);
@@ -13674,7 +13674,7 @@ impl std::fmt::Debug for GX  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LineStyle(u32);
 impl LineStyle {
     pub const SOLID: Self = Self(0);
@@ -13722,7 +13722,7 @@ impl std::fmt::Debug for LineStyle  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CapStyle(u32);
 impl CapStyle {
     pub const NOT_LAST: Self = Self(0);
@@ -13772,7 +13772,7 @@ impl std::fmt::Debug for CapStyle  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct JoinStyle(u32);
 impl JoinStyle {
     pub const MITER: Self = Self(0);
@@ -13820,7 +13820,7 @@ impl std::fmt::Debug for JoinStyle  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FillStyle(u32);
 impl FillStyle {
     pub const SOLID: Self = Self(0);
@@ -13870,7 +13870,7 @@ impl std::fmt::Debug for FillStyle  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FillRule(u32);
 impl FillRule {
     pub const EVEN_ODD: Self = Self(0);
@@ -13916,7 +13916,7 @@ impl std::fmt::Debug for FillRule  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubwindowMode(u32);
 impl SubwindowMode {
     pub const CLIP_BY_CHILDREN: Self = Self(0);
@@ -13962,7 +13962,7 @@ impl std::fmt::Debug for SubwindowMode  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ArcMode(u32);
 impl ArcMode {
     pub const CHORD: Self = Self(0);
@@ -14009,7 +14009,7 @@ impl std::fmt::Debug for ArcMode  {
 }
 
 /// Auxiliary and optional information for the `create_gc` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct CreateGCAux {
     pub function: Option<GX>,
     pub plane_mask: Option<u32>,
@@ -14560,7 +14560,7 @@ pub const CREATE_GC_REQUEST: u8 = 55;
 /// # See
 ///
 /// * `xcb_generate_id`: function
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateGCRequest<'input> {
     pub cid: Gcontext,
     pub drawable: Drawable,
@@ -14644,7 +14644,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateGCRequest<'input> {
 }
 
 /// Auxiliary and optional information for the `change_gc` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ChangeGCAux {
     pub function: Option<GX>,
     pub plane_mask: Option<u32>,
@@ -15216,7 +15216,7 @@ pub const CHANGE_GC_REQUEST: u8 = 56;
 ///     xcb_flush(conn);
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeGCRequest<'input> {
     pub gc: Gcontext,
     pub value_list: Cow<'input, ChangeGCAux>,
@@ -15292,7 +15292,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeGCRequest<'input> {
 
 /// Opcode for the CopyGC request
 pub const COPY_GC_REQUEST: u8 = 57;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CopyGCRequest {
     pub src_gc: Gcontext,
     pub dst_gc: Gcontext,
@@ -15363,7 +15363,7 @@ impl crate::x11_utils::VoidRequest for CopyGCRequest {
 
 /// Opcode for the SetDashes request
 pub const SET_DASHES_REQUEST: u8 = 58;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDashesRequest<'input> {
     pub gc: Gcontext,
     pub dash_offset: u16,
@@ -15441,7 +15441,7 @@ impl<'input> Request for SetDashesRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for SetDashesRequest<'input> {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClipOrdering(u8);
 impl ClipOrdering {
     pub const UNSORTED: Self = Self(0);
@@ -15505,7 +15505,7 @@ impl std::fmt::Debug for ClipOrdering  {
 
 /// Opcode for the SetClipRectangles request
 pub const SET_CLIP_RECTANGLES_REQUEST: u8 = 59;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetClipRectanglesRequest<'input> {
     pub ordering: ClipOrdering,
     pub gc: Gcontext,
@@ -15611,7 +15611,7 @@ pub const FREE_GC_REQUEST: u8 = 60;
 /// # Errors
 ///
 /// * `GContext` - The specified graphics context does not exist.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FreeGCRequest {
     pub gc: Gcontext,
 }
@@ -15666,7 +15666,7 @@ impl crate::x11_utils::VoidRequest for FreeGCRequest {
 
 /// Opcode for the ClearArea request
 pub const CLEAR_AREA_REQUEST: u8 = 61;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClearAreaRequest {
     pub exposures: bool,
     pub window: Window,
@@ -15769,7 +15769,7 @@ pub const COPY_AREA_REQUEST: u8 = 62;
 /// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Match` - `src_drawable` has a different root or depth than `dst_drawable`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CopyAreaRequest {
     pub src_drawable: Drawable,
     pub dst_drawable: Drawable,
@@ -15876,7 +15876,7 @@ impl crate::x11_utils::VoidRequest for CopyAreaRequest {
 
 /// Opcode for the CopyPlane request
 pub const COPY_PLANE_REQUEST: u8 = 63;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CopyPlaneRequest {
     pub src_drawable: Drawable,
     pub dst_drawable: Drawable,
@@ -15993,7 +15993,7 @@ impl crate::x11_utils::VoidRequest for CopyPlaneRequest {
 ///
 /// * `Origin` - Treats all coordinates as relative to the origin.
 /// * `Previous` - Treats all coordinates after the first as relative to the previous coordinate.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CoordMode(u8);
 impl CoordMode {
     pub const ORIGIN: Self = Self(0);
@@ -16053,7 +16053,7 @@ impl std::fmt::Debug for CoordMode  {
 
 /// Opcode for the PolyPoint request
 pub const POLY_POINT_REQUEST: u8 = 64;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PolyPointRequest<'input> {
     pub coordinate_mode: CoordMode,
     pub drawable: Drawable,
@@ -16182,7 +16182,7 @@ pub const POLY_LINE_REQUEST: u8 = 65;
 ///     xcb_flush(conn);
 /// }
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PolyLineRequest<'input> {
     pub coordinate_mode: CoordMode,
     pub drawable: Drawable,
@@ -16270,7 +16270,7 @@ impl<'input> Request for PolyLineRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for PolyLineRequest<'input> {
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Segment {
     pub x1: i16,
     pub y1: i16,
@@ -16342,7 +16342,7 @@ pub const POLY_SEGMENT_REQUEST: u8 = 66;
 /// * `Drawable` - The specified `drawable` does not exist.
 /// * `GContext` - The specified `gc` does not exist.
 /// * `Match` - TODO: reasons?
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PolySegmentRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -16427,7 +16427,7 @@ impl<'input> crate::x11_utils::VoidRequest for PolySegmentRequest<'input> {
 
 /// Opcode for the PolyRectangle request
 pub const POLY_RECTANGLE_REQUEST: u8 = 67;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PolyRectangleRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -16512,7 +16512,7 @@ impl<'input> crate::x11_utils::VoidRequest for PolyRectangleRequest<'input> {
 
 /// Opcode for the PolyArc request
 pub const POLY_ARC_REQUEST: u8 = 68;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PolyArcRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -16595,7 +16595,7 @@ impl<'input> Request for PolyArcRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for PolyArcRequest<'input> {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PolyShape(u8);
 impl PolyShape {
     pub const COMPLEX: Self = Self(0);
@@ -16657,7 +16657,7 @@ impl std::fmt::Debug for PolyShape  {
 
 /// Opcode for the FillPoly request
 pub const FILL_POLY_REQUEST: u8 = 69;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FillPolyRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -16784,7 +16784,7 @@ pub const POLY_FILL_RECTANGLE_REQUEST: u8 = 70;
 /// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Match` - TODO: reasons?
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PolyFillRectangleRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -16869,7 +16869,7 @@ impl<'input> crate::x11_utils::VoidRequest for PolyFillRectangleRequest<'input> 
 
 /// Opcode for the PolyFillArc request
 pub const POLY_FILL_ARC_REQUEST: u8 = 71;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PolyFillArcRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -16952,7 +16952,7 @@ impl<'input> Request for PolyFillArcRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for PolyFillArcRequest<'input> {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ImageFormat(u8);
 impl ImageFormat {
     pub const XY_BITMAP: Self = Self(0);
@@ -17014,7 +17014,7 @@ impl std::fmt::Debug for ImageFormat  {
 
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 72;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PutImageRequest<'input> {
     pub format: ImageFormat,
     pub drawable: Drawable,
@@ -17139,7 +17139,7 @@ impl<'input> crate::x11_utils::VoidRequest for PutImageRequest<'input> {
 
 /// Opcode for the GetImage request
 pub const GET_IMAGE_REQUEST: u8 = 73;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetImageRequest {
     pub format: ImageFormat,
     pub drawable: Drawable,
@@ -17229,7 +17229,7 @@ impl crate::x11_utils::ReplyRequest for GetImageRequest {
     type Reply = GetImageReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetImageReply {
     pub depth: u8,
     pub sequence: u16,
@@ -17276,7 +17276,7 @@ impl GetImageReply {
 
 /// Opcode for the PolyText8 request
 pub const POLY_TEXT8_REQUEST: u8 = 74;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PolyText8Request<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -17367,7 +17367,7 @@ impl<'input> crate::x11_utils::VoidRequest for PolyText8Request<'input> {
 
 /// Opcode for the PolyText16 request
 pub const POLY_TEXT16_REQUEST: u8 = 75;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PolyText16Request<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -17490,7 +17490,7 @@ pub const IMAGE_TEXT8_REQUEST: u8 = 76;
 /// # See
 ///
 /// * `ImageText16`: request
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ImageText8Request<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -17616,7 +17616,7 @@ pub const IMAGE_TEXT16_REQUEST: u8 = 77;
 /// # See
 ///
 /// * `ImageText8`: request
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ImageText16Request<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -17708,7 +17708,7 @@ impl<'input> Request for ImageText16Request<'input> {
 impl<'input> crate::x11_utils::VoidRequest for ImageText16Request<'input> {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ColormapAlloc(u8);
 impl ColormapAlloc {
     pub const NONE: Self = Self(0);
@@ -17768,7 +17768,7 @@ impl std::fmt::Debug for ColormapAlloc  {
 
 /// Opcode for the CreateColormap request
 pub const CREATE_COLORMAP_REQUEST: u8 = 78;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateColormapRequest {
     pub alloc: ColormapAlloc,
     pub mid: Colormap,
@@ -17843,7 +17843,7 @@ impl crate::x11_utils::VoidRequest for CreateColormapRequest {
 
 /// Opcode for the FreeColormap request
 pub const FREE_COLORMAP_REQUEST: u8 = 79;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FreeColormapRequest {
     pub cmap: Colormap,
 }
@@ -17898,7 +17898,7 @@ impl crate::x11_utils::VoidRequest for FreeColormapRequest {
 
 /// Opcode for the CopyColormapAndFree request
 pub const COPY_COLORMAP_AND_FREE_REQUEST: u8 = 80;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CopyColormapAndFreeRequest {
     pub mid: Colormap,
     pub src_cmap: Colormap,
@@ -17961,7 +17961,7 @@ impl crate::x11_utils::VoidRequest for CopyColormapAndFreeRequest {
 
 /// Opcode for the InstallColormap request
 pub const INSTALL_COLORMAP_REQUEST: u8 = 81;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct InstallColormapRequest {
     pub cmap: Colormap,
 }
@@ -18016,7 +18016,7 @@ impl crate::x11_utils::VoidRequest for InstallColormapRequest {
 
 /// Opcode for the UninstallColormap request
 pub const UNINSTALL_COLORMAP_REQUEST: u8 = 82;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UninstallColormapRequest {
     pub cmap: Colormap,
 }
@@ -18071,7 +18071,7 @@ impl crate::x11_utils::VoidRequest for UninstallColormapRequest {
 
 /// Opcode for the ListInstalledColormaps request
 pub const LIST_INSTALLED_COLORMAPS_REQUEST: u8 = 83;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListInstalledColormapsRequest {
     pub window: Window,
 }
@@ -18125,7 +18125,7 @@ impl crate::x11_utils::ReplyRequest for ListInstalledColormapsRequest {
     type Reply = ListInstalledColormapsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListInstalledColormapsReply {
     pub sequence: u16,
     pub length: u32,
@@ -18187,7 +18187,7 @@ pub const ALLOC_COLOR_REQUEST: u8 = 84;
 /// # Errors
 ///
 /// * `Colormap` - The specified colormap `cmap` does not exist.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AllocColorRequest {
     pub cmap: Colormap,
     pub red: u16,
@@ -18262,7 +18262,7 @@ impl crate::x11_utils::ReplyRequest for AllocColorRequest {
     type Reply = AllocColorReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AllocColorReply {
     pub sequence: u16,
     pub length: u32,
@@ -18296,7 +18296,7 @@ impl TryParse for AllocColorReply {
 
 /// Opcode for the AllocNamedColor request
 pub const ALLOC_NAMED_COLOR_REQUEST: u8 = 85;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AllocNamedColorRequest<'input> {
     pub cmap: Colormap,
     pub name: Cow<'input, [u8]>,
@@ -18371,7 +18371,7 @@ impl<'input> crate::x11_utils::ReplyRequest for AllocNamedColorRequest<'input> {
     type Reply = AllocNamedColorReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AllocNamedColorReply {
     pub sequence: u16,
     pub length: u32,
@@ -18410,7 +18410,7 @@ impl TryParse for AllocNamedColorReply {
 
 /// Opcode for the AllocColorCells request
 pub const ALLOC_COLOR_CELLS_REQUEST: u8 = 86;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AllocColorCellsRequest {
     pub contiguous: bool,
     pub cmap: Colormap,
@@ -18479,7 +18479,7 @@ impl crate::x11_utils::ReplyRequest for AllocColorCellsRequest {
     type Reply = AllocColorCellsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AllocColorCellsReply {
     pub sequence: u16,
     pub length: u32,
@@ -18539,7 +18539,7 @@ impl AllocColorCellsReply {
 
 /// Opcode for the AllocColorPlanes request
 pub const ALLOC_COLOR_PLANES_REQUEST: u8 = 87;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AllocColorPlanesRequest {
     pub contiguous: bool,
     pub cmap: Colormap,
@@ -18620,7 +18620,7 @@ impl crate::x11_utils::ReplyRequest for AllocColorPlanesRequest {
     type Reply = AllocColorPlanesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AllocColorPlanesReply {
     pub sequence: u16,
     pub length: u32,
@@ -18671,7 +18671,7 @@ impl AllocColorPlanesReply {
 
 /// Opcode for the FreeColors request
 pub const FREE_COLORS_REQUEST: u8 = 88;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FreeColorsRequest<'input> {
     pub cmap: Colormap,
     pub plane_mask: u32,
@@ -18754,7 +18754,7 @@ impl<'input> Request for FreeColorsRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for FreeColorsRequest<'input> {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ColorFlag(u8);
 impl ColorFlag {
     pub const RED: Self = Self(1 << 0);
@@ -18815,7 +18815,7 @@ impl std::fmt::Debug for ColorFlag  {
 }
 bitmask_binop!(ColorFlag, u8);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Coloritem {
     pub pixel: u32,
     pub red: u16,
@@ -18871,7 +18871,7 @@ impl Serialize for Coloritem {
 
 /// Opcode for the StoreColors request
 pub const STORE_COLORS_REQUEST: u8 = 89;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StoreColorsRequest<'input> {
     pub cmap: Colormap,
     pub items: Cow<'input, [Coloritem]>,
@@ -18947,7 +18947,7 @@ impl<'input> crate::x11_utils::VoidRequest for StoreColorsRequest<'input> {
 
 /// Opcode for the StoreNamedColor request
 pub const STORE_NAMED_COLOR_REQUEST: u8 = 90;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StoreNamedColorRequest<'input> {
     pub flags: u8,
     pub cmap: Colormap,
@@ -19034,7 +19034,7 @@ impl<'input> Request for StoreNamedColorRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for StoreNamedColorRequest<'input> {
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Rgb {
     pub red: u16,
     pub green: u16,
@@ -19078,7 +19078,7 @@ impl Serialize for Rgb {
 
 /// Opcode for the QueryColors request
 pub const QUERY_COLORS_REQUEST: u8 = 91;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryColorsRequest<'input> {
     pub cmap: Colormap,
     pub pixels: Cow<'input, [u32]>,
@@ -19153,7 +19153,7 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryColorsRequest<'input> {
     type Reply = QueryColorsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryColorsReply {
     pub sequence: u16,
     pub length: u32,
@@ -19197,7 +19197,7 @@ impl QueryColorsReply {
 
 /// Opcode for the LookupColor request
 pub const LOOKUP_COLOR_REQUEST: u8 = 92;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LookupColorRequest<'input> {
     pub cmap: Colormap,
     pub name: Cow<'input, [u8]>,
@@ -19272,7 +19272,7 @@ impl<'input> crate::x11_utils::ReplyRequest for LookupColorRequest<'input> {
     type Reply = LookupColorReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LookupColorReply {
     pub sequence: u16,
     pub length: u32,
@@ -19307,7 +19307,7 @@ impl TryParse for LookupColorReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PixmapEnum(u8);
 impl PixmapEnum {
     pub const NONE: Self = Self(0);
@@ -19365,7 +19365,7 @@ impl std::fmt::Debug for PixmapEnum  {
 
 /// Opcode for the CreateCursor request
 pub const CREATE_CURSOR_REQUEST: u8 = 93;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateCursorRequest {
     pub cid: Cursor,
     pub source: Pixmap,
@@ -19482,7 +19482,7 @@ impl Request for CreateCursorRequest {
 impl crate::x11_utils::VoidRequest for CreateCursorRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FontEnum(u8);
 impl FontEnum {
     pub const NONE: Self = Self(0);
@@ -19573,7 +19573,7 @@ pub const CREATE_GLYPH_CURSOR_REQUEST: u8 = 94;
 /// * `Alloc` - The X server could not allocate the requested resources (no memory?).
 /// * `Font` - The specified `source_font` or `mask_font` does not exist.
 /// * `Value` - Either `source_char` or `mask_char` are not defined in `source_font` or `mask_font`, respectively.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateGlyphCursorRequest {
     pub cid: Cursor,
     pub source_font: Font,
@@ -19704,7 +19704,7 @@ pub const FREE_CURSOR_REQUEST: u8 = 95;
 /// # Errors
 ///
 /// * `Cursor` - The specified cursor does not exist.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FreeCursorRequest {
     pub cursor: Cursor,
 }
@@ -19759,7 +19759,7 @@ impl crate::x11_utils::VoidRequest for FreeCursorRequest {
 
 /// Opcode for the RecolorCursor request
 pub const RECOLOR_CURSOR_REQUEST: u8 = 96;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RecolorCursorRequest {
     pub cursor: Cursor,
     pub fore_red: u16,
@@ -19848,7 +19848,7 @@ impl Request for RecolorCursorRequest {
 impl crate::x11_utils::VoidRequest for RecolorCursorRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryShapeOf(u8);
 impl QueryShapeOf {
     pub const LARGEST_CURSOR: Self = Self(0);
@@ -19910,7 +19910,7 @@ impl std::fmt::Debug for QueryShapeOf  {
 
 /// Opcode for the QueryBestSize request
 pub const QUERY_BEST_SIZE_REQUEST: u8 = 97;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryBestSizeRequest {
     pub class: QueryShapeOf,
     pub drawable: Drawable,
@@ -19980,7 +19980,7 @@ impl crate::x11_utils::ReplyRequest for QueryBestSizeRequest {
     type Reply = QueryBestSizeReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryBestSizeReply {
     pub sequence: u16,
     pub length: u32,
@@ -20030,7 +20030,7 @@ pub const QUERY_EXTENSION_REQUEST: u8 = 98;
 ///
 /// * `xdpyinfo`: program
 /// * `xcb_get_extension_data`: function
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryExtensionRequest<'input> {
     pub name: Cow<'input, [u8]>,
 }
@@ -20102,7 +20102,7 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryExtensionRequest<'input> {
 /// * `major_opcode` - The major opcode for requests.
 /// * `first_event` - The first event code, if any.
 /// * `first_error` - The first error code, if any.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryExtensionReply {
     pub sequence: u16,
     pub length: u32,
@@ -20135,7 +20135,7 @@ impl TryParse for QueryExtensionReply {
 
 /// Opcode for the ListExtensions request
 pub const LIST_EXTENSIONS_REQUEST: u8 = 99;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListExtensionsRequest;
 impl ListExtensionsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -20180,7 +20180,7 @@ impl crate::x11_utils::ReplyRequest for ListExtensionsRequest {
     type Reply = ListExtensionsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListExtensionsReply {
     pub sequence: u16,
     pub length: u32,
@@ -20223,7 +20223,7 @@ impl ListExtensionsReply {
 
 /// Opcode for the ChangeKeyboardMapping request
 pub const CHANGE_KEYBOARD_MAPPING_REQUEST: u8 = 100;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeKeyboardMappingRequest<'input> {
     pub keycode_count: u8,
     pub first_keycode: Keycode,
@@ -20303,7 +20303,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeKeyboardMappingRequest<'inp
 
 /// Opcode for the GetKeyboardMapping request
 pub const GET_KEYBOARD_MAPPING_REQUEST: u8 = 101;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetKeyboardMappingRequest {
     pub first_keycode: Keycode,
     pub count: u8,
@@ -20361,7 +20361,7 @@ impl crate::x11_utils::ReplyRequest for GetKeyboardMappingRequest {
     type Reply = GetKeyboardMappingReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetKeyboardMappingReply {
     pub keysyms_per_keycode: u8,
     pub sequence: u16,
@@ -20402,7 +20402,7 @@ impl GetKeyboardMappingReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KB(u8);
 impl KB {
     pub const KEY_CLICK_PERCENT: Self = Self(1 << 0);
@@ -20473,7 +20473,7 @@ impl std::fmt::Debug for KB  {
 }
 bitmask_binop!(KB, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LedMode(u32);
 impl LedMode {
     pub const OFF: Self = Self(0);
@@ -20519,7 +20519,7 @@ impl std::fmt::Debug for LedMode  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AutoRepeatMode(u32);
 impl AutoRepeatMode {
     pub const OFF: Self = Self(0);
@@ -20568,7 +20568,7 @@ impl std::fmt::Debug for AutoRepeatMode  {
 }
 
 /// Auxiliary and optional information for the `change_keyboard_control` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct ChangeKeyboardControlAux {
     pub key_click_percent: Option<i32>,
     pub bell_percent: Option<i32>,
@@ -20775,7 +20775,7 @@ impl ChangeKeyboardControlAux {
 
 /// Opcode for the ChangeKeyboardControl request
 pub const CHANGE_KEYBOARD_CONTROL_REQUEST: u8 = 102;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeKeyboardControlRequest<'input> {
     pub value_list: Cow<'input, ChangeKeyboardControlAux>,
 }
@@ -20842,7 +20842,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeKeyboardControlRequest<'inp
 
 /// Opcode for the GetKeyboardControl request
 pub const GET_KEYBOARD_CONTROL_REQUEST: u8 = 103;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetKeyboardControlRequest;
 impl GetKeyboardControlRequest {
     /// Serialize this request into bytes for the provided connection
@@ -20887,7 +20887,7 @@ impl crate::x11_utils::ReplyRequest for GetKeyboardControlRequest {
     type Reply = GetKeyboardControlReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetKeyboardControlReply {
     pub global_auto_repeat: AutoRepeatMode,
     pub sequence: u16,
@@ -20928,7 +20928,7 @@ impl TryParse for GetKeyboardControlReply {
 
 /// Opcode for the Bell request
 pub const BELL_REQUEST: u8 = 104;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BellRequest {
     pub percent: i8,
 }
@@ -20978,7 +20978,7 @@ impl crate::x11_utils::VoidRequest for BellRequest {
 
 /// Opcode for the ChangePointerControl request
 pub const CHANGE_POINTER_CONTROL_REQUEST: u8 = 105;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangePointerControlRequest {
     pub acceleration_numerator: i16,
     pub acceleration_denominator: i16,
@@ -21053,7 +21053,7 @@ impl crate::x11_utils::VoidRequest for ChangePointerControlRequest {
 
 /// Opcode for the GetPointerControl request
 pub const GET_POINTER_CONTROL_REQUEST: u8 = 106;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPointerControlRequest;
 impl GetPointerControlRequest {
     /// Serialize this request into bytes for the provided connection
@@ -21098,7 +21098,7 @@ impl crate::x11_utils::ReplyRequest for GetPointerControlRequest {
     type Reply = GetPointerControlReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPointerControlReply {
     pub sequence: u16,
     pub length: u32,
@@ -21128,7 +21128,7 @@ impl TryParse for GetPointerControlReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Blanking(u8);
 impl Blanking {
     pub const NOT_PREFERRED: Self = Self(0);
@@ -21188,7 +21188,7 @@ impl std::fmt::Debug for Blanking  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Exposures(u8);
 impl Exposures {
     pub const NOT_ALLOWED: Self = Self(0);
@@ -21250,7 +21250,7 @@ impl std::fmt::Debug for Exposures  {
 
 /// Opcode for the SetScreenSaver request
 pub const SET_SCREEN_SAVER_REQUEST: u8 = 107;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetScreenSaverRequest {
     pub timeout: i16,
     pub interval: i16,
@@ -21323,7 +21323,7 @@ impl crate::x11_utils::VoidRequest for SetScreenSaverRequest {
 
 /// Opcode for the GetScreenSaver request
 pub const GET_SCREEN_SAVER_REQUEST: u8 = 108;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenSaverRequest;
 impl GetScreenSaverRequest {
     /// Serialize this request into bytes for the provided connection
@@ -21368,7 +21368,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenSaverRequest {
     type Reply = GetScreenSaverReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetScreenSaverReply {
     pub sequence: u16,
     pub length: u32,
@@ -21402,7 +21402,7 @@ impl TryParse for GetScreenSaverReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HostMode(u8);
 impl HostMode {
     pub const INSERT: Self = Self(0);
@@ -21460,7 +21460,7 @@ impl std::fmt::Debug for HostMode  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Family(u8);
 impl Family {
     pub const INTERNET: Self = Self(0);
@@ -21526,7 +21526,7 @@ impl std::fmt::Debug for Family  {
 
 /// Opcode for the ChangeHosts request
 pub const CHANGE_HOSTS_REQUEST: u8 = 109;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChangeHostsRequest<'input> {
     pub mode: HostMode,
     pub family: Family,
@@ -21602,7 +21602,7 @@ impl<'input> Request for ChangeHostsRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for ChangeHostsRequest<'input> {
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Host {
     pub family: Family,
     pub address: Vec<u8>,
@@ -21659,7 +21659,7 @@ impl Host {
 
 /// Opcode for the ListHosts request
 pub const LIST_HOSTS_REQUEST: u8 = 110;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListHostsRequest;
 impl ListHostsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -21704,7 +21704,7 @@ impl crate::x11_utils::ReplyRequest for ListHostsRequest {
     type Reply = ListHostsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListHostsReply {
     pub mode: AccessControl,
     pub sequence: u16,
@@ -21748,7 +21748,7 @@ impl ListHostsReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AccessControl(u8);
 impl AccessControl {
     pub const DISABLE: Self = Self(0);
@@ -21808,7 +21808,7 @@ impl std::fmt::Debug for AccessControl  {
 
 /// Opcode for the SetAccessControl request
 pub const SET_ACCESS_CONTROL_REQUEST: u8 = 111;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetAccessControlRequest {
     pub mode: AccessControl,
 }
@@ -21857,7 +21857,7 @@ impl Request for SetAccessControlRequest {
 impl crate::x11_utils::VoidRequest for SetAccessControlRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CloseDown(u8);
 impl CloseDown {
     pub const DESTROY_ALL: Self = Self(0);
@@ -21919,7 +21919,7 @@ impl std::fmt::Debug for CloseDown  {
 
 /// Opcode for the SetCloseDownMode request
 pub const SET_CLOSE_DOWN_MODE_REQUEST: u8 = 112;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetCloseDownModeRequest {
     pub mode: CloseDown,
 }
@@ -21968,7 +21968,7 @@ impl Request for SetCloseDownModeRequest {
 impl crate::x11_utils::VoidRequest for SetCloseDownModeRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Kill(u8);
 impl Kill {
     pub const ALL_TEMPORARY: Self = Self(0);
@@ -22045,7 +22045,7 @@ pub const KILL_CLIENT_REQUEST: u8 = 113;
 /// # See
 ///
 /// * `xkill`: program
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct KillClientRequest {
     pub resource: u32,
 }
@@ -22100,7 +22100,7 @@ impl crate::x11_utils::VoidRequest for KillClientRequest {
 
 /// Opcode for the RotateProperties request
 pub const ROTATE_PROPERTIES_REQUEST: u8 = 114;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RotatePropertiesRequest<'input> {
     pub window: Window,
     pub delta: i16,
@@ -22179,7 +22179,7 @@ impl<'input> Request for RotatePropertiesRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for RotatePropertiesRequest<'input> {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScreenSaver(u8);
 impl ScreenSaver {
     pub const RESET: Self = Self(0);
@@ -22239,7 +22239,7 @@ impl std::fmt::Debug for ScreenSaver  {
 
 /// Opcode for the ForceScreenSaver request
 pub const FORCE_SCREEN_SAVER_REQUEST: u8 = 115;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ForceScreenSaverRequest {
     pub mode: ScreenSaver,
 }
@@ -22288,7 +22288,7 @@ impl Request for ForceScreenSaverRequest {
 impl crate::x11_utils::VoidRequest for ForceScreenSaverRequest {
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MappingStatus(u8);
 impl MappingStatus {
     pub const SUCCESS: Self = Self(0);
@@ -22350,7 +22350,7 @@ impl std::fmt::Debug for MappingStatus  {
 
 /// Opcode for the SetPointerMapping request
 pub const SET_POINTER_MAPPING_REQUEST: u8 = 116;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetPointerMappingRequest<'input> {
     pub map: Cow<'input, [u8]>,
 }
@@ -22410,7 +22410,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetPointerMappingRequest<'input>
     type Reply = SetPointerMappingReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetPointerMappingReply {
     pub status: MappingStatus,
     pub sequence: u16,
@@ -22437,7 +22437,7 @@ impl TryParse for SetPointerMappingReply {
 
 /// Opcode for the GetPointerMapping request
 pub const GET_POINTER_MAPPING_REQUEST: u8 = 117;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPointerMappingRequest;
 impl GetPointerMappingRequest {
     /// Serialize this request into bytes for the provided connection
@@ -22482,7 +22482,7 @@ impl crate::x11_utils::ReplyRequest for GetPointerMappingRequest {
     type Reply = GetPointerMappingReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPointerMappingReply {
     pub sequence: u16,
     pub length: u32,
@@ -22524,7 +22524,7 @@ impl GetPointerMappingReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MapIndex(u8);
 impl MapIndex {
     pub const SHIFT: Self = Self(0);
@@ -22596,7 +22596,7 @@ impl std::fmt::Debug for MapIndex  {
 
 /// Opcode for the SetModifierMapping request
 pub const SET_MODIFIER_MAPPING_REQUEST: u8 = 118;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetModifierMappingRequest<'input> {
     pub keycodes: Cow<'input, [Keycode]>,
 }
@@ -22657,7 +22657,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetModifierMappingRequest<'input
     type Reply = SetModifierMappingReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetModifierMappingReply {
     pub status: MappingStatus,
     pub sequence: u16,
@@ -22684,7 +22684,7 @@ impl TryParse for SetModifierMappingReply {
 
 /// Opcode for the GetModifierMapping request
 pub const GET_MODIFIER_MAPPING_REQUEST: u8 = 119;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetModifierMappingRequest;
 impl GetModifierMappingRequest {
     /// Serialize this request into bytes for the provided connection
@@ -22729,7 +22729,7 @@ impl crate::x11_utils::ReplyRequest for GetModifierMappingRequest {
     type Reply = GetModifierMappingReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetModifierMappingReply {
     pub sequence: u16,
     pub length: u32,
@@ -22774,7 +22774,7 @@ impl GetModifierMappingReply {
 
 /// Opcode for the NoOperation request
 pub const NO_OPERATION_REQUEST: u8 = 127;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NoOperationRequest;
 impl NoOperationRequest {
     /// Serialize this request into bytes for the provided connection

--- a/x11rb-protocol/src/protocol/xselinux.rs
+++ b/x11rb-protocol/src/protocol/xselinux.rs
@@ -34,7 +34,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest {
     pub client_major: u8,
     pub client_minor: u8,
@@ -89,7 +89,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -118,7 +118,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the SetDeviceCreateContext request
 pub const SET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 1;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDeviceCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
@@ -181,7 +181,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetDeviceCreateContextRequest<'in
 
 /// Opcode for the GetDeviceCreateContext request
 pub const GET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceCreateContextRequest;
 impl GetDeviceCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -223,7 +223,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceCreateContextRequest {
     type Reply = GetDeviceCreateContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceCreateContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -268,7 +268,7 @@ impl GetDeviceCreateContextReply {
 
 /// Opcode for the SetDeviceContext request
 pub const SET_DEVICE_CONTEXT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetDeviceContextRequest<'input> {
     pub device: u32,
     pub context: Cow<'input, [u8]>,
@@ -340,7 +340,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetDeviceContextRequest<'input> {
 
 /// Opcode for the GetDeviceContext request
 pub const GET_DEVICE_CONTEXT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceContextRequest {
     pub device: u32,
 }
@@ -391,7 +391,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceContextRequest {
     type Reply = GetDeviceContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetDeviceContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -436,7 +436,7 @@ impl GetDeviceContextReply {
 
 /// Opcode for the SetWindowCreateContext request
 pub const SET_WINDOW_CREATE_CONTEXT_REQUEST: u8 = 5;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetWindowCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
@@ -499,7 +499,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetWindowCreateContextRequest<'in
 
 /// Opcode for the GetWindowCreateContext request
 pub const GET_WINDOW_CREATE_CONTEXT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetWindowCreateContextRequest;
 impl GetWindowCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -541,7 +541,7 @@ impl crate::x11_utils::ReplyRequest for GetWindowCreateContextRequest {
     type Reply = GetWindowCreateContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetWindowCreateContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -586,7 +586,7 @@ impl GetWindowCreateContextReply {
 
 /// Opcode for the GetWindowContext request
 pub const GET_WINDOW_CONTEXT_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetWindowContextRequest {
     pub window: xproto::Window,
 }
@@ -637,7 +637,7 @@ impl crate::x11_utils::ReplyRequest for GetWindowContextRequest {
     type Reply = GetWindowContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetWindowContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -680,7 +680,7 @@ impl GetWindowContextReply {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListItem {
     pub name: xproto::Atom,
     pub object_context: Vec<u8>,
@@ -759,7 +759,7 @@ impl ListItem {
 
 /// Opcode for the SetPropertyCreateContext request
 pub const SET_PROPERTY_CREATE_CONTEXT_REQUEST: u8 = 8;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetPropertyCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
@@ -822,7 +822,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetPropertyCreateContextRequest<'
 
 /// Opcode for the GetPropertyCreateContext request
 pub const GET_PROPERTY_CREATE_CONTEXT_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPropertyCreateContextRequest;
 impl GetPropertyCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -864,7 +864,7 @@ impl crate::x11_utils::ReplyRequest for GetPropertyCreateContextRequest {
     type Reply = GetPropertyCreateContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPropertyCreateContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -909,7 +909,7 @@ impl GetPropertyCreateContextReply {
 
 /// Opcode for the SetPropertyUseContext request
 pub const SET_PROPERTY_USE_CONTEXT_REQUEST: u8 = 10;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetPropertyUseContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
@@ -972,7 +972,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetPropertyUseContextRequest<'inp
 
 /// Opcode for the GetPropertyUseContext request
 pub const GET_PROPERTY_USE_CONTEXT_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPropertyUseContextRequest;
 impl GetPropertyUseContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1014,7 +1014,7 @@ impl crate::x11_utils::ReplyRequest for GetPropertyUseContextRequest {
     type Reply = GetPropertyUseContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPropertyUseContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1059,7 +1059,7 @@ impl GetPropertyUseContextReply {
 
 /// Opcode for the GetPropertyContext request
 pub const GET_PROPERTY_CONTEXT_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPropertyContextRequest {
     pub window: xproto::Window,
     pub property: xproto::Atom,
@@ -1118,7 +1118,7 @@ impl crate::x11_utils::ReplyRequest for GetPropertyContextRequest {
     type Reply = GetPropertyContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPropertyContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1163,7 +1163,7 @@ impl GetPropertyContextReply {
 
 /// Opcode for the GetPropertyDataContext request
 pub const GET_PROPERTY_DATA_CONTEXT_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPropertyDataContextRequest {
     pub window: xproto::Window,
     pub property: xproto::Atom,
@@ -1222,7 +1222,7 @@ impl crate::x11_utils::ReplyRequest for GetPropertyDataContextRequest {
     type Reply = GetPropertyDataContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPropertyDataContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1267,7 +1267,7 @@ impl GetPropertyDataContextReply {
 
 /// Opcode for the ListProperties request
 pub const LIST_PROPERTIES_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListPropertiesRequest {
     pub window: xproto::Window,
 }
@@ -1318,7 +1318,7 @@ impl crate::x11_utils::ReplyRequest for ListPropertiesRequest {
     type Reply = ListPropertiesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListPropertiesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1362,7 +1362,7 @@ impl ListPropertiesReply {
 
 /// Opcode for the SetSelectionCreateContext request
 pub const SET_SELECTION_CREATE_CONTEXT_REQUEST: u8 = 15;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetSelectionCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
@@ -1425,7 +1425,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetSelectionCreateContextRequest<
 
 /// Opcode for the GetSelectionCreateContext request
 pub const GET_SELECTION_CREATE_CONTEXT_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSelectionCreateContextRequest;
 impl GetSelectionCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1467,7 +1467,7 @@ impl crate::x11_utils::ReplyRequest for GetSelectionCreateContextRequest {
     type Reply = GetSelectionCreateContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSelectionCreateContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1512,7 +1512,7 @@ impl GetSelectionCreateContextReply {
 
 /// Opcode for the SetSelectionUseContext request
 pub const SET_SELECTION_USE_CONTEXT_REQUEST: u8 = 17;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetSelectionUseContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
@@ -1575,7 +1575,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetSelectionUseContextRequest<'in
 
 /// Opcode for the GetSelectionUseContext request
 pub const GET_SELECTION_USE_CONTEXT_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSelectionUseContextRequest;
 impl GetSelectionUseContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1617,7 +1617,7 @@ impl crate::x11_utils::ReplyRequest for GetSelectionUseContextRequest {
     type Reply = GetSelectionUseContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSelectionUseContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1662,7 +1662,7 @@ impl GetSelectionUseContextReply {
 
 /// Opcode for the GetSelectionContext request
 pub const GET_SELECTION_CONTEXT_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSelectionContextRequest {
     pub selection: xproto::Atom,
 }
@@ -1713,7 +1713,7 @@ impl crate::x11_utils::ReplyRequest for GetSelectionContextRequest {
     type Reply = GetSelectionContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSelectionContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1758,7 +1758,7 @@ impl GetSelectionContextReply {
 
 /// Opcode for the GetSelectionDataContext request
 pub const GET_SELECTION_DATA_CONTEXT_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSelectionDataContextRequest {
     pub selection: xproto::Atom,
 }
@@ -1809,7 +1809,7 @@ impl crate::x11_utils::ReplyRequest for GetSelectionDataContextRequest {
     type Reply = GetSelectionDataContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetSelectionDataContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1854,7 +1854,7 @@ impl GetSelectionDataContextReply {
 
 /// Opcode for the ListSelections request
 pub const LIST_SELECTIONS_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListSelectionsRequest;
 impl ListSelectionsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1896,7 +1896,7 @@ impl crate::x11_utils::ReplyRequest for ListSelectionsRequest {
     type Reply = ListSelectionsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListSelectionsReply {
     pub sequence: u16,
     pub length: u32,
@@ -1940,7 +1940,7 @@ impl ListSelectionsReply {
 
 /// Opcode for the GetClientContext request
 pub const GET_CLIENT_CONTEXT_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetClientContextRequest {
     pub resource: u32,
 }
@@ -1991,7 +1991,7 @@ impl crate::x11_utils::ReplyRequest for GetClientContextRequest {
     type Reply = GetClientContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetClientContextReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/xtest.rs
+++ b/x11rb-protocol/src/protocol/xtest.rs
@@ -34,7 +34,7 @@ pub const X11_XML_VERSION: (u32, u32) = (2, 2);
 
 /// Opcode for the GetVersion request
 pub const GET_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetVersionRequest {
     pub major_version: u8,
     pub minor_version: u16,
@@ -90,7 +90,7 @@ impl crate::x11_utils::ReplyRequest for GetVersionRequest {
     type Reply = GetVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetVersionReply {
     pub major_version: u8,
     pub sequence: u16,
@@ -116,7 +116,7 @@ impl TryParse for GetVersionReply {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Cursor(bool);
 impl Cursor {
     pub const NONE: Self = Self(false);
@@ -188,7 +188,7 @@ impl std::fmt::Debug for Cursor  {
 
 /// Opcode for the CompareCursor request
 pub const COMPARE_CURSOR_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompareCursorRequest {
     pub window: xproto::Window,
     pub cursor: xproto::Cursor,
@@ -247,7 +247,7 @@ impl crate::x11_utils::ReplyRequest for CompareCursorRequest {
     type Reply = CompareCursorReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CompareCursorReply {
     pub same: bool,
     pub sequence: u16,
@@ -273,7 +273,7 @@ impl TryParse for CompareCursorReply {
 
 /// Opcode for the FakeInput request
 pub const FAKE_INPUT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FakeInputRequest {
     pub type_: u8,
     pub detail: u8,
@@ -380,7 +380,7 @@ impl crate::x11_utils::VoidRequest for FakeInputRequest {
 
 /// Opcode for the GrabControl request
 pub const GRAB_CONTROL_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabControlRequest {
     pub impervious: bool,
 }

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -38,7 +38,7 @@ pub type Port = u32;
 
 pub type Encoding = u32;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Type(u8);
 impl Type {
     pub const INPUT_MASK: Self = Self(1 << 0);
@@ -103,7 +103,7 @@ impl std::fmt::Debug for Type  {
 }
 bitmask_binop!(Type, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ImageFormatInfoType(u8);
 impl ImageFormatInfoType {
     pub const RGB: Self = Self(0);
@@ -161,7 +161,7 @@ impl std::fmt::Debug for ImageFormatInfoType  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ImageFormatInfoFormat(u8);
 impl ImageFormatInfoFormat {
     pub const PACKED: Self = Self(0);
@@ -219,7 +219,7 @@ impl std::fmt::Debug for ImageFormatInfoFormat  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AttributeFlag(u8);
 impl AttributeFlag {
     pub const GETTABLE: Self = Self(1 << 0);
@@ -278,7 +278,7 @@ impl std::fmt::Debug for AttributeFlag  {
 }
 bitmask_binop!(AttributeFlag, u8);
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VideoNotifyReason(u8);
 impl VideoNotifyReason {
     pub const STARTED: Self = Self(0);
@@ -342,7 +342,7 @@ impl std::fmt::Debug for VideoNotifyReason  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScanlineOrder(u8);
 impl ScanlineOrder {
     pub const TOP_TO_BOTTOM: Self = Self(0);
@@ -400,7 +400,7 @@ impl std::fmt::Debug for ScanlineOrder  {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabPortStatus(u8);
 impl GrabPortStatus {
     pub const SUCCESS: Self = Self(0);
@@ -466,7 +466,7 @@ impl std::fmt::Debug for GrabPortStatus  {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Rational {
     pub numerator: i32,
     pub denominator: i32,
@@ -502,7 +502,7 @@ impl Serialize for Rational {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Format {
     pub visual: xproto::Visualid,
     pub depth: u8,
@@ -540,7 +540,7 @@ impl Serialize for Format {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AdaptorInfo {
     pub base_id: Port,
     pub num_ports: u16,
@@ -619,7 +619,7 @@ impl AdaptorInfo {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EncodingInfo {
     pub encoding: Encoding,
     pub width: u16,
@@ -682,7 +682,7 @@ impl EncodingInfo {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Image {
     pub id: u32,
     pub width: u16,
@@ -757,7 +757,7 @@ impl Image {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AttributeInfo {
     pub flags: u32,
     pub min: i32,
@@ -815,7 +815,7 @@ impl AttributeInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ImageFormatInfo {
     pub id: u32,
     pub type_: ImageFormatInfoType,
@@ -1076,7 +1076,7 @@ pub const BAD_CONTROL_ERROR: u8 = 2;
 
 /// Opcode for the VideoNotify event
 pub const VIDEO_NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct VideoNotifyEvent {
     pub response_type: u8,
     pub reason: VideoNotifyReason,
@@ -1155,7 +1155,7 @@ impl From<VideoNotifyEvent> for [u8; 32] {
 
 /// Opcode for the PortNotify event
 pub const PORT_NOTIFY_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PortNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -1234,7 +1234,7 @@ impl From<PortNotifyEvent> for [u8; 32] {
 
 /// Opcode for the QueryExtension request
 pub const QUERY_EXTENSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryExtensionRequest;
 impl QueryExtensionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1276,7 +1276,7 @@ impl crate::x11_utils::ReplyRequest for QueryExtensionRequest {
     type Reply = QueryExtensionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryExtensionReply {
     pub sequence: u16,
     pub length: u32,
@@ -1305,7 +1305,7 @@ impl TryParse for QueryExtensionReply {
 
 /// Opcode for the QueryAdaptors request
 pub const QUERY_ADAPTORS_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryAdaptorsRequest {
     pub window: xproto::Window,
 }
@@ -1356,7 +1356,7 @@ impl crate::x11_utils::ReplyRequest for QueryAdaptorsRequest {
     type Reply = QueryAdaptorsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryAdaptorsReply {
     pub sequence: u16,
     pub length: u32,
@@ -1400,7 +1400,7 @@ impl QueryAdaptorsReply {
 
 /// Opcode for the QueryEncodings request
 pub const QUERY_ENCODINGS_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryEncodingsRequest {
     pub port: Port,
 }
@@ -1451,7 +1451,7 @@ impl crate::x11_utils::ReplyRequest for QueryEncodingsRequest {
     type Reply = QueryEncodingsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryEncodingsReply {
     pub sequence: u16,
     pub length: u32,
@@ -1495,7 +1495,7 @@ impl QueryEncodingsReply {
 
 /// Opcode for the GrabPort request
 pub const GRAB_PORT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabPortRequest {
     pub port: Port,
     pub time: xproto::Timestamp,
@@ -1554,7 +1554,7 @@ impl crate::x11_utils::ReplyRequest for GrabPortRequest {
     type Reply = GrabPortReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GrabPortReply {
     pub result: GrabPortStatus,
     pub sequence: u16,
@@ -1581,7 +1581,7 @@ impl TryParse for GrabPortReply {
 
 /// Opcode for the UngrabPort request
 pub const UNGRAB_PORT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct UngrabPortRequest {
     pub port: Port,
     pub time: xproto::Timestamp,
@@ -1641,7 +1641,7 @@ impl crate::x11_utils::VoidRequest for UngrabPortRequest {
 
 /// Opcode for the PutVideo request
 pub const PUT_VIDEO_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PutVideoRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
@@ -1757,7 +1757,7 @@ impl crate::x11_utils::VoidRequest for PutVideoRequest {
 
 /// Opcode for the PutStill request
 pub const PUT_STILL_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PutStillRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
@@ -1873,7 +1873,7 @@ impl crate::x11_utils::VoidRequest for PutStillRequest {
 
 /// Opcode for the GetVideo request
 pub const GET_VIDEO_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetVideoRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
@@ -1989,7 +1989,7 @@ impl crate::x11_utils::VoidRequest for GetVideoRequest {
 
 /// Opcode for the GetStill request
 pub const GET_STILL_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetStillRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
@@ -2105,7 +2105,7 @@ impl crate::x11_utils::VoidRequest for GetStillRequest {
 
 /// Opcode for the StopVideo request
 pub const STOP_VIDEO_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StopVideoRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
@@ -2165,7 +2165,7 @@ impl crate::x11_utils::VoidRequest for StopVideoRequest {
 
 /// Opcode for the SelectVideoNotify request
 pub const SELECT_VIDEO_NOTIFY_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectVideoNotifyRequest {
     pub drawable: xproto::Drawable,
     pub onoff: bool,
@@ -2226,7 +2226,7 @@ impl crate::x11_utils::VoidRequest for SelectVideoNotifyRequest {
 
 /// Opcode for the SelectPortNotify request
 pub const SELECT_PORT_NOTIFY_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SelectPortNotifyRequest {
     pub port: Port,
     pub onoff: bool,
@@ -2287,7 +2287,7 @@ impl crate::x11_utils::VoidRequest for SelectPortNotifyRequest {
 
 /// Opcode for the QueryBestSize request
 pub const QUERY_BEST_SIZE_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryBestSizeRequest {
     pub port: Port,
     pub vid_w: u16,
@@ -2371,7 +2371,7 @@ impl crate::x11_utils::ReplyRequest for QueryBestSizeRequest {
     type Reply = QueryBestSizeReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryBestSizeReply {
     pub sequence: u16,
     pub length: u32,
@@ -2400,7 +2400,7 @@ impl TryParse for QueryBestSizeReply {
 
 /// Opcode for the SetPortAttribute request
 pub const SET_PORT_ATTRIBUTE_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SetPortAttributeRequest {
     pub port: Port,
     pub attribute: xproto::Atom,
@@ -2468,7 +2468,7 @@ impl crate::x11_utils::VoidRequest for SetPortAttributeRequest {
 
 /// Opcode for the GetPortAttribute request
 pub const GET_PORT_ATTRIBUTE_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPortAttributeRequest {
     pub port: Port,
     pub attribute: xproto::Atom,
@@ -2527,7 +2527,7 @@ impl crate::x11_utils::ReplyRequest for GetPortAttributeRequest {
     type Reply = GetPortAttributeReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GetPortAttributeReply {
     pub sequence: u16,
     pub length: u32,
@@ -2554,7 +2554,7 @@ impl TryParse for GetPortAttributeReply {
 
 /// Opcode for the QueryPortAttributes request
 pub const QUERY_PORT_ATTRIBUTES_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryPortAttributesRequest {
     pub port: Port,
 }
@@ -2605,7 +2605,7 @@ impl crate::x11_utils::ReplyRequest for QueryPortAttributesRequest {
     type Reply = QueryPortAttributesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryPortAttributesReply {
     pub sequence: u16,
     pub length: u32,
@@ -2651,7 +2651,7 @@ impl QueryPortAttributesReply {
 
 /// Opcode for the ListImageFormats request
 pub const LIST_IMAGE_FORMATS_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListImageFormatsRequest {
     pub port: Port,
 }
@@ -2702,7 +2702,7 @@ impl crate::x11_utils::ReplyRequest for ListImageFormatsRequest {
     type Reply = ListImageFormatsReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListImageFormatsReply {
     pub sequence: u16,
     pub length: u32,
@@ -2746,7 +2746,7 @@ impl ListImageFormatsReply {
 
 /// Opcode for the QueryImageAttributes request
 pub const QUERY_IMAGE_ATTRIBUTES_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryImageAttributesRequest {
     pub port: Port,
     pub id: u32,
@@ -2817,7 +2817,7 @@ impl crate::x11_utils::ReplyRequest for QueryImageAttributesRequest {
     type Reply = QueryImageAttributesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryImageAttributesReply {
     pub sequence: u16,
     pub length: u32,
@@ -2869,7 +2869,7 @@ impl QueryImageAttributesReply {
 
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 18;
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PutImageRequest<'input> {
     pub port: Port,
     pub drawable: xproto::Drawable,
@@ -3031,7 +3031,7 @@ impl<'input> crate::x11_utils::VoidRequest for PutImageRequest<'input> {
 
 /// Opcode for the ShmPutImage request
 pub const SHM_PUT_IMAGE_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ShmPutImageRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,

--- a/x11rb-protocol/src/protocol/xvmc.rs
+++ b/x11rb-protocol/src/protocol/xvmc.rs
@@ -38,7 +38,7 @@ pub type Surface = u32;
 
 pub type Subpicture = u32;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SurfaceInfo {
     pub id: Surface,
     pub chroma_format: u16,
@@ -120,7 +120,7 @@ impl Serialize for SurfaceInfo {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -162,7 +162,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -191,7 +191,7 @@ impl TryParse for QueryVersionReply {
 
 /// Opcode for the ListSurfaceTypes request
 pub const LIST_SURFACE_TYPES_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListSurfaceTypesRequest {
     pub port_id: xv::Port,
 }
@@ -242,7 +242,7 @@ impl crate::x11_utils::ReplyRequest for ListSurfaceTypesRequest {
     type Reply = ListSurfaceTypesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListSurfaceTypesReply {
     pub sequence: u16,
     pub length: u32,
@@ -286,7 +286,7 @@ impl ListSurfaceTypesReply {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateContextRequest {
     pub context_id: Context,
     pub port_id: xv::Port,
@@ -373,7 +373,7 @@ impl crate::x11_utils::ReplyRequest for CreateContextRequest {
     type Reply = CreateContextReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateContextReply {
     pub sequence: u16,
     pub width_actual: u16,
@@ -421,7 +421,7 @@ impl CreateContextReply {
 
 /// Opcode for the DestroyContext request
 pub const DESTROY_CONTEXT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroyContextRequest {
     pub context_id: Context,
 }
@@ -473,7 +473,7 @@ impl crate::x11_utils::VoidRequest for DestroyContextRequest {
 
 /// Opcode for the CreateSurface request
 pub const CREATE_SURFACE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateSurfaceRequest {
     pub surface_id: Surface,
     pub context_id: Context,
@@ -532,7 +532,7 @@ impl crate::x11_utils::ReplyRequest for CreateSurfaceRequest {
     type Reply = CreateSurfaceReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateSurfaceReply {
     pub sequence: u16,
     pub priv_data: Vec<u32>,
@@ -574,7 +574,7 @@ impl CreateSurfaceReply {
 
 /// Opcode for the DestroySurface request
 pub const DESTROY_SURFACE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroySurfaceRequest {
     pub surface_id: Surface,
 }
@@ -626,7 +626,7 @@ impl crate::x11_utils::VoidRequest for DestroySurfaceRequest {
 
 /// Opcode for the CreateSubpicture request
 pub const CREATE_SUBPICTURE_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateSubpictureRequest {
     pub subpicture_id: Subpicture,
     pub context: Context,
@@ -705,7 +705,7 @@ impl crate::x11_utils::ReplyRequest for CreateSubpictureRequest {
     type Reply = CreateSubpictureReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CreateSubpictureReply {
     pub sequence: u16,
     pub width_actual: u16,
@@ -758,7 +758,7 @@ impl CreateSubpictureReply {
 
 /// Opcode for the DestroySubpicture request
 pub const DESTROY_SUBPICTURE_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DestroySubpictureRequest {
     pub subpicture_id: Subpicture,
 }
@@ -810,7 +810,7 @@ impl crate::x11_utils::VoidRequest for DestroySubpictureRequest {
 
 /// Opcode for the ListSubpictureTypes request
 pub const LIST_SUBPICTURE_TYPES_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListSubpictureTypesRequest {
     pub port_id: xv::Port,
     pub surface_id: Surface,
@@ -869,7 +869,7 @@ impl crate::x11_utils::ReplyRequest for ListSubpictureTypesRequest {
     type Reply = ListSubpictureTypesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ListSubpictureTypesReply {
     pub sequence: u16,
     pub length: u32,


### PR DESCRIPTION
According to the [Rust API guidelines checklist](https://rust-lang.github.io/api-guidelines/interoperability.html#c-common-traits), it is recommended that all types derive `PartialOrd`, `Ord`, `Hash` and `Default` if they can. In the generated protocol, these traits are often ignored. This PR modifies the generator to add these traits to the generated output.

Note that none of these new traits are added to `eventstruct` and `union` types, as well as any types that use them.