### PR TITLE
Fix the appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ install:
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - rustc -V
   - cargo -V
+  - curl -sSf -o C:\cygwin\setup-x86.exe https://cygwin.com/setup-x86.exe
   - C:\cygwin\setup-x86.exe --quiet-mode --no-shortcuts --no-startmenu --no-desktop --upgrade-also --root c:\cygwin --packages xorg-server-extra
   # This uses libc::mmap and thus is Unix-only
   - del x11rb\examples\shared_memory.rs


### PR DESCRIPTION
The rror message from setup-x86.exe was:
```
mbox Parse Errors:  line 12: The current ini file requires at least version 2.903 of setup.
Please download a newer version from https://cygwin.com/setup-x86.exe
```
Google found https://github.com/appveyor/ci/issues/3820 which says that
one should just download the latest setup.exe during the build. The
provided solution uses powershell. I translated that to the commands
that are already used to also download the rust installer.

Signed-off-by: Uli Schlachter <psychon@znc.in>