### PR TITLE
Set up x11rb-protocol to be no_std

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,6 +98,10 @@ jobs:
     - name: cargo build with all features
       run: cargo build --workspace --verbose --all-targets --all-features
 
+    # build no_std
+    - name: cargo build protocol with no default features
+      run: cargo build --manifest-path x11rb-protocol/Cargo.toml --no-default-features
+
     # test
     - name: cargo test with all features
       run: cargo test --workspace --verbose --all-features

--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -46,8 +46,9 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> Vec<Generated> {
         );
     }
     outln!(main_proto_out, "");
-    outln!(main_proto_out, "use std::borrow::Cow;");
-    outln!(main_proto_out, "use std::convert::TryInto;");
+    outln!(main_proto_out, "use alloc::borrow::Cow;");
+    outln!(main_proto_out, "use alloc::vec::Vec;");
+    outln!(main_proto_out, "use core::convert::TryInto;");
     outln!(main_proto_out, "use crate::errors::ParseError;");
     outln!(main_proto_out, "use crate::RawFdContainer;");
     outln!(

--- a/generator/src/generator/namespace/header.rs
+++ b/generator/src/generator/namespace/header.rs
@@ -28,15 +28,23 @@ pub(super) fn write_header(out: &mut Output, ns: &xcbdefs::Namespace, mode: Mode
         );
         outln!(out, "//! specific errors, events, or requests.");
     }
+
+    let (alloc_name, core_name) = match mode {
+        Mode::Protocol => ("alloc", "core"),
+        Mode::X11rb => ("std", "std"),
+    };
+
     outln!(out, "");
     outln!(out, "#![allow(clippy::too_many_arguments)]");
     outln!(out, "");
     outln!(out, "#[allow(unused_imports)]");
-    outln!(out, "use std::borrow::Cow;");
+    outln!(out, "use {}::borrow::Cow;", alloc_name);
     outln!(out, "#[allow(unused_imports)]");
-    outln!(out, "use std::convert::TryInto;");
+    outln!(out, "use {}::convert::TryInto;", core_name);
     if mode == Mode::Protocol {
-        outln!(out, "use std::convert::TryFrom;");
+        outln!(out, "use alloc::vec;");
+        outln!(out, "use alloc::vec::Vec;");
+        outln!(out, "use core::convert::TryFrom;");
         outln!(out, "use crate::errors::ParseError;");
         outln!(out, "#[allow(unused_imports)]");
         outln!(out, "use crate::x11_utils::TryIntoUSize;");

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -815,11 +815,11 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 xcbdefs::EnumValue::Bit(_) => true,
             });
 
-        outln!(out, "impl std::fmt::Debug for {}  {{", rust_name);
+        outln!(out, "impl core::fmt::Debug for {}  {{", rust_name);
         out.indented(|out| {
             outln!(
                 out,
-                "fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{"
+                "fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {{"
             );
             out.indented(|out| {
                 let into = match global_enum_size {

--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -19,28 +19,31 @@ keywords = ["xcb", "X11"]
 criterion = "0.3"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.24"
+nix = { version = "0.24", optional = true }
 
 [features]
+default = ["std"]
+std = ["nix"]
+
 # Enable utility functions in `x11rb::resource_manager` for querying the
 # resource databases.
-resource_manager = []
+resource_manager = ["std"]
 
 # Features to enable individual X11 extensions
 composite = ["xfixes"]
 damage = ["xfixes"]
 dpms = []
 dri2 = []
-dri3 = []
+dri3 = ["std"]
 glx = []
 present = ["randr", "xfixes", "sync"]
-randr = ["render"]
+randr = ["render", "std"]
 record = []
 render = []
 res = []
 screensaver = []
 shape = []
-shm = []
+shm = ["std"]
 sync = []
 xevie = []
 xf86dri = []

--- a/x11rb-protocol/src/connect.rs
+++ b/x11rb-protocol/src/connect.rs
@@ -3,10 +3,14 @@
 use crate::errors::{ConnectError, ParseError};
 use crate::protocol::xproto::{Setup, SetupAuthenticate, SetupFailed, SetupRequest};
 use crate::x11_utils::{Serialize, TryParse};
+
+#[cfg(feature = "std")]
 use crate::xauth::{get_auth, Family};
 
-use std::convert::TryFrom;
-use std::fmt;
+use alloc::{vec, vec::Vec};
+
+use core::convert::TryFrom;
+use core::fmt;
 
 /// The connection handshake used to connect to the X11 server.
 ///
@@ -147,6 +151,7 @@ impl Connect {
     /// Create a new `Connect` from the information necessary to connect to the X11 server.
     ///
     /// This returns the connection handshake object as well as the setup request to send to the server.
+    #[cfg(feature = "std")]
     pub fn new(
         family: Family,
         address: &[u8],
@@ -263,7 +268,8 @@ mod tests {
     use crate::errors::ConnectError;
     use crate::protocol::xproto::{ImageOrder, Setup, SetupAuthenticate, SetupFailed};
     use crate::x11_utils::Serialize;
-    use std::mem::drop;
+    use alloc::vec;
+    use core::mem::drop;
 
     fn test_setup() -> Setup {
         let mut s = Setup {

--- a/x11rb-protocol/src/connection/mod.rs
+++ b/x11rb-protocol/src/connection/mod.rs
@@ -1,6 +1,7 @@
 //! Helper types for implementing an X11 client.
 
-use std::collections::VecDeque;
+use alloc::collections::VecDeque;
+use alloc::vec::Vec;
 
 use crate::utils::RawFdContainer;
 use crate::{DiscardMode, SequenceNumber};

--- a/x11rb-protocol/src/id_allocator.rs
+++ b/x11rb-protocol/src/id_allocator.rs
@@ -3,8 +3,10 @@
 use crate::errors::ConnectError;
 use crate::protocol::xc_misc::GetXIDRangeReply;
 
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::fmt;
+
+use core::fmt;
 
 /// An allocator for X11 IDs.
 ///
@@ -75,6 +77,7 @@ impl fmt::Display for IdsExhausted {
     }
 }
 
+#[cfg(feature = "std")]
 impl Error for IdsExhausted {}
 
 #[cfg(test)]

--- a/x11rb-protocol/src/lib.rs
+++ b/x11rb-protocol/src/lib.rs
@@ -29,8 +29,15 @@
     // Not everything in x11rb_protocol::protocol has doc comments
     missing_docs,
 )]
+#![no_std]
 
-use std::borrow::Cow;
+// std crate imports
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
 
 pub mod connect;
 pub mod connection;
@@ -47,6 +54,7 @@ pub mod protocol;
 pub mod resource_manager;
 mod utils;
 pub mod wrapper;
+#[cfg(feature = "std")]
 pub mod xauth;
 
 pub use utils::RawFdContainer;

--- a/x11rb-protocol/src/packet_reader.rs
+++ b/x11rb-protocol/src/packet_reader.rs
@@ -1,8 +1,10 @@
 //! Collects X11 data into "packets" to be parsed by a display.
 
-use std::convert::TryInto;
-use std::fmt;
-use std::mem::replace;
+use core::convert::TryInto;
+use core::fmt;
+use core::mem::replace;
+
+use alloc::{vec, vec::Vec};
 
 /// Minimal length of an X11 packet.
 const MINIMAL_PACKET_LENGTH: usize = 32;
@@ -126,6 +128,7 @@ fn extra_length(buffer: &[u8]) -> usize {
 #[cfg(test)]
 mod tests {
     use super::PacketReader;
+    use alloc::{vec, vec::Vec};
 
     fn test_packets(packets: Vec<Vec<u8>>) {
         let mut reader = PacketReader::new();

--- a/x11rb-protocol/src/parse_display/connect_instruction.rs
+++ b/x11rb-protocol/src/parse_display/connect_instruction.rs
@@ -2,6 +2,8 @@
 //! to be transformed into a server connection.
 
 use super::ParsedDisplay;
+use alloc::format;
+use alloc::vec::Vec;
 use std::path::PathBuf;
 
 /// Either a hostname and port to connect to, or a socket to connect to.
@@ -57,6 +59,7 @@ pub(super) fn connect_addresses(p: &ParsedDisplay) -> impl Iterator<Item = Conne
 mod tests {
     // make sure iterator properties are clean
     use super::{super::parse_display, ConnectAddress};
+    use alloc::{vec, vec::Vec};
     use std::path::PathBuf;
 
     #[test]

--- a/x11rb-protocol/src/parse_display/mod.rs
+++ b/x11rb-protocol/src/parse_display/mod.rs
@@ -1,7 +1,11 @@
 //! Utilities for parsing X11 display strings.
 
+#![cfg(feature = "std")]
+
 mod connect_instruction;
 pub use connect_instruction::ConnectAddress;
+
+use alloc::string::{String, ToString};
 
 /// A parsed X11 display string.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -76,6 +80,7 @@ fn parse_display_impl(dpy_name: &str) -> Option<ParsedDisplay> {
 #[cfg(test)]
 mod test {
     use super::{parse_display, ParsedDisplay};
+    use alloc::string::ToString;
 
     fn do_parse_display(input: &str) -> Option<ParsedDisplay> {
         std::env::set_var("DISPLAY", input);

--- a/x11rb-protocol/src/protocol/bigreq.rs
+++ b/x11rb-protocol/src/protocol/bigreq.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;

--- a/x11rb-protocol/src/protocol/composite.rs
+++ b/x11rb-protocol/src/protocol/composite.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -82,8 +84,8 @@ impl From<u8> for Redirect {
         Self(value)
     }
 }
-impl std::fmt::Debug for Redirect  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Redirect  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::AUTOMATIC.0.into(), "AUTOMATIC", "Automatic"),
             (Self::MANUAL.0.into(), "MANUAL", "Manual"),

--- a/x11rb-protocol/src/protocol/damage.rs
+++ b/x11rb-protocol/src/protocol/damage.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -86,8 +88,8 @@ impl From<u8> for ReportLevel {
         Self(value)
     }
 }
-impl std::fmt::Debug for ReportLevel  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ReportLevel  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::RAW_RECTANGLES.0.into(), "RAW_RECTANGLES", "RawRectangles"),
             (Self::DELTA_RECTANGLES.0.into(), "DELTA_RECTANGLES", "DeltaRectangles"),

--- a/x11rb-protocol/src/protocol/dpms.rs
+++ b/x11rb-protocol/src/protocol/dpms.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -452,8 +454,8 @@ impl From<u16> for DPMSMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for DPMSMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DPMSMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ON.0.into(), "ON", "On"),
             (Self::STANDBY.0.into(), "STANDBY", "Standby"),

--- a/x11rb-protocol/src/protocol/dri2.rs
+++ b/x11rb-protocol/src/protocol/dri2.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -77,8 +79,8 @@ impl From<u32> for Attachment {
         Self(value)
     }
 }
-impl std::fmt::Debug for Attachment  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Attachment  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::BUFFER_FRONT_LEFT.0, "BUFFER_FRONT_LEFT", "BufferFrontLeft"),
             (Self::BUFFER_BACK_LEFT.0, "BUFFER_BACK_LEFT", "BufferBackLeft"),
@@ -132,8 +134,8 @@ impl From<u32> for DriverType {
         Self(value)
     }
 }
-impl std::fmt::Debug for DriverType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DriverType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DRI.0, "DRI", "DRI"),
             (Self::VDPAU.0, "VDPAU", "VDPAU"),
@@ -185,8 +187,8 @@ impl From<u16> for EventType {
         Self(value)
     }
 }
-impl std::fmt::Debug for EventType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for EventType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::EXCHANGE_COMPLETE.0.into(), "EXCHANGE_COMPLETE", "ExchangeComplete"),
             (Self::BLIT_COMPLETE.0.into(), "BLIT_COMPLETE", "BlitComplete"),

--- a/x11rb-protocol/src/protocol/dri3.rs
+++ b/x11rb-protocol/src/protocol/dri3.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;

--- a/x11rb-protocol/src/protocol/ge.rs
+++ b/x11rb-protocol/src/protocol/ge.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;

--- a/x11rb-protocol/src/protocol/glx.rs
+++ b/x11rb-protocol/src/protocol/glx.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -322,8 +324,8 @@ impl From<u16> for PBCET {
         Self(value)
     }
 }
-impl std::fmt::Debug for PBCET  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PBCET  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DAMAGED.0.into(), "DAMAGED", "Damaged"),
             (Self::SAVED.0.into(), "SAVED", "Saved"),
