### PR TITLE
Fix an uint underflow on BigRequest handling on xtrace-example

### DIFF
--- a/xtrace-example/src/connection.rs
+++ b/xtrace-example/src/connection.rs
@@ -51,7 +51,7 @@ impl Connection {
             } else {
                 // Big requests
                 let length_field = match packet.get(4..8) {
-                    None => return Some(packet.len() - 8),
+                    None => return Some(8 - packet.len()),
                     Some(length_field) => u32::from_ne_bytes(length_field.try_into().unwrap()),
                 };
                 usize::try_from(length_field).unwrap() * 4


### PR DESCRIPTION
When trying to start with xtrace I discovered an underflow, it's easily fixed and works now.

Kinda related to https://github.com/psychon/x11rb/issues/698.