### PR TITLE
Change dyn trait to Impl trait on ExtInfoProvider

### DIFF
--- a/generator/src/generator/error_events.rs
+++ b/generator/src/generator/error_events.rs
@@ -68,7 +68,7 @@ fn generate_errors(out: &mut Output, module: &xcbgen::defs::Module) {
         outln!(out, "#[allow(clippy::match_single_binding)]");
         outln!(out, "pub fn from_wire_error_code(");
         outln!(out.indent(), "error_code: u8,");
-        outln!(out.indent(), "ext_info_provider: &dyn ExtInfoProvider,");
+        outln!(out.indent(), "ext_info_provider: &impl ExtInfoProvider,");
         outln!(out, ") -> Self {{");
         out.indented(|out| {
             outln!(out, "// Check if this is a core protocol error");
@@ -184,7 +184,7 @@ fn generate_events(out: &mut Output, module: &xcbgen::defs::Module) {
         );
         outln!(out, "pub fn parse(");
         outln!(out.indent(), "event: &[u8],");
-        outln!(out.indent(), "ext_info_provider: &dyn ExtInfoProvider,");
+        outln!(out.indent(), "ext_info_provider: &impl ExtInfoProvider,");
         outln!(out, ") -> Result<Self, ParseError> {{");
         out.indented(|out| {
             outln!(out, "let event_code = response_type(event)?;");
@@ -290,7 +290,7 @@ fn generate_events(out: &mut Output, module: &xcbgen::defs::Module) {
         outln!(out, "#[allow(clippy::match_single_binding)]");
         outln!(out, "fn from_generic_event(");
         outln!(out.indent(), "event: &[u8],");
-        outln!(out.indent(), "ext_info_provider: &dyn ExtInfoProvider,");
+        outln!(out.indent(), "ext_info_provider: &impl ExtInfoProvider,");
         outln!(out, ") -> Result<Self, ParseError> {{");
         out.indented(|out| {
             outln!(

--- a/generator/src/generator/requests_replies.rs
+++ b/generator/src/generator/requests_replies.rs
@@ -70,7 +70,7 @@ pub(super) fn generate(out: &mut Output, module: &xcbdefs::Module, mut enum_case
             );
             outln!(out, "#[allow(unused_variables, clippy::ptr_arg)]");
             outln!(out, "fds: &mut Vec<RawFdContainer>,");
-            outln!(out, "ext_info_provider: &dyn ExtInfoProvider,");
+            outln!(out, "ext_info_provider: &impl ExtInfoProvider,");
         });
         outln!(out, ") -> Result<Self, ParseError> {{");
         out.indented(|out| {

--- a/x11rb-protocol/src/protocol/mod.rs
+++ b/x11rb-protocol/src/protocol/mod.rs
@@ -1283,7 +1283,7 @@ impl<'input> Request<'input> {
         // Might not be used if none of the extensions that use FD passing is enabled
         #[allow(unused_variables, clippy::ptr_arg)]
         fds: &mut Vec<RawFdContainer>,
-        ext_info_provider: &dyn ExtInfoProvider,
+        ext_info_provider: &impl ExtInfoProvider,
     ) -> Result<Self, ParseError> {
         let remaining = body;
         // Check if this is a core protocol request.
@@ -8295,7 +8295,7 @@ impl ErrorKind {
     #[allow(clippy::match_single_binding)]
     pub fn from_wire_error_code(
         error_code: u8,
-        ext_info_provider: &dyn ExtInfoProvider,
+        ext_info_provider: &impl ExtInfoProvider,
     ) -> Self {
         // Check if this is a core protocol error
         match error_code {
@@ -8656,7 +8656,7 @@ impl Event {
     #[allow(clippy::cognitive_complexity, clippy::match_single_binding)]
     pub fn parse(
         event: &[u8],
-        ext_info_provider: &dyn ExtInfoProvider,
+        ext_info_provider: &impl ExtInfoProvider,
     ) -> Result<Self, ParseError> {
         let event_code = response_type(event)?;
 
@@ -8844,7 +8844,7 @@ impl Event {
     #[allow(clippy::match_single_binding)]
     fn from_generic_event(
         event: &[u8],
-        ext_info_provider: &dyn ExtInfoProvider,
+        ext_info_provider: &impl ExtInfoProvider,
     ) -> Result<Self, ParseError> {
         let ge_event = xproto::GeGenericEvent::try_parse(event)?.0;
         let ext_name = ext_info_provider

--- a/x11rb-protocol/src/x11_utils.rs
+++ b/x11rb-protocol/src/x11_utils.rs
@@ -36,7 +36,7 @@ impl X11Error {
     /// Parse an X11 error.
     pub fn try_parse(
         data: &[u8],
-        ext_info_provider: &dyn ExtInfoProvider,
+        ext_info_provider: &impl ExtInfoProvider,
     ) -> Result<Self, ParseError> {
         let (response_type, remaining) = u8::try_parse(data)?;
         let (error_code, remaining) = u8::try_parse(remaining)?;


### PR DESCRIPTION
Desugars into regular old trait bounds on the affected functions and gets rid of the fat pointer, shouldn't affect output size at all  since the only alternate extension manager is in an example crate, basically ditching the fat pointer for free here, although I did also make the change in that crate. 

Could be done with <EP: ExtInfoProvider> as well, but that's slightly more annoying to replace in the generator than just a search replace of `&dyn` -> `&impl`.