@@ -374,8 +376,8 @@ impl From<u16> for PBCDT {
         Self(value)
     }
 }
-impl std::fmt::Debug for PBCDT  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PBCDT  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::WINDOW.0.into(), "WINDOW", "Window"),
             (Self::PBUFFER.0.into(), "PBUFFER", "Pbuffer"),
@@ -1170,8 +1172,8 @@ impl From<u32> for GC {
         Self(value)
     }
 }
-impl std::fmt::Debug for GC  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GC  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::GL_CURRENT_BIT.0, "GL_CURRENT_BIT", "GL_CURRENT_BIT"),
             (Self::GL_POINT_BIT.0, "GL_POINT_BIT", "GL_POINT_BIT"),
@@ -3915,8 +3917,8 @@ impl From<u16> for RM {
         Self(value)
     }
 }
-impl std::fmt::Debug for RM  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for RM  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::GL_RENDER.0.into(), "GL_RENDER", "GL_RENDER"),
             (Self::GL_FEEDBACK.0.into(), "GL_FEEDBACK", "GL_FEEDBACK"),

--- a/x11rb-protocol/src/protocol/mod.rs
+++ b/x11rb-protocol/src/protocol/mod.rs
@@ -11,8 +11,9 @@
 // This is not easy to fix, so ignore it.
 #![allow(clippy::needless_borrow, clippy::needless_lifetimes)]
 
-use std::borrow::Cow;
-use std::convert::TryInto;
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+use core::convert::TryInto;
 use crate::errors::ParseError;
 use crate::RawFdContainer;
 use crate::x11_utils::{TryParse, TryParseFd, X11Error, ReplyRequest, ReplyFDsRequest};

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -88,8 +90,8 @@ impl From<u8> for EventEnum {
         Self(value)
     }
 }
-impl std::fmt::Debug for EventEnum  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for EventEnum  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::CONFIGURE_NOTIFY.0.into(), "CONFIGURE_NOTIFY", "ConfigureNotify"),
             (Self::COMPLETE_NOTIFY.0.into(), "COMPLETE_NOTIFY", "CompleteNotify"),
@@ -151,8 +153,8 @@ impl From<u8> for EventMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for EventMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for EventMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NO_EVENT.0.into(), "NO_EVENT", "NoEvent"),
             (Self::CONFIGURE_NOTIFY.0.into(), "CONFIGURE_NOTIFY", "ConfigureNotify"),
@@ -216,8 +218,8 @@ impl From<u8> for Option {
         Self(value)
     }
 }
-impl std::fmt::Debug for Option  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Option  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
             (Self::ASYNC.0.into(), "ASYNC", "Async"),
@@ -280,8 +282,8 @@ impl From<u8> for Capability {
         Self(value)
     }
 }
-impl std::fmt::Debug for Capability  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Capability  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
             (Self::ASYNC.0.into(), "ASYNC", "Async"),
@@ -341,8 +343,8 @@ impl From<u8> for CompleteKind {
         Self(value)
     }
 }
-impl std::fmt::Debug for CompleteKind  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CompleteKind  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::PIXMAP.0.into(), "PIXMAP", "Pixmap"),
             (Self::NOTIFY_MSC.0.into(), "NOTIFY_MSC", "NotifyMSC"),
@@ -401,8 +403,8 @@ impl From<u8> for CompleteMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for CompleteMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CompleteMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::COPY.0.into(), "COPY", "Copy"),
             (Self::FLIP.0.into(), "FLIP", "Flip"),

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -108,8 +110,8 @@ impl From<u8> for Rotation {
         Self(value)
     }
 }
-impl std::fmt::Debug for Rotation  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Rotation  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ROTATE0.0.into(), "ROTATE0", "Rotate0"),
             (Self::ROTATE90.0.into(), "ROTATE90", "Rotate90"),
@@ -347,8 +349,8 @@ impl From<u8> for SetConfig {
         Self(value)
     }
 }
-impl std::fmt::Debug for SetConfig  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SetConfig  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SUCCESS.0.into(), "SUCCESS", "Success"),
             (Self::INVALID_CONFIG_TIME.0.into(), "INVALID_CONFIG_TIME", "InvalidConfigTime"),
@@ -538,8 +540,8 @@ impl From<u8> for NotifyMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for NotifyMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NotifyMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SCREEN_CHANGE.0.into(), "SCREEN_CHANGE", "ScreenChange"),
             (Self::CRTC_CHANGE.0.into(), "CRTC_CHANGE", "CrtcChange"),
@@ -947,8 +949,8 @@ impl From<u16> for ModeFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for ModeFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ModeFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::HSYNC_POSITIVE.0.into(), "HSYNC_POSITIVE", "HsyncPositive"),
             (Self::HSYNC_NEGATIVE.0.into(), "HSYNC_NEGATIVE", "HsyncNegative"),
@@ -1271,8 +1273,8 @@ impl From<u8> for Connection {
         Self(value)
     }
 }
-impl std::fmt::Debug for Connection  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Connection  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::CONNECTED.0.into(), "CONNECTED", "Connected"),
             (Self::DISCONNECTED.0.into(), "DISCONNECTED", "Disconnected"),
@@ -3105,8 +3107,8 @@ impl From<u8> for Transform {
         Self(value)
     }
 }
-impl std::fmt::Debug for Transform  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Transform  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::UNIT.0.into(), "UNIT", "Unit"),
             (Self::SCALE_UP.0.into(), "SCALE_UP", "ScaleUp"),
@@ -3961,8 +3963,8 @@ impl From<u8> for ProviderCapability {
         Self(value)
     }
 }
-impl std::fmt::Debug for ProviderCapability  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ProviderCapability  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SOURCE_OUTPUT.0.into(), "SOURCE_OUTPUT", "SourceOutput"),
             (Self::SINK_OUTPUT.0.into(), "SINK_OUTPUT", "SinkOutput"),
@@ -5020,8 +5022,8 @@ impl From<u8> for Notify {
         Self(value)
     }
 }
-impl std::fmt::Debug for Notify  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Notify  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::CRTC_CHANGE.0.into(), "CRTC_CHANGE", "CrtcChange"),
             (Self::OUTPUT_CHANGE.0.into(), "OUTPUT_CHANGE", "OutputChange"),

--- a/x11rb-protocol/src/protocol/record.rs
+++ b/x11rb-protocol/src/protocol/record.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -259,8 +261,8 @@ impl From<u8> for HType {
         Self(value)
     }
 }
-impl std::fmt::Debug for HType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for HType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::FROM_SERVER_TIME.0.into(), "FROM_SERVER_TIME", "FromServerTime"),
             (Self::FROM_CLIENT_TIME.0.into(), "FROM_CLIENT_TIME", "FromClientTime"),
@@ -322,8 +324,8 @@ impl From<u8> for CS {
         Self(value)
     }
 }
-impl std::fmt::Debug for CS  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CS  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::CURRENT_CLIENTS.0.into(), "CURRENT_CLIENTS", "CurrentClients"),
             (Self::FUTURE_CLIENTS.0.into(), "FUTURE_CLIENTS", "FutureClients"),

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -80,8 +82,8 @@ impl From<u8> for PictType {
         Self(value)
     }
 }
-impl std::fmt::Debug for PictType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PictType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::INDEXED.0.into(), "INDEXED", "Indexed"),
             (Self::DIRECT.0.into(), "DIRECT", "Direct"),
@@ -137,8 +139,8 @@ impl From<u8> for PictureEnum {
         Self(value)
     }
 }
-impl std::fmt::Debug for PictureEnum  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PictureEnum  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
         ];
@@ -245,8 +247,8 @@ impl From<u8> for PictOp {
         Self(value)
     }
 }
-impl std::fmt::Debug for PictOp  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PictOp  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::CLEAR.0.into(), "CLEAR", "Clear"),
             (Self::SRC.0.into(), "SRC", "Src"),
@@ -342,8 +344,8 @@ impl From<u32> for PolyEdge {
         Self(value)
     }
 }
-impl std::fmt::Debug for PolyEdge  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PolyEdge  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SHARP.0, "SHARP", "Sharp"),
             (Self::SMOOTH.0, "SMOOTH", "Smooth"),
@@ -388,8 +390,8 @@ impl From<u32> for PolyMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for PolyMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PolyMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::PRECISE.0, "PRECISE", "Precise"),
             (Self::IMPRECISE.0, "IMPRECISE", "Imprecise"),
@@ -451,8 +453,8 @@ impl From<u16> for CP {
         Self(value)
     }
 }
-impl std::fmt::Debug for CP  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CP  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::REPEAT.0.into(), "REPEAT", "Repeat"),
             (Self::ALPHA_MAP.0.into(), "ALPHA_MAP", "AlphaMap"),
@@ -513,8 +515,8 @@ impl From<u32> for SubPixel {
         Self(value)
     }
 }
-impl std::fmt::Debug for SubPixel  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SubPixel  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::UNKNOWN.0, "UNKNOWN", "Unknown"),
             (Self::HORIZONTAL_RGB.0, "HORIZONTAL_RGB", "HorizontalRGB"),
@@ -565,8 +567,8 @@ impl From<u32> for Repeat {
         Self(value)
     }
 }
-impl std::fmt::Debug for Repeat  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Repeat  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0, "NONE", "None"),
             (Self::NORMAL.0, "NORMAL", "Normal"),

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -152,8 +154,8 @@ impl From<u8> for ClientIdMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for ClientIdMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ClientIdMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::CLIENT_XID.0.into(), "CLIENT_XID", "ClientXID"),
             (Self::LOCAL_CLIENT_PID.0.into(), "LOCAL_CLIENT_PID", "LocalClientPID"),

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -81,8 +83,8 @@ impl From<u8> for Kind {
         Self(value)
     }
 }
-impl std::fmt::Debug for Kind  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Kind  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::BLANKED.0.into(), "BLANKED", "Blanked"),
             (Self::INTERNAL.0.into(), "INTERNAL", "Internal"),
@@ -140,8 +142,8 @@ impl From<u8> for Event {
         Self(value)
     }
 }
-impl std::fmt::Debug for Event  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Event  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NOTIFY_MASK.0.into(), "NOTIFY_MASK", "NotifyMask"),
             (Self::CYCLE_MASK.0.into(), "CYCLE_MASK", "CycleMask"),
@@ -201,8 +203,8 @@ impl From<u8> for State {
         Self(value)
     }
 }
-impl std::fmt::Debug for State  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for State  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::OFF.0.into(), "OFF", "Off"),
             (Self::ON.0.into(), "ON", "On"),

--- a/x11rb-protocol/src/protocol/shape.rs
+++ b/x11rb-protocol/src/protocol/shape.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -87,8 +89,8 @@ impl From<u8> for SO {
         Self(value)
     }
 }
-impl std::fmt::Debug for SO  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SO  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SET.0.into(), "SET", "Set"),
             (Self::UNION.0.into(), "UNION", "Union"),
@@ -149,8 +151,8 @@ impl From<u8> for SK {
         Self(value)
     }
 }
-impl std::fmt::Debug for SK  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SK  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::BOUNDING.0.into(), "BOUNDING", "Bounding"),
             (Self::CLIP.0.into(), "CLIP", "Clip"),

--- a/x11rb-protocol/src/protocol/shm.rs
+++ b/x11rb-protocol/src/protocol/shm.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -83,8 +85,8 @@ impl From<u8> for ALARMSTATE {
         Self(value)
     }
 }
-impl std::fmt::Debug for ALARMSTATE  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ALARMSTATE  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ACTIVE.0.into(), "ACTIVE", "Active"),
             (Self::INACTIVE.0.into(), "INACTIVE", "Inactive"),
@@ -136,8 +138,8 @@ impl From<u32> for TESTTYPE {
         Self(value)
     }
 }
-impl std::fmt::Debug for TESTTYPE  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for TESTTYPE  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::POSITIVE_TRANSITION.0, "POSITIVE_TRANSITION", "PositiveTransition"),
             (Self::NEGATIVE_TRANSITION.0, "NEGATIVE_TRANSITION", "NegativeTransition"),
@@ -184,8 +186,8 @@ impl From<u32> for VALUETYPE {
         Self(value)
     }
 }
-impl std::fmt::Debug for VALUETYPE  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for VALUETYPE  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ABSOLUTE.0, "ABSOLUTE", "Absolute"),
             (Self::RELATIVE.0, "RELATIVE", "Relative"),
@@ -246,8 +248,8 @@ impl From<u8> for CA {
         Self(value)
     }
 }
-impl std::fmt::Debug for CA  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CA  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::COUNTER.0.into(), "COUNTER", "Counter"),
             (Self::VALUE_TYPE.0.into(), "VALUE_TYPE", "ValueType"),

--- a/x11rb-protocol/src/protocol/xc_misc.rs
+++ b/x11rb-protocol/src/protocol/xc_misc.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;

--- a/x11rb-protocol/src/protocol/xevie.rs
+++ b/x11rb-protocol/src/protocol/xevie.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -329,8 +331,8 @@ impl From<bool> for Datatype {
         Self(value)
     }
 }
-impl std::fmt::Debug for Datatype  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Datatype  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::UNMODIFIED.0.into(), "UNMODIFIED", "Unmodified"),
             (Self::MODIFIED.0.into(), "MODIFIED", "Modified"),

--- a/x11rb-protocol/src/protocol/xf86dri.rs
+++ b/x11rb-protocol/src/protocol/xf86dri.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -87,8 +89,8 @@ impl From<u16> for ModeFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for ModeFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ModeFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::POSITIVE_H_SYNC.0.into(), "POSITIVE_H_SYNC", "PositiveHSync"),
             (Self::NEGATIVE_H_SYNC.0.into(), "NEGATIVE_H_SYNC", "NegativeHSync"),
@@ -156,8 +158,8 @@ impl From<u8> for ClockFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for ClockFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ClockFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::PROGRAMABLE.0.into(), "PROGRAMABLE", "Programable"),
         ];
@@ -214,8 +216,8 @@ impl From<u8> for Permission {
         Self(value)
     }
 }
-impl std::fmt::Debug for Permission  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Permission  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::READ.0.into(), "READ", "Read"),
             (Self::WRITE.0.into(), "WRITE", "Write"),

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -173,8 +175,8 @@ impl From<u8> for SaveSetMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for SaveSetMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SaveSetMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::INSERT.0.into(), "INSERT", "Insert"),
             (Self::DELETE.0.into(), "DELETE", "Delete"),
@@ -231,8 +233,8 @@ impl From<u8> for SaveSetTarget {
         Self(value)
     }
 }
-impl std::fmt::Debug for SaveSetTarget  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SaveSetTarget  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NEAREST.0.into(), "NEAREST", "Nearest"),
             (Self::ROOT.0.into(), "ROOT", "Root"),
@@ -289,8 +291,8 @@ impl From<u8> for SaveSetMapping {
         Self(value)
     }
 }
-impl std::fmt::Debug for SaveSetMapping  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SaveSetMapping  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::MAP.0.into(), "MAP", "Map"),
             (Self::UNMAP.0.into(), "UNMAP", "Unmap"),
@@ -420,8 +422,8 @@ impl From<u8> for SelectionEvent {
         Self(value)
     }
 }
-impl std::fmt::Debug for SelectionEvent  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SelectionEvent  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SET_SELECTION_OWNER.0.into(), "SET_SELECTION_OWNER", "SetSelectionOwner"),
             (Self::SELECTION_WINDOW_DESTROY.0.into(), "SELECTION_WINDOW_DESTROY", "SelectionWindowDestroy"),
@@ -480,8 +482,8 @@ impl From<u8> for SelectionEventMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for SelectionEventMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SelectionEventMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SET_SELECTION_OWNER.0.into(), "SET_SELECTION_OWNER", "SetSelectionOwner"),
             (Self::SELECTION_WINDOW_DESTROY.0.into(), "SELECTION_WINDOW_DESTROY", "SelectionWindowDestroy"),
@@ -692,8 +694,8 @@ impl From<u8> for CursorNotify {
         Self(value)
     }
 }
-impl std::fmt::Debug for CursorNotify  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CursorNotify  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DISPLAY_CURSOR.0.into(), "DISPLAY_CURSOR", "DisplayCursor"),
         ];
@@ -748,8 +750,8 @@ impl From<u8> for CursorNotifyMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for CursorNotifyMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CursorNotifyMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DISPLAY_CURSOR.0.into(), "DISPLAY_CURSOR", "DisplayCursor"),
         ];
@@ -1036,8 +1038,8 @@ impl From<u8> for RegionEnum {
         Self(value)
     }
 }
-impl std::fmt::Debug for RegionEnum  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for RegionEnum  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
         ];
@@ -2924,8 +2926,8 @@ impl From<u8> for BarrierDirections {
         Self(value)
     }
 }
-impl std::fmt::Debug for BarrierDirections  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for BarrierDirections  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::POSITIVE_X.0.into(), "POSITIVE_X", "PositiveX"),
             (Self::POSITIVE_Y.0.into(), "POSITIVE_Y", "PositiveY"),

--- a/x11rb-protocol/src/protocol/xinerama.rs
+++ b/x11rb-protocol/src/protocol/xinerama.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -225,8 +227,8 @@ impl From<u8> for DeviceUse {
         Self(value)
     }
 }
-impl std::fmt::Debug for DeviceUse  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DeviceUse  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::IS_X_POINTER.0.into(), "IS_X_POINTER", "IsXPointer"),
             (Self::IS_X_KEYBOARD.0.into(), "IS_X_KEYBOARD", "IsXKeyboard"),
@@ -291,8 +293,8 @@ impl From<u8> for InputClass {
         Self(value)
     }
 }
-impl std::fmt::Debug for InputClass  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for InputClass  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KEY.0.into(), "KEY", "Key"),
             (Self::BUTTON.0.into(), "BUTTON", "Button"),
@@ -354,8 +356,8 @@ impl From<u8> for ValuatorMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for ValuatorMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ValuatorMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::RELATIVE.0.into(), "RELATIVE", "Relative"),
             (Self::ABSOLUTE.0.into(), "ABSOLUTE", "Absolute"),
@@ -1481,8 +1483,8 @@ impl From<u8> for PropagateMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for PropagateMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PropagateMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ADD_TO_LIST.0.into(), "ADD_TO_LIST", "AddToList"),
             (Self::DELETE_FROM_LIST.0.into(), "DELETE_FROM_LIST", "DeleteFromList"),
@@ -2237,8 +2239,8 @@ impl From<u8> for ModifierDevice {
         Self(value)
     }
 }
-impl std::fmt::Debug for ModifierDevice  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ModifierDevice  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::USE_X_KEYBOARD.0.into(), "USE_X_KEYBOARD", "UseXKeyboard"),
         ];
@@ -2689,8 +2691,8 @@ impl From<u8> for DeviceInputMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for DeviceInputMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DeviceInputMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ASYNC_THIS_DEVICE.0.into(), "ASYNC_THIS_DEVICE", "AsyncThisDevice"),
             (Self::SYNC_THIS_DEVICE.0.into(), "SYNC_THIS_DEVICE", "SyncThisDevice"),
@@ -2981,8 +2983,8 @@ impl From<u8> for FeedbackClass {
         Self(value)
     }
 }
-impl std::fmt::Debug for FeedbackClass  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for FeedbackClass  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KEYBOARD.0.into(), "KEYBOARD", "Keyboard"),
             (Self::POINTER.0.into(), "POINTER", "Pointer"),
@@ -4811,8 +4813,8 @@ impl From<u8> for ChangeFeedbackControlMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for ChangeFeedbackControlMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ChangeFeedbackControlMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KEY_CLICK_PERCENT.0.into(), "KEY_CLICK_PERCENT", "KeyClickPercent"),
             (Self::PERCENT.0.into(), "PERCENT", "Percent"),
@@ -5689,8 +5691,8 @@ impl From<u8> for ValuatorStateModeMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for ValuatorStateModeMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ValuatorStateModeMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DEVICE_MODE_ABSOLUTE.0.into(), "DEVICE_MODE_ABSOLUTE", "DeviceModeAbsolute"),
             (Self::OUT_OF_PROXIMITY.0.into(), "OUT_OF_PROXIMITY", "OutOfProximity"),
@@ -6354,8 +6356,8 @@ impl From<u16> for DeviceControl {
         Self(value)
     }
 }
-impl std::fmt::Debug for DeviceControl  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DeviceControl  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::RESOLUTION.0.into(), "RESOLUTION", "Resolution"),
             (Self::ABSCALIB.0.into(), "ABSCALIB", "Abscalib"),
@@ -8109,8 +8111,8 @@ impl From<u8> for PropertyFormat {
         Self(value)
     }
 }
-impl std::fmt::Debug for PropertyFormat  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PropertyFormat  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::M8_BITS.0.into(), "M8_BITS", "M8Bits"),
             (Self::M16_BITS.0.into(), "M16_BITS", "M16Bits"),
@@ -8666,8 +8668,8 @@ impl From<bool> for Device {
         Self(value)
     }
 }
-impl std::fmt::Debug for Device  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Device  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ALL.0.into(), "ALL", "All"),
             (Self::ALL_MASTER.0.into(), "ALL_MASTER", "AllMaster"),
@@ -9116,8 +9118,8 @@ impl From<u16> for HierarchyChangeType {
         Self(value)
     }
 }
-impl std::fmt::Debug for HierarchyChangeType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for HierarchyChangeType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ADD_MASTER.0.into(), "ADD_MASTER", "AddMaster"),
             (Self::REMOVE_MASTER.0.into(), "REMOVE_MASTER", "RemoveMaster"),
@@ -9176,8 +9178,8 @@ impl From<u8> for ChangeMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for ChangeMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ChangeMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ATTACH.0.into(), "ATTACH", "Attach"),
             (Self::FLOAT.0.into(), "FLOAT", "Float"),
@@ -9961,8 +9963,8 @@ impl From<u32> for XIEventMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for XIEventMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for XIEventMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DEVICE_CHANGED.0, "DEVICE_CHANGED", "DeviceChanged"),
             (Self::KEY_PRESS.0, "KEY_PRESS", "KeyPress"),
@@ -10245,8 +10247,8 @@ impl From<u16> for DeviceClassType {
         Self(value)
     }
 }
-impl std::fmt::Debug for DeviceClassType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DeviceClassType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KEY.0.into(), "KEY", "Key"),
             (Self::BUTTON.0.into(), "BUTTON", "Button"),
@@ -10303,8 +10305,8 @@ impl From<u16> for DeviceType {
         Self(value)
     }
 }
-impl std::fmt::Debug for DeviceType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DeviceType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::MASTER_POINTER.0.into(), "MASTER_POINTER", "MasterPointer"),
             (Self::MASTER_KEYBOARD.0.into(), "MASTER_KEYBOARD", "MasterKeyboard"),
@@ -10364,8 +10366,8 @@ impl From<u8> for ScrollFlags {
         Self(value)
     }
 }
-impl std::fmt::Debug for ScrollFlags  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ScrollFlags  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NO_EMULATION.0.into(), "NO_EMULATION", "NoEmulation"),
             (Self::PREFERRED.0.into(), "PREFERRED", "Preferred"),
@@ -10417,8 +10419,8 @@ impl From<u16> for ScrollType {
         Self(value)
     }
 }
-impl std::fmt::Debug for ScrollType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ScrollType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::VERTICAL.0.into(), "VERTICAL", "Vertical"),
             (Self::HORIZONTAL.0.into(), "HORIZONTAL", "Horizontal"),
@@ -10475,8 +10477,8 @@ impl From<u8> for TouchMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for TouchMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for TouchMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DIRECT.0.into(), "DIRECT", "Direct"),
             (Self::DEPENDENT.0.into(), "DEPENDENT", "Dependent"),
@@ -11628,8 +11630,8 @@ impl From<bool> for GrabOwner {
         Self(value)
     }
 }
-impl std::fmt::Debug for GrabOwner  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GrabOwner  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NO_OWNER.0.into(), "NO_OWNER", "NoOwner"),
             (Self::OWNER.0.into(), "OWNER", "Owner"),
@@ -11900,8 +11902,8 @@ impl From<u8> for EventMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for EventMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for EventMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ASYNC_DEVICE.0.into(), "ASYNC_DEVICE", "AsyncDevice"),
             (Self::SYNC_DEVICE.0.into(), "SYNC_DEVICE", "SyncDevice"),
@@ -12047,8 +12049,8 @@ impl From<u8> for GrabMode22 {
         Self(value)
     }
 }
-impl std::fmt::Debug for GrabMode22  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GrabMode22  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SYNC.0.into(), "SYNC", "Sync"),
             (Self::ASYNC.0.into(), "ASYNC", "Async"),
@@ -12109,8 +12111,8 @@ impl From<u8> for GrabType {
         Self(value)
     }
 }
-impl std::fmt::Debug for GrabType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GrabType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::BUTTON.0.into(), "BUTTON", "Button"),
             (Self::KEYCODE.0.into(), "KEYCODE", "Keycode"),
@@ -12157,8 +12159,8 @@ impl From<u32> for ModifierMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for ModifierMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ModifierMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ANY.0, "ANY", "Any"),
         ];
@@ -13422,8 +13424,8 @@ impl From<u8> for MoreEventsMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for MoreEventsMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for MoreEventsMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::MORE_EVENTS.0.into(), "MORE_EVENTS", "MoreEvents"),
         ];
@@ -13695,8 +13697,8 @@ impl From<u8> for ClassesReportedMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for ClassesReportedMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ClassesReportedMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::OUT_OF_PROXIMITY.0.into(), "OUT_OF_PROXIMITY", "OutOfProximity"),
             (Self::DEVICE_MODE_ABSOLUTE.0.into(), "DEVICE_MODE_ABSOLUTE", "DeviceModeAbsolute"),
@@ -13941,8 +13943,8 @@ impl From<u8> for ChangeDevice {
         Self(value)
     }
 }
-impl std::fmt::Debug for ChangeDevice  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ChangeDevice  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NEW_POINTER.0.into(), "NEW_POINTER", "NewPointer"),
             (Self::NEW_KEYBOARD.0.into(), "NEW_KEYBOARD", "NewKeyboard"),
@@ -14221,8 +14223,8 @@ impl From<u8> for DeviceChange {
         Self(value)
     }
 }
-impl std::fmt::Debug for DeviceChange  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DeviceChange  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ADDED.0.into(), "ADDED", "Added"),
             (Self::REMOVED.0.into(), "REMOVED", "Removed"),
@@ -14442,8 +14444,8 @@ impl From<u8> for ChangeReason {
         Self(value)
     }
 }
-impl std::fmt::Debug for ChangeReason  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ChangeReason  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SLAVE_SWITCH.0.into(), "SLAVE_SWITCH", "SlaveSwitch"),
             (Self::DEVICE_CHANGE.0.into(), "DEVICE_CHANGE", "DeviceChange"),
@@ -14541,8 +14543,8 @@ impl From<u32> for KeyEventFlags {
         Self(value)
     }
 }
-impl std::fmt::Debug for KeyEventFlags  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for KeyEventFlags  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KEY_REPEAT.0, "KEY_REPEAT", "KeyRepeat"),
         ];
@@ -14681,8 +14683,8 @@ impl From<u32> for PointerEventFlags {
         Self(value)
     }
 }
-impl std::fmt::Debug for PointerEventFlags  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PointerEventFlags  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::POINTER_EMULATED.0, "POINTER_EMULATED", "PointerEmulated"),
         ];
@@ -14842,8 +14844,8 @@ impl From<u8> for NotifyMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for NotifyMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NotifyMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NORMAL.0.into(), "NORMAL", "Normal"),
             (Self::GRAB.0.into(), "GRAB", "Grab"),
@@ -14910,8 +14912,8 @@ impl From<u8> for NotifyDetail {
         Self(value)
     }
 }
-impl std::fmt::Debug for NotifyDetail  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NotifyDetail  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ANCESTOR.0.into(), "ANCESTOR", "Ancestor"),
             (Self::VIRTUAL.0.into(), "VIRTUAL", "Virtual"),
@@ -15070,8 +15072,8 @@ impl From<u8> for HierarchyMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for HierarchyMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for HierarchyMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::MASTER_ADDED.0.into(), "MASTER_ADDED", "MasterAdded"),
             (Self::MASTER_REMOVED.0.into(), "MASTER_REMOVED", "MasterRemoved"),
@@ -15242,8 +15244,8 @@ impl From<u8> for PropertyFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for PropertyFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PropertyFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DELETED.0.into(), "DELETED", "Deleted"),
             (Self::CREATED.0.into(), "CREATED", "Created"),
@@ -15455,8 +15457,8 @@ impl From<u32> for TouchEventFlags {
         Self(value)
     }
 }
-impl std::fmt::Debug for TouchEventFlags  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for TouchEventFlags  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::TOUCH_PENDING_END.0, "TOUCH_PENDING_END", "TouchPendingEnd"),
             (Self::TOUCH_EMULATING_POINTER.0, "TOUCH_EMULATING_POINTER", "TouchEmulatingPointer"),
@@ -15600,8 +15602,8 @@ impl From<u32> for TouchOwnershipFlags {
         Self(value)
     }
 }
-impl std::fmt::Debug for TouchOwnershipFlags  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for TouchOwnershipFlags  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0, "NONE", "None"),
         ];
@@ -15769,8 +15771,8 @@ impl From<u8> for BarrierFlags {
         Self(value)
     }
 }
-impl std::fmt::Debug for BarrierFlags  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for BarrierFlags  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::POINTER_RELEASED.0.into(), "POINTER_RELEASED", "PointerReleased"),
             (Self::DEVICE_IS_GRABBED.0.into(), "DEVICE_IS_GRABBED", "DeviceIsGrabbed"),

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -81,8 +83,8 @@ impl From<u8> for Const {
         Self(value)
     }
 }
-impl std::fmt::Debug for Const  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Const  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::MAX_LEGAL_KEY_CODE.0.into(), "MAX_LEGAL_KEY_CODE", "MaxLegalKeyCode"),
             (Self::PER_KEY_BIT_ARRAY_SIZE.0.into(), "PER_KEY_BIT_ARRAY_SIZE", "PerKeyBitArraySize"),
@@ -144,8 +146,8 @@ impl From<u16> for EventType {
         Self(value)
     }
 }
-impl std::fmt::Debug for EventType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for EventType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NEW_KEYBOARD_NOTIFY.0.into(), "NEW_KEYBOARD_NOTIFY", "NewKeyboardNotify"),
             (Self::MAP_NOTIFY.0.into(), "MAP_NOTIFY", "MapNotify"),
@@ -214,8 +216,8 @@ impl From<u8> for NKNDetail {
         Self(value)
     }
 }
-impl std::fmt::Debug for NKNDetail  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NKNDetail  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KEYCODES.0.into(), "KEYCODES", "Keycodes"),
             (Self::GEOMETRY.0.into(), "GEOMETRY", "Geometry"),
@@ -279,8 +281,8 @@ impl From<u8> for AXNDetail {
         Self(value)
     }
 }
-impl std::fmt::Debug for AXNDetail  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for AXNDetail  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SK_PRESS.0.into(), "SK_PRESS", "SKPress"),
             (Self::SK_ACCEPT.0.into(), "SK_ACCEPT", "SKAccept"),
@@ -349,8 +351,8 @@ impl From<u8> for MapPart {
         Self(value)
     }
 }
-impl std::fmt::Debug for MapPart  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for MapPart  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KEY_TYPES.0.into(), "KEY_TYPES", "KeyTypes"),
             (Self::KEY_SYMS.0.into(), "KEY_SYMS", "KeySyms"),
@@ -414,8 +416,8 @@ impl From<u8> for SetMapFlags {
         Self(value)
     }
 }
-impl std::fmt::Debug for SetMapFlags  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SetMapFlags  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::RESIZE_TYPES.0.into(), "RESIZE_TYPES", "ResizeTypes"),
             (Self::RECOMPUTE_ACTIONS.0.into(), "RECOMPUTE_ACTIONS", "RecomputeActions"),
@@ -479,8 +481,8 @@ impl From<u16> for StatePart {
         Self(value)
     }
 }
-impl std::fmt::Debug for StatePart  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for StatePart  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::MODIFIER_STATE.0.into(), "MODIFIER_STATE", "ModifierState"),
             (Self::MODIFIER_BASE.0.into(), "MODIFIER_BASE", "ModifierBase"),
@@ -555,8 +557,8 @@ impl From<u16> for BoolCtrl {
         Self(value)
     }
 }
-impl std::fmt::Debug for BoolCtrl  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for BoolCtrl  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::REPEAT_KEYS.0.into(), "REPEAT_KEYS", "RepeatKeys"),
             (Self::SLOW_KEYS.0.into(), "SLOW_KEYS", "SlowKeys"),
@@ -616,8 +618,8 @@ impl From<u32> for Control {
         Self(value)
     }
 }
-impl std::fmt::Debug for Control  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Control  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::GROUPS_WRAP.0, "GROUPS_WRAP", "GroupsWrap"),
             (Self::INTERNAL_MODS.0, "INTERNAL_MODS", "InternalMods"),
@@ -682,8 +684,8 @@ impl From<u16> for AXOption {
         Self(value)
     }
 }
-impl std::fmt::Debug for AXOption  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for AXOption  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SK_PRESS_FB.0.into(), "SK_PRESS_FB", "SKPressFB"),
             (Self::SK_ACCEPT_FB.0.into(), "SK_ACCEPT_FB", "SKAcceptFB"),
@@ -747,8 +749,8 @@ impl From<u16> for LedClassResult {
         Self(value)
     }
 }
-impl std::fmt::Debug for LedClassResult  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for LedClassResult  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KBD_FEEDBACK_CLASS.0.into(), "KBD_FEEDBACK_CLASS", "KbdFeedbackClass"),
             (Self::LED_FEEDBACK_CLASS.0.into(), "LED_FEEDBACK_CLASS", "LedFeedbackClass"),
@@ -801,8 +803,8 @@ impl From<u16> for LedClass {
         Self(value)
     }
 }
-impl std::fmt::Debug for LedClass  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for LedClass  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KBD_FEEDBACK_CLASS.0.into(), "KBD_FEEDBACK_CLASS", "KbdFeedbackClass"),
             (Self::LED_FEEDBACK_CLASS.0.into(), "LED_FEEDBACK_CLASS", "LedFeedbackClass"),
@@ -863,8 +865,8 @@ impl From<u8> for BellClassResult {
         Self(value)
     }
 }
-impl std::fmt::Debug for BellClassResult  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for BellClassResult  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KBD_FEEDBACK_CLASS.0.into(), "KBD_FEEDBACK_CLASS", "KbdFeedbackClass"),
             (Self::BELL_FEEDBACK_CLASS.0.into(), "BELL_FEEDBACK_CLASS", "BellFeedbackClass"),
@@ -916,8 +918,8 @@ impl From<u16> for BellClass {
         Self(value)
     }
 }
-impl std::fmt::Debug for BellClass  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for BellClass  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KBD_FEEDBACK_CLASS.0.into(), "KBD_FEEDBACK_CLASS", "KbdFeedbackClass"),
             (Self::BELL_FEEDBACK_CLASS.0.into(), "BELL_FEEDBACK_CLASS", "BellFeedbackClass"),
@@ -976,8 +978,8 @@ impl From<u16> for ID {
         Self(value)
     }
 }
-impl std::fmt::Debug for ID  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ID  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::USE_CORE_KBD.0.into(), "USE_CORE_KBD", "UseCoreKbd"),
             (Self::USE_CORE_PTR.0.into(), "USE_CORE_PTR", "UseCorePtr"),
@@ -1043,8 +1045,8 @@ impl From<u8> for Group {
         Self(value)
     }
 }
-impl std::fmt::Debug for Group  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Group  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::M1.0.into(), "M1", "M1"),
             (Self::M2.0.into(), "M2", "M2"),
@@ -1103,8 +1105,8 @@ impl From<u8> for Groups {
         Self(value)
     }
 }
-impl std::fmt::Debug for Groups  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Groups  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ANY.0.into(), "ANY", "Any"),
             (Self::ALL.0.into(), "ALL", "All"),
@@ -1163,8 +1165,8 @@ impl From<u8> for SetOfGroup {
         Self(value)
     }
 }
-impl std::fmt::Debug for SetOfGroup  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SetOfGroup  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::GROUP1.0.into(), "GROUP1", "Group1"),
             (Self::GROUP2.0.into(), "GROUP2", "Group2"),
@@ -1223,8 +1225,8 @@ impl From<u8> for SetOfGroups {
         Self(value)
     }
 }
-impl std::fmt::Debug for SetOfGroups  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SetOfGroups  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ANY.0.into(), "ANY", "Any"),
         ];
@@ -1282,8 +1284,8 @@ impl From<u8> for GroupsWrap {
         Self(value)
     }
 }
-impl std::fmt::Debug for GroupsWrap  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GroupsWrap  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::WRAP_INTO_RANGE.0.into(), "WRAP_INTO_RANGE", "WrapIntoRange"),
             (Self::CLAMP_INTO_RANGE.0.into(), "CLAMP_INTO_RANGE", "ClampIntoRange"),
@@ -1348,8 +1350,8 @@ impl From<u8> for VModsHigh {
         Self(value)
     }
 }
-impl std::fmt::Debug for VModsHigh  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for VModsHigh  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::M15.0.into(), "M15", "M15"),
             (Self::M14.0.into(), "M14", "M14"),
@@ -1419,8 +1421,8 @@ impl From<u8> for VModsLow {
         Self(value)
     }
 }
-impl std::fmt::Debug for VModsLow  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for VModsLow  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::M7.0.into(), "M7", "M7"),
             (Self::M6.0.into(), "M6", "M6"),
@@ -1492,8 +1494,8 @@ impl From<u16> for VMod {
         Self(value)
     }
 }
-impl std::fmt::Debug for VMod  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for VMod  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::M15.0.into(), "M15", "M15"),
             (Self::M14.0.into(), "M14", "M14"),
@@ -1571,8 +1573,8 @@ impl From<u8> for Explicit {
         Self(value)
     }
 }
-impl std::fmt::Debug for Explicit  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Explicit  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::V_MOD_MAP.0.into(), "V_MOD_MAP", "VModMap"),
             (Self::BEHAVIOR.0.into(), "BEHAVIOR", "Behavior"),
@@ -1639,8 +1641,8 @@ impl From<u8> for SymInterpretMatch {
         Self(value)
     }
 }
-impl std::fmt::Debug for SymInterpretMatch  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SymInterpretMatch  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE_OF.0.into(), "NONE_OF", "NoneOf"),
             (Self::ANY_OF_OR_NONE.0.into(), "ANY_OF_OR_NONE", "AnyOfOrNone"),
@@ -1700,8 +1702,8 @@ impl From<u8> for SymInterpMatch {
         Self(value)
     }
 }
-impl std::fmt::Debug for SymInterpMatch  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SymInterpMatch  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::LEVEL_ONE_ONLY.0.into(), "LEVEL_ONE_ONLY", "LevelOneOnly"),
             (Self::OP_MASK.0.into(), "OP_MASK", "OpMask"),
@@ -1759,8 +1761,8 @@ impl From<u8> for IMFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for IMFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for IMFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NO_EXPLICIT.0.into(), "NO_EXPLICIT", "NoExplicit"),
             (Self::NO_AUTOMATIC.0.into(), "NO_AUTOMATIC", "NoAutomatic"),
@@ -1822,8 +1824,8 @@ impl From<u8> for IMModsWhich {
         Self(value)
     }
 }
-impl std::fmt::Debug for IMModsWhich  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for IMModsWhich  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::USE_COMPAT.0.into(), "USE_COMPAT", "UseCompat"),
             (Self::USE_EFFECTIVE.0.into(), "USE_EFFECTIVE", "UseEffective"),
@@ -1887,8 +1889,8 @@ impl From<u8> for IMGroupsWhich {
         Self(value)
     }
 }
-impl std::fmt::Debug for IMGroupsWhich  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for IMGroupsWhich  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::USE_COMPAT.0.into(), "USE_COMPAT", "UseCompat"),
             (Self::USE_EFFECTIVE.0.into(), "USE_EFFECTIVE", "UseEffective"),
@@ -2017,8 +2019,8 @@ impl From<u8> for CMDetail {
         Self(value)
     }
 }
-impl std::fmt::Debug for CMDetail  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CMDetail  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SYM_INTERP.0.into(), "SYM_INTERP", "SymInterp"),
             (Self::GROUP_COMPAT.0.into(), "GROUP_COMPAT", "GroupCompat"),
@@ -2082,8 +2084,8 @@ impl From<u16> for NameDetail {
         Self(value)
     }
 }
-impl std::fmt::Debug for NameDetail  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NameDetail  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KEYCODES.0.into(), "KEYCODES", "Keycodes"),
             (Self::GEOMETRY.0.into(), "GEOMETRY", "Geometry"),
@@ -2159,8 +2161,8 @@ impl From<u8> for GBNDetail {
         Self(value)
     }
 }
-impl std::fmt::Debug for GBNDetail  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GBNDetail  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::TYPES.0.into(), "TYPES", "Types"),
             (Self::COMPAT_MAP.0.into(), "COMPAT_MAP", "CompatMap"),
@@ -2227,8 +2229,8 @@ impl From<u8> for XIFeature {
         Self(value)
     }
 }
-impl std::fmt::Debug for XIFeature  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for XIFeature  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KEYBOARDS.0.into(), "KEYBOARDS", "Keyboards"),
             (Self::BUTTON_ACTIONS.0.into(), "BUTTON_ACTIONS", "ButtonActions"),
@@ -2292,8 +2294,8 @@ impl From<u8> for PerClientFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for PerClientFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PerClientFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DETECTABLE_AUTO_REPEAT.0.into(), "DETECTABLE_AUTO_REPEAT", "DetectableAutoRepeat"),
             (Self::GRABS_USE_XKB_STATE.0.into(), "GRABS_USE_XKB_STATE", "GrabsUseXKBState"),
@@ -2945,8 +2947,8 @@ impl From<u8> for BehaviorType {
         Self(value)
     }
 }
-impl std::fmt::Debug for BehaviorType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for BehaviorType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DEFAULT.0.into(), "DEFAULT", "Default"),
             (Self::LOCK.0.into(), "LOCK", "Lock"),
@@ -3569,8 +3571,8 @@ impl From<u8> for DoodadType {
         Self(value)
     }
 }
-impl std::fmt::Debug for DoodadType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for DoodadType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::OUTLINE.0.into(), "OUTLINE", "Outline"),
             (Self::SOLID.0.into(), "SOLID", "Solid"),
@@ -3731,8 +3733,8 @@ impl From<u8> for Error {
         Self(value)
     }
 }
-impl std::fmt::Debug for Error  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Error  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::BAD_DEVICE.0.into(), "BAD_DEVICE", "BadDevice"),
             (Self::BAD_CLASS.0.into(), "BAD_CLASS", "BadClass"),
@@ -3795,8 +3797,8 @@ impl From<u8> for SA {
         Self(value)
     }
 }
-impl std::fmt::Debug for SA  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SA  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::CLEAR_LOCKS.0.into(), "CLEAR_LOCKS", "ClearLocks"),
             (Self::LATCH_TO_LOCK.0.into(), "LATCH_TO_LOCK", "LatchToLock"),
@@ -3875,8 +3877,8 @@ impl From<u8> for SAType {
         Self(value)
     }
 }
-impl std::fmt::Debug for SAType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SAType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NO_ACTION.0.into(), "NO_ACTION", "NoAction"),
             (Self::SET_MODS.0.into(), "SET_MODS", "SetMods"),
@@ -4094,8 +4096,8 @@ impl From<u8> for SAMovePtrFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for SAMovePtrFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SAMovePtrFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NO_ACCELERATION.0.into(), "NO_ACCELERATION", "NoAcceleration"),
             (Self::MOVE_ABSOLUTE_X.0.into(), "MOVE_ABSOLUTE_X", "MoveAbsoluteX"),
@@ -4301,8 +4303,8 @@ impl From<u8> for SASetPtrDfltFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for SASetPtrDfltFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SASetPtrDfltFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DFLT_BTN_ABSOLUTE.0.into(), "DFLT_BTN_ABSOLUTE", "DfltBtnAbsolute"),
             (Self::AFFECT_DFLT_BUTTON.0.into(), "AFFECT_DFLT_BUTTON", "AffectDfltButton"),
@@ -4410,8 +4412,8 @@ impl From<u8> for SAIsoLockFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for SAIsoLockFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SAIsoLockFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NO_LOCK.0.into(), "NO_LOCK", "NoLock"),
             (Self::NO_UNLOCK.0.into(), "NO_UNLOCK", "NoUnlock"),
@@ -4474,8 +4476,8 @@ impl From<u8> for SAIsoLockNoAffect {
         Self(value)
     }
 }
-impl std::fmt::Debug for SAIsoLockNoAffect  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SAIsoLockNoAffect  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::CTRLS.0.into(), "CTRLS", "Ctrls"),
             (Self::PTR.0.into(), "PTR", "Ptr"),
@@ -4631,8 +4633,8 @@ impl From<u8> for SwitchScreenFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for SwitchScreenFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SwitchScreenFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::APPLICATION.0.into(), "APPLICATION", "Application"),
             (Self::ABSOLUTE.0.into(), "ABSOLUTE", "Absolute"),
@@ -4736,8 +4738,8 @@ impl From<u8> for BoolCtrlsHigh {
         Self(value)
     }
 }
-impl std::fmt::Debug for BoolCtrlsHigh  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for BoolCtrlsHigh  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ACCESS_X_FEEDBACK.0.into(), "ACCESS_X_FEEDBACK", "AccessXFeedback"),
             (Self::AUDIBLE_BELL.0.into(), "AUDIBLE_BELL", "AudibleBell"),
@@ -4804,8 +4806,8 @@ impl From<u8> for BoolCtrlsLow {
         Self(value)
     }
 }
-impl std::fmt::Debug for BoolCtrlsLow  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for BoolCtrlsLow  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::REPEAT_KEYS.0.into(), "REPEAT_KEYS", "RepeatKeys"),
             (Self::SLOW_KEYS.0.into(), "SLOW_KEYS", "SlowKeys"),
@@ -4917,8 +4919,8 @@ impl From<u8> for ActionMessageFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for ActionMessageFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ActionMessageFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ON_PRESS.0.into(), "ON_PRESS", "OnPress"),
             (Self::ON_RELEASE.0.into(), "ON_RELEASE", "OnRelease"),
@@ -5130,8 +5132,8 @@ impl From<u8> for LockDeviceFlags {
         Self(value)
     }
 }
-impl std::fmt::Debug for LockDeviceFlags  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for LockDeviceFlags  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NO_LOCK.0.into(), "NO_LOCK", "NoLock"),
             (Self::NO_UNLOCK.0.into(), "NO_UNLOCK", "NoUnlock"),
@@ -5242,8 +5244,8 @@ impl From<u8> for SAValWhat {
         Self(value)
     }
 }
-impl std::fmt::Debug for SAValWhat  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SAValWhat  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::IGNORE_VAL.0.into(), "IGNORE_VAL", "IgnoreVal"),
             (Self::SET_VAL_MIN.0.into(), "SET_VAL_MIN", "SetValMin"),

--- a/x11rb-protocol/src/protocol/xprint.rs
+++ b/x11rb-protocol/src/protocol/xprint.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -169,8 +171,8 @@ impl From<bool> for GetDoc {
         Self(value)
     }
 }
-impl std::fmt::Debug for GetDoc  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GetDoc  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::FINISHED.0.into(), "FINISHED", "Finished"),
             (Self::SECOND_CONSUMER.0.into(), "SECOND_CONSUMER", "SecondConsumer"),
@@ -228,8 +230,8 @@ impl From<u8> for EvMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for EvMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for EvMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NO_EVENT_MASK.0.into(), "NO_EVENT_MASK", "NoEventMask"),
             (Self::PRINT_MASK.0.into(), "PRINT_MASK", "PrintMask"),
@@ -292,8 +294,8 @@ impl From<u8> for Detail {
         Self(value)
     }
 }
-impl std::fmt::Debug for Detail  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Detail  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::START_JOB_NOTIFY.0.into(), "START_JOB_NOTIFY", "StartJobNotify"),
             (Self::END_JOB_NOTIFY.0.into(), "END_JOB_NOTIFY", "EndJobNotify"),
@@ -359,8 +361,8 @@ impl From<u8> for Attr {
         Self(value)
     }
 }
-impl std::fmt::Debug for Attr  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Attr  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::JOB_ATTR.0.into(), "JOB_ATTR", "JobAttr"),
             (Self::DOC_ATTR.0.into(), "DOC_ATTR", "DocAttr"),

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -11,10 +11,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -312,8 +314,8 @@ impl From<u8> for VisualClass {
         Self(value)
     }
 }
-impl std::fmt::Debug for VisualClass  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for VisualClass  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::STATIC_GRAY.0.into(), "STATIC_GRAY", "StaticGray"),
             (Self::GRAY_SCALE.0.into(), "GRAY_SCALE", "GrayScale"),
@@ -510,8 +512,8 @@ impl From<u32> for EventMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for EventMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for EventMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NO_EVENT.0, "NO_EVENT", "NoEvent"),
             (Self::KEY_PRESS.0, "KEY_PRESS", "KeyPress"),
@@ -582,8 +584,8 @@ impl From<u32> for BackingStore {
         Self(value)
     }
 }
-impl std::fmt::Debug for BackingStore  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for BackingStore  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NOT_USEFUL.0, "NOT_USEFUL", "NotUseful"),
             (Self::WHEN_MAPPED.0, "WHEN_MAPPED", "WhenMapped"),
@@ -921,8 +923,8 @@ impl From<u8> for ImageOrder {
         Self(value)
     }
 }
-impl std::fmt::Debug for ImageOrder  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ImageOrder  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::LSB_FIRST.0.into(), "LSB_FIRST", "LSBFirst"),
             (Self::MSB_FIRST.0.into(), "MSB_FIRST", "MSBFirst"),
@@ -1118,8 +1120,8 @@ impl From<u16> for ModMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for ModMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ModMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SHIFT.0.into(), "SHIFT", "Shift"),
             (Self::LOCK.0.into(), "LOCK", "Lock"),
@@ -1189,8 +1191,8 @@ impl From<u16> for KeyButMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for KeyButMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for KeyButMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SHIFT.0.into(), "SHIFT", "Shift"),
             (Self::LOCK.0.into(), "LOCK", "Lock"),
@@ -1258,8 +1260,8 @@ impl From<u8> for WindowEnum {
         Self(value)
     }
 }
-impl std::fmt::Debug for WindowEnum  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for WindowEnum  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
         ];
@@ -1440,8 +1442,8 @@ impl From<u16> for ButtonMask {
         Self(value)
     }
 }
-impl std::fmt::Debug for ButtonMask  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ButtonMask  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::M1.0.into(), "M1", "M1"),
             (Self::M2.0.into(), "M2", "M2"),
@@ -1630,8 +1632,8 @@ impl From<u8> for Motion {
         Self(value)
     }
 }
-impl std::fmt::Debug for Motion  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Motion  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NORMAL.0.into(), "NORMAL", "Normal"),
             (Self::HINT.0.into(), "HINT", "Hint"),
@@ -1818,8 +1820,8 @@ impl From<u8> for NotifyDetail {
         Self(value)
     }
 }
-impl std::fmt::Debug for NotifyDetail  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NotifyDetail  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ANCESTOR.0.into(), "ANCESTOR", "Ancestor"),
             (Self::VIRTUAL.0.into(), "VIRTUAL", "Virtual"),
@@ -1884,8 +1886,8 @@ impl From<u8> for NotifyMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for NotifyMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NotifyMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NORMAL.0.into(), "NORMAL", "Normal"),
             (Self::GRAB.0.into(), "GRAB", "Grab"),
@@ -2492,8 +2494,8 @@ impl From<u8> for Visibility {
         Self(value)
     }
 }
-impl std::fmt::Debug for Visibility  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Visibility  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::UNOBSCURED.0.into(), "UNOBSCURED", "Unobscured"),
             (Self::PARTIALLY_OBSCURED.0.into(), "PARTIALLY_OBSCURED", "PartiallyObscured"),
@@ -3523,8 +3525,8 @@ impl From<u8> for Place {
         Self(value)
     }
 }
-impl std::fmt::Debug for Place  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Place  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ON_TOP.0.into(), "ON_TOP", "OnTop"),
             (Self::ON_BOTTOM.0.into(), "ON_BOTTOM", "OnBottom"),
@@ -3676,8 +3678,8 @@ impl From<u8> for Property {
         Self(value)
     }
 }
-impl std::fmt::Debug for Property  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Property  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NEW_VALUE.0.into(), "NEW_VALUE", "NewValue"),
             (Self::DELETE.0.into(), "DELETE", "Delete"),
@@ -3902,8 +3904,8 @@ impl From<u8> for Time {
         Self(value)
     }
 }
-impl std::fmt::Debug for Time  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Time  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::CURRENT_TIME.0.into(), "CURRENT_TIME", "CurrentTime"),
         ];
@@ -4027,8 +4029,8 @@ impl From<u8> for AtomEnum {
         Self(value)
     }
 }
-impl std::fmt::Debug for AtomEnum  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for AtomEnum  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
             (Self::ANY.0.into(), "ANY", "Any"),
@@ -4324,8 +4326,8 @@ impl From<u8> for ColormapState {
         Self(value)
     }
 }
-impl std::fmt::Debug for ColormapState  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ColormapState  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::UNINSTALLED.0.into(), "UNINSTALLED", "Uninstalled"),
             (Self::INSTALLED.0.into(), "INSTALLED", "Installed"),
@@ -4381,8 +4383,8 @@ impl From<u8> for ColormapEnum {
         Self(value)
     }
 }
-impl std::fmt::Debug for ColormapEnum  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ColormapEnum  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
         ];
@@ -4802,8 +4804,8 @@ impl From<u8> for Mapping {
         Self(value)
     }
 }
-impl std::fmt::Debug for Mapping  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Mapping  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::MODIFIER.0.into(), "MODIFIER", "Modifier"),
             (Self::KEYBOARD.0.into(), "KEYBOARD", "Keyboard"),
@@ -5026,8 +5028,8 @@ impl From<u16> for WindowClass {
         Self(value)
     }
 }
-impl std::fmt::Debug for WindowClass  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for WindowClass  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::COPY_FROM_PARENT.0.into(), "COPY_FROM_PARENT", "CopyFromParent"),
             (Self::INPUT_OUTPUT.0.into(), "INPUT_OUTPUT", "InputOutput"),
@@ -5162,8 +5164,8 @@ impl From<u16> for CW {
         Self(value)
     }
 }
-impl std::fmt::Debug for CW  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CW  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::BACK_PIXMAP.0.into(), "BACK_PIXMAP", "BackPixmap"),
             (Self::BACK_PIXEL.0.into(), "BACK_PIXEL", "BackPixel"),
@@ -5246,8 +5248,8 @@ impl From<bool> for BackPixmap {
         Self(value)
     }
 }
-impl std::fmt::Debug for BackPixmap  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for BackPixmap  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
             (Self::PARENT_RELATIVE.0.into(), "PARENT_RELATIVE", "ParentRelative"),
@@ -5302,8 +5304,8 @@ impl From<u32> for Gravity {
         Self(value)
     }
 }
-impl std::fmt::Debug for Gravity  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Gravity  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::BIT_FORGET.0, "BIT_FORGET", "BitForget"),
             (Self::WIN_UNMAP.0, "WIN_UNMAP", "WinUnmap"),
@@ -6370,8 +6372,8 @@ impl From<u8> for MapState {
         Self(value)
     }
 }
-impl std::fmt::Debug for MapState  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for MapState  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::UNMAPPED.0.into(), "UNMAPPED", "Unmapped"),
             (Self::UNVIEWABLE.0.into(), "UNVIEWABLE", "Unviewable"),
@@ -6703,8 +6705,8 @@ impl From<u8> for SetMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for SetMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SetMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::INSERT.0.into(), "INSERT", "Insert"),
             (Self::DELETE.0.into(), "DELETE", "Delete"),
@@ -7230,8 +7232,8 @@ impl From<u8> for ConfigWindow {
         Self(value)
     }
 }
-impl std::fmt::Debug for ConfigWindow  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ConfigWindow  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::X.0.into(), "X", "X"),
             (Self::Y.0.into(), "Y", "Y"),
@@ -7285,8 +7287,8 @@ impl From<u32> for StackMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for StackMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for StackMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ABOVE.0, "ABOVE", "Above"),
             (Self::BELOW.0, "BELOW", "Below"),
@@ -7688,8 +7690,8 @@ impl From<u8> for Circulate {
         Self(value)
     }
 }
-impl std::fmt::Debug for Circulate  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Circulate  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::RAISE_LOWEST.0.into(), "RAISE_LOWEST", "RaiseLowest"),
             (Self::LOWER_HIGHEST.0.into(), "LOWER_HIGHEST", "LowerHighest"),
@@ -8357,8 +8359,8 @@ impl From<u8> for PropMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for PropMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PropMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::REPLACE.0.into(), "REPLACE", "Replace"),
             (Self::PREPEND.0.into(), "PREPEND", "Prepend"),
@@ -8640,8 +8642,8 @@ impl From<u8> for GetPropertyType {
         Self(value)
     }
 }
-impl std::fmt::Debug for GetPropertyType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GetPropertyType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ANY.0.into(), "ANY", "Any"),
         ];
@@ -9455,8 +9457,8 @@ impl From<bool> for SendEventDest {
         Self(value)
     }
 }
-impl std::fmt::Debug for SendEventDest  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SendEventDest  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::POINTER_WINDOW.0.into(), "POINTER_WINDOW", "PointerWindow"),
             (Self::ITEM_FOCUS.0.into(), "ITEM_FOCUS", "ItemFocus"),
@@ -9672,8 +9674,8 @@ impl From<u8> for GrabMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for GrabMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GrabMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SYNC.0.into(), "SYNC", "Sync"),
             (Self::ASYNC.0.into(), "ASYNC", "Async"),
@@ -9733,8 +9735,8 @@ impl From<u8> for GrabStatus {
         Self(value)
     }
 }
-impl std::fmt::Debug for GrabStatus  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GrabStatus  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SUCCESS.0.into(), "SUCCESS", "Success"),
             (Self::ALREADY_GRABBED.0.into(), "ALREADY_GRABBED", "AlreadyGrabbed"),
@@ -9793,8 +9795,8 @@ impl From<u8> for CursorEnum {
         Self(value)
     }
 }
-impl std::fmt::Debug for CursorEnum  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CursorEnum  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
         ];
@@ -10137,8 +10139,8 @@ impl From<u8> for ButtonIndex {
         Self(value)
     }
 }
-impl std::fmt::Debug for ButtonIndex  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ButtonIndex  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ANY.0.into(), "ANY", "Any"),
             (Self::M1.0.into(), "M1", "M1"),
@@ -10735,8 +10737,8 @@ impl From<u8> for Grab {
         Self(value)
     }
 }
-impl std::fmt::Debug for Grab  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Grab  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ANY.0.into(), "ANY", "Any"),
         ];
@@ -11094,8 +11096,8 @@ impl From<u8> for Allow {
         Self(value)
     }
 }
-impl std::fmt::Debug for Allow  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Allow  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ASYNC_POINTER.0.into(), "ASYNC_POINTER", "AsyncPointer"),
             (Self::SYNC_POINTER.0.into(), "SYNC_POINTER", "SyncPointer"),
@@ -11856,8 +11858,8 @@ impl From<u8> for InputFocus {
         Self(value)
     }
 }
-impl std::fmt::Debug for InputFocus  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for InputFocus  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
             (Self::POINTER_ROOT.0.into(), "POINTER_ROOT", "PointerRoot"),
@@ -12315,8 +12317,8 @@ impl From<u8> for FontDraw {
         Self(value)
     }
 }
-impl std::fmt::Debug for FontDraw  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for FontDraw  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::LEFT_TO_RIGHT.0.into(), "LEFT_TO_RIGHT", "LeftToRight"),
             (Self::RIGHT_TO_LEFT.0.into(), "RIGHT_TO_LEFT", "RightToLeft"),
@@ -13568,8 +13570,8 @@ impl From<u32> for GC {
         Self(value)
     }
 }
-impl std::fmt::Debug for GC  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GC  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::FUNCTION.0, "FUNCTION", "Function"),
             (Self::PLANE_MASK.0, "PLANE_MASK", "PlaneMask"),
@@ -13650,8 +13652,8 @@ impl From<u32> for GX {
         Self(value)
     }
 }
-impl std::fmt::Debug for GX  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GX  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::CLEAR.0, "CLEAR", "Clear"),
             (Self::AND.0, "AND", "And"),
@@ -13711,8 +13713,8 @@ impl From<u32> for LineStyle {
         Self(value)
     }
 }
-impl std::fmt::Debug for LineStyle  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for LineStyle  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SOLID.0, "SOLID", "Solid"),
             (Self::ON_OFF_DASH.0, "ON_OFF_DASH", "OnOffDash"),
@@ -13760,8 +13762,8 @@ impl From<u32> for CapStyle {
         Self(value)
     }
 }
-impl std::fmt::Debug for CapStyle  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CapStyle  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NOT_LAST.0, "NOT_LAST", "NotLast"),
             (Self::BUTT.0, "BUTT", "Butt"),
@@ -13809,8 +13811,8 @@ impl From<u32> for JoinStyle {
         Self(value)
     }
 }
-impl std::fmt::Debug for JoinStyle  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for JoinStyle  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::MITER.0, "MITER", "Miter"),
             (Self::ROUND.0, "ROUND", "Round"),
@@ -13858,8 +13860,8 @@ impl From<u32> for FillStyle {
         Self(value)
     }
 }
-impl std::fmt::Debug for FillStyle  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for FillStyle  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SOLID.0, "SOLID", "Solid"),
             (Self::TILED.0, "TILED", "Tiled"),
@@ -13906,8 +13908,8 @@ impl From<u32> for FillRule {
         Self(value)
     }
 }
-impl std::fmt::Debug for FillRule  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for FillRule  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::EVEN_ODD.0, "EVEN_ODD", "EvenOdd"),
             (Self::WINDING.0, "WINDING", "Winding"),
@@ -13952,8 +13954,8 @@ impl From<u32> for SubwindowMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for SubwindowMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for SubwindowMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::CLIP_BY_CHILDREN.0, "CLIP_BY_CHILDREN", "ClipByChildren"),
             (Self::INCLUDE_INFERIORS.0, "INCLUDE_INFERIORS", "IncludeInferiors"),
@@ -13998,8 +14000,8 @@ impl From<u32> for ArcMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for ArcMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ArcMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::CHORD.0, "CHORD", "Chord"),
             (Self::PIE_SLICE.0, "PIE_SLICE", "PieSlice"),
@@ -15491,8 +15493,8 @@ impl From<u8> for ClipOrdering {
         Self(value)
     }
 }
-impl std::fmt::Debug for ClipOrdering  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ClipOrdering  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::UNSORTED.0.into(), "UNSORTED", "Unsorted"),
             (Self::Y_SORTED.0.into(), "Y_SORTED", "YSorted"),
@@ -16041,8 +16043,8 @@ impl From<u8> for CoordMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for CoordMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CoordMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ORIGIN.0.into(), "ORIGIN", "Origin"),
             (Self::PREVIOUS.0.into(), "PREVIOUS", "Previous"),
@@ -16644,8 +16646,8 @@ impl From<u8> for PolyShape {
         Self(value)
     }
 }
-impl std::fmt::Debug for PolyShape  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PolyShape  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::COMPLEX.0.into(), "COMPLEX", "Complex"),
             (Self::NONCONVEX.0.into(), "NONCONVEX", "Nonconvex"),
@@ -17001,8 +17003,8 @@ impl From<u8> for ImageFormat {
         Self(value)
     }
 }
-impl std::fmt::Debug for ImageFormat  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ImageFormat  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::XY_BITMAP.0.into(), "XY_BITMAP", "XYBitmap"),
             (Self::XY_PIXMAP.0.into(), "XY_PIXMAP", "XYPixmap"),
@@ -17756,8 +17758,8 @@ impl From<u8> for ColormapAlloc {
         Self(value)
     }
 }
-impl std::fmt::Debug for ColormapAlloc  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ColormapAlloc  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
             (Self::ALL.0.into(), "ALL", "All"),
@@ -18803,8 +18805,8 @@ impl From<u8> for ColorFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for ColorFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ColorFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::RED.0.into(), "RED", "Red"),
             (Self::GREEN.0.into(), "GREEN", "Green"),
@@ -19354,8 +19356,8 @@ impl From<u8> for PixmapEnum {
         Self(value)
     }
 }
-impl std::fmt::Debug for PixmapEnum  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PixmapEnum  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
         ];
@@ -19529,8 +19531,8 @@ impl From<u8> for FontEnum {
         Self(value)
     }
 }
-impl std::fmt::Debug for FontEnum  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for FontEnum  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
         ];
@@ -19897,8 +19899,8 @@ impl From<u8> for QueryShapeOf {
         Self(value)
     }
 }
-impl std::fmt::Debug for QueryShapeOf  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for QueryShapeOf  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::LARGEST_CURSOR.0.into(), "LARGEST_CURSOR", "LargestCursor"),
             (Self::FASTEST_TILE.0.into(), "FASTEST_TILE", "FastestTile"),
@@ -20456,8 +20458,8 @@ impl From<u8> for KB {
         Self(value)
     }
 }
-impl std::fmt::Debug for KB  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for KB  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::KEY_CLICK_PERCENT.0.into(), "KEY_CLICK_PERCENT", "KeyClickPercent"),
             (Self::BELL_PERCENT.0.into(), "BELL_PERCENT", "BellPercent"),
@@ -20509,8 +20511,8 @@ impl From<u32> for LedMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for LedMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for LedMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::OFF.0, "OFF", "Off"),
             (Self::ON.0, "ON", "On"),
@@ -20556,8 +20558,8 @@ impl From<u32> for AutoRepeatMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for AutoRepeatMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for AutoRepeatMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::OFF.0, "OFF", "Off"),
             (Self::ON.0, "ON", "On"),
@@ -21177,8 +21179,8 @@ impl From<u8> for Blanking {
         Self(value)
     }
 }
-impl std::fmt::Debug for Blanking  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Blanking  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NOT_PREFERRED.0.into(), "NOT_PREFERRED", "NotPreferred"),
             (Self::PREFERRED.0.into(), "PREFERRED", "Preferred"),
@@ -21237,8 +21239,8 @@ impl From<u8> for Exposures {
         Self(value)
     }
 }
-impl std::fmt::Debug for Exposures  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Exposures  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NOT_ALLOWED.0.into(), "NOT_ALLOWED", "NotAllowed"),
             (Self::ALLOWED.0.into(), "ALLOWED", "Allowed"),
@@ -21450,8 +21452,8 @@ impl From<u8> for HostMode {
         Self(value)
     }
 }
-impl std::fmt::Debug for HostMode  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for HostMode  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::INSERT.0.into(), "INSERT", "Insert"),
             (Self::DELETE.0.into(), "DELETE", "Delete"),
@@ -21511,8 +21513,8 @@ impl From<u8> for Family {
         Self(value)
     }
 }
-impl std::fmt::Debug for Family  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Family  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::INTERNET.0.into(), "INTERNET", "Internet"),
             (Self::DEC_NET.0.into(), "DEC_NET", "DECnet"),
@@ -21796,8 +21798,8 @@ impl From<u8> for AccessControl {
         Self(value)
     }
 }
-impl std::fmt::Debug for AccessControl  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for AccessControl  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DISABLE.0.into(), "DISABLE", "Disable"),
             (Self::ENABLE.0.into(), "ENABLE", "Enable"),
@@ -21906,8 +21908,8 @@ impl From<u8> for CloseDown {
         Self(value)
     }
 }
-impl std::fmt::Debug for CloseDown  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for CloseDown  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::DESTROY_ALL.0.into(), "DESTROY_ALL", "DestroyAll"),
             (Self::RETAIN_PERMANENT.0.into(), "RETAIN_PERMANENT", "RetainPermanent"),
@@ -22015,8 +22017,8 @@ impl From<u8> for Kill {
         Self(value)
     }
 }
-impl std::fmt::Debug for Kill  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Kill  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::ALL_TEMPORARY.0.into(), "ALL_TEMPORARY", "AllTemporary"),
         ];
@@ -22227,8 +22229,8 @@ impl From<u8> for ScreenSaver {
         Self(value)
     }
 }
-impl std::fmt::Debug for ScreenSaver  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ScreenSaver  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::RESET.0.into(), "RESET", "Reset"),
             (Self::ACTIVE.0.into(), "ACTIVE", "Active"),
@@ -22337,8 +22339,8 @@ impl From<u8> for MappingStatus {
         Self(value)
     }
 }
-impl std::fmt::Debug for MappingStatus  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for MappingStatus  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SUCCESS.0.into(), "SUCCESS", "Success"),
             (Self::BUSY.0.into(), "BUSY", "Busy"),
@@ -22578,8 +22580,8 @@ impl From<u8> for MapIndex {
         Self(value)
     }
 }
-impl std::fmt::Debug for MapIndex  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for MapIndex  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SHIFT.0.into(), "SHIFT", "Shift"),
             (Self::LOCK.0.into(), "LOCK", "Lock"),

--- a/x11rb-protocol/src/protocol/xselinux.rs
+++ b/x11rb-protocol/src/protocol/xselinux.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;

--- a/x11rb-protocol/src/protocol/xtest.rs
+++ b/x11rb-protocol/src/protocol/xtest.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -176,8 +178,8 @@ impl From<bool> for Cursor {
         Self(value)
     }
 }
-impl std::fmt::Debug for Cursor  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Cursor  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::NONE.0.into(), "NONE", "None"),
             (Self::CURRENT.0.into(), "CURRENT", "Current"),

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;
@@ -89,8 +91,8 @@ impl From<u8> for Type {
         Self(value)
     }
 }
-impl std::fmt::Debug for Type  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Type  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::INPUT_MASK.0.into(), "INPUT_MASK", "InputMask"),
             (Self::OUTPUT_MASK.0.into(), "OUTPUT_MASK", "OutputMask"),
@@ -151,8 +153,8 @@ impl From<u8> for ImageFormatInfoType {
         Self(value)
     }
 }
-impl std::fmt::Debug for ImageFormatInfoType  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ImageFormatInfoType  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::RGB.0.into(), "RGB", "RGB"),
             (Self::YUV.0.into(), "YUV", "YUV"),
@@ -209,8 +211,8 @@ impl From<u8> for ImageFormatInfoFormat {
         Self(value)
     }
 }
-impl std::fmt::Debug for ImageFormatInfoFormat  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ImageFormatInfoFormat  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::PACKED.0.into(), "PACKED", "Packed"),
             (Self::PLANAR.0.into(), "PLANAR", "Planar"),
@@ -267,8 +269,8 @@ impl From<u8> for AttributeFlag {
         Self(value)
     }
 }
-impl std::fmt::Debug for AttributeFlag  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for AttributeFlag  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::GETTABLE.0.into(), "GETTABLE", "Gettable"),
             (Self::SETTABLE.0.into(), "SETTABLE", "Settable"),
@@ -329,8 +331,8 @@ impl From<u8> for VideoNotifyReason {
         Self(value)
     }
 }
-impl std::fmt::Debug for VideoNotifyReason  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for VideoNotifyReason  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::STARTED.0.into(), "STARTED", "Started"),
             (Self::STOPPED.0.into(), "STOPPED", "Stopped"),
@@ -390,8 +392,8 @@ impl From<u8> for ScanlineOrder {
         Self(value)
     }
 }
-impl std::fmt::Debug for ScanlineOrder  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ScanlineOrder  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::TOP_TO_BOTTOM.0.into(), "TOP_TO_BOTTOM", "TopToBottom"),
             (Self::BOTTOM_TO_TOP.0.into(), "BOTTOM_TO_TOP", "BottomToTop"),
@@ -452,8 +454,8 @@ impl From<u8> for GrabPortStatus {
         Self(value)
     }
 }
-impl std::fmt::Debug for GrabPortStatus  {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GrabPortStatus  {
+    fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
             (Self::SUCCESS.0.into(), "SUCCESS", "Success"),
             (Self::BAD_EXTENSION.0.into(), "BAD_EXTENSION", "BadExtension"),

--- a/x11rb-protocol/src/protocol/xvmc.rs
+++ b/x11rb-protocol/src/protocol/xvmc.rs
@@ -6,10 +6,12 @@
 #![allow(clippy::too_many_arguments)]
 
 #[allow(unused_imports)]
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 #[allow(unused_imports)]
-use std::convert::TryInto;
-use std::convert::TryFrom;
+use core::convert::TryInto;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 use crate::errors::ParseError;
 #[allow(unused_imports)]
 use crate::x11_utils::TryIntoUSize;

--- a/x11rb-protocol/src/resource_manager/matcher.rs
+++ b/x11rb-protocol/src/resource_manager/matcher.rs
@@ -1,5 +1,8 @@
 //! Match Xrm entries against a query.
 
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 use std::cmp::Ordering;
 
 use super::parser::parse_query;
@@ -47,6 +50,7 @@ mod zip_longest {
     #[cfg(test)]
     mod test_zip_longest {
         use super::zip_longest;
+        use alloc::vec::Vec;
 
         #[test]
         fn empty() {
@@ -340,6 +344,11 @@ pub(crate) fn match_entry<'a>(
 mod test {
     use super::super::parser::parse_database;
     use super::match_entry;
+
+    use alloc::format;
+    use alloc::string::{String, ToString};
+    use alloc::vec::Vec;
+    use std::eprintln;
 
     // Most tests in here are based on [1], which is: Copyright © 2016 Ingo Bürk
     // [1]: https://github.com/Airblader/xcb-util-xrm/blob/master/tests/tests_match.c

--- a/x11rb-protocol/src/resource_manager/mod.rs
+++ b/x11rb-protocol/src/resource_manager/mod.rs
@@ -10,10 +10,15 @@
 //! The code in this module is only available when the `resource_manager` feature of the library is
 //! enabled.
 
+#![cfg(feature = "std")]
+
 use std::env::var_os;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+
+use alloc::string::String;
+use alloc::vec::Vec;
 
 use crate::protocol::xproto::{GetPropertyReply, GetPropertyRequest};
 

--- a/x11rb-protocol/src/resource_manager/parser.rs
+++ b/x11rb-protocol/src/resource_manager/parser.rs
@@ -1,6 +1,8 @@
 //! Code for parsing resource management things
 
 use super::{Binding, Component, Entry};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 // =======================
 // Common helper functions
@@ -267,6 +269,10 @@ pub(crate) fn parse_query(data: &[u8]) -> Option<Vec<String>> {
 #[cfg(test)]
 mod test {
     use super::{parse_database, parse_entry, parse_query, Binding, Component, Entry};
+    use alloc::string::{String, ToString};
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use std::eprintln;
 
     // Most tests in here are based on [1], which is: Copyright © 2016 Ingo Bürk
     // [1]: https://github.com/Airblader/xcb-util-xrm/blob/master/tests/tests_parser.c

--- a/x11rb-protocol/src/wrapper.rs
+++ b/x11rb-protocol/src/wrapper.rs
@@ -1,7 +1,7 @@
 //! Helpers for the generated code
 
 use super::x11_utils::TryParse;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 /// Iterator implementation used by [GetPropertyReply].
 ///
@@ -41,9 +41,9 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let size = self.0.len() / std::mem::size_of::<T>();
+        let size = self.0.len() / core::mem::size_of::<T>();
         (size, Some(size))
     }
 }
 
-impl<T: TryParse> std::iter::FusedIterator for PropertyIterator<'_, T> {}
+impl<T: TryParse> core::iter::FusedIterator for PropertyIterator<'_, T> {}

--- a/x11rb-protocol/src/x11_utils.rs
+++ b/x11rb-protocol/src/x11_utils.rs
@@ -4,7 +4,10 @@
 //! [`Serialize`] traits. These traits are used internally for parsing incoming data and producing
 //! outgoing data when talking with the X11 server.
 
-use std::convert::TryInto;
+use core::convert::TryInto;
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 
 use crate::errors::ParseError;
 use crate::protocol::{request_name, ErrorKind};
@@ -249,7 +252,7 @@ macro_rules! implement_try_parse {
     ($t:ty) => {
         impl TryParse for $t {
             fn try_parse(value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-                let len = std::mem::size_of::<$t>();
+                let len = core::mem::size_of::<$t>();
                 let bytes = value
                     .get(..len)
                     .ok_or(ParseError::InsufficientData)?
@@ -455,30 +458,30 @@ impl<T: Serialize> Serialize for [T] {
 // `std::ops::BitOrAssign`.
 macro_rules! bitmask_binop {
     ($t:ty, $u:ty) => {
-        impl std::ops::BitOr for $t {
+        impl core::ops::BitOr for $t {
             type Output = $t;
             fn bitor(self, other: Self) -> Self::Output {
                 Self::from(<$u>::from(self) | <$u>::from(other))
             }
         }
-        impl std::ops::BitOr<$u> for $t {
+        impl core::ops::BitOr<$u> for $t {
             type Output = $t;
             fn bitor(self, other: $u) -> Self::Output {
                 self | Self::from(other)
             }
         }
-        impl std::ops::BitOr<$t> for $u {
+        impl core::ops::BitOr<$t> for $u {
             type Output = $t;
             fn bitor(self, other: $t) -> Self::Output {
                 <$t>::from(self) | other
             }
         }
-        impl std::ops::BitOrAssign<$t> for $u {
+        impl core::ops::BitOrAssign<$t> for $u {
             fn bitor_assign(&mut self, other: $t) {
                 *self |= Self::from(other)
             }
         }
-        impl std::ops::BitOrAssign<$u> for $t {
+        impl core::ops::BitOrAssign<$u> for $t {
             fn bitor_assign(&mut self, other: $u) {
                 *self = *self | Self::from(other)
             }

--- a/x11rb-protocol/src/xauth.rs
+++ b/x11rb-protocol/src/xauth.rs
@@ -1,5 +1,9 @@
 //! Helpers for working with `~/.Xauthority`.
 
+#![cfg(feature = "std")]
+
+use alloc::string::ToString;
+use alloc::vec::Vec;
 use std::io::Error;
 
 use crate::protocol::xproto::Family as X11Family;
@@ -67,6 +71,7 @@ pub(crate) struct AuthEntry {
 mod file {
     //! Code for actually reading `~/.Xauthority`.
 
+    use alloc::{vec, vec::Vec};
     use std::env::var_os;
     use std::fs::File;
     use std::io::{BufReader, Error, ErrorKind, Read};
@@ -168,6 +173,7 @@ mod file {
     mod test {
         use super::super::{AuthEntry, Family};
         use super::read_entry;
+        use alloc::vec;
         use std::io::Cursor;
 
         #[test]
@@ -289,6 +295,7 @@ fn get_auth_impl(
 #[cfg(test)]
 mod test {
     use super::{get_auth_impl, AuthEntry, Family, MIT_MAGIC_COOKIE_1};
+    use alloc::vec;
 
     // Call the given function on a matching auth entry. The function can change the entry.
     // Afterwards, it should still be a match.


### PR DESCRIPTION
This pull request adds a new feature to x11rb-protocol, "std", which is enabled by default. With this feature disabled, the crate is able to be used on `no_std` platforms. Note that several features, including display parsing, resource management, and extensions using file descriptors are locked behind this feature.

~~While I was setting up the extensions to be locked behind `no_std`, I also realized that, since FD passing is a well-defined operation only on Unix targets, having these extensions on non-Unix targets would likely lead to errors or undefined behavior. So I also locked these extensions behind the `cfg(unix)` directive.~~ On second thought, I'll leave the option open.