### PR TITLE
Derive `serde` traits for protocol objects

### DIFF
--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -375,6 +375,10 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         let union_size = union_def.size();
 
         outln!(out, "#[derive(Debug, Copy, Clone)]");
+        outln!(
+            out,
+            r#"#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]"#
+        );
         outln!(out, "pub struct {}([u8; {}]);", rust_name, union_size);
 
         let fields = union_def.fields.as_slice();
@@ -557,6 +561,10 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         }
 
         outln!(out, "#[derive(Debug, Copy, Clone)]");
+        outln!(
+            out,
+            r#"#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]"#
+        );
         outln!(out, "pub struct {}([u8; 32]);", rust_name);
 
         outln!(out, "impl {} {{", rust_name);
@@ -691,6 +699,10 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         outln!(
             out,
             "#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]"
+        );
+        outln!(
+            out,
+            r#"#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]"#
         );
         outln!(out, "pub struct {}({});", rust_name, raw_type);
 

--- a/generator/src/generator/namespace/request.rs
+++ b/generator/src/generator/namespace/request.rs
@@ -404,6 +404,12 @@ fn emit_request_struct(
     if !derives.is_empty() {
         outln!(out, "#[derive({})]", derives.join(", "));
     }
+    if !gathered.has_fds() {
+        outln!(
+            out,
+            r#"#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]"#
+        );
+    }
 
     let (struct_lifetime_block, serialize_lifetime_return, parse_lifetime_block) =
         if gathered.needs_lifetime {

--- a/generator/src/generator/namespace/switch.rs
+++ b/generator/src/generator/namespace/switch.rs
@@ -128,6 +128,10 @@ pub(super) fn emit_switch_type(
     if !derives.is_empty() {
         outln!(out, "#[derive({})]", derives.join(", "));
     }
+    outln!(
+        out,
+        r#"#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]"#
+    );
 
     if switch.kind == xcbdefs::SwitchKind::BitCase {
         outln!(out, "pub struct {} {{", name);

--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -14,6 +14,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["xcb", "X11"]
 
 [dependencies]
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/x11rb-protocol/src/lib.rs
+++ b/x11rb-protocol/src/lib.rs
@@ -10,7 +10,6 @@
     missing_copy_implementations,
     missing_debug_implementations,
     private_doc_tests,
-    rust_2018_idioms,
     //single_use_lifetimes,
     trivial_casts,
     trivial_numeric_casts,
@@ -26,6 +25,8 @@
 #![deny(
     // #[derive] generates an #[allow] for this
     unused_qualifications,
+    // serde's Deserialize/Serialize impls add allows for this
+    rust_2018_idioms,
     // Not everything in x11rb_protocol::protocol has doc comments
     missing_docs,
 )]

--- a/x11rb-protocol/src/protocol/bigreq.rs
+++ b/x11rb-protocol/src/protocol/bigreq.rs
@@ -35,6 +35,7 @@ pub const X11_XML_VERSION: (u32, u32) = (0, 0);
 /// Opcode for the Enable request
 pub const ENABLE_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnableRequest;
 impl EnableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -77,6 +78,7 @@ impl crate::x11_utils::ReplyRequest for EnableRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnableReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/composite.rs
+++ b/x11rb-protocol/src/protocol/composite.rs
@@ -37,6 +37,7 @@ pub const X11_EXTENSION_NAME: &str = "Composite";
 pub const X11_XML_VERSION: (u32, u32) = (0, 4);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Redirect(u8);
 impl Redirect {
     pub const AUTOMATIC: Self = Self(0);
@@ -97,6 +98,7 @@ impl core::fmt::Debug for Redirect  {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
@@ -156,6 +158,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -186,6 +189,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the RedirectWindow request
 pub const REDIRECT_WINDOW_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RedirectWindowRequest {
     pub window: xproto::Window,
     pub update: Redirect,
@@ -248,6 +252,7 @@ impl crate::x11_utils::VoidRequest for RedirectWindowRequest {
 /// Opcode for the RedirectSubwindows request
 pub const REDIRECT_SUBWINDOWS_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RedirectSubwindowsRequest {
     pub window: xproto::Window,
     pub update: Redirect,
@@ -310,6 +315,7 @@ impl crate::x11_utils::VoidRequest for RedirectSubwindowsRequest {
 /// Opcode for the UnredirectWindow request
 pub const UNREDIRECT_WINDOW_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnredirectWindowRequest {
     pub window: xproto::Window,
     pub update: Redirect,
@@ -372,6 +378,7 @@ impl crate::x11_utils::VoidRequest for UnredirectWindowRequest {
 /// Opcode for the UnredirectSubwindows request
 pub const UNREDIRECT_SUBWINDOWS_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnredirectSubwindowsRequest {
     pub window: xproto::Window,
     pub update: Redirect,
@@ -434,6 +441,7 @@ impl crate::x11_utils::VoidRequest for UnredirectSubwindowsRequest {
 /// Opcode for the CreateRegionFromBorderClip request
 pub const CREATE_REGION_FROM_BORDER_CLIP_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRegionFromBorderClipRequest {
     pub region: xfixes::Region,
     pub window: xproto::Window,
@@ -494,6 +502,7 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromBorderClipRequest {
 /// Opcode for the NameWindowPixmap request
 pub const NAME_WINDOW_PIXMAP_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NameWindowPixmapRequest {
     pub window: xproto::Window,
     pub pixmap: xproto::Pixmap,
@@ -554,6 +563,7 @@ impl crate::x11_utils::VoidRequest for NameWindowPixmapRequest {
 /// Opcode for the GetOverlayWindow request
 pub const GET_OVERLAY_WINDOW_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOverlayWindowRequest {
     pub window: xproto::Window,
 }
@@ -605,6 +615,7 @@ impl crate::x11_utils::ReplyRequest for GetOverlayWindowRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOverlayWindowReply {
     pub sequence: u16,
     pub length: u32,
@@ -633,6 +644,7 @@ impl TryParse for GetOverlayWindowReply {
 /// Opcode for the ReleaseOverlayWindow request
 pub const RELEASE_OVERLAY_WINDOW_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReleaseOverlayWindowRequest {
     pub window: xproto::Window,
 }

--- a/x11rb-protocol/src/protocol/damage.rs
+++ b/x11rb-protocol/src/protocol/damage.rs
@@ -39,6 +39,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 pub type Damage = u32;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReportLevel(u8);
 impl ReportLevel {
     pub const RAW_RECTANGLES: Self = Self(0);
@@ -106,6 +107,7 @@ pub const BAD_DAMAGE_ERROR: u8 = 0;
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
@@ -165,6 +167,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -195,6 +198,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the Create request
 pub const CREATE_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRequest {
     pub damage: Damage,
     pub drawable: xproto::Drawable,
@@ -265,6 +269,7 @@ impl crate::x11_utils::VoidRequest for CreateRequest {
 /// Opcode for the Destroy request
 pub const DESTROY_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyRequest {
     pub damage: Damage,
 }
@@ -317,6 +322,7 @@ impl crate::x11_utils::VoidRequest for DestroyRequest {
 /// Opcode for the Subtract request
 pub const SUBTRACT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SubtractRequest {
     pub damage: Damage,
     pub repair: xfixes::Region,
@@ -385,6 +391,7 @@ impl crate::x11_utils::VoidRequest for SubtractRequest {
 /// Opcode for the Add request
 pub const ADD_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddRequest {
     pub drawable: xproto::Drawable,
     pub region: xfixes::Region,
@@ -445,6 +452,7 @@ impl crate::x11_utils::VoidRequest for AddRequest {
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyEvent {
     pub response_type: u8,
     pub level: ReportLevel,

--- a/x11rb-protocol/src/protocol/dpms.rs
+++ b/x11rb-protocol/src/protocol/dpms.rs
@@ -35,6 +35,7 @@ pub const X11_XML_VERSION: (u32, u32) = (0, 0);
 /// Opcode for the GetVersion request
 pub const GET_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
@@ -90,6 +91,7 @@ impl crate::x11_utils::ReplyRequest for GetVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -119,6 +121,7 @@ impl TryParse for GetVersionReply {
 /// Opcode for the Capable request
 pub const CAPABLE_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CapableRequest;
 impl CapableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -161,6 +164,7 @@ impl crate::x11_utils::ReplyRequest for CapableRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CapableReply {
     pub sequence: u16,
     pub length: u32,
@@ -189,6 +193,7 @@ impl TryParse for CapableReply {
 /// Opcode for the GetTimeouts request
 pub const GET_TIMEOUTS_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTimeoutsRequest;
 impl GetTimeoutsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -231,6 +236,7 @@ impl crate::x11_utils::ReplyRequest for GetTimeoutsRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTimeoutsReply {
     pub sequence: u16,
     pub length: u32,
@@ -263,6 +269,7 @@ impl TryParse for GetTimeoutsReply {
 /// Opcode for the SetTimeouts request
 pub const SET_TIMEOUTS_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetTimeoutsRequest {
     pub standby_timeout: u16,
     pub suspend_timeout: u16,
@@ -327,6 +334,7 @@ impl crate::x11_utils::VoidRequest for SetTimeoutsRequest {
 /// Opcode for the Enable request
 pub const ENABLE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnableRequest;
 impl EnableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -370,6 +378,7 @@ impl crate::x11_utils::VoidRequest for EnableRequest {
 /// Opcode for the Disable request
 pub const DISABLE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DisableRequest;
 impl DisableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -411,6 +420,7 @@ impl crate::x11_utils::VoidRequest for DisableRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DPMSMode(u16);
 impl DPMSMode {
     pub const ON: Self = Self(0);
@@ -469,6 +479,7 @@ impl core::fmt::Debug for DPMSMode  {
 /// Opcode for the ForceLevel request
 pub const FORCE_LEVEL_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ForceLevelRequest {
     pub power_level: DPMSMode,
 }
@@ -522,6 +533,7 @@ impl crate::x11_utils::VoidRequest for ForceLevelRequest {
 /// Opcode for the Info request
 pub const INFO_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InfoRequest;
 impl InfoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -564,6 +576,7 @@ impl crate::x11_utils::ReplyRequest for InfoRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InfoReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/dri2.rs
+++ b/x11rb-protocol/src/protocol/dri2.rs
@@ -35,6 +35,7 @@ pub const X11_EXTENSION_NAME: &str = "DRI2";
 pub const X11_XML_VERSION: (u32, u32) = (1, 4);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Attachment(u32);
 impl Attachment {
     pub const BUFFER_FRONT_LEFT: Self = Self(0);
@@ -99,6 +100,7 @@ impl core::fmt::Debug for Attachment  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DriverType(u32);
 impl DriverType {
     pub const DRI: Self = Self(0);
@@ -145,6 +147,7 @@ impl core::fmt::Debug for DriverType  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EventType(u16);
 impl EventType {
     pub const EXCHANGE_COMPLETE: Self = Self(1);
@@ -199,6 +202,7 @@ impl core::fmt::Debug for EventType  {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DRI2Buffer {
     pub attachment: Attachment,
     pub name: u32,
@@ -260,6 +264,7 @@ impl Serialize for DRI2Buffer {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttachFormat {
     pub attachment: Attachment,
     pub format: u32,
@@ -299,6 +304,7 @@ impl Serialize for AttachFormat {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
@@ -358,6 +364,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -387,6 +394,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the Connect request
 pub const CONNECT_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConnectRequest {
     pub window: xproto::Window,
     pub driver_type: DriverType,
@@ -447,6 +455,7 @@ impl crate::x11_utils::ReplyRequest for ConnectRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConnectReply {
     pub sequence: u16,
     pub length: u32,
@@ -512,6 +521,7 @@ impl ConnectReply {
 /// Opcode for the Authenticate request
 pub const AUTHENTICATE_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AuthenticateRequest {
     pub window: xproto::Window,
     pub magic: u32,
@@ -571,6 +581,7 @@ impl crate::x11_utils::ReplyRequest for AuthenticateRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AuthenticateReply {
     pub sequence: u16,
     pub length: u32,
@@ -598,6 +609,7 @@ impl TryParse for AuthenticateReply {
 /// Opcode for the CreateDrawable request
 pub const CREATE_DRAWABLE_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateDrawableRequest {
     pub drawable: xproto::Drawable,
 }
@@ -650,6 +662,7 @@ impl crate::x11_utils::VoidRequest for CreateDrawableRequest {
 /// Opcode for the DestroyDrawable request
 pub const DESTROY_DRAWABLE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyDrawableRequest {
     pub drawable: xproto::Drawable,
 }
@@ -702,6 +715,7 @@ impl crate::x11_utils::VoidRequest for DestroyDrawableRequest {
 /// Opcode for the GetBuffers request
 pub const GET_BUFFERS_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBuffersRequest<'input> {
     pub drawable: xproto::Drawable,
     pub count: u32,
@@ -783,6 +797,7 @@ impl<'input> crate::x11_utils::ReplyRequest for GetBuffersRequest<'input> {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBuffersReply {
     pub sequence: u16,
     pub length: u32,
@@ -831,6 +846,7 @@ impl GetBuffersReply {
 /// Opcode for the CopyRegion request
 pub const COPY_REGION_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyRegionRequest {
     pub drawable: xproto::Drawable,
     pub region: u32,
@@ -906,6 +922,7 @@ impl crate::x11_utils::ReplyRequest for CopyRegionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyRegionReply {
     pub sequence: u16,
     pub length: u32,
@@ -931,6 +948,7 @@ impl TryParse for CopyRegionReply {
 /// Opcode for the GetBuffersWithFormat request
 pub const GET_BUFFERS_WITH_FORMAT_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBuffersWithFormatRequest<'input> {
     pub drawable: xproto::Drawable,
     pub count: u32,
@@ -1012,6 +1030,7 @@ impl<'input> crate::x11_utils::ReplyRequest for GetBuffersWithFormatRequest<'inp
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBuffersWithFormatReply {
     pub sequence: u16,
     pub length: u32,
@@ -1060,6 +1079,7 @@ impl GetBuffersWithFormatReply {
 /// Opcode for the SwapBuffers request
 pub const SWAP_BUFFERS_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwapBuffersRequest {
     pub drawable: xproto::Drawable,
     pub target_msc_hi: u32,
@@ -1159,6 +1179,7 @@ impl crate::x11_utils::ReplyRequest for SwapBuffersRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwapBuffersReply {
     pub sequence: u16,
     pub length: u32,
@@ -1188,6 +1209,7 @@ impl TryParse for SwapBuffersReply {
 /// Opcode for the GetMSC request
 pub const GET_MSC_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMSCRequest {
     pub drawable: xproto::Drawable,
 }
@@ -1239,6 +1261,7 @@ impl crate::x11_utils::ReplyRequest for GetMSCRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMSCReply {
     pub sequence: u16,
     pub length: u32,
@@ -1276,6 +1299,7 @@ impl TryParse for GetMSCReply {
 /// Opcode for the WaitMSC request
 pub const WAIT_MSC_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaitMSCRequest {
     pub drawable: xproto::Drawable,
     pub target_msc_hi: u32,
@@ -1375,6 +1399,7 @@ impl crate::x11_utils::ReplyRequest for WaitMSCRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaitMSCReply {
     pub sequence: u16,
     pub length: u32,
@@ -1412,6 +1437,7 @@ impl TryParse for WaitMSCReply {
 /// Opcode for the WaitSBC request
 pub const WAIT_SBC_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaitSBCRequest {
     pub drawable: xproto::Drawable,
     pub target_sbc_hi: u32,
@@ -1479,6 +1505,7 @@ impl crate::x11_utils::ReplyRequest for WaitSBCRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaitSBCReply {
     pub sequence: u16,
     pub length: u32,
@@ -1516,6 +1543,7 @@ impl TryParse for WaitSBCReply {
 /// Opcode for the SwapInterval request
 pub const SWAP_INTERVAL_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwapIntervalRequest {
     pub drawable: xproto::Drawable,
     pub interval: u32,
@@ -1576,6 +1604,7 @@ impl crate::x11_utils::VoidRequest for SwapIntervalRequest {
 /// Opcode for the GetParam request
 pub const GET_PARAM_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetParamRequest {
     pub drawable: xproto::Drawable,
     pub param: u32,
@@ -1635,6 +1664,7 @@ impl crate::x11_utils::ReplyRequest for GetParamRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetParamReply {
     pub is_param_recognized: bool,
     pub sequence: u16,
@@ -1665,6 +1695,7 @@ impl TryParse for GetParamReply {
 /// Opcode for the BufferSwapComplete event
 pub const BUFFER_SWAP_COMPLETE_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BufferSwapCompleteEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -1754,6 +1785,7 @@ impl From<BufferSwapCompleteEvent> for [u8; 32] {
 /// Opcode for the InvalidateBuffers event
 pub const INVALIDATE_BUFFERS_EVENT: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InvalidateBuffersEvent {
     pub response_type: u8,
     pub sequence: u16,

--- a/x11rb-protocol/src/protocol/dri3.rs
+++ b/x11rb-protocol/src/protocol/dri3.rs
@@ -37,6 +37,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
@@ -96,6 +97,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -125,6 +127,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the Open request
 pub const OPEN_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenRequest {
     pub drawable: xproto::Drawable,
     pub provider: u32,
@@ -314,6 +317,7 @@ impl crate::x11_utils::VoidRequest for PixmapFromBufferRequest {
 /// Opcode for the BufferFromPixmap request
 pub const BUFFER_FROM_PIXMAP_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BufferFromPixmapRequest {
     pub pixmap: xproto::Pixmap,
 }
@@ -480,6 +484,7 @@ impl crate::x11_utils::VoidRequest for FenceFromFDRequest {
 /// Opcode for the FDFromFence request
 pub const FD_FROM_FENCE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FDFromFenceRequest {
     pub drawable: xproto::Drawable,
     pub fence: u32,
@@ -569,6 +574,7 @@ impl TryParseFd for FDFromFenceReply {
 /// Opcode for the GetSupportedModifiers request
 pub const GET_SUPPORTED_MODIFIERS_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSupportedModifiersRequest {
     pub window: u32,
     pub depth: u8,
@@ -633,6 +639,7 @@ impl crate::x11_utils::ReplyRequest for GetSupportedModifiersRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSupportedModifiersReply {
     pub sequence: u16,
     pub length: u32,
@@ -868,6 +875,7 @@ impl crate::x11_utils::VoidRequest for PixmapFromBuffersRequest {
 /// Opcode for the BuffersFromPixmap request
 pub const BUFFERS_FROM_PIXMAP_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BuffersFromPixmapRequest {
     pub pixmap: xproto::Pixmap,
 }

--- a/x11rb-protocol/src/protocol/ge.rs
+++ b/x11rb-protocol/src/protocol/ge.rs
@@ -35,6 +35,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
@@ -90,6 +91,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/glx.rs
+++ b/x11rb-protocol/src/protocol/glx.rs
@@ -100,6 +100,7 @@ pub const GLX_BAD_PROFILE_ARB_ERROR: u8 = 13;
 /// Opcode for the PbufferClobber event
 pub const PBUFFER_CLOBBER_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PbufferClobberEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -197,6 +198,7 @@ impl From<PbufferClobberEvent> for [u8; 32] {
 /// Opcode for the BufferSwapComplete event
 pub const BUFFER_SWAP_COMPLETE_EVENT: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BufferSwapCompleteEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -283,6 +285,7 @@ impl From<BufferSwapCompleteEvent> for [u8; 32] {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PBCET(u16);
 impl PBCET {
     pub const DAMAGED: Self = Self(32791);
@@ -335,6 +338,7 @@ impl core::fmt::Debug for PBCET  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PBCDT(u16);
 impl PBCDT {
     pub const WINDOW: Self = Self(32793);
@@ -389,6 +393,7 @@ impl core::fmt::Debug for PBCDT  {
 /// Opcode for the Render request
 pub const RENDER_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RenderRequest<'input> {
     pub context_tag: ContextTag,
     pub data: Cow<'input, [u8]>,
@@ -454,6 +459,7 @@ impl<'input> crate::x11_utils::VoidRequest for RenderRequest<'input> {
 /// Opcode for the RenderLarge request
 pub const RENDER_LARGE_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RenderLargeRequest<'input> {
     pub context_tag: ContextTag,
     pub request_num: u16,
@@ -540,6 +546,7 @@ impl<'input> crate::x11_utils::VoidRequest for RenderLargeRequest<'input> {
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextRequest {
     pub context: Context,
     pub visual: xproto::Visualid,
@@ -625,6 +632,7 @@ impl crate::x11_utils::VoidRequest for CreateContextRequest {
 /// Opcode for the DestroyContext request
 pub const DESTROY_CONTEXT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyContextRequest {
     pub context: Context,
 }
@@ -677,6 +685,7 @@ impl crate::x11_utils::VoidRequest for DestroyContextRequest {
 /// Opcode for the MakeCurrent request
 pub const MAKE_CURRENT_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MakeCurrentRequest {
     pub drawable: Drawable,
     pub context: Context,
@@ -744,6 +753,7 @@ impl crate::x11_utils::ReplyRequest for MakeCurrentRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MakeCurrentReply {
     pub sequence: u16,
     pub length: u32,
@@ -772,6 +782,7 @@ impl TryParse for MakeCurrentReply {
 /// Opcode for the IsDirect request
 pub const IS_DIRECT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsDirectRequest {
     pub context: Context,
 }
@@ -823,6 +834,7 @@ impl crate::x11_utils::ReplyRequest for IsDirectRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsDirectReply {
     pub sequence: u16,
     pub length: u32,
@@ -851,6 +863,7 @@ impl TryParse for IsDirectReply {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
@@ -910,6 +923,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -940,6 +954,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the WaitGL request
 pub const WAIT_GL_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaitGLRequest {
     pub context_tag: ContextTag,
 }
@@ -992,6 +1007,7 @@ impl crate::x11_utils::VoidRequest for WaitGLRequest {
 /// Opcode for the WaitX request
 pub const WAIT_X_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaitXRequest {
     pub context_tag: ContextTag,
 }
@@ -1044,6 +1060,7 @@ impl crate::x11_utils::VoidRequest for WaitXRequest {
 /// Opcode for the CopyContext request
 pub const COPY_CONTEXT_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyContextRequest {
     pub src: Context,
     pub dest: Context,
@@ -1118,6 +1135,7 @@ impl crate::x11_utils::VoidRequest for CopyContextRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GC(u32);
 impl GC {
     pub const GL_CURRENT_BIT: Self = Self(1 << 0);
@@ -1204,6 +1222,7 @@ impl core::fmt::Debug for GC  {
 /// Opcode for the SwapBuffers request
 pub const SWAP_BUFFERS_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwapBuffersRequest {
     pub context_tag: ContextTag,
     pub drawable: Drawable,
@@ -1264,6 +1283,7 @@ impl crate::x11_utils::VoidRequest for SwapBuffersRequest {
 /// Opcode for the UseXFont request
 pub const USE_X_FONT_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UseXFontRequest {
     pub context_tag: ContextTag,
     pub font: xproto::Font,
@@ -1348,6 +1368,7 @@ impl crate::x11_utils::VoidRequest for UseXFontRequest {
 /// Opcode for the CreateGLXPixmap request
 pub const CREATE_GLX_PIXMAP_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateGLXPixmapRequest {
     pub screen: u32,
     pub visual: xproto::Visualid,
@@ -1424,6 +1445,7 @@ impl crate::x11_utils::VoidRequest for CreateGLXPixmapRequest {
 /// Opcode for the GetVisualConfigs request
 pub const GET_VISUAL_CONFIGS_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVisualConfigsRequest {
     pub screen: u32,
 }
@@ -1475,6 +1497,7 @@ impl crate::x11_utils::ReplyRequest for GetVisualConfigsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVisualConfigsReply {
     pub sequence: u16,
     pub num_visuals: u32,
@@ -1521,6 +1544,7 @@ impl GetVisualConfigsReply {
 /// Opcode for the DestroyGLXPixmap request
 pub const DESTROY_GLX_PIXMAP_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyGLXPixmapRequest {
     pub glx_pixmap: Pixmap,
 }
@@ -1573,6 +1597,7 @@ impl crate::x11_utils::VoidRequest for DestroyGLXPixmapRequest {
 /// Opcode for the VendorPrivate request
 pub const VENDOR_PRIVATE_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VendorPrivateRequest<'input> {
     pub vendor_code: u32,
     pub context_tag: ContextTag,
@@ -1647,6 +1672,7 @@ impl<'input> crate::x11_utils::VoidRequest for VendorPrivateRequest<'input> {
 /// Opcode for the VendorPrivateWithReply request
 pub const VENDOR_PRIVATE_WITH_REPLY_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VendorPrivateWithReplyRequest<'input> {
     pub vendor_code: u32,
     pub context_tag: ContextTag,
@@ -1720,6 +1746,7 @@ impl<'input> crate::x11_utils::ReplyRequest for VendorPrivateWithReplyRequest<'i
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VendorPrivateWithReplyReply {
     pub sequence: u16,
     pub retval: u32,
@@ -1768,6 +1795,7 @@ impl VendorPrivateWithReplyReply {
 /// Opcode for the QueryExtensionsString request
 pub const QUERY_EXTENSIONS_STRING_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionsStringRequest {
     pub screen: u32,
 }
@@ -1819,6 +1847,7 @@ impl crate::x11_utils::ReplyRequest for QueryExtensionsStringRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionsStringReply {
     pub sequence: u16,
     pub length: u32,
@@ -1848,6 +1877,7 @@ impl TryParse for QueryExtensionsStringReply {
 /// Opcode for the QueryServerString request
 pub const QUERY_SERVER_STRING_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryServerStringRequest {
     pub screen: u32,
     pub name: u32,
@@ -1907,6 +1937,7 @@ impl crate::x11_utils::ReplyRequest for QueryServerStringRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryServerStringReply {
     pub sequence: u16,
     pub length: u32,
@@ -1953,6 +1984,7 @@ impl QueryServerStringReply {
 /// Opcode for the ClientInfo request
 pub const CLIENT_INFO_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientInfoRequest<'input> {
     pub major_version: u32,
     pub minor_version: u32,
@@ -2034,6 +2066,7 @@ impl<'input> crate::x11_utils::VoidRequest for ClientInfoRequest<'input> {
 /// Opcode for the GetFBConfigs request
 pub const GET_FB_CONFIGS_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFBConfigsRequest {
     pub screen: u32,
 }
@@ -2085,6 +2118,7 @@ impl crate::x11_utils::ReplyRequest for GetFBConfigsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFBConfigsReply {
     pub sequence: u16,
     pub num_fb_configs: u32,
@@ -2131,6 +2165,7 @@ impl GetFBConfigsReply {
 /// Opcode for the CreatePixmap request
 pub const CREATE_PIXMAP_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePixmapRequest<'input> {
     pub screen: u32,
     pub fbconfig: Fbconfig,
@@ -2232,6 +2267,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreatePixmapRequest<'input> {
 /// Opcode for the DestroyPixmap request
 pub const DESTROY_PIXMAP_REQUEST: u8 = 23;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyPixmapRequest {
     pub glx_pixmap: Pixmap,
 }
@@ -2284,6 +2320,7 @@ impl crate::x11_utils::VoidRequest for DestroyPixmapRequest {
 /// Opcode for the CreateNewContext request
 pub const CREATE_NEW_CONTEXT_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateNewContextRequest {
     pub context: Context,
     pub fbconfig: Fbconfig,
@@ -2377,6 +2414,7 @@ impl crate::x11_utils::VoidRequest for CreateNewContextRequest {
 /// Opcode for the QueryContext request
 pub const QUERY_CONTEXT_REQUEST: u8 = 25;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryContextRequest {
     pub context: Context,
 }
@@ -2428,6 +2466,7 @@ impl crate::x11_utils::ReplyRequest for QueryContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -2473,6 +2512,7 @@ impl QueryContextReply {
 /// Opcode for the MakeContextCurrent request
 pub const MAKE_CONTEXT_CURRENT_REQUEST: u8 = 26;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MakeContextCurrentRequest {
     pub old_context_tag: ContextTag,
     pub drawable: Drawable,
@@ -2548,6 +2588,7 @@ impl crate::x11_utils::ReplyRequest for MakeContextCurrentRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MakeContextCurrentReply {
     pub sequence: u16,
     pub length: u32,
@@ -2576,6 +2617,7 @@ impl TryParse for MakeContextCurrentReply {
 /// Opcode for the CreatePbuffer request
 pub const CREATE_PBUFFER_REQUEST: u8 = 27;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePbufferRequest<'input> {
     pub screen: u32,
     pub fbconfig: Fbconfig,
@@ -2668,6 +2710,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreatePbufferRequest<'input> {
 /// Opcode for the DestroyPbuffer request
 pub const DESTROY_PBUFFER_REQUEST: u8 = 28;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyPbufferRequest {
     pub pbuffer: Pbuffer,
 }
@@ -2720,6 +2763,7 @@ impl crate::x11_utils::VoidRequest for DestroyPbufferRequest {
 /// Opcode for the GetDrawableAttributes request
 pub const GET_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 29;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDrawableAttributesRequest {
     pub drawable: Drawable,
 }
@@ -2771,6 +2815,7 @@ impl crate::x11_utils::ReplyRequest for GetDrawableAttributesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDrawableAttributesReply {
     pub sequence: u16,
     pub length: u32,
@@ -2816,6 +2861,7 @@ impl GetDrawableAttributesReply {
 /// Opcode for the ChangeDrawableAttributes request
 pub const CHANGE_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 30;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDrawableAttributesRequest<'input> {
     pub drawable: Drawable,
     pub attribs: Cow<'input, [u32]>,
@@ -2890,6 +2936,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeDrawableAttributesRequest<'
 /// Opcode for the CreateWindow request
 pub const CREATE_WINDOW_REQUEST: u8 = 31;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateWindowRequest<'input> {
     pub screen: u32,
     pub fbconfig: Fbconfig,
@@ -2991,6 +3038,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateWindowRequest<'input> {
 /// Opcode for the DeleteWindow request
 pub const DELETE_WINDOW_REQUEST: u8 = 32;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteWindowRequest {
     pub glxwindow: Window,
 }
@@ -3043,6 +3091,7 @@ impl crate::x11_utils::VoidRequest for DeleteWindowRequest {
 /// Opcode for the SetClientInfoARB request
 pub const SET_CLIENT_INFO_ARB_REQUEST: u8 = 33;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetClientInfoARBRequest<'input> {
     pub major_version: u32,
     pub minor_version: u32,
@@ -3150,6 +3199,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetClientInfoARBRequest<'input> {
 /// Opcode for the CreateContextAttribsARB request
 pub const CREATE_CONTEXT_ATTRIBS_ARB_REQUEST: u8 = 34;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextAttribsARBRequest<'input> {
     pub context: Context,
     pub fbconfig: Fbconfig,
@@ -3261,6 +3311,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateContextAttribsARBRequest<'i
 /// Opcode for the SetClientInfo2ARB request
 pub const SET_CLIENT_INFO2_ARB_REQUEST: u8 = 35;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetClientInfo2ARBRequest<'input> {
     pub major_version: u32,
     pub minor_version: u32,
@@ -3368,6 +3419,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetClientInfo2ARBRequest<'input> 
 /// Opcode for the NewList request
 pub const NEW_LIST_REQUEST: u8 = 101;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NewListRequest {
     pub context_tag: ContextTag,
     pub list: u32,
@@ -3436,6 +3488,7 @@ impl crate::x11_utils::VoidRequest for NewListRequest {
 /// Opcode for the EndList request
 pub const END_LIST_REQUEST: u8 = 102;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EndListRequest {
     pub context_tag: ContextTag,
 }
@@ -3488,6 +3541,7 @@ impl crate::x11_utils::VoidRequest for EndListRequest {
 /// Opcode for the DeleteLists request
 pub const DELETE_LISTS_REQUEST: u8 = 103;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteListsRequest {
     pub context_tag: ContextTag,
     pub list: u32,
@@ -3556,6 +3610,7 @@ impl crate::x11_utils::VoidRequest for DeleteListsRequest {
 /// Opcode for the GenLists request
 pub const GEN_LISTS_REQUEST: u8 = 104;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenListsRequest {
     pub context_tag: ContextTag,
     pub range: i32,
@@ -3615,6 +3670,7 @@ impl crate::x11_utils::ReplyRequest for GenListsRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenListsReply {
     pub sequence: u16,
     pub length: u32,
@@ -3642,6 +3698,7 @@ impl TryParse for GenListsReply {
 /// Opcode for the FeedbackBuffer request
 pub const FEEDBACK_BUFFER_REQUEST: u8 = 105;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackBufferRequest {
     pub context_tag: ContextTag,
     pub size: i32,
@@ -3710,6 +3767,7 @@ impl crate::x11_utils::VoidRequest for FeedbackBufferRequest {
 /// Opcode for the SelectBuffer request
 pub const SELECT_BUFFER_REQUEST: u8 = 106;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectBufferRequest {
     pub context_tag: ContextTag,
     pub size: i32,
@@ -3770,6 +3828,7 @@ impl crate::x11_utils::VoidRequest for SelectBufferRequest {
 /// Opcode for the RenderMode request
 pub const RENDER_MODE_REQUEST: u8 = 107;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RenderModeRequest {
     pub context_tag: ContextTag,
     pub mode: u32,
@@ -3829,6 +3888,7 @@ impl crate::x11_utils::ReplyRequest for RenderModeRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RenderModeReply {
     pub sequence: u16,
     pub length: u32,
@@ -3875,6 +3935,7 @@ impl RenderModeReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RM(u16);
 impl RM {
     pub const GL_RENDER: Self = Self(7168);
@@ -3931,6 +3992,7 @@ impl core::fmt::Debug for RM  {
 /// Opcode for the Finish request
 pub const FINISH_REQUEST: u8 = 108;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FinishRequest {
     pub context_tag: ContextTag,
 }
@@ -3982,6 +4044,7 @@ impl crate::x11_utils::ReplyRequest for FinishRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FinishReply {
     pub sequence: u16,
     pub length: u32,
@@ -4007,6 +4070,7 @@ impl TryParse for FinishReply {
 /// Opcode for the PixelStoref request
 pub const PIXEL_STOREF_REQUEST: u8 = 109;
 #[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PixelStorefRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
@@ -4075,6 +4139,7 @@ impl crate::x11_utils::VoidRequest for PixelStorefRequest {
 /// Opcode for the PixelStorei request
 pub const PIXEL_STOREI_REQUEST: u8 = 110;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PixelStoreiRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
@@ -4143,6 +4208,7 @@ impl crate::x11_utils::VoidRequest for PixelStoreiRequest {
 /// Opcode for the ReadPixels request
 pub const READ_PIXELS_REQUEST: u8 = 111;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReadPixelsRequest {
     pub context_tag: ContextTag,
     pub x: i32,
@@ -4254,6 +4320,7 @@ impl crate::x11_utils::ReplyRequest for ReadPixelsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReadPixelsReply {
     pub sequence: u16,
     pub data: Vec<u8>,
@@ -4298,6 +4365,7 @@ impl ReadPixelsReply {
 /// Opcode for the GetBooleanv request
 pub const GET_BOOLEANV_REQUEST: u8 = 112;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBooleanvRequest {
     pub context_tag: ContextTag,
     pub pname: i32,
@@ -4357,6 +4425,7 @@ impl crate::x11_utils::ReplyRequest for GetBooleanvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBooleanvReply {
     pub sequence: u16,
     pub length: u32,
@@ -4404,6 +4473,7 @@ impl GetBooleanvReply {
 /// Opcode for the GetClipPlane request
 pub const GET_CLIP_PLANE_REQUEST: u8 = 113;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClipPlaneRequest {
     pub context_tag: ContextTag,
     pub plane: i32,
@@ -4463,6 +4533,7 @@ impl crate::x11_utils::ReplyRequest for GetClipPlaneRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClipPlaneReply {
     pub sequence: u16,
     pub data: Vec<Float64>,
@@ -4506,6 +4577,7 @@ impl GetClipPlaneReply {
 /// Opcode for the GetDoublev request
 pub const GET_DOUBLEV_REQUEST: u8 = 114;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDoublevRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
@@ -4565,6 +4637,7 @@ impl crate::x11_utils::ReplyRequest for GetDoublevRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDoublevReply {
     pub sequence: u16,
     pub length: u32,
@@ -4612,6 +4685,7 @@ impl GetDoublevReply {
 /// Opcode for the GetError request
 pub const GET_ERROR_REQUEST: u8 = 115;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetErrorRequest {
     pub context_tag: ContextTag,
 }
@@ -4663,6 +4737,7 @@ impl crate::x11_utils::ReplyRequest for GetErrorRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetErrorReply {
     pub sequence: u16,
     pub length: u32,
@@ -4690,6 +4765,7 @@ impl TryParse for GetErrorReply {
 /// Opcode for the GetFloatv request
 pub const GET_FLOATV_REQUEST: u8 = 116;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFloatvRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
@@ -4749,6 +4825,7 @@ impl crate::x11_utils::ReplyRequest for GetFloatvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFloatvReply {
     pub sequence: u16,
     pub length: u32,
@@ -4796,6 +4873,7 @@ impl GetFloatvReply {
 /// Opcode for the GetIntegerv request
 pub const GET_INTEGERV_REQUEST: u8 = 117;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetIntegervRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
@@ -4855,6 +4933,7 @@ impl crate::x11_utils::ReplyRequest for GetIntegervRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetIntegervReply {
     pub sequence: u16,
     pub length: u32,
@@ -4902,6 +4981,7 @@ impl GetIntegervReply {
 /// Opcode for the GetLightfv request
 pub const GET_LIGHTFV_REQUEST: u8 = 118;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetLightfvRequest {
     pub context_tag: ContextTag,
     pub light: u32,
@@ -4969,6 +5049,7 @@ impl crate::x11_utils::ReplyRequest for GetLightfvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetLightfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -5016,6 +5097,7 @@ impl GetLightfvReply {
 /// Opcode for the GetLightiv request
 pub const GET_LIGHTIV_REQUEST: u8 = 119;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetLightivRequest {
     pub context_tag: ContextTag,
     pub light: u32,
@@ -5083,6 +5165,7 @@ impl crate::x11_utils::ReplyRequest for GetLightivRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetLightivReply {
     pub sequence: u16,
     pub length: u32,
@@ -5130,6 +5213,7 @@ impl GetLightivReply {
 /// Opcode for the GetMapdv request
 pub const GET_MAPDV_REQUEST: u8 = 120;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapdvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -5197,6 +5281,7 @@ impl crate::x11_utils::ReplyRequest for GetMapdvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapdvReply {
     pub sequence: u16,
     pub length: u32,
@@ -5244,6 +5329,7 @@ impl GetMapdvReply {
 /// Opcode for the GetMapfv request
 pub const GET_MAPFV_REQUEST: u8 = 121;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -5311,6 +5397,7 @@ impl crate::x11_utils::ReplyRequest for GetMapfvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -5358,6 +5445,7 @@ impl GetMapfvReply {
 /// Opcode for the GetMapiv request
 pub const GET_MAPIV_REQUEST: u8 = 122;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -5425,6 +5513,7 @@ impl crate::x11_utils::ReplyRequest for GetMapivRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapivReply {
     pub sequence: u16,
     pub length: u32,
@@ -5472,6 +5561,7 @@ impl GetMapivReply {
 /// Opcode for the GetMaterialfv request
 pub const GET_MATERIALFV_REQUEST: u8 = 123;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMaterialfvRequest {
     pub context_tag: ContextTag,
     pub face: u32,
@@ -5539,6 +5629,7 @@ impl crate::x11_utils::ReplyRequest for GetMaterialfvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMaterialfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -5586,6 +5677,7 @@ impl GetMaterialfvReply {
 /// Opcode for the GetMaterialiv request
 pub const GET_MATERIALIV_REQUEST: u8 = 124;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMaterialivRequest {
     pub context_tag: ContextTag,
     pub face: u32,
@@ -5653,6 +5745,7 @@ impl crate::x11_utils::ReplyRequest for GetMaterialivRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMaterialivReply {
     pub sequence: u16,
     pub length: u32,
@@ -5700,6 +5793,7 @@ impl GetMaterialivReply {
 /// Opcode for the GetPixelMapfv request
 pub const GET_PIXEL_MAPFV_REQUEST: u8 = 125;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPixelMapfvRequest {
     pub context_tag: ContextTag,
     pub map: u32,
@@ -5759,6 +5853,7 @@ impl crate::x11_utils::ReplyRequest for GetPixelMapfvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPixelMapfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -5806,6 +5901,7 @@ impl GetPixelMapfvReply {
 /// Opcode for the GetPixelMapuiv request
 pub const GET_PIXEL_MAPUIV_REQUEST: u8 = 126;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPixelMapuivRequest {
     pub context_tag: ContextTag,
     pub map: u32,
@@ -5865,6 +5961,7 @@ impl crate::x11_utils::ReplyRequest for GetPixelMapuivRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPixelMapuivReply {
     pub sequence: u16,
     pub length: u32,
@@ -5912,6 +6009,7 @@ impl GetPixelMapuivReply {
 /// Opcode for the GetPixelMapusv request
 pub const GET_PIXEL_MAPUSV_REQUEST: u8 = 127;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPixelMapusvRequest {
     pub context_tag: ContextTag,
     pub map: u32,
@@ -5971,6 +6069,7 @@ impl crate::x11_utils::ReplyRequest for GetPixelMapusvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPixelMapusvReply {
     pub sequence: u16,
     pub length: u32,
@@ -6018,6 +6117,7 @@ impl GetPixelMapusvReply {
 /// Opcode for the GetPolygonStipple request
 pub const GET_POLYGON_STIPPLE_REQUEST: u8 = 128;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPolygonStippleRequest {
     pub context_tag: ContextTag,
     pub lsb_first: bool,
@@ -6077,6 +6177,7 @@ impl crate::x11_utils::ReplyRequest for GetPolygonStippleRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPolygonStippleReply {
     pub sequence: u16,
     pub data: Vec<u8>,
@@ -6121,6 +6222,7 @@ impl GetPolygonStippleReply {
 /// Opcode for the GetString request
 pub const GET_STRING_REQUEST: u8 = 129;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStringRequest {
     pub context_tag: ContextTag,
     pub name: u32,
@@ -6180,6 +6282,7 @@ impl crate::x11_utils::ReplyRequest for GetStringRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStringReply {
     pub sequence: u16,
     pub length: u32,
@@ -6226,6 +6329,7 @@ impl GetStringReply {
 /// Opcode for the GetTexEnvfv request
 pub const GET_TEX_ENVFV_REQUEST: u8 = 130;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexEnvfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -6293,6 +6397,7 @@ impl crate::x11_utils::ReplyRequest for GetTexEnvfvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexEnvfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -6340,6 +6445,7 @@ impl GetTexEnvfvReply {
 /// Opcode for the GetTexEnviv request
 pub const GET_TEX_ENVIV_REQUEST: u8 = 131;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexEnvivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -6407,6 +6513,7 @@ impl crate::x11_utils::ReplyRequest for GetTexEnvivRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexEnvivReply {
     pub sequence: u16,
     pub length: u32,
@@ -6454,6 +6561,7 @@ impl GetTexEnvivReply {
 /// Opcode for the GetTexGendv request
 pub const GET_TEX_GENDV_REQUEST: u8 = 132;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexGendvRequest {
     pub context_tag: ContextTag,
     pub coord: u32,
@@ -6521,6 +6629,7 @@ impl crate::x11_utils::ReplyRequest for GetTexGendvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexGendvReply {
     pub sequence: u16,
     pub length: u32,
@@ -6568,6 +6677,7 @@ impl GetTexGendvReply {
 /// Opcode for the GetTexGenfv request
 pub const GET_TEX_GENFV_REQUEST: u8 = 133;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexGenfvRequest {
     pub context_tag: ContextTag,
     pub coord: u32,
@@ -6635,6 +6745,7 @@ impl crate::x11_utils::ReplyRequest for GetTexGenfvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexGenfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -6682,6 +6793,7 @@ impl GetTexGenfvReply {
 /// Opcode for the GetTexGeniv request
 pub const GET_TEX_GENIV_REQUEST: u8 = 134;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexGenivRequest {
     pub context_tag: ContextTag,
     pub coord: u32,
@@ -6749,6 +6861,7 @@ impl crate::x11_utils::ReplyRequest for GetTexGenivRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexGenivReply {
     pub sequence: u16,
     pub length: u32,
@@ -6796,6 +6909,7 @@ impl GetTexGenivReply {
 /// Opcode for the GetTexImage request
 pub const GET_TEX_IMAGE_REQUEST: u8 = 135;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexImageRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -6887,6 +7001,7 @@ impl crate::x11_utils::ReplyRequest for GetTexImageRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexImageReply {
     pub sequence: u16,
     pub width: i32,
@@ -6938,6 +7053,7 @@ impl GetTexImageReply {
 /// Opcode for the GetTexParameterfv request
 pub const GET_TEX_PARAMETERFV_REQUEST: u8 = 136;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -7005,6 +7121,7 @@ impl crate::x11_utils::ReplyRequest for GetTexParameterfvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexParameterfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -7052,6 +7169,7 @@ impl GetTexParameterfvReply {
 /// Opcode for the GetTexParameteriv request
 pub const GET_TEX_PARAMETERIV_REQUEST: u8 = 137;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -7119,6 +7237,7 @@ impl crate::x11_utils::ReplyRequest for GetTexParameterivRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexParameterivReply {
     pub sequence: u16,
     pub length: u32,
@@ -7166,6 +7285,7 @@ impl GetTexParameterivReply {
 /// Opcode for the GetTexLevelParameterfv request
 pub const GET_TEX_LEVEL_PARAMETERFV_REQUEST: u8 = 138;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexLevelParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -7241,6 +7361,7 @@ impl crate::x11_utils::ReplyRequest for GetTexLevelParameterfvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexLevelParameterfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -7288,6 +7409,7 @@ impl GetTexLevelParameterfvReply {
 /// Opcode for the GetTexLevelParameteriv request
 pub const GET_TEX_LEVEL_PARAMETERIV_REQUEST: u8 = 139;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexLevelParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -7363,6 +7485,7 @@ impl crate::x11_utils::ReplyRequest for GetTexLevelParameterivRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexLevelParameterivReply {
     pub sequence: u16,
     pub length: u32,
@@ -7410,6 +7533,7 @@ impl GetTexLevelParameterivReply {
 /// Opcode for the IsEnabled request
 pub const IS_ENABLED_REQUEST: u8 = 140;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsEnabledRequest {
     pub context_tag: ContextTag,
     pub capability: u32,
@@ -7469,6 +7593,7 @@ impl crate::x11_utils::ReplyRequest for IsEnabledRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsEnabledReply {
     pub sequence: u16,
     pub length: u32,
@@ -7496,6 +7621,7 @@ impl TryParse for IsEnabledReply {
 /// Opcode for the IsList request
 pub const IS_LIST_REQUEST: u8 = 141;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsListRequest {
     pub context_tag: ContextTag,
     pub list: u32,
@@ -7555,6 +7681,7 @@ impl crate::x11_utils::ReplyRequest for IsListRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsListReply {
     pub sequence: u16,
     pub length: u32,
@@ -7582,6 +7709,7 @@ impl TryParse for IsListReply {
 /// Opcode for the Flush request
 pub const FLUSH_REQUEST: u8 = 142;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FlushRequest {
     pub context_tag: ContextTag,
 }
@@ -7634,6 +7762,7 @@ impl crate::x11_utils::VoidRequest for FlushRequest {
 /// Opcode for the AreTexturesResident request
 pub const ARE_TEXTURES_RESIDENT_REQUEST: u8 = 143;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AreTexturesResidentRequest<'input> {
     pub context_tag: ContextTag,
     pub textures: Cow<'input, [u32]>,
@@ -7706,6 +7835,7 @@ impl<'input> crate::x11_utils::ReplyRequest for AreTexturesResidentRequest<'inpu
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AreTexturesResidentReply {
     pub sequence: u16,
     pub ret_val: Bool32,
@@ -7751,6 +7881,7 @@ impl AreTexturesResidentReply {
 /// Opcode for the DeleteTextures request
 pub const DELETE_TEXTURES_REQUEST: u8 = 144;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteTexturesRequest<'input> {
     pub context_tag: ContextTag,
     pub textures: Cow<'input, [u32]>,
@@ -7824,6 +7955,7 @@ impl<'input> crate::x11_utils::VoidRequest for DeleteTexturesRequest<'input> {
 /// Opcode for the GenTextures request
 pub const GEN_TEXTURES_REQUEST: u8 = 145;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenTexturesRequest {
     pub context_tag: ContextTag,
     pub n: i32,
@@ -7883,6 +8015,7 @@ impl crate::x11_utils::ReplyRequest for GenTexturesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenTexturesReply {
     pub sequence: u16,
     pub data: Vec<u32>,
@@ -7925,6 +8058,7 @@ impl GenTexturesReply {
 /// Opcode for the IsTexture request
 pub const IS_TEXTURE_REQUEST: u8 = 146;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsTextureRequest {
     pub context_tag: ContextTag,
     pub texture: u32,
@@ -7984,6 +8118,7 @@ impl crate::x11_utils::ReplyRequest for IsTextureRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsTextureReply {
     pub sequence: u16,
     pub length: u32,
@@ -8011,6 +8146,7 @@ impl TryParse for IsTextureReply {
 /// Opcode for the GetColorTable request
 pub const GET_COLOR_TABLE_REQUEST: u8 = 147;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetColorTableRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8094,6 +8230,7 @@ impl crate::x11_utils::ReplyRequest for GetColorTableRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetColorTableReply {
     pub sequence: u16,
     pub width: i32,
@@ -8141,6 +8278,7 @@ impl GetColorTableReply {
 /// Opcode for the GetColorTableParameterfv request
 pub const GET_COLOR_TABLE_PARAMETERFV_REQUEST: u8 = 148;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetColorTableParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8208,6 +8346,7 @@ impl crate::x11_utils::ReplyRequest for GetColorTableParameterfvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetColorTableParameterfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -8255,6 +8394,7 @@ impl GetColorTableParameterfvReply {
 /// Opcode for the GetColorTableParameteriv request
 pub const GET_COLOR_TABLE_PARAMETERIV_REQUEST: u8 = 149;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetColorTableParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8322,6 +8462,7 @@ impl crate::x11_utils::ReplyRequest for GetColorTableParameterivRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetColorTableParameterivReply {
     pub sequence: u16,
     pub length: u32,
@@ -8369,6 +8510,7 @@ impl GetColorTableParameterivReply {
 /// Opcode for the GetConvolutionFilter request
 pub const GET_CONVOLUTION_FILTER_REQUEST: u8 = 150;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetConvolutionFilterRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8452,6 +8594,7 @@ impl crate::x11_utils::ReplyRequest for GetConvolutionFilterRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetConvolutionFilterReply {
     pub sequence: u16,
     pub width: i32,
@@ -8501,6 +8644,7 @@ impl GetConvolutionFilterReply {
 /// Opcode for the GetConvolutionParameterfv request
 pub const GET_CONVOLUTION_PARAMETERFV_REQUEST: u8 = 151;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetConvolutionParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8568,6 +8712,7 @@ impl crate::x11_utils::ReplyRequest for GetConvolutionParameterfvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetConvolutionParameterfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -8615,6 +8760,7 @@ impl GetConvolutionParameterfvReply {
 /// Opcode for the GetConvolutionParameteriv request
 pub const GET_CONVOLUTION_PARAMETERIV_REQUEST: u8 = 152;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetConvolutionParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8682,6 +8828,7 @@ impl crate::x11_utils::ReplyRequest for GetConvolutionParameterivRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetConvolutionParameterivReply {
     pub sequence: u16,
     pub length: u32,
@@ -8729,6 +8876,7 @@ impl GetConvolutionParameterivReply {
 /// Opcode for the GetSeparableFilter request
 pub const GET_SEPARABLE_FILTER_REQUEST: u8 = 153;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSeparableFilterRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8812,6 +8960,7 @@ impl crate::x11_utils::ReplyRequest for GetSeparableFilterRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSeparableFilterReply {
     pub sequence: u16,
     pub row_w: i32,
@@ -8861,6 +9010,7 @@ impl GetSeparableFilterReply {
 /// Opcode for the GetHistogram request
 pub const GET_HISTOGRAM_REQUEST: u8 = 154;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetHistogramRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -8948,6 +9098,7 @@ impl crate::x11_utils::ReplyRequest for GetHistogramRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetHistogramReply {
     pub sequence: u16,
     pub width: i32,
@@ -8995,6 +9146,7 @@ impl GetHistogramReply {
 /// Opcode for the GetHistogramParameterfv request
 pub const GET_HISTOGRAM_PARAMETERFV_REQUEST: u8 = 155;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetHistogramParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -9062,6 +9214,7 @@ impl crate::x11_utils::ReplyRequest for GetHistogramParameterfvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetHistogramParameterfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -9109,6 +9262,7 @@ impl GetHistogramParameterfvReply {
 /// Opcode for the GetHistogramParameteriv request
 pub const GET_HISTOGRAM_PARAMETERIV_REQUEST: u8 = 156;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetHistogramParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -9176,6 +9330,7 @@ impl crate::x11_utils::ReplyRequest for GetHistogramParameterivRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetHistogramParameterivReply {
     pub sequence: u16,
     pub length: u32,
@@ -9223,6 +9378,7 @@ impl GetHistogramParameterivReply {
 /// Opcode for the GetMinmax request
 pub const GET_MINMAX_REQUEST: u8 = 157;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMinmaxRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -9310,6 +9466,7 @@ impl crate::x11_utils::ReplyRequest for GetMinmaxRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMinmaxReply {
     pub sequence: u16,
     pub data: Vec<u8>,
@@ -9354,6 +9511,7 @@ impl GetMinmaxReply {
 /// Opcode for the GetMinmaxParameterfv request
 pub const GET_MINMAX_PARAMETERFV_REQUEST: u8 = 158;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMinmaxParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -9421,6 +9579,7 @@ impl crate::x11_utils::ReplyRequest for GetMinmaxParameterfvRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMinmaxParameterfvReply {
     pub sequence: u16,
     pub length: u32,
@@ -9468,6 +9627,7 @@ impl GetMinmaxParameterfvReply {
 /// Opcode for the GetMinmaxParameteriv request
 pub const GET_MINMAX_PARAMETERIV_REQUEST: u8 = 159;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMinmaxParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -9535,6 +9695,7 @@ impl crate::x11_utils::ReplyRequest for GetMinmaxParameterivRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMinmaxParameterivReply {
     pub sequence: u16,
     pub length: u32,
@@ -9582,6 +9743,7 @@ impl GetMinmaxParameterivReply {
 /// Opcode for the GetCompressedTexImageARB request
 pub const GET_COMPRESSED_TEX_IMAGE_ARB_REQUEST: u8 = 160;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCompressedTexImageARBRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -9649,6 +9811,7 @@ impl crate::x11_utils::ReplyRequest for GetCompressedTexImageARBRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCompressedTexImageARBReply {
     pub sequence: u16,
     pub size: i32,
@@ -9696,6 +9859,7 @@ impl GetCompressedTexImageARBReply {
 /// Opcode for the DeleteQueriesARB request
 pub const DELETE_QUERIES_ARB_REQUEST: u8 = 161;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteQueriesARBRequest<'input> {
     pub context_tag: ContextTag,
     pub ids: Cow<'input, [u32]>,
@@ -9769,6 +9933,7 @@ impl<'input> crate::x11_utils::VoidRequest for DeleteQueriesARBRequest<'input> {
 /// Opcode for the GenQueriesARB request
 pub const GEN_QUERIES_ARB_REQUEST: u8 = 162;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenQueriesARBRequest {
     pub context_tag: ContextTag,
     pub n: i32,
@@ -9828,6 +9993,7 @@ impl crate::x11_utils::ReplyRequest for GenQueriesARBRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenQueriesARBReply {
     pub sequence: u16,
     pub data: Vec<u32>,
@@ -9870,6 +10036,7 @@ impl GenQueriesARBReply {
 /// Opcode for the IsQueryARB request
 pub const IS_QUERY_ARB_REQUEST: u8 = 163;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsQueryARBRequest {
     pub context_tag: ContextTag,
     pub id: u32,
@@ -9929,6 +10096,7 @@ impl crate::x11_utils::ReplyRequest for IsQueryARBRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsQueryARBReply {
     pub sequence: u16,
     pub length: u32,
@@ -9956,6 +10124,7 @@ impl TryParse for IsQueryARBReply {
 /// Opcode for the GetQueryivARB request
 pub const GET_QUERYIV_ARB_REQUEST: u8 = 164;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetQueryivARBRequest {
     pub context_tag: ContextTag,
     pub target: u32,
@@ -10023,6 +10192,7 @@ impl crate::x11_utils::ReplyRequest for GetQueryivARBRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetQueryivARBReply {
     pub sequence: u16,
     pub length: u32,
@@ -10070,6 +10240,7 @@ impl GetQueryivARBReply {
 /// Opcode for the GetQueryObjectivARB request
 pub const GET_QUERY_OBJECTIV_ARB_REQUEST: u8 = 165;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetQueryObjectivARBRequest {
     pub context_tag: ContextTag,
     pub id: u32,
@@ -10137,6 +10308,7 @@ impl crate::x11_utils::ReplyRequest for GetQueryObjectivARBRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetQueryObjectivARBReply {
     pub sequence: u16,
     pub length: u32,
@@ -10184,6 +10356,7 @@ impl GetQueryObjectivARBReply {
 /// Opcode for the GetQueryObjectuivARB request
 pub const GET_QUERY_OBJECTUIV_ARB_REQUEST: u8 = 166;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetQueryObjectuivARBRequest {
     pub context_tag: ContextTag,
     pub id: u32,
@@ -10251,6 +10424,7 @@ impl crate::x11_utils::ReplyRequest for GetQueryObjectuivARBRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetQueryObjectuivARBReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -41,6 +41,7 @@ pub const X11_EXTENSION_NAME: &str = "Present";
 pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EventEnum(u8);
 impl EventEnum {
     pub const CONFIGURE_NOTIFY: Self = Self(0);
@@ -103,6 +104,7 @@ impl core::fmt::Debug for EventEnum  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EventMask(u8);
 impl EventMask {
     pub const NO_EVENT: Self = Self(0);
@@ -168,6 +170,7 @@ impl core::fmt::Debug for EventMask  {
 bitmask_binop!(EventMask, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Option(u8);
 impl Option {
     pub const NONE: Self = Self(0);
@@ -233,6 +236,7 @@ impl core::fmt::Debug for Option  {
 bitmask_binop!(Option, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Capability(u8);
 impl Capability {
     pub const NONE: Self = Self(0);
@@ -296,6 +300,7 @@ impl core::fmt::Debug for Capability  {
 bitmask_binop!(Capability, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompleteKind(u8);
 impl CompleteKind {
     pub const PIXMAP: Self = Self(0);
@@ -354,6 +359,7 @@ impl core::fmt::Debug for CompleteKind  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompleteMode(u8);
 impl CompleteMode {
     pub const COPY: Self = Self(0);
@@ -416,6 +422,7 @@ impl core::fmt::Debug for CompleteMode  {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Notify {
     pub window: xproto::Window,
     pub serial: u32,
@@ -454,6 +461,7 @@ impl Serialize for Notify {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
@@ -513,6 +521,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -542,6 +551,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the Pixmap request
 pub const PIXMAP_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PixmapRequest<'input> {
     pub window: xproto::Window,
     pub pixmap: xproto::Pixmap,
@@ -745,6 +755,7 @@ impl<'input> crate::x11_utils::VoidRequest for PixmapRequest<'input> {
 /// Opcode for the NotifyMSC request
 pub const NOTIFY_MSC_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyMSCRequest {
     pub window: xproto::Window,
     pub serial: u32,
@@ -848,6 +859,7 @@ pub type Event = u32;
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputRequest {
     pub eid: Event,
     pub window: xproto::Window,
@@ -916,6 +928,7 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 /// Opcode for the QueryCapabilities request
 pub const QUERY_CAPABILITIES_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryCapabilitiesRequest {
     pub target: u32,
 }
@@ -967,6 +980,7 @@ impl crate::x11_utils::ReplyRequest for QueryCapabilitiesRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryCapabilitiesReply {
     pub sequence: u16,
     pub length: u32,
@@ -994,6 +1008,7 @@ impl TryParse for QueryCapabilitiesReply {
 /// Opcode for the Generic event
 pub const GENERIC_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenericEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -1073,6 +1088,7 @@ impl From<GenericEvent> for [u8; 32] {
 /// Opcode for the ConfigureNotify event
 pub const CONFIGURE_NOTIFY_EVENT: u16 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureNotifyEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -1122,6 +1138,7 @@ impl TryParse for ConfigureNotifyEvent {
 /// Opcode for the CompleteNotify event
 pub const COMPLETE_NOTIFY_EVENT: u16 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompleteNotifyEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -1164,6 +1181,7 @@ impl TryParse for CompleteNotifyEvent {
 /// Opcode for the IdleNotify event
 pub const IDLE_NOTIFY_EVENT: u16 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IdleNotifyEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -1201,6 +1219,7 @@ impl TryParse for IdleNotifyEvent {
 /// Opcode for the RedirectNotify event
 pub const REDIRECT_NOTIFY_EVENT: u16 = 3;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RedirectNotifyEvent {
     pub response_type: u8,
     pub extension: u8,

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -59,6 +59,7 @@ pub const BAD_MODE_ERROR: u8 = 2;
 pub const BAD_PROVIDER_ERROR: u8 = 3;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rotation(u8);
 impl Rotation {
     pub const ROTATE0: Self = Self(1 << 0);
@@ -126,6 +127,7 @@ impl core::fmt::Debug for Rotation  {
 bitmask_binop!(Rotation, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScreenSize {
     pub width: u16,
     pub height: u16,
@@ -170,6 +172,7 @@ impl Serialize for ScreenSize {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RefreshRates {
     pub rates: Vec<u16>,
 }
@@ -213,6 +216,7 @@ impl RefreshRates {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
@@ -272,6 +276,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -300,6 +305,7 @@ impl TryParse for QueryVersionReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetConfig(u8);
 impl SetConfig {
     pub const SUCCESS: Self = Self(0);
@@ -364,6 +370,7 @@ impl core::fmt::Debug for SetConfig  {
 /// Opcode for the SetScreenConfig request
 pub const SET_SCREEN_CONFIG_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetScreenConfigRequest {
     pub window: xproto::Window,
     pub timestamp: xproto::Timestamp,
@@ -452,6 +459,7 @@ impl crate::x11_utils::ReplyRequest for SetScreenConfigRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetScreenConfigReply {
     pub status: SetConfig,
     pub sequence: u16,
@@ -487,6 +495,7 @@ impl TryParse for SetScreenConfigReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyMask(u8);
 impl NotifyMask {
     pub const SCREEN_CHANGE: Self = Self(1 << 0);
@@ -560,6 +569,7 @@ bitmask_binop!(NotifyMask, u8);
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputRequest {
     pub window: xproto::Window,
     pub enable: u16,
@@ -621,6 +631,7 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 /// Opcode for the GetScreenInfo request
 pub const GET_SCREEN_INFO_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenInfoRequest {
     pub window: xproto::Window,
 }
@@ -672,6 +683,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenInfoRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenInfoReply {
     pub rotations: u8,
     pub sequence: u16,
@@ -733,6 +745,7 @@ impl GetScreenInfoReply {
 /// Opcode for the GetScreenSizeRange request
 pub const GET_SCREEN_SIZE_RANGE_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSizeRangeRequest {
     pub window: xproto::Window,
 }
@@ -784,6 +797,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenSizeRangeRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSizeRangeReply {
     pub sequence: u16,
     pub length: u32,
@@ -818,6 +832,7 @@ impl TryParse for GetScreenSizeRangeReply {
 /// Opcode for the SetScreenSize request
 pub const SET_SCREEN_SIZE_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetScreenSizeRequest {
     pub window: xproto::Window,
     pub width: u16,
@@ -896,6 +911,7 @@ impl crate::x11_utils::VoidRequest for SetScreenSizeRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModeFlag(u16);
 impl ModeFlag {
     pub const HSYNC_POSITIVE: Self = Self(1 << 0);
@@ -973,6 +989,7 @@ impl core::fmt::Debug for ModeFlag  {
 bitmask_binop!(ModeFlag, u16);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModeInfo {
     pub id: u32,
     pub width: u16,
@@ -1079,6 +1096,7 @@ impl Serialize for ModeInfo {
 /// Opcode for the GetScreenResources request
 pub const GET_SCREEN_RESOURCES_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenResourcesRequest {
     pub window: xproto::Window,
 }
@@ -1130,6 +1148,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenResourcesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenResourcesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1225,6 +1244,7 @@ impl GetScreenResourcesReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Connection(u8);
 impl Connection {
     pub const CONNECTED: Self = Self(0);
@@ -1287,6 +1307,7 @@ impl core::fmt::Debug for Connection  {
 /// Opcode for the GetOutputInfo request
 pub const GET_OUTPUT_INFO_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOutputInfoRequest {
     pub output: Output,
     pub config_timestamp: xproto::Timestamp,
@@ -1346,6 +1367,7 @@ impl crate::x11_utils::ReplyRequest for GetOutputInfoRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOutputInfoReply {
     pub status: SetConfig,
     pub sequence: u16,
@@ -1456,6 +1478,7 @@ impl GetOutputInfoReply {
 /// Opcode for the ListOutputProperties request
 pub const LIST_OUTPUT_PROPERTIES_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListOutputPropertiesRequest {
     pub output: Output,
 }
@@ -1507,6 +1530,7 @@ impl crate::x11_utils::ReplyRequest for ListOutputPropertiesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListOutputPropertiesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1551,6 +1575,7 @@ impl ListOutputPropertiesReply {
 /// Opcode for the QueryOutputProperty request
 pub const QUERY_OUTPUT_PROPERTY_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryOutputPropertyRequest {
     pub output: Output,
     pub property: xproto::Atom,
@@ -1610,6 +1635,7 @@ impl crate::x11_utils::ReplyRequest for QueryOutputPropertyRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryOutputPropertyReply {
     pub sequence: u16,
     pub pending: bool,
@@ -1658,6 +1684,7 @@ impl QueryOutputPropertyReply {
 /// Opcode for the ConfigureOutputProperty request
 pub const CONFIGURE_OUTPUT_PROPERTY_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureOutputPropertyRequest<'input> {
     pub output: Output,
     pub property: xproto::Atom,
@@ -1755,6 +1782,7 @@ impl<'input> crate::x11_utils::VoidRequest for ConfigureOutputPropertyRequest<'i
 /// Opcode for the ChangeOutputProperty request
 pub const CHANGE_OUTPUT_PROPERTY_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeOutputPropertyRequest<'input> {
     pub output: Output,
     pub property: xproto::Atom,
@@ -1864,6 +1892,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeOutputPropertyRequest<'inpu
 /// Opcode for the DeleteOutputProperty request
 pub const DELETE_OUTPUT_PROPERTY_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteOutputPropertyRequest {
     pub output: Output,
     pub property: xproto::Atom,
@@ -1924,6 +1953,7 @@ impl crate::x11_utils::VoidRequest for DeleteOutputPropertyRequest {
 /// Opcode for the GetOutputProperty request
 pub const GET_OUTPUT_PROPERTY_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOutputPropertyRequest {
     pub output: Output,
     pub property: xproto::Atom,
@@ -2020,6 +2050,7 @@ impl crate::x11_utils::ReplyRequest for GetOutputPropertyRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOutputPropertyReply {
     pub format: u8,
     pub sequence: u16,
@@ -2056,6 +2087,7 @@ impl TryParse for GetOutputPropertyReply {
 /// Opcode for the CreateMode request
 pub const CREATE_MODE_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateModeRequest<'input> {
     pub window: xproto::Window,
     pub mode_info: ModeInfo,
@@ -2157,6 +2189,7 @@ impl<'input> crate::x11_utils::ReplyRequest for CreateModeRequest<'input> {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateModeReply {
     pub sequence: u16,
     pub length: u32,
@@ -2185,6 +2218,7 @@ impl TryParse for CreateModeReply {
 /// Opcode for the DestroyMode request
 pub const DESTROY_MODE_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyModeRequest {
     pub mode: Mode,
 }
@@ -2237,6 +2271,7 @@ impl crate::x11_utils::VoidRequest for DestroyModeRequest {
 /// Opcode for the AddOutputMode request
 pub const ADD_OUTPUT_MODE_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddOutputModeRequest {
     pub output: Output,
     pub mode: Mode,
@@ -2297,6 +2332,7 @@ impl crate::x11_utils::VoidRequest for AddOutputModeRequest {
 /// Opcode for the DeleteOutputMode request
 pub const DELETE_OUTPUT_MODE_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteOutputModeRequest {
     pub output: Output,
     pub mode: Mode,
@@ -2357,6 +2393,7 @@ impl crate::x11_utils::VoidRequest for DeleteOutputModeRequest {
 /// Opcode for the GetCrtcInfo request
 pub const GET_CRTC_INFO_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcInfoRequest {
     pub crtc: Crtc,
     pub config_timestamp: xproto::Timestamp,
@@ -2416,6 +2453,7 @@ impl crate::x11_utils::ReplyRequest for GetCrtcInfoRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcInfoReply {
     pub status: SetConfig,
     pub sequence: u16,
@@ -2493,6 +2531,7 @@ impl GetCrtcInfoReply {
 /// Opcode for the SetCrtcConfig request
 pub const SET_CRTC_CONFIG_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCrtcConfigRequest<'input> {
     pub crtc: Crtc,
     pub timestamp: xproto::Timestamp,
@@ -2616,6 +2655,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetCrtcConfigRequest<'input> {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCrtcConfigReply {
     pub status: SetConfig,
     pub sequence: u16,
@@ -2646,6 +2686,7 @@ impl TryParse for SetCrtcConfigReply {
 /// Opcode for the GetCrtcGammaSize request
 pub const GET_CRTC_GAMMA_SIZE_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcGammaSizeRequest {
     pub crtc: Crtc,
 }
@@ -2697,6 +2738,7 @@ impl crate::x11_utils::ReplyRequest for GetCrtcGammaSizeRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcGammaSizeReply {
     pub sequence: u16,
     pub length: u32,
@@ -2725,6 +2767,7 @@ impl TryParse for GetCrtcGammaSizeReply {
 /// Opcode for the GetCrtcGamma request
 pub const GET_CRTC_GAMMA_REQUEST: u8 = 23;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcGammaRequest {
     pub crtc: Crtc,
 }
@@ -2776,6 +2819,7 @@ impl crate::x11_utils::ReplyRequest for GetCrtcGammaRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcGammaReply {
     pub sequence: u16,
     pub length: u32,
@@ -2824,6 +2868,7 @@ impl GetCrtcGammaReply {
 /// Opcode for the SetCrtcGamma request
 pub const SET_CRTC_GAMMA_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCrtcGammaRequest<'input> {
     pub crtc: Crtc,
     pub red: Cow<'input, [u16]>,
@@ -2912,6 +2957,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetCrtcGammaRequest<'input> {
 /// Opcode for the GetScreenResourcesCurrent request
 pub const GET_SCREEN_RESOURCES_CURRENT_REQUEST: u8 = 25;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenResourcesCurrentRequest {
     pub window: xproto::Window,
 }
@@ -2963,6 +3009,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenResourcesCurrentRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenResourcesCurrentReply {
     pub sequence: u16,
     pub length: u32,
@@ -3058,6 +3105,7 @@ impl GetScreenResourcesCurrentReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Transform(u8);
 impl Transform {
     pub const UNIT: Self = Self(1 << 0);
@@ -3123,6 +3171,7 @@ bitmask_binop!(Transform, u8);
 /// Opcode for the SetCrtcTransform request
 pub const SET_CRTC_TRANSFORM_REQUEST: u8 = 26;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCrtcTransformRequest<'input> {
     pub crtc: Crtc,
     pub transform: render::Transform,
@@ -3256,6 +3305,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetCrtcTransformRequest<'input> {
 /// Opcode for the GetCrtcTransform request
 pub const GET_CRTC_TRANSFORM_REQUEST: u8 = 27;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcTransformRequest {
     pub crtc: Crtc,
 }
@@ -3307,6 +3357,7 @@ impl crate::x11_utils::ReplyRequest for GetCrtcTransformRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcTransformReply {
     pub sequence: u16,
     pub length: u32,
@@ -3417,6 +3468,7 @@ impl GetCrtcTransformReply {
 /// Opcode for the GetPanning request
 pub const GET_PANNING_REQUEST: u8 = 28;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPanningRequest {
     pub crtc: Crtc,
 }
@@ -3468,6 +3520,7 @@ impl crate::x11_utils::ReplyRequest for GetPanningRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPanningReply {
     pub status: SetConfig,
     pub sequence: u16,
@@ -3521,6 +3574,7 @@ impl TryParse for GetPanningReply {
 /// Opcode for the SetPanning request
 pub const SET_PANNING_REQUEST: u8 = 29;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPanningRequest {
     pub crtc: Crtc,
     pub timestamp: xproto::Timestamp,
@@ -3652,6 +3706,7 @@ impl crate::x11_utils::ReplyRequest for SetPanningRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPanningReply {
     pub status: SetConfig,
     pub sequence: u16,
@@ -3681,6 +3736,7 @@ impl TryParse for SetPanningReply {
 /// Opcode for the SetOutputPrimary request
 pub const SET_OUTPUT_PRIMARY_REQUEST: u8 = 30;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetOutputPrimaryRequest {
     pub window: xproto::Window,
     pub output: Output,
@@ -3741,6 +3797,7 @@ impl crate::x11_utils::VoidRequest for SetOutputPrimaryRequest {
 /// Opcode for the GetOutputPrimary request
 pub const GET_OUTPUT_PRIMARY_REQUEST: u8 = 31;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOutputPrimaryRequest {
     pub window: xproto::Window,
 }
@@ -3792,6 +3849,7 @@ impl crate::x11_utils::ReplyRequest for GetOutputPrimaryRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOutputPrimaryReply {
     pub sequence: u16,
     pub length: u32,
@@ -3819,6 +3877,7 @@ impl TryParse for GetOutputPrimaryReply {
 /// Opcode for the GetProviders request
 pub const GET_PROVIDERS_REQUEST: u8 = 32;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetProvidersRequest {
     pub window: xproto::Window,
 }
@@ -3870,6 +3929,7 @@ impl crate::x11_utils::ReplyRequest for GetProvidersRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetProvidersReply {
     pub sequence: u16,
     pub length: u32,
@@ -3914,6 +3974,7 @@ impl GetProvidersReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProviderCapability(u8);
 impl ProviderCapability {
     pub const SOURCE_OUTPUT: Self = Self(1 << 0);
@@ -3979,6 +4040,7 @@ bitmask_binop!(ProviderCapability, u8);
 /// Opcode for the GetProviderInfo request
 pub const GET_PROVIDER_INFO_REQUEST: u8 = 33;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetProviderInfoRequest {
     pub provider: Provider,
     pub config_timestamp: xproto::Timestamp,
@@ -4038,6 +4100,7 @@ impl crate::x11_utils::ReplyRequest for GetProviderInfoRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetProviderInfoReply {
     pub status: u8,
     pub sequence: u16,
@@ -4138,6 +4201,7 @@ impl GetProviderInfoReply {
 /// Opcode for the SetProviderOffloadSink request
 pub const SET_PROVIDER_OFFLOAD_SINK_REQUEST: u8 = 34;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetProviderOffloadSinkRequest {
     pub provider: Provider,
     pub sink_provider: Provider,
@@ -4206,6 +4270,7 @@ impl crate::x11_utils::VoidRequest for SetProviderOffloadSinkRequest {
 /// Opcode for the SetProviderOutputSource request
 pub const SET_PROVIDER_OUTPUT_SOURCE_REQUEST: u8 = 35;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetProviderOutputSourceRequest {
     pub provider: Provider,
     pub source_provider: Provider,
@@ -4274,6 +4339,7 @@ impl crate::x11_utils::VoidRequest for SetProviderOutputSourceRequest {
 /// Opcode for the ListProviderProperties request
 pub const LIST_PROVIDER_PROPERTIES_REQUEST: u8 = 36;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListProviderPropertiesRequest {
     pub provider: Provider,
 }
@@ -4325,6 +4391,7 @@ impl crate::x11_utils::ReplyRequest for ListProviderPropertiesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListProviderPropertiesReply {
     pub sequence: u16,
     pub length: u32,
@@ -4369,6 +4436,7 @@ impl ListProviderPropertiesReply {
 /// Opcode for the QueryProviderProperty request
 pub const QUERY_PROVIDER_PROPERTY_REQUEST: u8 = 37;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryProviderPropertyRequest {
     pub provider: Provider,
     pub property: xproto::Atom,
@@ -4428,6 +4496,7 @@ impl crate::x11_utils::ReplyRequest for QueryProviderPropertyRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryProviderPropertyReply {
     pub sequence: u16,
     pub pending: bool,
@@ -4476,6 +4545,7 @@ impl QueryProviderPropertyReply {
 /// Opcode for the ConfigureProviderProperty request
 pub const CONFIGURE_PROVIDER_PROPERTY_REQUEST: u8 = 38;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureProviderPropertyRequest<'input> {
     pub provider: Provider,
     pub property: xproto::Atom,
@@ -4573,6 +4643,7 @@ impl<'input> crate::x11_utils::VoidRequest for ConfigureProviderPropertyRequest<
 /// Opcode for the ChangeProviderProperty request
 pub const CHANGE_PROVIDER_PROPERTY_REQUEST: u8 = 39;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeProviderPropertyRequest<'input> {
     pub provider: Provider,
     pub property: xproto::Atom,
@@ -4681,6 +4752,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeProviderPropertyRequest<'in
 /// Opcode for the DeleteProviderProperty request
 pub const DELETE_PROVIDER_PROPERTY_REQUEST: u8 = 40;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteProviderPropertyRequest {
     pub provider: Provider,
     pub property: xproto::Atom,
@@ -4741,6 +4813,7 @@ impl crate::x11_utils::VoidRequest for DeleteProviderPropertyRequest {
 /// Opcode for the GetProviderProperty request
 pub const GET_PROVIDER_PROPERTY_REQUEST: u8 = 41;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetProviderPropertyRequest {
     pub provider: Provider,
     pub property: xproto::Atom,
@@ -4837,6 +4910,7 @@ impl crate::x11_utils::ReplyRequest for GetProviderPropertyRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetProviderPropertyReply {
     pub format: u8,
     pub sequence: u16,
@@ -4873,6 +4947,7 @@ impl TryParse for GetProviderPropertyReply {
 /// Opcode for the ScreenChangeNotify event
 pub const SCREEN_CHANGE_NOTIFY_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScreenChangeNotifyEvent {
     pub response_type: u8,
     pub rotation: u8,
@@ -4970,6 +5045,7 @@ impl From<ScreenChangeNotifyEvent> for [u8; 32] {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Notify(u8);
 impl Notify {
     pub const CRTC_CHANGE: Self = Self(0);
@@ -5038,6 +5114,7 @@ impl core::fmt::Debug for Notify  {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CrtcChange {
     pub timestamp: xproto::Timestamp,
     pub window: xproto::Window,
@@ -5124,6 +5201,7 @@ impl Serialize for CrtcChange {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OutputChange {
     pub timestamp: xproto::Timestamp,
     pub config_timestamp: xproto::Timestamp,
@@ -5210,6 +5288,7 @@ impl Serialize for OutputChange {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OutputProperty {
     pub window: xproto::Window,
     pub output: Output,
@@ -5281,6 +5360,7 @@ impl Serialize for OutputProperty {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProviderChange {
     pub timestamp: xproto::Timestamp,
     pub window: xproto::Window,
@@ -5343,6 +5423,7 @@ impl Serialize for ProviderChange {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProviderProperty {
     pub window: xproto::Window,
     pub provider: Provider,
@@ -5413,6 +5494,7 @@ impl Serialize for ProviderProperty {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResourceChange {
     pub timestamp: xproto::Timestamp,
     pub window: xproto::Window,
@@ -5471,6 +5553,7 @@ impl Serialize for ResourceChange {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MonitorInfo {
     pub name: xproto::Atom,
     pub primary: bool,
@@ -5542,6 +5625,7 @@ impl MonitorInfo {
 /// Opcode for the GetMonitors request
 pub const GET_MONITORS_REQUEST: u8 = 42;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMonitorsRequest {
     pub window: xproto::Window,
     pub get_active: bool,
@@ -5601,6 +5685,7 @@ impl crate::x11_utils::ReplyRequest for GetMonitorsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMonitorsReply {
     pub sequence: u16,
     pub length: u32,
@@ -5649,6 +5734,7 @@ impl GetMonitorsReply {
 /// Opcode for the SetMonitor request
 pub const SET_MONITOR_REQUEST: u8 = 43;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetMonitorRequest {
     pub window: xproto::Window,
     pub monitorinfo: MonitorInfo,
@@ -5708,6 +5794,7 @@ impl crate::x11_utils::VoidRequest for SetMonitorRequest {
 /// Opcode for the DeleteMonitor request
 pub const DELETE_MONITOR_REQUEST: u8 = 44;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteMonitorRequest {
     pub window: xproto::Window,
     pub name: xproto::Atom,
@@ -5768,6 +5855,7 @@ impl crate::x11_utils::VoidRequest for DeleteMonitorRequest {
 /// Opcode for the CreateLease request
 pub const CREATE_LEASE_REQUEST: u8 = 45;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateLeaseRequest<'input> {
     pub window: xproto::Window,
     pub lid: Lease,
@@ -5888,6 +5976,7 @@ impl TryParseFd for CreateLeaseReply {
 /// Opcode for the FreeLease request
 pub const FREE_LEASE_REQUEST: u8 = 46;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeLeaseRequest {
     pub lid: Lease,
     pub terminate: u8,
@@ -5946,6 +6035,7 @@ impl crate::x11_utils::VoidRequest for FreeLeaseRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LeaseNotify {
     pub timestamp: xproto::Timestamp,
     pub window: xproto::Window,
@@ -6012,6 +6102,7 @@ impl Serialize for LeaseNotify {
 }
 
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyData([u8; 28]);
 impl NotifyData {
     pub fn as_cc(&self) -> CrtcChange {
@@ -6136,6 +6227,7 @@ impl From<LeaseNotify> for NotifyData {
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 1;
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyEvent {
     pub response_type: u8,
     pub sub_code: Notify,

--- a/x11rb-protocol/src/protocol/record.rs
+++ b/x11rb-protocol/src/protocol/record.rs
@@ -35,6 +35,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 13);
 pub type Context = u32;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Range8 {
     pub first: u8,
     pub last: u8,
@@ -65,6 +66,7 @@ impl Serialize for Range8 {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Range16 {
     pub first: u16,
     pub last: u16,
@@ -97,6 +99,7 @@ impl Serialize for Range16 {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtRange {
     pub major: Range8,
     pub minor: Range16,
@@ -131,6 +134,7 @@ impl Serialize for ExtRange {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Range {
     pub core_requests: Range8,
     pub core_replies: Range8,
@@ -213,6 +217,7 @@ impl Serialize for Range {
 pub type ElementHeader = u8;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HType(u8);
 impl HType {
     pub const FROM_SERVER_TIME: Self = Self(1 << 0);
@@ -276,6 +281,7 @@ bitmask_binop!(HType, u8);
 pub type ClientSpec = u32;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CS(u8);
 impl CS {
     pub const CURRENT_CLIENTS: Self = Self(1);
@@ -336,6 +342,7 @@ impl core::fmt::Debug for CS  {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientInfo {
     pub client_resource: ClientSpec,
     pub ranges: Vec<Range>,
@@ -386,6 +393,7 @@ pub const BAD_CONTEXT_ERROR: u8 = 0;
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u16,
     pub minor_version: u16,
@@ -441,6 +449,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -470,6 +479,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextRequest<'input> {
     pub context: Context,
     pub element_header: ElementHeader,
@@ -566,6 +576,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateContextRequest<'input> {
 /// Opcode for the RegisterClients request
 pub const REGISTER_CLIENTS_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RegisterClientsRequest<'input> {
     pub context: Context,
     pub element_header: ElementHeader,
@@ -662,6 +673,7 @@ impl<'input> crate::x11_utils::VoidRequest for RegisterClientsRequest<'input> {
 /// Opcode for the UnregisterClients request
 pub const UNREGISTER_CLIENTS_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnregisterClientsRequest<'input> {
     pub context: Context,
     pub client_specs: Cow<'input, [ClientSpec]>,
@@ -735,6 +747,7 @@ impl<'input> crate::x11_utils::VoidRequest for UnregisterClientsRequest<'input> 
 /// Opcode for the GetContext request
 pub const GET_CONTEXT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetContextRequest {
     pub context: Context,
 }
@@ -786,6 +799,7 @@ impl crate::x11_utils::ReplyRequest for GetContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetContextReply {
     pub enabled: bool,
     pub sequence: u16,
@@ -834,6 +848,7 @@ impl GetContextReply {
 /// Opcode for the EnableContext request
 pub const ENABLE_CONTEXT_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnableContextRequest {
     pub context: Context,
 }
@@ -885,6 +900,7 @@ impl crate::x11_utils::ReplyRequest for EnableContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnableContextReply {
     pub category: u8,
     pub sequence: u16,
@@ -941,6 +957,7 @@ impl EnableContextReply {
 /// Opcode for the DisableContext request
 pub const DISABLE_CONTEXT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DisableContextRequest {
     pub context: Context,
 }
@@ -993,6 +1010,7 @@ impl crate::x11_utils::VoidRequest for DisableContextRequest {
 /// Opcode for the FreeContext request
 pub const FREE_CONTEXT_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeContextRequest {
     pub context: Context,
 }

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -35,6 +35,7 @@ pub const X11_EXTENSION_NAME: &str = "RENDER";
 pub const X11_XML_VERSION: (u32, u32) = (0, 11);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PictType(u8);
 impl PictType {
     pub const INDEXED: Self = Self(0);
@@ -93,6 +94,7 @@ impl core::fmt::Debug for PictType  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PictureEnum(u8);
 impl PictureEnum {
     pub const NONE: Self = Self(0);
@@ -149,6 +151,7 @@ impl core::fmt::Debug for PictureEnum  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PictOp(u8);
 impl PictOp {
     pub const CLEAR: Self = Self(0);
@@ -309,6 +312,7 @@ impl core::fmt::Debug for PictOp  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyEdge(u32);
 impl PolyEdge {
     pub const SHARP: Self = Self(0);
@@ -355,6 +359,7 @@ impl core::fmt::Debug for PolyEdge  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyMode(u32);
 impl PolyMode {
     pub const PRECISE: Self = Self(0);
@@ -401,6 +406,7 @@ impl core::fmt::Debug for PolyMode  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CP(u16);
 impl CP {
     pub const REPEAT: Self = Self(1 << 0);
@@ -476,6 +482,7 @@ impl core::fmt::Debug for CP  {
 bitmask_binop!(CP, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SubPixel(u32);
 impl SubPixel {
     pub const UNKNOWN: Self = Self(0);
@@ -530,6 +537,7 @@ impl core::fmt::Debug for SubPixel  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Repeat(u32);
 impl Repeat {
     pub const NONE: Self = Self(0);
@@ -605,6 +613,7 @@ pub const GLYPH_SET_ERROR: u8 = 3;
 pub const GLYPH_ERROR: u8 = 4;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Directformat {
     pub red_shift: u16,
     pub red_mask: u16,
@@ -673,6 +682,7 @@ impl Serialize for Directformat {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pictforminfo {
     pub id: Pictformat,
     pub type_: PictType,
@@ -744,6 +754,7 @@ impl Serialize for Pictforminfo {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pictvisual {
     pub visual: xproto::Visualid,
     pub format: Pictformat,
@@ -780,6 +791,7 @@ impl Serialize for Pictvisual {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pictdepth {
     pub depth: u8,
     pub visuals: Vec<Pictvisual>,
@@ -829,6 +841,7 @@ impl Pictdepth {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pictscreen {
     pub fallback: Pictformat,
     pub depths: Vec<Pictdepth>,
@@ -874,6 +887,7 @@ impl Pictscreen {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Indexvalue {
     pub pixel: u32,
     pub red: u16,
@@ -926,6 +940,7 @@ impl Serialize for Indexvalue {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Color {
     pub red: u16,
     pub green: u16,
@@ -970,6 +985,7 @@ impl Serialize for Color {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pointfix {
     pub x: Fixed,
     pub y: Fixed,
@@ -1006,6 +1022,7 @@ impl Serialize for Pointfix {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Linefix {
     pub p1: Pointfix,
     pub p2: Pointfix,
@@ -1050,6 +1067,7 @@ impl Serialize for Linefix {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Triangle {
     pub p1: Pointfix,
     pub p2: Pointfix,
@@ -1106,6 +1124,7 @@ impl Serialize for Triangle {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Trapezoid {
     pub top: Fixed,
     pub bottom: Fixed,
@@ -1182,6 +1201,7 @@ impl Serialize for Trapezoid {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Glyphinfo {
     pub width: u16,
     pub height: u16,
@@ -1240,6 +1260,7 @@ impl Serialize for Glyphinfo {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
@@ -1299,6 +1320,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -1329,6 +1351,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the QueryPictFormats request
 pub const QUERY_PICT_FORMATS_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPictFormatsRequest;
 impl QueryPictFormatsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1371,6 +1394,7 @@ impl crate::x11_utils::ReplyRequest for QueryPictFormatsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPictFormatsReply {
     pub sequence: u16,
     pub length: u32,
@@ -1459,6 +1483,7 @@ impl QueryPictFormatsReply {
 /// Opcode for the QueryPictIndexValues request
 pub const QUERY_PICT_INDEX_VALUES_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPictIndexValuesRequest {
     pub format: Pictformat,
 }
@@ -1510,6 +1535,7 @@ impl crate::x11_utils::ReplyRequest for QueryPictIndexValuesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPictIndexValuesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1553,6 +1579,7 @@ impl QueryPictIndexValuesReply {
 
 /// Auxiliary and optional information for the `create_picture` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePictureAux {
     pub repeat: Option<Repeat>,
     pub alphamap: Option<Picture>,
@@ -1867,6 +1894,7 @@ impl CreatePictureAux {
 /// Opcode for the CreatePicture request
 pub const CREATE_PICTURE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePictureRequest<'input> {
     pub pid: Picture,
     pub drawable: xproto::Drawable,
@@ -1957,6 +1985,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreatePictureRequest<'input> {
 
 /// Auxiliary and optional information for the `change_picture` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangePictureAux {
     pub repeat: Option<Repeat>,
     pub alphamap: Option<Picture>,
@@ -2271,6 +2300,7 @@ impl ChangePictureAux {
 /// Opcode for the ChangePicture request
 pub const CHANGE_PICTURE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangePictureRequest<'input> {
     pub picture: Picture,
     pub value_list: Cow<'input, ChangePictureAux>,
@@ -2344,6 +2374,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangePictureRequest<'input> {
 /// Opcode for the SetPictureClipRectangles request
 pub const SET_PICTURE_CLIP_RECTANGLES_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPictureClipRectanglesRequest<'input> {
     pub picture: Picture,
     pub clip_x_origin: i16,
@@ -2431,6 +2462,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetPictureClipRectanglesRequest<'
 /// Opcode for the FreePicture request
 pub const FREE_PICTURE_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreePictureRequest {
     pub picture: Picture,
 }
@@ -2483,6 +2515,7 @@ impl crate::x11_utils::VoidRequest for FreePictureRequest {
 /// Opcode for the Composite request
 pub const COMPOSITE_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompositeRequest {
     pub op: PictOp,
     pub src: Picture,
@@ -2609,6 +2642,7 @@ impl crate::x11_utils::VoidRequest for CompositeRequest {
 /// Opcode for the Trapezoids request
 pub const TRAPEZOIDS_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TrapezoidsRequest<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -2725,6 +2759,7 @@ impl<'input> crate::x11_utils::VoidRequest for TrapezoidsRequest<'input> {
 /// Opcode for the Triangles request
 pub const TRIANGLES_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TrianglesRequest<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -2841,6 +2876,7 @@ impl<'input> crate::x11_utils::VoidRequest for TrianglesRequest<'input> {
 /// Opcode for the TriStrip request
 pub const TRI_STRIP_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TriStripRequest<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -2957,6 +2993,7 @@ impl<'input> crate::x11_utils::VoidRequest for TriStripRequest<'input> {
 /// Opcode for the TriFan request
 pub const TRI_FAN_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TriFanRequest<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -3073,6 +3110,7 @@ impl<'input> crate::x11_utils::VoidRequest for TriFanRequest<'input> {
 /// Opcode for the CreateGlyphSet request
 pub const CREATE_GLYPH_SET_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateGlyphSetRequest {
     pub gsid: Glyphset,
     pub format: Pictformat,
@@ -3133,6 +3171,7 @@ impl crate::x11_utils::VoidRequest for CreateGlyphSetRequest {
 /// Opcode for the ReferenceGlyphSet request
 pub const REFERENCE_GLYPH_SET_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReferenceGlyphSetRequest {
     pub gsid: Glyphset,
     pub existing: Glyphset,
@@ -3193,6 +3232,7 @@ impl crate::x11_utils::VoidRequest for ReferenceGlyphSetRequest {
 /// Opcode for the FreeGlyphSet request
 pub const FREE_GLYPH_SET_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeGlyphSetRequest {
     pub glyphset: Glyphset,
 }
@@ -3245,6 +3285,7 @@ impl crate::x11_utils::VoidRequest for FreeGlyphSetRequest {
 /// Opcode for the AddGlyphs request
 pub const ADD_GLYPHS_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddGlyphsRequest<'input> {
     pub glyphset: Glyphset,
     pub glyphids: Cow<'input, [u32]>,
@@ -3330,6 +3371,7 @@ impl<'input> crate::x11_utils::VoidRequest for AddGlyphsRequest<'input> {
 /// Opcode for the FreeGlyphs request
 pub const FREE_GLYPHS_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeGlyphsRequest<'input> {
     pub glyphset: Glyphset,
     pub glyphs: Cow<'input, [Glyph]>,
@@ -3403,6 +3445,7 @@ impl<'input> crate::x11_utils::VoidRequest for FreeGlyphsRequest<'input> {
 /// Opcode for the CompositeGlyphs8 request
 pub const COMPOSITE_GLYPHS8_REQUEST: u8 = 23;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompositeGlyphs8Request<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -3520,6 +3563,7 @@ impl<'input> crate::x11_utils::VoidRequest for CompositeGlyphs8Request<'input> {
 /// Opcode for the CompositeGlyphs16 request
 pub const COMPOSITE_GLYPHS16_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompositeGlyphs16Request<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -3637,6 +3681,7 @@ impl<'input> crate::x11_utils::VoidRequest for CompositeGlyphs16Request<'input> 
 /// Opcode for the CompositeGlyphs32 request
 pub const COMPOSITE_GLYPHS32_REQUEST: u8 = 25;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompositeGlyphs32Request<'input> {
     pub op: PictOp,
     pub src: Picture,
@@ -3754,6 +3799,7 @@ impl<'input> crate::x11_utils::VoidRequest for CompositeGlyphs32Request<'input> 
 /// Opcode for the FillRectangles request
 pub const FILL_RECTANGLES_REQUEST: u8 = 26;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FillRectanglesRequest<'input> {
     pub op: PictOp,
     pub dst: Picture,
@@ -3851,6 +3897,7 @@ impl<'input> crate::x11_utils::VoidRequest for FillRectanglesRequest<'input> {
 /// Opcode for the CreateCursor request
 pub const CREATE_CURSOR_REQUEST: u8 = 27;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateCursorRequest {
     pub cid: xproto::Cursor,
     pub source: Picture,
@@ -3921,6 +3968,7 @@ impl crate::x11_utils::VoidRequest for CreateCursorRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Transform {
     pub matrix11: Fixed,
     pub matrix12: Fixed,
@@ -4015,6 +4063,7 @@ impl Serialize for Transform {
 /// Opcode for the SetPictureTransform request
 pub const SET_PICTURE_TRANSFORM_REQUEST: u8 = 28;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPictureTransformRequest {
     pub picture: Picture,
     pub transform: Transform,
@@ -4107,6 +4156,7 @@ impl crate::x11_utils::VoidRequest for SetPictureTransformRequest {
 /// Opcode for the QueryFilters request
 pub const QUERY_FILTERS_REQUEST: u8 = 29;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryFiltersRequest {
     pub drawable: xproto::Drawable,
 }
@@ -4158,6 +4208,7 @@ impl crate::x11_utils::ReplyRequest for QueryFiltersRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryFiltersReply {
     pub sequence: u16,
     pub length: u32,
@@ -4218,6 +4269,7 @@ impl QueryFiltersReply {
 /// Opcode for the SetPictureFilter request
 pub const SET_PICTURE_FILTER_REQUEST: u8 = 30;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPictureFilterRequest<'input> {
     pub picture: Picture,
     pub filter: Cow<'input, [u8]>,
@@ -4308,6 +4360,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetPictureFilterRequest<'input> {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Animcursorelt {
     pub cursor: xproto::Cursor,
     pub delay: u32,
@@ -4346,6 +4399,7 @@ impl Serialize for Animcursorelt {
 /// Opcode for the CreateAnimCursor request
 pub const CREATE_ANIM_CURSOR_REQUEST: u8 = 31;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateAnimCursorRequest<'input> {
     pub cid: xproto::Cursor,
     pub cursors: Cow<'input, [Animcursorelt]>,
@@ -4417,6 +4471,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateAnimCursorRequest<'input> {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Spanfix {
     pub l: Fixed,
     pub r: Fixed,
@@ -4461,6 +4516,7 @@ impl Serialize for Spanfix {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Trap {
     pub top: Spanfix,
     pub bot: Spanfix,
@@ -4515,6 +4571,7 @@ impl Serialize for Trap {
 /// Opcode for the AddTraps request
 pub const ADD_TRAPS_REQUEST: u8 = 32;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddTrapsRequest<'input> {
     pub picture: Picture,
     pub x_off: i16,
@@ -4602,6 +4659,7 @@ impl<'input> crate::x11_utils::VoidRequest for AddTrapsRequest<'input> {
 /// Opcode for the CreateSolidFill request
 pub const CREATE_SOLID_FILL_REQUEST: u8 = 33;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateSolidFillRequest {
     pub picture: Picture,
     pub color: Color,
@@ -4666,6 +4724,7 @@ impl crate::x11_utils::VoidRequest for CreateSolidFillRequest {
 /// Opcode for the CreateLinearGradient request
 pub const CREATE_LINEAR_GRADIENT_REQUEST: u8 = 34;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateLinearGradientRequest<'input> {
     pub picture: Picture,
     pub p1: Pointfix,
@@ -4772,6 +4831,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateLinearGradientRequest<'inpu
 /// Opcode for the CreateRadialGradient request
 pub const CREATE_RADIAL_GRADIENT_REQUEST: u8 = 35;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRadialGradientRequest<'input> {
     pub picture: Picture,
     pub inner: Pointfix,
@@ -4896,6 +4956,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateRadialGradientRequest<'inpu
 /// Opcode for the CreateConicalGradient request
 pub const CREATE_CONICAL_GRADIENT_REQUEST: u8 = 36;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateConicalGradientRequest<'input> {
     pub picture: Picture,
     pub center: Pointfix,

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -35,6 +35,7 @@ pub const X11_EXTENSION_NAME: &str = "X-Resource";
 pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Client {
     pub resource_base: u32,
     pub resource_mask: u32,
@@ -71,6 +72,7 @@ impl Serialize for Client {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Type {
     pub resource_type: xproto::Atom,
     pub count: u32,
@@ -107,6 +109,7 @@ impl Serialize for Type {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientIdMask(u8);
 impl ClientIdMask {
     pub const CLIENT_XID: Self = Self(1 << 0);
@@ -166,6 +169,7 @@ impl core::fmt::Debug for ClientIdMask  {
 bitmask_binop!(ClientIdMask, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientIdSpec {
     pub client: u32,
     pub mask: u32,
@@ -202,6 +206,7 @@ impl Serialize for ClientIdSpec {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientIdValue {
     pub spec: ClientIdSpec,
     pub value: Vec<u32>,
@@ -248,6 +253,7 @@ impl ClientIdValue {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResourceIdSpec {
     pub resource: u32,
     pub type_: u32,
@@ -284,6 +290,7 @@ impl Serialize for ResourceIdSpec {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResourceSizeSpec {
     pub spec: ResourceIdSpec,
     pub bytes: u32,
@@ -340,6 +347,7 @@ impl Serialize for ResourceSizeSpec {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResourceSizeValue {
     pub size: ResourceSizeSpec,
     pub cross_references: Vec<ResourceSizeSpec>,
@@ -387,6 +395,7 @@ impl ResourceSizeValue {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major: u8,
     pub client_minor: u8,
@@ -442,6 +451,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -471,6 +481,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the QueryClients request
 pub const QUERY_CLIENTS_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientsRequest;
 impl QueryClientsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -513,6 +524,7 @@ impl crate::x11_utils::ReplyRequest for QueryClientsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientsReply {
     pub sequence: u16,
     pub length: u32,
@@ -557,6 +569,7 @@ impl QueryClientsReply {
 /// Opcode for the QueryClientResources request
 pub const QUERY_CLIENT_RESOURCES_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientResourcesRequest {
     pub xid: u32,
 }
@@ -608,6 +621,7 @@ impl crate::x11_utils::ReplyRequest for QueryClientResourcesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientResourcesReply {
     pub sequence: u16,
     pub length: u32,
@@ -652,6 +666,7 @@ impl QueryClientResourcesReply {
 /// Opcode for the QueryClientPixmapBytes request
 pub const QUERY_CLIENT_PIXMAP_BYTES_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientPixmapBytesRequest {
     pub xid: u32,
 }
@@ -703,6 +718,7 @@ impl crate::x11_utils::ReplyRequest for QueryClientPixmapBytesRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientPixmapBytesReply {
     pub sequence: u16,
     pub length: u32,
@@ -732,6 +748,7 @@ impl TryParse for QueryClientPixmapBytesReply {
 /// Opcode for the QueryClientIds request
 pub const QUERY_CLIENT_IDS_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientIdsRequest<'input> {
     pub specs: Cow<'input, [ClientIdSpec]>,
 }
@@ -795,6 +812,7 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryClientIdsRequest<'input> {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientIdsReply {
     pub sequence: u16,
     pub length: u32,
@@ -839,6 +857,7 @@ impl QueryClientIdsReply {
 /// Opcode for the QueryResourceBytes request
 pub const QUERY_RESOURCE_BYTES_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryResourceBytesRequest<'input> {
     pub client: u32,
     pub specs: Cow<'input, [ResourceIdSpec]>,
@@ -911,6 +930,7 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryResourceBytesRequest<'input
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryResourceBytesReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -35,6 +35,7 @@ pub const X11_EXTENSION_NAME: &str = "MIT-SCREEN-SAVER";
 pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Kind(u8);
 impl Kind {
     pub const BLANKED: Self = Self(0);
@@ -95,6 +96,7 @@ impl core::fmt::Debug for Kind  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Event(u8);
 impl Event {
     pub const NOTIFY_MASK: Self = Self(1 << 0);
@@ -154,6 +156,7 @@ impl core::fmt::Debug for Event  {
 bitmask_binop!(Event, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct State(u8);
 impl State {
     pub const OFF: Self = Self(0);
@@ -218,6 +221,7 @@ impl core::fmt::Debug for State  {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u8,
     pub client_minor_version: u8,
@@ -274,6 +278,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -304,6 +309,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the QueryInfo request
 pub const QUERY_INFO_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryInfoRequest {
     pub drawable: xproto::Drawable,
 }
@@ -355,6 +361,7 @@ impl crate::x11_utils::ReplyRequest for QueryInfoRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryInfoReply {
     pub state: u8,
     pub sequence: u16,
@@ -393,6 +400,7 @@ impl TryParse for QueryInfoReply {
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputRequest {
     pub drawable: xproto::Drawable,
     pub event_mask: u32,
@@ -452,6 +460,7 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 
 /// Auxiliary and optional information for the `set_attributes` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetAttributesAux {
     pub background_pixmap: Option<xproto::Pixmap>,
     pub background_pixel: Option<u32>,
@@ -807,6 +816,7 @@ impl SetAttributesAux {
 /// Opcode for the SetAttributes request
 pub const SET_ATTRIBUTES_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetAttributesRequest<'input> {
     pub drawable: xproto::Drawable,
     pub x: i16,
@@ -937,6 +947,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetAttributesRequest<'input> {
 /// Opcode for the UnsetAttributes request
 pub const UNSET_ATTRIBUTES_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnsetAttributesRequest {
     pub drawable: xproto::Drawable,
 }
@@ -989,6 +1000,7 @@ impl crate::x11_utils::VoidRequest for UnsetAttributesRequest {
 /// Opcode for the Suspend request
 pub const SUSPEND_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SuspendRequest {
     pub suspend: u32,
 }
@@ -1041,6 +1053,7 @@ impl crate::x11_utils::VoidRequest for SuspendRequest {
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyEvent {
     pub response_type: u8,
     pub state: State,

--- a/x11rb-protocol/src/protocol/shape.rs
+++ b/x11rb-protocol/src/protocol/shape.rs
@@ -39,6 +39,7 @@ pub type Op = u8;
 pub type Kind = u8;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SO(u8);
 impl SO {
     pub const SET: Self = Self(0);
@@ -103,6 +104,7 @@ impl core::fmt::Debug for SO  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SK(u8);
 impl SK {
     pub const BOUNDING: Self = Self(0);
@@ -165,6 +167,7 @@ impl core::fmt::Debug for SK  {
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyEvent {
     pub response_type: u8,
     pub shape_kind: SK,
@@ -256,6 +259,7 @@ impl From<NotifyEvent> for [u8; 32] {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -298,6 +302,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -327,6 +332,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the Rectangles request
 pub const RECTANGLES_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RectanglesRequest<'input> {
     pub operation: SO,
     pub destination_kind: SK,
@@ -437,6 +443,7 @@ impl<'input> crate::x11_utils::VoidRequest for RectanglesRequest<'input> {
 /// Opcode for the Mask request
 pub const MASK_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MaskRequest {
     pub operation: SO,
     pub destination_kind: SK,
@@ -524,6 +531,7 @@ impl crate::x11_utils::VoidRequest for MaskRequest {
 /// Opcode for the Combine request
 pub const COMBINE_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CombineRequest {
     pub operation: SO,
     pub destination_kind: SK,
@@ -616,6 +624,7 @@ impl crate::x11_utils::VoidRequest for CombineRequest {
 /// Opcode for the Offset request
 pub const OFFSET_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OffsetRequest {
     pub destination_kind: SK,
     pub destination_window: xproto::Window,
@@ -690,6 +699,7 @@ impl crate::x11_utils::VoidRequest for OffsetRequest {
 /// Opcode for the QueryExtents request
 pub const QUERY_EXTENTS_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtentsRequest {
     pub destination_window: xproto::Window,
 }
@@ -741,6 +751,7 @@ impl crate::x11_utils::ReplyRequest for QueryExtentsRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtentsReply {
     pub sequence: u16,
     pub length: u32,
@@ -787,6 +798,7 @@ impl TryParse for QueryExtentsReply {
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputRequest {
     pub destination_window: xproto::Window,
     pub enable: bool,
@@ -848,6 +860,7 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 /// Opcode for the InputSelected request
 pub const INPUT_SELECTED_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputSelectedRequest {
     pub destination_window: xproto::Window,
 }
@@ -899,6 +912,7 @@ impl crate::x11_utils::ReplyRequest for InputSelectedRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputSelectedReply {
     pub enabled: bool,
     pub sequence: u16,
@@ -925,6 +939,7 @@ impl TryParse for InputSelectedReply {
 /// Opcode for the GetRectangles request
 pub const GET_RECTANGLES_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetRectanglesRequest {
     pub window: xproto::Window,
     pub source_kind: SK,
@@ -986,6 +1001,7 @@ impl crate::x11_utils::ReplyRequest for GetRectanglesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetRectanglesReply {
     pub ordering: xproto::ClipOrdering,
     pub sequence: u16,

--- a/x11rb-protocol/src/protocol/shm.rs
+++ b/x11rb-protocol/src/protocol/shm.rs
@@ -39,6 +39,7 @@ pub type Seg = u32;
 /// Opcode for the Completion event
 pub const COMPLETION_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompletionEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -125,6 +126,7 @@ pub const BAD_SEG_ERROR: u8 = 0;
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -167,6 +169,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub shared_pixmaps: bool,
     pub sequence: u16,
@@ -204,6 +207,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the Attach request
 pub const ATTACH_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttachRequest {
     pub shmseg: Seg,
     pub shmid: u32,
@@ -273,6 +277,7 @@ impl crate::x11_utils::VoidRequest for AttachRequest {
 /// Opcode for the Detach request
 pub const DETACH_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DetachRequest {
     pub shmseg: Seg,
 }
@@ -325,6 +330,7 @@ impl crate::x11_utils::VoidRequest for DetachRequest {
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PutImageRequest {
     pub drawable: xproto::Drawable,
     pub gc: xproto::Gcontext,
@@ -466,6 +472,7 @@ impl crate::x11_utils::VoidRequest for PutImageRequest {
 /// Opcode for the GetImage request
 pub const GET_IMAGE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetImageRequest {
     pub drawable: xproto::Drawable,
     pub x: i16,
@@ -574,6 +581,7 @@ impl crate::x11_utils::ReplyRequest for GetImageRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetImageReply {
     pub depth: u8,
     pub sequence: u16,
@@ -604,6 +612,7 @@ impl TryParse for GetImageReply {
 /// Opcode for the CreatePixmap request
 pub const CREATE_PIXMAP_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePixmapRequest {
     pub pid: xproto::Pixmap,
     pub drawable: xproto::Drawable,
@@ -766,6 +775,7 @@ impl crate::x11_utils::VoidRequest for AttachFdRequest {
 /// Opcode for the CreateSegment request
 pub const CREATE_SEGMENT_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateSegmentRequest {
     pub shmseg: Seg,
     pub size: u32,

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -37,6 +37,7 @@ pub const X11_XML_VERSION: (u32, u32) = (3, 1);
 pub type Alarm = u32;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ALARMSTATE(u8);
 impl ALARMSTATE {
     pub const ACTIVE: Self = Self(0);
@@ -101,6 +102,7 @@ pub type Counter = u32;
 pub type Fence = u32;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TESTTYPE(u32);
 impl TESTTYPE {
     pub const POSITIVE_TRANSITION: Self = Self(0);
@@ -151,6 +153,7 @@ impl core::fmt::Debug for TESTTYPE  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VALUETYPE(u32);
 impl VALUETYPE {
     pub const ABSOLUTE: Self = Self(0);
@@ -197,6 +200,7 @@ impl core::fmt::Debug for VALUETYPE  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CA(u8);
 impl CA {
     pub const COUNTER: Self = Self(1 << 0);
@@ -264,6 +268,7 @@ impl core::fmt::Debug for CA  {
 bitmask_binop!(CA, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Int64 {
     pub hi: i32,
     pub lo: u32,
@@ -300,6 +305,7 @@ impl Serialize for Int64 {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Systemcounter {
     pub counter: Counter,
     pub resolution: Int64,
@@ -355,6 +361,7 @@ impl Systemcounter {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Trigger {
     pub counter: Counter,
     pub wait_type: VALUETYPE,
@@ -413,6 +420,7 @@ impl Serialize for Trigger {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Waitcondition {
     pub trigger: Trigger,
     pub event_threshold: Int64,
@@ -477,6 +485,7 @@ pub const ALARM_ERROR: u8 = 1;
 /// Opcode for the Initialize request
 pub const INITIALIZE_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InitializeRequest {
     pub desired_major_version: u8,
     pub desired_minor_version: u8,
@@ -532,6 +541,7 @@ impl crate::x11_utils::ReplyRequest for InitializeRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InitializeReply {
     pub sequence: u16,
     pub length: u32,
@@ -562,6 +572,7 @@ impl TryParse for InitializeReply {
 /// Opcode for the ListSystemCounters request
 pub const LIST_SYSTEM_COUNTERS_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSystemCountersRequest;
 impl ListSystemCountersRequest {
     /// Serialize this request into bytes for the provided connection
@@ -604,6 +615,7 @@ impl crate::x11_utils::ReplyRequest for ListSystemCountersRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSystemCountersReply {
     pub sequence: u16,
     pub length: u32,
@@ -648,6 +660,7 @@ impl ListSystemCountersReply {
 /// Opcode for the CreateCounter request
 pub const CREATE_COUNTER_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateCounterRequest {
     pub id: Counter,
     pub initial_value: Int64,
@@ -712,6 +725,7 @@ impl crate::x11_utils::VoidRequest for CreateCounterRequest {
 /// Opcode for the DestroyCounter request
 pub const DESTROY_COUNTER_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyCounterRequest {
     pub counter: Counter,
 }
@@ -764,6 +778,7 @@ impl crate::x11_utils::VoidRequest for DestroyCounterRequest {
 /// Opcode for the QueryCounter request
 pub const QUERY_COUNTER_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryCounterRequest {
     pub counter: Counter,
 }
@@ -815,6 +830,7 @@ impl crate::x11_utils::ReplyRequest for QueryCounterRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryCounterReply {
     pub sequence: u16,
     pub length: u32,
@@ -842,6 +858,7 @@ impl TryParse for QueryCounterReply {
 /// Opcode for the Await request
 pub const AWAIT_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AwaitRequest<'input> {
     pub wait_list: Cow<'input, [Waitcondition]>,
 }
@@ -906,6 +923,7 @@ impl<'input> crate::x11_utils::VoidRequest for AwaitRequest<'input> {
 /// Opcode for the ChangeCounter request
 pub const CHANGE_COUNTER_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeCounterRequest {
     pub counter: Counter,
     pub amount: Int64,
@@ -970,6 +988,7 @@ impl crate::x11_utils::VoidRequest for ChangeCounterRequest {
 /// Opcode for the SetCounter request
 pub const SET_COUNTER_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCounterRequest {
     pub counter: Counter,
     pub value: Int64,
@@ -1033,6 +1052,7 @@ impl crate::x11_utils::VoidRequest for SetCounterRequest {
 
 /// Auxiliary and optional information for the `create_alarm` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateAlarmAux {
     pub counter: Option<Counter>,
     pub value_type: Option<VALUETYPE>,
@@ -1198,6 +1218,7 @@ impl CreateAlarmAux {
 /// Opcode for the CreateAlarm request
 pub const CREATE_ALARM_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateAlarmRequest<'input> {
     pub id: Alarm,
     pub value_list: Cow<'input, CreateAlarmAux>,
@@ -1270,6 +1291,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateAlarmRequest<'input> {
 
 /// Auxiliary and optional information for the `change_alarm` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeAlarmAux {
     pub counter: Option<Counter>,
     pub value_type: Option<VALUETYPE>,
@@ -1435,6 +1457,7 @@ impl ChangeAlarmAux {
 /// Opcode for the ChangeAlarm request
 pub const CHANGE_ALARM_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeAlarmRequest<'input> {
     pub id: Alarm,
     pub value_list: Cow<'input, ChangeAlarmAux>,
@@ -1508,6 +1531,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeAlarmRequest<'input> {
 /// Opcode for the DestroyAlarm request
 pub const DESTROY_ALARM_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyAlarmRequest {
     pub alarm: Alarm,
 }
@@ -1560,6 +1584,7 @@ impl crate::x11_utils::VoidRequest for DestroyAlarmRequest {
 /// Opcode for the QueryAlarm request
 pub const QUERY_ALARM_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryAlarmRequest {
     pub alarm: Alarm,
 }
@@ -1611,6 +1636,7 @@ impl crate::x11_utils::ReplyRequest for QueryAlarmRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryAlarmReply {
     pub sequence: u16,
     pub length: u32,
@@ -1646,6 +1672,7 @@ impl TryParse for QueryAlarmReply {
 /// Opcode for the SetPriority request
 pub const SET_PRIORITY_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPriorityRequest {
     pub id: u32,
     pub priority: i32,
@@ -1706,6 +1733,7 @@ impl crate::x11_utils::VoidRequest for SetPriorityRequest {
 /// Opcode for the GetPriority request
 pub const GET_PRIORITY_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPriorityRequest {
     pub id: u32,
 }
@@ -1757,6 +1785,7 @@ impl crate::x11_utils::ReplyRequest for GetPriorityRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPriorityReply {
     pub sequence: u16,
     pub length: u32,
@@ -1784,6 +1813,7 @@ impl TryParse for GetPriorityReply {
 /// Opcode for the CreateFence request
 pub const CREATE_FENCE_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateFenceRequest {
     pub drawable: xproto::Drawable,
     pub fence: Fence,
@@ -1852,6 +1882,7 @@ impl crate::x11_utils::VoidRequest for CreateFenceRequest {
 /// Opcode for the TriggerFence request
 pub const TRIGGER_FENCE_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TriggerFenceRequest {
     pub fence: Fence,
 }
@@ -1904,6 +1935,7 @@ impl crate::x11_utils::VoidRequest for TriggerFenceRequest {
 /// Opcode for the ResetFence request
 pub const RESET_FENCE_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResetFenceRequest {
     pub fence: Fence,
 }
@@ -1956,6 +1988,7 @@ impl crate::x11_utils::VoidRequest for ResetFenceRequest {
 /// Opcode for the DestroyFence request
 pub const DESTROY_FENCE_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyFenceRequest {
     pub fence: Fence,
 }
@@ -2008,6 +2041,7 @@ impl crate::x11_utils::VoidRequest for DestroyFenceRequest {
 /// Opcode for the QueryFence request
 pub const QUERY_FENCE_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryFenceRequest {
     pub fence: Fence,
 }
@@ -2059,6 +2093,7 @@ impl crate::x11_utils::ReplyRequest for QueryFenceRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryFenceReply {
     pub sequence: u16,
     pub length: u32,
@@ -2087,6 +2122,7 @@ impl TryParse for QueryFenceReply {
 /// Opcode for the AwaitFence request
 pub const AWAIT_FENCE_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AwaitFenceRequest<'input> {
     pub fence_list: Cow<'input, [Fence]>,
 }
@@ -2151,6 +2187,7 @@ impl<'input> crate::x11_utils::VoidRequest for AwaitFenceRequest<'input> {
 /// Opcode for the CounterNotify event
 pub const COUNTER_NOTIFY_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CounterNotifyEvent {
     pub response_type: u8,
     pub kind: u8,
@@ -2238,6 +2275,7 @@ impl From<CounterNotifyEvent> for [u8; 32] {
 /// Opcode for the AlarmNotify event
 pub const ALARM_NOTIFY_EVENT: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AlarmNotifyEvent {
     pub response_type: u8,
     pub kind: u8,

--- a/x11rb-protocol/src/protocol/xc_misc.rs
+++ b/x11rb-protocol/src/protocol/xc_misc.rs
@@ -35,6 +35,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 /// Opcode for the GetVersion request
 pub const GET_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
@@ -90,6 +91,7 @@ impl crate::x11_utils::ReplyRequest for GetVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -119,6 +121,7 @@ impl TryParse for GetVersionReply {
 /// Opcode for the GetXIDRange request
 pub const GET_XID_RANGE_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetXIDRangeRequest;
 impl GetXIDRangeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -161,6 +164,7 @@ impl crate::x11_utils::ReplyRequest for GetXIDRangeRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetXIDRangeReply {
     pub sequence: u16,
     pub length: u32,
@@ -190,6 +194,7 @@ impl TryParse for GetXIDRangeReply {
 /// Opcode for the GetXIDList request
 pub const GET_XID_LIST_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetXIDListRequest {
     pub count: u32,
 }
@@ -241,6 +246,7 @@ impl crate::x11_utils::ReplyRequest for GetXIDListRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetXIDListReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/xevie.rs
+++ b/x11rb-protocol/src/protocol/xevie.rs
@@ -35,6 +35,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
@@ -90,6 +91,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -120,6 +122,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the Start request
 pub const START_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StartRequest {
     pub screen: u32,
 }
@@ -171,6 +174,7 @@ impl crate::x11_utils::ReplyRequest for StartRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StartReply {
     pub sequence: u16,
     pub length: u32,
@@ -197,6 +201,7 @@ impl TryParse for StartReply {
 /// Opcode for the End request
 pub const END_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EndRequest {
     pub cmap: u32,
 }
@@ -248,6 +253,7 @@ impl crate::x11_utils::ReplyRequest for EndRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EndReply {
     pub sequence: u16,
     pub length: u32,
@@ -272,6 +278,7 @@ impl TryParse for EndReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Datatype(bool);
 impl Datatype {
     pub const UNMODIFIED: Self = Self(false);
@@ -342,6 +349,7 @@ impl core::fmt::Debug for Datatype  {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Event {
 }
 impl TryParse for Event {
@@ -398,6 +406,7 @@ impl Serialize for Event {
 /// Opcode for the Send request
 pub const SEND_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SendRequest {
     pub event: Event,
     pub data_type: u32,
@@ -550,6 +559,7 @@ impl crate::x11_utils::ReplyRequest for SendRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SendReply {
     pub sequence: u16,
     pub length: u32,
@@ -576,6 +586,7 @@ impl TryParse for SendReply {
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputRequest {
     pub event_mask: u32,
 }
@@ -627,6 +638,7 @@ impl crate::x11_utils::ReplyRequest for SelectInputRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/xf86dri.rs
+++ b/x11rb-protocol/src/protocol/xf86dri.rs
@@ -33,6 +33,7 @@ pub const X11_EXTENSION_NAME: &str = "XFree86-DRI";
 pub const X11_XML_VERSION: (u32, u32) = (4, 1);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DrmClipRect {
     pub x1: i16,
     pub y1: i16,
@@ -79,6 +80,7 @@ impl Serialize for DrmClipRect {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -121,6 +123,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -152,6 +155,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the QueryDirectRenderingCapable request
 pub const QUERY_DIRECT_RENDERING_CAPABLE_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryDirectRenderingCapableRequest {
     pub screen: u32,
 }
@@ -203,6 +207,7 @@ impl crate::x11_utils::ReplyRequest for QueryDirectRenderingCapableRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryDirectRenderingCapableReply {
     pub sequence: u16,
     pub length: u32,
@@ -230,6 +235,7 @@ impl TryParse for QueryDirectRenderingCapableReply {
 /// Opcode for the OpenConnection request
 pub const OPEN_CONNECTION_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenConnectionRequest {
     pub screen: u32,
 }
@@ -281,6 +287,7 @@ impl crate::x11_utils::ReplyRequest for OpenConnectionRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenConnectionReply {
     pub sequence: u16,
     pub length: u32,
@@ -330,6 +337,7 @@ impl OpenConnectionReply {
 /// Opcode for the CloseConnection request
 pub const CLOSE_CONNECTION_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CloseConnectionRequest {
     pub screen: u32,
 }
@@ -382,6 +390,7 @@ impl crate::x11_utils::VoidRequest for CloseConnectionRequest {
 /// Opcode for the GetClientDriverName request
 pub const GET_CLIENT_DRIVER_NAME_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClientDriverNameRequest {
     pub screen: u32,
 }
@@ -433,6 +442,7 @@ impl crate::x11_utils::ReplyRequest for GetClientDriverNameRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClientDriverNameReply {
     pub sequence: u16,
     pub length: u32,
@@ -484,6 +494,7 @@ impl GetClientDriverNameReply {
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextRequest {
     pub screen: u32,
     pub visual: u32,
@@ -551,6 +562,7 @@ impl crate::x11_utils::ReplyRequest for CreateContextRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -578,6 +590,7 @@ impl TryParse for CreateContextReply {
 /// Opcode for the DestroyContext request
 pub const DESTROY_CONTEXT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyContextRequest {
     pub screen: u32,
     pub context: u32,
@@ -638,6 +651,7 @@ impl crate::x11_utils::VoidRequest for DestroyContextRequest {
 /// Opcode for the CreateDrawable request
 pub const CREATE_DRAWABLE_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateDrawableRequest {
     pub screen: u32,
     pub drawable: u32,
@@ -697,6 +711,7 @@ impl crate::x11_utils::ReplyRequest for CreateDrawableRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateDrawableReply {
     pub sequence: u16,
     pub length: u32,
@@ -724,6 +739,7 @@ impl TryParse for CreateDrawableReply {
 /// Opcode for the DestroyDrawable request
 pub const DESTROY_DRAWABLE_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyDrawableRequest {
     pub screen: u32,
     pub drawable: u32,
@@ -784,6 +800,7 @@ impl crate::x11_utils::VoidRequest for DestroyDrawableRequest {
 /// Opcode for the GetDrawableInfo request
 pub const GET_DRAWABLE_INFO_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDrawableInfoRequest {
     pub screen: u32,
     pub drawable: u32,
@@ -843,6 +860,7 @@ impl crate::x11_utils::ReplyRequest for GetDrawableInfoRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDrawableInfoReply {
     pub sequence: u16,
     pub length: u32,
@@ -918,6 +936,7 @@ impl GetDrawableInfoReply {
 /// Opcode for the GetDeviceInfo request
 pub const GET_DEVICE_INFO_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceInfoRequest {
     pub screen: u32,
 }
@@ -969,6 +988,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceInfoRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceInfoReply {
     pub sequence: u16,
     pub length: u32,
@@ -1022,6 +1042,7 @@ impl GetDeviceInfoReply {
 /// Opcode for the AuthConnection request
 pub const AUTH_CONNECTION_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AuthConnectionRequest {
     pub screen: u32,
     pub magic: u32,
@@ -1081,6 +1102,7 @@ impl crate::x11_utils::ReplyRequest for AuthConnectionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AuthConnectionReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -37,6 +37,7 @@ pub type Syncrange = u32;
 pub type Dotclock = u32;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModeFlag(u16);
 impl ModeFlag {
     pub const POSITIVE_H_SYNC: Self = Self(1 << 0);
@@ -112,6 +113,7 @@ impl core::fmt::Debug for ModeFlag  {
 bitmask_binop!(ModeFlag, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClockFlag(u8);
 impl ClockFlag {
     pub const PROGRAMABLE: Self = Self(1 << 0);
@@ -169,6 +171,7 @@ impl core::fmt::Debug for ClockFlag  {
 bitmask_binop!(ClockFlag, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Permission(u8);
 impl Permission {
     pub const READ: Self = Self(1 << 0);
@@ -228,6 +231,7 @@ impl core::fmt::Debug for Permission  {
 bitmask_binop!(Permission, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModeInfo {
     pub dotclock: Dotclock,
     pub hdisplay: u16,
@@ -350,6 +354,7 @@ impl Serialize for ModeInfo {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -392,6 +397,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -421,6 +427,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the GetModeLine request
 pub const GET_MODE_LINE_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetModeLineRequest {
     pub screen: u16,
 }
@@ -473,6 +480,7 @@ impl crate::x11_utils::ReplyRequest for GetModeLineRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetModeLineReply {
     pub sequence: u16,
     pub length: u32,
@@ -541,6 +549,7 @@ impl GetModeLineReply {
 /// Opcode for the ModModeLine request
 pub const MOD_MODE_LINE_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModModeLineRequest<'input> {
     pub screen: u32,
     pub hdisplay: u16,
@@ -701,6 +710,7 @@ impl<'input> crate::x11_utils::VoidRequest for ModModeLineRequest<'input> {
 /// Opcode for the SwitchMode request
 pub const SWITCH_MODE_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwitchModeRequest {
     pub screen: u16,
     pub zoom: u16,
@@ -757,6 +767,7 @@ impl crate::x11_utils::VoidRequest for SwitchModeRequest {
 /// Opcode for the GetMonitor request
 pub const GET_MONITOR_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMonitorRequest {
     pub screen: u16,
 }
@@ -809,6 +820,7 @@ impl crate::x11_utils::ReplyRequest for GetMonitorRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMonitorReply {
     pub sequence: u16,
     pub length: u32,
@@ -906,6 +918,7 @@ impl GetMonitorReply {
 /// Opcode for the LockModeSwitch request
 pub const LOCK_MODE_SWITCH_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LockModeSwitchRequest {
     pub screen: u16,
     pub lock: u16,
@@ -962,6 +975,7 @@ impl crate::x11_utils::VoidRequest for LockModeSwitchRequest {
 /// Opcode for the GetAllModeLines request
 pub const GET_ALL_MODE_LINES_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetAllModeLinesRequest {
     pub screen: u16,
 }
@@ -1014,6 +1028,7 @@ impl crate::x11_utils::ReplyRequest for GetAllModeLinesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetAllModeLinesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1058,6 +1073,7 @@ impl GetAllModeLinesReply {
 /// Opcode for the AddModeLine request
 pub const ADD_MODE_LINE_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddModeLineRequest<'input> {
     pub screen: u32,
     pub dotclock: Dotclock,
@@ -1324,6 +1340,7 @@ impl<'input> crate::x11_utils::VoidRequest for AddModeLineRequest<'input> {
 /// Opcode for the DeleteModeLine request
 pub const DELETE_MODE_LINE_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteModeLineRequest<'input> {
     pub screen: u32,
     pub dotclock: Dotclock,
@@ -1493,6 +1510,7 @@ impl<'input> crate::x11_utils::VoidRequest for DeleteModeLineRequest<'input> {
 /// Opcode for the ValidateModeLine request
 pub const VALIDATE_MODE_LINE_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValidateModeLineRequest<'input> {
     pub screen: u32,
     pub dotclock: Dotclock,
@@ -1661,6 +1679,7 @@ impl<'input> crate::x11_utils::ReplyRequest for ValidateModeLineRequest<'input> 
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValidateModeLineReply {
     pub sequence: u16,
     pub length: u32,
@@ -1689,6 +1708,7 @@ impl TryParse for ValidateModeLineReply {
 /// Opcode for the SwitchToMode request
 pub const SWITCH_TO_MODE_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwitchToModeRequest<'input> {
     pub screen: u32,
     pub dotclock: Dotclock,
@@ -1858,6 +1878,7 @@ impl<'input> crate::x11_utils::VoidRequest for SwitchToModeRequest<'input> {
 /// Opcode for the GetViewPort request
 pub const GET_VIEW_PORT_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetViewPortRequest {
     pub screen: u16,
 }
@@ -1910,6 +1931,7 @@ impl crate::x11_utils::ReplyRequest for GetViewPortRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetViewPortReply {
     pub sequence: u16,
     pub length: u32,
@@ -1940,6 +1962,7 @@ impl TryParse for GetViewPortReply {
 /// Opcode for the SetViewPort request
 pub const SET_VIEW_PORT_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetViewPortRequest {
     pub screen: u16,
     pub x: u32,
@@ -2009,6 +2032,7 @@ impl crate::x11_utils::VoidRequest for SetViewPortRequest {
 /// Opcode for the GetDotClocks request
 pub const GET_DOT_CLOCKS_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDotClocksRequest {
     pub screen: u16,
 }
@@ -2061,6 +2085,7 @@ impl crate::x11_utils::ReplyRequest for GetDotClocksRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDotClocksReply {
     pub sequence: u16,
     pub length: u32,
@@ -2095,6 +2120,7 @@ impl TryParse for GetDotClocksReply {
 /// Opcode for the SetClientVersion request
 pub const SET_CLIENT_VERSION_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetClientVersionRequest {
     pub major: u16,
     pub minor: u16,
@@ -2151,6 +2177,7 @@ impl crate::x11_utils::VoidRequest for SetClientVersionRequest {
 /// Opcode for the SetGamma request
 pub const SET_GAMMA_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetGammaRequest {
     pub screen: u16,
     pub red: u32,
@@ -2241,6 +2268,7 @@ impl crate::x11_utils::VoidRequest for SetGammaRequest {
 /// Opcode for the GetGamma request
 pub const GET_GAMMA_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGammaRequest {
     pub screen: u16,
 }
@@ -2317,6 +2345,7 @@ impl crate::x11_utils::ReplyRequest for GetGammaRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGammaReply {
     pub sequence: u16,
     pub length: u32,
@@ -2349,6 +2378,7 @@ impl TryParse for GetGammaReply {
 /// Opcode for the GetGammaRamp request
 pub const GET_GAMMA_RAMP_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGammaRampRequest {
     pub screen: u16,
     pub size: u16,
@@ -2404,6 +2434,7 @@ impl crate::x11_utils::ReplyRequest for GetGammaRampRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGammaRampReply {
     pub sequence: u16,
     pub length: u32,
@@ -2438,6 +2469,7 @@ impl TryParse for GetGammaRampReply {
 /// Opcode for the SetGammaRamp request
 pub const SET_GAMMA_RAMP_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetGammaRampRequest<'input> {
     pub screen: u16,
     pub size: u16,
@@ -2524,6 +2556,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetGammaRampRequest<'input> {
 /// Opcode for the GetGammaRampSize request
 pub const GET_GAMMA_RAMP_SIZE_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGammaRampSizeRequest {
     pub screen: u16,
 }
@@ -2576,6 +2609,7 @@ impl crate::x11_utils::ReplyRequest for GetGammaRampSizeRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGammaRampSizeReply {
     pub sequence: u16,
     pub length: u32,
@@ -2604,6 +2638,7 @@ impl TryParse for GetGammaRampSizeReply {
 /// Opcode for the GetPermissions request
 pub const GET_PERMISSIONS_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPermissionsRequest {
     pub screen: u16,
 }
@@ -2656,6 +2691,7 @@ impl crate::x11_utils::ReplyRequest for GetPermissionsRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPermissionsReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -41,6 +41,7 @@ pub const X11_XML_VERSION: (u32, u32) = (5, 0);
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
@@ -100,6 +101,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -128,6 +130,7 @@ impl TryParse for QueryVersionReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SaveSetMode(u8);
 impl SaveSetMode {
     pub const INSERT: Self = Self(0);
@@ -186,6 +189,7 @@ impl core::fmt::Debug for SaveSetMode  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SaveSetTarget(u8);
 impl SaveSetTarget {
     pub const NEAREST: Self = Self(0);
@@ -244,6 +248,7 @@ impl core::fmt::Debug for SaveSetTarget  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SaveSetMapping(u8);
 impl SaveSetMapping {
     pub const MAP: Self = Self(0);
@@ -304,6 +309,7 @@ impl core::fmt::Debug for SaveSetMapping  {
 /// Opcode for the ChangeSaveSet request
 pub const CHANGE_SAVE_SET_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeSaveSetRequest {
     pub mode: SaveSetMode,
     pub target: SaveSetTarget,
@@ -374,6 +380,7 @@ impl crate::x11_utils::VoidRequest for ChangeSaveSetRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectionEvent(u8);
 impl SelectionEvent {
     pub const SET_SELECTION_OWNER: Self = Self(0);
@@ -434,6 +441,7 @@ impl core::fmt::Debug for SelectionEvent  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectionEventMask(u8);
 impl SelectionEventMask {
     pub const SET_SELECTION_OWNER: Self = Self(1 << 0);
@@ -497,6 +505,7 @@ bitmask_binop!(SelectionEventMask, u8);
 /// Opcode for the SelectionNotify event
 pub const SELECTION_NOTIFY_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectionNotifyEvent {
     pub response_type: u8,
     pub subtype: SelectionEvent,
@@ -582,6 +591,7 @@ impl From<SelectionNotifyEvent> for [u8; 32] {
 /// Opcode for the SelectSelectionInput request
 pub const SELECT_SELECTION_INPUT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectSelectionInputRequest {
     pub window: xproto::Window,
     pub selection: xproto::Atom,
@@ -648,6 +658,7 @@ impl crate::x11_utils::VoidRequest for SelectSelectionInputRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorNotify(u8);
 impl CursorNotify {
     pub const DISPLAY_CURSOR: Self = Self(0);
@@ -704,6 +715,7 @@ impl core::fmt::Debug for CursorNotify  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorNotifyMask(u8);
 impl CursorNotifyMask {
     pub const DISPLAY_CURSOR: Self = Self(1 << 0);
@@ -763,6 +775,7 @@ bitmask_binop!(CursorNotifyMask, u8);
 /// Opcode for the CursorNotify event
 pub const CURSOR_NOTIFY_EVENT: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorNotifyEvent {
     pub response_type: u8,
     pub subtype: CursorNotify,
@@ -845,6 +858,7 @@ impl From<CursorNotifyEvent> for [u8; 32] {
 /// Opcode for the SelectCursorInput request
 pub const SELECT_CURSOR_INPUT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectCursorInputRequest {
     pub window: xproto::Window,
     pub event_mask: u32,
@@ -905,6 +919,7 @@ impl crate::x11_utils::VoidRequest for SelectCursorInputRequest {
 /// Opcode for the GetCursorImage request
 pub const GET_CURSOR_IMAGE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorImageRequest;
 impl GetCursorImageRequest {
     /// Serialize this request into bytes for the provided connection
@@ -947,6 +962,7 @@ impl crate::x11_utils::ReplyRequest for GetCursorImageRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorImageReply {
     pub sequence: u16,
     pub length: u32,
@@ -992,6 +1008,7 @@ pub type Region = u32;
 pub const BAD_REGION_ERROR: u8 = 0;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RegionEnum(u8);
 impl RegionEnum {
     pub const NONE: Self = Self(0);
@@ -1050,6 +1067,7 @@ impl core::fmt::Debug for RegionEnum  {
 /// Opcode for the CreateRegion request
 pub const CREATE_REGION_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRegionRequest<'input> {
     pub region: Region,
     pub rectangles: Cow<'input, [xproto::Rectangle]>,
@@ -1123,6 +1141,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateRegionRequest<'input> {
 /// Opcode for the CreateRegionFromBitmap request
 pub const CREATE_REGION_FROM_BITMAP_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRegionFromBitmapRequest {
     pub region: Region,
     pub bitmap: xproto::Pixmap,
@@ -1183,6 +1202,7 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromBitmapRequest {
 /// Opcode for the CreateRegionFromWindow request
 pub const CREATE_REGION_FROM_WINDOW_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRegionFromWindowRequest {
     pub region: Region,
     pub window: xproto::Window,
@@ -1253,6 +1273,7 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromWindowRequest {
 /// Opcode for the CreateRegionFromGC request
 pub const CREATE_REGION_FROM_GC_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRegionFromGCRequest {
     pub region: Region,
     pub gc: xproto::Gcontext,
@@ -1313,6 +1334,7 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromGCRequest {
 /// Opcode for the CreateRegionFromPicture request
 pub const CREATE_REGION_FROM_PICTURE_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRegionFromPictureRequest {
     pub region: Region,
     pub picture: render::Picture,
@@ -1373,6 +1395,7 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromPictureRequest {
 /// Opcode for the DestroyRegion request
 pub const DESTROY_REGION_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyRegionRequest {
     pub region: Region,
 }
@@ -1425,6 +1448,7 @@ impl crate::x11_utils::VoidRequest for DestroyRegionRequest {
 /// Opcode for the SetRegion request
 pub const SET_REGION_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetRegionRequest<'input> {
     pub region: Region,
     pub rectangles: Cow<'input, [xproto::Rectangle]>,
@@ -1498,6 +1522,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetRegionRequest<'input> {
 /// Opcode for the CopyRegion request
 pub const COPY_REGION_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyRegionRequest {
     pub source: Region,
     pub destination: Region,
@@ -1558,6 +1583,7 @@ impl crate::x11_utils::VoidRequest for CopyRegionRequest {
 /// Opcode for the UnionRegion request
 pub const UNION_REGION_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnionRegionRequest {
     pub source1: Region,
     pub source2: Region,
@@ -1626,6 +1652,7 @@ impl crate::x11_utils::VoidRequest for UnionRegionRequest {
 /// Opcode for the IntersectRegion request
 pub const INTERSECT_REGION_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IntersectRegionRequest {
     pub source1: Region,
     pub source2: Region,
@@ -1694,6 +1721,7 @@ impl crate::x11_utils::VoidRequest for IntersectRegionRequest {
 /// Opcode for the SubtractRegion request
 pub const SUBTRACT_REGION_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SubtractRegionRequest {
     pub source1: Region,
     pub source2: Region,
@@ -1762,6 +1790,7 @@ impl crate::x11_utils::VoidRequest for SubtractRegionRequest {
 /// Opcode for the InvertRegion request
 pub const INVERT_REGION_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InvertRegionRequest {
     pub source: Region,
     pub bounds: xproto::Rectangle,
@@ -1834,6 +1863,7 @@ impl crate::x11_utils::VoidRequest for InvertRegionRequest {
 /// Opcode for the TranslateRegion request
 pub const TRANSLATE_REGION_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TranslateRegionRequest {
     pub region: Region,
     pub dx: i16,
@@ -1898,6 +1928,7 @@ impl crate::x11_utils::VoidRequest for TranslateRegionRequest {
 /// Opcode for the RegionExtents request
 pub const REGION_EXTENTS_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RegionExtentsRequest {
     pub source: Region,
     pub destination: Region,
@@ -1958,6 +1989,7 @@ impl crate::x11_utils::VoidRequest for RegionExtentsRequest {
 /// Opcode for the FetchRegion request
 pub const FETCH_REGION_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FetchRegionRequest {
     pub region: Region,
 }
@@ -2009,6 +2041,7 @@ impl crate::x11_utils::ReplyRequest for FetchRegionRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FetchRegionReply {
     pub sequence: u16,
     pub extents: xproto::Rectangle,
@@ -2054,6 +2087,7 @@ impl FetchRegionReply {
 /// Opcode for the SetGCClipRegion request
 pub const SET_GC_CLIP_REGION_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetGCClipRegionRequest {
     pub gc: xproto::Gcontext,
     pub region: Region,
@@ -2126,6 +2160,7 @@ impl crate::x11_utils::VoidRequest for SetGCClipRegionRequest {
 /// Opcode for the SetWindowShapeRegion request
 pub const SET_WINDOW_SHAPE_REGION_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetWindowShapeRegionRequest {
     pub dest: xproto::Window,
     pub dest_kind: shape::SK,
@@ -2208,6 +2243,7 @@ impl crate::x11_utils::VoidRequest for SetWindowShapeRegionRequest {
 /// Opcode for the SetPictureClipRegion request
 pub const SET_PICTURE_CLIP_REGION_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPictureClipRegionRequest {
     pub picture: render::Picture,
     pub region: Region,
@@ -2280,6 +2316,7 @@ impl crate::x11_utils::VoidRequest for SetPictureClipRegionRequest {
 /// Opcode for the SetCursorName request
 pub const SET_CURSOR_NAME_REQUEST: u8 = 23;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCursorNameRequest<'input> {
     pub cursor: xproto::Cursor,
     pub name: Cow<'input, [u8]>,
@@ -2353,6 +2390,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetCursorNameRequest<'input> {
 /// Opcode for the GetCursorName request
 pub const GET_CURSOR_NAME_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorNameRequest {
     pub cursor: xproto::Cursor,
 }
@@ -2404,6 +2442,7 @@ impl crate::x11_utils::ReplyRequest for GetCursorNameRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorNameReply {
     pub sequence: u16,
     pub length: u32,
@@ -2451,6 +2490,7 @@ impl GetCursorNameReply {
 /// Opcode for the GetCursorImageAndName request
 pub const GET_CURSOR_IMAGE_AND_NAME_REQUEST: u8 = 25;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorImageAndNameRequest;
 impl GetCursorImageAndNameRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2493,6 +2533,7 @@ impl crate::x11_utils::ReplyRequest for GetCursorImageAndNameRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorImageAndNameReply {
     pub sequence: u16,
     pub length: u32,
@@ -2556,6 +2597,7 @@ impl GetCursorImageAndNameReply {
 /// Opcode for the ChangeCursor request
 pub const CHANGE_CURSOR_REQUEST: u8 = 26;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeCursorRequest {
     pub source: xproto::Cursor,
     pub destination: xproto::Cursor,
@@ -2616,6 +2658,7 @@ impl crate::x11_utils::VoidRequest for ChangeCursorRequest {
 /// Opcode for the ChangeCursorByName request
 pub const CHANGE_CURSOR_BY_NAME_REQUEST: u8 = 27;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeCursorByNameRequest<'input> {
     pub src: xproto::Cursor,
     pub name: Cow<'input, [u8]>,
@@ -2689,6 +2732,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeCursorByNameRequest<'input>
 /// Opcode for the ExpandRegion request
 pub const EXPAND_REGION_REQUEST: u8 = 28;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExpandRegionRequest {
     pub source: Region,
     pub destination: Region,
@@ -2773,6 +2817,7 @@ impl crate::x11_utils::VoidRequest for ExpandRegionRequest {
 /// Opcode for the HideCursor request
 pub const HIDE_CURSOR_REQUEST: u8 = 29;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HideCursorRequest {
     pub window: xproto::Window,
 }
@@ -2825,6 +2870,7 @@ impl crate::x11_utils::VoidRequest for HideCursorRequest {
 /// Opcode for the ShowCursor request
 pub const SHOW_CURSOR_REQUEST: u8 = 30;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ShowCursorRequest {
     pub window: xproto::Window,
 }
@@ -2877,6 +2923,7 @@ impl crate::x11_utils::VoidRequest for ShowCursorRequest {
 pub type Barrier = u32;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BarrierDirections(u8);
 impl BarrierDirections {
     pub const POSITIVE_X: Self = Self(1 << 0);
@@ -2942,6 +2989,7 @@ bitmask_binop!(BarrierDirections, u8);
 /// Opcode for the CreatePointerBarrier request
 pub const CREATE_POINTER_BARRIER_REQUEST: u8 = 31;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePointerBarrierRequest<'input> {
     pub barrier: Barrier,
     pub window: xproto::Window,
@@ -3062,6 +3110,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreatePointerBarrierRequest<'inpu
 /// Opcode for the DeletePointerBarrier request
 pub const DELETE_POINTER_BARRIER_REQUEST: u8 = 32;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeletePointerBarrierRequest {
     pub barrier: Barrier,
 }

--- a/x11rb-protocol/src/protocol/xinerama.rs
+++ b/x11rb-protocol/src/protocol/xinerama.rs
@@ -35,6 +35,7 @@ pub const X11_EXTENSION_NAME: &str = "XINERAMA";
 pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScreenInfo {
     pub x_org: i16,
     pub y_org: i16,
@@ -81,6 +82,7 @@ impl Serialize for ScreenInfo {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major: u8,
     pub minor: u8,
@@ -136,6 +138,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -165,6 +168,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the GetState request
 pub const GET_STATE_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStateRequest {
     pub window: xproto::Window,
 }
@@ -216,6 +220,7 @@ impl crate::x11_utils::ReplyRequest for GetStateRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStateReply {
     pub state: u8,
     pub sequence: u16,
@@ -244,6 +249,7 @@ impl TryParse for GetStateReply {
 /// Opcode for the GetScreenCount request
 pub const GET_SCREEN_COUNT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenCountRequest {
     pub window: xproto::Window,
 }
@@ -295,6 +301,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenCountRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenCountReply {
     pub screen_count: u8,
     pub sequence: u16,
@@ -323,6 +330,7 @@ impl TryParse for GetScreenCountReply {
 /// Opcode for the GetScreenSize request
 pub const GET_SCREEN_SIZE_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSizeRequest {
     pub window: xproto::Window,
     pub screen: u32,
@@ -382,6 +390,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenSizeRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSizeReply {
     pub sequence: u16,
     pub length: u32,
@@ -415,6 +424,7 @@ impl TryParse for GetScreenSizeReply {
 /// Opcode for the IsActive request
 pub const IS_ACTIVE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsActiveRequest;
 impl IsActiveRequest {
     /// Serialize this request into bytes for the provided connection
@@ -457,6 +467,7 @@ impl crate::x11_utils::ReplyRequest for IsActiveRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsActiveReply {
     pub sequence: u16,
     pub length: u32,
@@ -484,6 +495,7 @@ impl TryParse for IsActiveReply {
 /// Opcode for the QueryScreens request
 pub const QUERY_SCREENS_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryScreensRequest;
 impl QueryScreensRequest {
     /// Serialize this request into bytes for the provided connection
@@ -526,6 +538,7 @@ impl crate::x11_utils::ReplyRequest for QueryScreensRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryScreensReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -45,6 +45,7 @@ pub type DeviceId = u16;
 pub type Fp1616 = i32;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Fp3232 {
     pub integral: i32,
     pub frac: u32,
@@ -83,6 +84,7 @@ impl Serialize for Fp3232 {
 /// Opcode for the GetExtensionVersion request
 pub const GET_EXTENSION_VERSION_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetExtensionVersionRequest<'input> {
     pub name: Cow<'input, [u8]>,
 }
@@ -146,6 +148,7 @@ impl<'input> crate::x11_utils::ReplyRequest for GetExtensionVersionRequest<'inpu
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetExtensionVersionReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -177,6 +180,7 @@ impl TryParse for GetExtensionVersionReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceUse(u8);
 impl DeviceUse {
     pub const IS_X_POINTER: Self = Self(0);
@@ -241,6 +245,7 @@ impl core::fmt::Debug for DeviceUse  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputClass(u8);
 impl InputClass {
     pub const KEY: Self = Self(0);
@@ -309,6 +314,7 @@ impl core::fmt::Debug for InputClass  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValuatorMode(u8);
 impl ValuatorMode {
     pub const RELATIVE: Self = Self(0);
@@ -367,6 +373,7 @@ impl core::fmt::Debug for ValuatorMode  {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceInfo {
     pub device_type: xproto::Atom,
     pub device_id: u8,
@@ -414,6 +421,7 @@ impl Serialize for DeviceInfo {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyInfo {
     pub class_id: InputClass,
     pub len: u8,
@@ -465,6 +473,7 @@ impl Serialize for KeyInfo {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ButtonInfo {
     pub class_id: InputClass,
     pub len: u8,
@@ -502,6 +511,7 @@ impl Serialize for ButtonInfo {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AxisInfo {
     pub resolution: u32,
     pub minimum: i32,
@@ -546,6 +556,7 @@ impl Serialize for AxisInfo {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValuatorInfo {
     pub class_id: InputClass,
     pub len: u8,
@@ -602,6 +613,7 @@ impl ValuatorInfo {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputInfoInfoKey {
     pub min_keycode: KeyCode,
     pub max_keycode: KeyCode,
@@ -641,6 +653,7 @@ impl Serialize for InputInfoInfoKey {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputInfoInfoButton {
     pub num_buttons: u16,
 }
@@ -666,6 +679,7 @@ impl Serialize for InputInfoInfoButton {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputInfoInfoValuator {
     pub mode: ValuatorMode,
     pub motion_size: u32,
@@ -714,6 +728,7 @@ impl InputInfoInfoValuator {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum InputInfoInfo {
     Key(InputInfoInfoKey),
     Button(InputInfoInfoButton),
@@ -806,6 +821,7 @@ impl InputInfoInfo {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputInfo {
     pub len: u8,
     pub info: InputInfoInfo,
@@ -836,6 +852,7 @@ impl Serialize for InputInfo {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceName {
     pub string: Vec<u8>,
 }
@@ -881,6 +898,7 @@ impl DeviceName {
 /// Opcode for the ListInputDevices request
 pub const LIST_INPUT_DEVICES_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListInputDevicesRequest;
 impl ListInputDevicesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -923,6 +941,7 @@ impl crate::x11_utils::ReplyRequest for ListInputDevicesRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListInputDevicesReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -977,6 +996,7 @@ impl ListInputDevicesReply {
 pub type EventTypeBase = u8;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputClassInfo {
     pub class_id: InputClass,
     pub event_type_base: EventTypeBase,
@@ -1010,6 +1030,7 @@ impl Serialize for InputClassInfo {
 /// Opcode for the OpenDevice request
 pub const OPEN_DEVICE_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenDeviceRequest {
     pub device_id: u8,
 }
@@ -1062,6 +1083,7 @@ impl crate::x11_utils::ReplyRequest for OpenDeviceRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenDeviceReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1112,6 +1134,7 @@ impl OpenDeviceReply {
 /// Opcode for the CloseDevice request
 pub const CLOSE_DEVICE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CloseDeviceRequest {
     pub device_id: u8,
 }
@@ -1165,6 +1188,7 @@ impl crate::x11_utils::VoidRequest for CloseDeviceRequest {
 /// Opcode for the SetDeviceMode request
 pub const SET_DEVICE_MODE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceModeRequest {
     pub device_id: u8,
     pub mode: ValuatorMode,
@@ -1222,6 +1246,7 @@ impl crate::x11_utils::ReplyRequest for SetDeviceModeRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceModeReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1252,6 +1277,7 @@ impl TryParse for SetDeviceModeReply {
 /// Opcode for the SelectExtensionEvent request
 pub const SELECT_EXTENSION_EVENT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectExtensionEventRequest<'input> {
     pub window: xproto::Window,
     pub classes: Cow<'input, [EventClass]>,
@@ -1326,6 +1352,7 @@ impl<'input> crate::x11_utils::VoidRequest for SelectExtensionEventRequest<'inpu
 /// Opcode for the GetSelectedExtensionEvents request
 pub const GET_SELECTED_EXTENSION_EVENTS_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectedExtensionEventsRequest {
     pub window: xproto::Window,
 }
@@ -1377,6 +1404,7 @@ impl crate::x11_utils::ReplyRequest for GetSelectedExtensionEventsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectedExtensionEventsReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1436,6 +1464,7 @@ impl GetSelectedExtensionEventsReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PropagateMode(u8);
 impl PropagateMode {
     pub const ADD_TO_LIST: Self = Self(0);
@@ -1496,6 +1525,7 @@ impl core::fmt::Debug for PropagateMode  {
 /// Opcode for the ChangeDeviceDontPropagateList request
 pub const CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDeviceDontPropagateListRequest<'input> {
     pub window: xproto::Window,
     pub mode: PropagateMode,
@@ -1576,6 +1606,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeDeviceDontPropagateListRequ
 /// Opcode for the GetDeviceDontPropagateList request
 pub const GET_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceDontPropagateListRequest {
     pub window: xproto::Window,
 }
@@ -1627,6 +1658,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceDontPropagateListRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceDontPropagateListReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1670,6 +1702,7 @@ impl GetDeviceDontPropagateListReply {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceTimeCoord {
     pub time: xproto::Timestamp,
     pub axisvalues: Vec<i32>,
@@ -1699,6 +1732,7 @@ impl DeviceTimeCoord {
 /// Opcode for the GetDeviceMotionEvents request
 pub const GET_DEVICE_MOTION_EVENTS_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceMotionEventsRequest {
     pub start: xproto::Timestamp,
     pub stop: xproto::Timestamp,
@@ -1767,6 +1801,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceMotionEventsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceMotionEventsReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1824,6 +1859,7 @@ impl GetDeviceMotionEventsReply {
 /// Opcode for the ChangeKeyboardDevice request
 pub const CHANGE_KEYBOARD_DEVICE_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeKeyboardDeviceRequest {
     pub device_id: u8,
 }
@@ -1876,6 +1912,7 @@ impl crate::x11_utils::ReplyRequest for ChangeKeyboardDeviceRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeKeyboardDeviceReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1906,6 +1943,7 @@ impl TryParse for ChangeKeyboardDeviceReply {
 /// Opcode for the ChangePointerDevice request
 pub const CHANGE_POINTER_DEVICE_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangePointerDeviceRequest {
     pub x_axis: u8,
     pub y_axis: u8,
@@ -1966,6 +2004,7 @@ impl crate::x11_utils::ReplyRequest for ChangePointerDeviceRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangePointerDeviceReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -1996,6 +2035,7 @@ impl TryParse for ChangePointerDeviceReply {
 /// Opcode for the GrabDevice request
 pub const GRAB_DEVICE_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabDeviceRequest<'input> {
     pub grab_window: xproto::Window,
     pub time: xproto::Timestamp,
@@ -2104,6 +2144,7 @@ impl<'input> crate::x11_utils::ReplyRequest for GrabDeviceRequest<'input> {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabDeviceReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -2134,6 +2175,7 @@ impl TryParse for GrabDeviceReply {
 /// Opcode for the UngrabDevice request
 pub const UNGRAB_DEVICE_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabDeviceRequest {
     pub time: xproto::Timestamp,
     pub device_id: u8,
@@ -2193,6 +2235,7 @@ impl crate::x11_utils::VoidRequest for UngrabDeviceRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModifierDevice(u8);
 impl ModifierDevice {
     pub const USE_X_KEYBOARD: Self = Self(255);
@@ -2251,6 +2294,7 @@ impl core::fmt::Debug for ModifierDevice  {
 /// Opcode for the GrabDeviceKey request
 pub const GRAB_DEVICE_KEY_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabDeviceKeyRequest<'input> {
     pub grab_window: xproto::Window,
     pub modifiers: u16,
@@ -2370,6 +2414,7 @@ impl<'input> crate::x11_utils::VoidRequest for GrabDeviceKeyRequest<'input> {
 /// Opcode for the UngrabDeviceKey request
 pub const UNGRAB_DEVICE_KEY_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabDeviceKeyRequest {
     pub grab_window: xproto::Window,
     pub modifiers: u16,
@@ -2446,6 +2491,7 @@ impl crate::x11_utils::VoidRequest for UngrabDeviceKeyRequest {
 /// Opcode for the GrabDeviceButton request
 pub const GRAB_DEVICE_BUTTON_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabDeviceButtonRequest<'input> {
     pub grab_window: xproto::Window,
     pub grabbed_device: u8,
@@ -2565,6 +2611,7 @@ impl<'input> crate::x11_utils::VoidRequest for GrabDeviceButtonRequest<'input> {
 /// Opcode for the UngrabDeviceButton request
 pub const UNGRAB_DEVICE_BUTTON_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabDeviceButtonRequest {
     pub grab_window: xproto::Window,
     pub modifiers: u16,
@@ -2640,6 +2687,7 @@ impl crate::x11_utils::VoidRequest for UngrabDeviceButtonRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceInputMode(u8);
 impl DeviceInputMode {
     pub const ASYNC_THIS_DEVICE: Self = Self(0);
@@ -2708,6 +2756,7 @@ impl core::fmt::Debug for DeviceInputMode  {
 /// Opcode for the AllowDeviceEvents request
 pub const ALLOW_DEVICE_EVENTS_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllowDeviceEventsRequest {
     pub time: xproto::Timestamp,
     pub mode: DeviceInputMode,
@@ -2774,6 +2823,7 @@ impl crate::x11_utils::VoidRequest for AllowDeviceEventsRequest {
 /// Opcode for the GetDeviceFocus request
 pub const GET_DEVICE_FOCUS_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceFocusRequest {
     pub device_id: u8,
 }
@@ -2826,6 +2876,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceFocusRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceFocusReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -2860,6 +2911,7 @@ impl TryParse for GetDeviceFocusReply {
 /// Opcode for the SetDeviceFocus request
 pub const SET_DEVICE_FOCUS_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceFocusRequest {
     pub focus: xproto::Window,
     pub time: xproto::Timestamp,
@@ -2932,6 +2984,7 @@ impl crate::x11_utils::VoidRequest for SetDeviceFocusRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackClass(u8);
 impl FeedbackClass {
     pub const KEYBOARD: Self = Self(0);
@@ -2998,6 +3051,7 @@ impl core::fmt::Debug for FeedbackClass  {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KbdFeedbackState {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -3117,6 +3171,7 @@ impl Serialize for KbdFeedbackState {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PtrFeedbackState {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -3176,6 +3231,7 @@ impl Serialize for PtrFeedbackState {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IntegerFeedbackState {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -3237,6 +3293,7 @@ impl Serialize for IntegerFeedbackState {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StringFeedbackState {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -3292,6 +3349,7 @@ impl StringFeedbackState {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BellFeedbackState {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -3351,6 +3409,7 @@ impl Serialize for BellFeedbackState {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LedFeedbackState {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -3404,6 +3463,7 @@ impl Serialize for LedFeedbackState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackStateDataKeyboard {
     pub pitch: u16,
     pub duration: u16,
@@ -3505,6 +3565,7 @@ impl Serialize for FeedbackStateDataKeyboard {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackStateDataPointer {
     pub accel_num: u16,
     pub accel_denom: u16,
@@ -3546,6 +3607,7 @@ impl Serialize for FeedbackStateDataPointer {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackStateDataString {
     pub max_symbols: u16,
     pub keysyms: Vec<xproto::Keysym>,
@@ -3590,6 +3652,7 @@ impl FeedbackStateDataString {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackStateDataInteger {
     pub resolution: u32,
     pub min_value: i32,
@@ -3633,6 +3696,7 @@ impl Serialize for FeedbackStateDataInteger {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackStateDataLed {
     pub led_mask: u32,
     pub led_values: u32,
@@ -3668,6 +3732,7 @@ impl Serialize for FeedbackStateDataLed {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackStateDataBell {
     pub percent: u8,
     pub pitch: u16,
@@ -3709,6 +3774,7 @@ impl Serialize for FeedbackStateDataBell {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FeedbackStateData {
     Keyboard(FeedbackStateDataKeyboard),
     Pointer(FeedbackStateDataPointer),
@@ -3846,6 +3912,7 @@ impl FeedbackStateData {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackState {
     pub feedback_id: u8,
     pub len: u16,
@@ -3881,6 +3948,7 @@ impl Serialize for FeedbackState {
 /// Opcode for the GetFeedbackControl request
 pub const GET_FEEDBACK_CONTROL_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFeedbackControlRequest {
     pub device_id: u8,
 }
@@ -3933,6 +4001,7 @@ impl crate::x11_utils::ReplyRequest for GetFeedbackControlRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFeedbackControlReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -3976,6 +4045,7 @@ impl GetFeedbackControlReply {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KbdFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -4061,6 +4131,7 @@ impl Serialize for KbdFeedbackCtl {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PtrFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -4120,6 +4191,7 @@ impl Serialize for PtrFeedbackCtl {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IntegerFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -4165,6 +4237,7 @@ impl Serialize for IntegerFeedbackCtl {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StringFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -4219,6 +4292,7 @@ impl StringFeedbackCtl {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BellFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -4278,6 +4352,7 @@ impl Serialize for BellFeedbackCtl {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LedFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
@@ -4331,6 +4406,7 @@ impl Serialize for LedFeedbackCtl {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtlDataKeyboard {
     pub key: KeyCode,
     pub auto_repeat_mode: u8,
@@ -4398,6 +4474,7 @@ impl Serialize for FeedbackCtlDataKeyboard {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtlDataPointer {
     pub num: i16,
     pub denom: i16,
@@ -4439,6 +4516,7 @@ impl Serialize for FeedbackCtlDataPointer {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtlDataString {
     pub keysyms: Vec<xproto::Keysym>,
 }
@@ -4482,6 +4560,7 @@ impl FeedbackCtlDataString {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtlDataInteger {
     pub int_to_display: i32,
 }
@@ -4509,6 +4588,7 @@ impl Serialize for FeedbackCtlDataInteger {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtlDataLed {
     pub led_mask: u32,
     pub led_values: u32,
@@ -4544,6 +4624,7 @@ impl Serialize for FeedbackCtlDataLed {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtlDataBell {
     pub percent: i8,
     pub pitch: i16,
@@ -4585,6 +4666,7 @@ impl Serialize for FeedbackCtlDataBell {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FeedbackCtlData {
     Keyboard(FeedbackCtlDataKeyboard),
     Pointer(FeedbackCtlDataPointer),
@@ -4722,6 +4804,7 @@ impl FeedbackCtlData {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtl {
     pub feedback_id: u8,
     pub len: u16,
@@ -4755,6 +4838,7 @@ impl Serialize for FeedbackCtl {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeFeedbackControlMask(u8);
 impl ChangeFeedbackControlMask {
     pub const KEY_CLICK_PERCENT: Self = Self(1 << 0);
@@ -4838,6 +4922,7 @@ bitmask_binop!(ChangeFeedbackControlMask, u8);
 /// Opcode for the ChangeFeedbackControl request
 pub const CHANGE_FEEDBACK_CONTROL_REQUEST: u8 = 23;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeFeedbackControlRequest {
     pub mask: u32,
     pub device_id: u8,
@@ -4910,6 +4995,7 @@ impl crate::x11_utils::VoidRequest for ChangeFeedbackControlRequest {
 /// Opcode for the GetDeviceKeyMapping request
 pub const GET_DEVICE_KEY_MAPPING_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceKeyMappingRequest {
     pub device_id: u8,
     pub first_keycode: KeyCode,
@@ -4970,6 +5056,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceKeyMappingRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceKeyMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -5015,6 +5102,7 @@ impl GetDeviceKeyMappingReply {
 /// Opcode for the ChangeDeviceKeyMapping request
 pub const CHANGE_DEVICE_KEY_MAPPING_REQUEST: u8 = 25;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDeviceKeyMappingRequest<'input> {
     pub device_id: u8,
     pub first_keycode: KeyCode,
@@ -5097,6 +5185,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeDeviceKeyMappingRequest<'in
 /// Opcode for the GetDeviceModifierMapping request
 pub const GET_DEVICE_MODIFIER_MAPPING_REQUEST: u8 = 26;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceModifierMappingRequest {
     pub device_id: u8,
 }
@@ -5149,6 +5238,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceModifierMappingRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceModifierMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -5196,6 +5286,7 @@ impl GetDeviceModifierMappingReply {
 /// Opcode for the SetDeviceModifierMapping request
 pub const SET_DEVICE_MODIFIER_MAPPING_REQUEST: u8 = 27;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceModifierMappingRequest<'input> {
     pub device_id: u8,
     pub keymaps: Cow<'input, [u8]>,
@@ -5265,6 +5356,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetDeviceModifierMappingRequest<
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceModifierMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -5295,6 +5387,7 @@ impl TryParse for SetDeviceModifierMappingReply {
 /// Opcode for the GetDeviceButtonMapping request
 pub const GET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 28;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceButtonMappingRequest {
     pub device_id: u8,
 }
@@ -5347,6 +5440,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceButtonMappingRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceButtonMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -5398,6 +5492,7 @@ impl GetDeviceButtonMappingReply {
 /// Opcode for the SetDeviceButtonMapping request
 pub const SET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 29;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceButtonMappingRequest<'input> {
     pub device_id: u8,
     pub map: Cow<'input, [u8]>,
@@ -5466,6 +5561,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetDeviceButtonMappingRequest<'i
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceButtonMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -5494,6 +5590,7 @@ impl TryParse for SetDeviceButtonMappingReply {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyState {
     pub class_id: InputClass,
     pub len: u8,
@@ -5569,6 +5666,7 @@ impl Serialize for KeyState {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ButtonState {
     pub class_id: InputClass,
     pub len: u8,
@@ -5644,6 +5742,7 @@ impl Serialize for ButtonState {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValuatorStateModeMask(u8);
 impl ValuatorStateModeMask {
     pub const DEVICE_MODE_ABSOLUTE: Self = Self(1 << 0);
@@ -5703,6 +5802,7 @@ impl core::fmt::Debug for ValuatorStateModeMask  {
 bitmask_binop!(ValuatorStateModeMask, u8);
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValuatorState {
     pub class_id: InputClass,
     pub len: u8,
@@ -5755,6 +5855,7 @@ impl ValuatorState {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputStateDataKey {
     pub num_keys: u8,
     pub keys: [u8; 32],
@@ -5818,6 +5919,7 @@ impl Serialize for InputStateDataKey {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputStateDataButton {
     pub num_buttons: u8,
     pub buttons: [u8; 32],
@@ -5881,6 +5983,7 @@ impl Serialize for InputStateDataButton {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputStateDataValuator {
     pub mode: u8,
     pub valuators: Vec<i32>,
@@ -5925,6 +6028,7 @@ impl InputStateDataValuator {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum InputStateData {
     Key(InputStateDataKey),
     Button(InputStateDataButton),
@@ -6017,6 +6121,7 @@ impl InputStateData {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputState {
     pub len: u8,
     pub data: InputStateData,
@@ -6049,6 +6154,7 @@ impl Serialize for InputState {
 /// Opcode for the QueryDeviceState request
 pub const QUERY_DEVICE_STATE_REQUEST: u8 = 30;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryDeviceStateRequest {
     pub device_id: u8,
 }
@@ -6101,6 +6207,7 @@ impl crate::x11_utils::ReplyRequest for QueryDeviceStateRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryDeviceStateReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -6146,6 +6253,7 @@ impl QueryDeviceStateReply {
 /// Opcode for the DeviceBell request
 pub const DEVICE_BELL_REQUEST: u8 = 32;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceBellRequest {
     pub device_id: u8,
     pub feedback_id: u8,
@@ -6210,6 +6318,7 @@ impl crate::x11_utils::VoidRequest for DeviceBellRequest {
 /// Opcode for the SetDeviceValuators request
 pub const SET_DEVICE_VALUATORS_REQUEST: u8 = 33;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceValuatorsRequest<'input> {
     pub device_id: u8,
     pub first_valuator: u8,
@@ -6284,6 +6393,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetDeviceValuatorsRequest<'input
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceValuatorsReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -6312,6 +6422,7 @@ impl TryParse for SetDeviceValuatorsReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceControl(u16);
 impl DeviceControl {
     pub const RESOLUTION: Self = Self(1);
@@ -6370,6 +6481,7 @@ impl core::fmt::Debug for DeviceControl  {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceResolutionState {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -6427,6 +6539,7 @@ impl DeviceResolutionState {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceAbsCalibState {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -6524,6 +6637,7 @@ impl Serialize for DeviceAbsCalibState {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceAbsAreaState {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -6605,6 +6719,7 @@ impl Serialize for DeviceAbsAreaState {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCoreState {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -6652,6 +6767,7 @@ impl Serialize for DeviceCoreState {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceEnableState {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -6695,6 +6811,7 @@ impl Serialize for DeviceEnableState {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceStateDataResolution {
     pub resolution_values: Vec<u32>,
     pub resolution_min: Vec<u32>,
@@ -6743,6 +6860,7 @@ impl DeviceStateDataResolution {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceStateDataAbsCalib {
     pub min_x: i32,
     pub max_x: i32,
@@ -6826,6 +6944,7 @@ impl Serialize for DeviceStateDataAbsCalib {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceStateDataCore {
     pub status: u8,
     pub iscore: u8,
@@ -6859,6 +6978,7 @@ impl Serialize for DeviceStateDataCore {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceStateDataAbsArea {
     pub offset_x: u32,
     pub offset_y: u32,
@@ -6926,6 +7046,7 @@ impl Serialize for DeviceStateDataAbsArea {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceStateData {
     Resolution(DeviceStateDataResolution),
     AbsCalib(DeviceStateDataAbsCalib),
@@ -7054,6 +7175,7 @@ impl DeviceStateData {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceState {
     pub len: u16,
     pub data: DeviceStateData,
@@ -7086,6 +7208,7 @@ impl Serialize for DeviceState {
 /// Opcode for the GetDeviceControl request
 pub const GET_DEVICE_CONTROL_REQUEST: u8 = 34;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceControlRequest {
     pub control_id: DeviceControl,
     pub device_id: u8,
@@ -7143,6 +7266,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceControlRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceControlReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -7172,6 +7296,7 @@ impl TryParse for GetDeviceControlReply {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceResolutionCtl {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -7226,6 +7351,7 @@ impl DeviceResolutionCtl {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceAbsCalibCtl {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -7323,6 +7449,7 @@ impl Serialize for DeviceAbsCalibCtl {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceAbsAreaCtrl {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -7404,6 +7531,7 @@ impl Serialize for DeviceAbsAreaCtrl {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCoreCtrl {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -7447,6 +7575,7 @@ impl Serialize for DeviceCoreCtrl {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceEnableCtrl {
     pub control_id: DeviceControl,
     pub len: u16,
@@ -7490,6 +7619,7 @@ impl Serialize for DeviceEnableCtrl {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCtlDataResolution {
     pub first_valuator: u8,
     pub resolution_values: Vec<u32>,
@@ -7536,6 +7666,7 @@ impl DeviceCtlDataResolution {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCtlDataAbsCalib {
     pub min_x: i32,
     pub max_x: i32,
@@ -7619,6 +7750,7 @@ impl Serialize for DeviceCtlDataAbsCalib {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCtlDataCore {
     pub status: u8,
 }
@@ -7648,6 +7780,7 @@ impl Serialize for DeviceCtlDataCore {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCtlDataAbsArea {
     pub offset_x: u32,
     pub offset_y: u32,
@@ -7715,6 +7848,7 @@ impl Serialize for DeviceCtlDataAbsArea {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceCtlData {
     Resolution(DeviceCtlDataResolution),
     AbsCalib(DeviceCtlDataAbsCalib),
@@ -7843,6 +7977,7 @@ impl DeviceCtlData {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCtl {
     pub len: u16,
     pub data: DeviceCtlData,
@@ -7875,6 +8010,7 @@ impl Serialize for DeviceCtl {
 /// Opcode for the ChangeDeviceControl request
 pub const CHANGE_DEVICE_CONTROL_REQUEST: u8 = 35;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDeviceControlRequest {
     pub control_id: DeviceControl,
     pub device_id: u8,
@@ -7939,6 +8075,7 @@ impl crate::x11_utils::ReplyRequest for ChangeDeviceControlRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDeviceControlReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -7968,6 +8105,7 @@ impl TryParse for ChangeDeviceControlReply {
 /// Opcode for the ListDeviceProperties request
 pub const LIST_DEVICE_PROPERTIES_REQUEST: u8 = 36;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListDevicePropertiesRequest {
     pub device_id: u8,
 }
@@ -8020,6 +8158,7 @@ impl crate::x11_utils::ReplyRequest for ListDevicePropertiesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListDevicePropertiesReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -8063,6 +8202,7 @@ impl ListDevicePropertiesReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PropertyFormat(u8);
 impl PropertyFormat {
     pub const M8_BITS: Self = Self(8);
@@ -8123,6 +8263,7 @@ impl core::fmt::Debug for PropertyFormat  {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ChangeDevicePropertyAux {
     Data8(Vec<u8>),
     Data16(Vec<u16>),
@@ -8242,6 +8383,7 @@ impl ChangeDevicePropertyAux {
 /// Opcode for the ChangeDeviceProperty request
 pub const CHANGE_DEVICE_PROPERTY_REQUEST: u8 = 37;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDevicePropertyRequest<'input> {
     pub property: xproto::Atom,
     pub type_: xproto::Atom,
@@ -8345,6 +8487,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeDevicePropertyRequest<'inpu
 /// Opcode for the DeleteDeviceProperty request
 pub const DELETE_DEVICE_PROPERTY_REQUEST: u8 = 38;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteDevicePropertyRequest {
     pub property: xproto::Atom,
     pub device_id: u8,
@@ -8406,6 +8549,7 @@ impl crate::x11_utils::VoidRequest for DeleteDevicePropertyRequest {
 /// Opcode for the GetDeviceProperty request
 pub const GET_DEVICE_PROPERTY_REQUEST: u8 = 39;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDevicePropertyRequest {
     pub property: xproto::Atom,
     pub type_: xproto::Atom,
@@ -8494,6 +8638,7 @@ impl crate::x11_utils::ReplyRequest for GetDevicePropertyRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GetDevicePropertyItems {
     Data8(Vec<u8>),
     Data16(Vec<u16>),
@@ -8573,6 +8718,7 @@ impl GetDevicePropertyItems {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDevicePropertyReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
@@ -8609,6 +8755,7 @@ impl TryParse for GetDevicePropertyReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Device(bool);
 impl Device {
     pub const ALL: Self = Self(false);
@@ -8679,6 +8826,7 @@ impl core::fmt::Debug for Device  {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GroupInfo {
     pub base: u8,
     pub latched: u8,
@@ -8719,6 +8867,7 @@ impl Serialize for GroupInfo {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModifierInfo {
     pub base: u32,
     pub latched: u32,
@@ -8773,6 +8922,7 @@ impl Serialize for ModifierInfo {
 /// Opcode for the XIQueryPointer request
 pub const XI_QUERY_POINTER_REQUEST: u8 = 40;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIQueryPointerRequest {
     pub window: xproto::Window,
     pub deviceid: DeviceId,
@@ -8833,6 +8983,7 @@ impl crate::x11_utils::ReplyRequest for XIQueryPointerRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIQueryPointerReply {
     pub sequence: u16,
     pub length: u32,
@@ -8895,6 +9046,7 @@ impl XIQueryPointerReply {
 /// Opcode for the XIWarpPointer request
 pub const XI_WARP_POINTER_REQUEST: u8 = 41;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIWarpPointerRequest {
     pub src_win: xproto::Window,
     pub dst_win: xproto::Window,
@@ -9008,6 +9160,7 @@ impl crate::x11_utils::VoidRequest for XIWarpPointerRequest {
 /// Opcode for the XIChangeCursor request
 pub const XI_CHANGE_CURSOR_REQUEST: u8 = 42;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIChangeCursorRequest {
     pub window: xproto::Window,
     pub cursor: xproto::Cursor,
@@ -9075,6 +9228,7 @@ impl crate::x11_utils::VoidRequest for XIChangeCursorRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyChangeType(u16);
 impl HierarchyChangeType {
     pub const ADD_MASTER: Self = Self(1);
@@ -9131,6 +9285,7 @@ impl core::fmt::Debug for HierarchyChangeType  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeMode(u8);
 impl ChangeMode {
     pub const ATTACH: Self = Self(1);
@@ -9189,6 +9344,7 @@ impl core::fmt::Debug for ChangeMode  {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddMaster {
     pub type_: HierarchyChangeType,
     pub len: u16,
@@ -9251,6 +9407,7 @@ impl AddMaster {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RemoveMaster {
     pub type_: HierarchyChangeType,
     pub len: u16,
@@ -9311,6 +9468,7 @@ impl Serialize for RemoveMaster {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttachSlave {
     pub type_: HierarchyChangeType,
     pub len: u16,
@@ -9356,6 +9514,7 @@ impl Serialize for AttachSlave {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DetachSlave {
     pub type_: HierarchyChangeType,
     pub len: u16,
@@ -9399,6 +9558,7 @@ impl Serialize for DetachSlave {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyChangeDataAddMaster {
     pub send_core: bool,
     pub enable: bool,
@@ -9453,6 +9613,7 @@ impl HierarchyChangeDataAddMaster {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyChangeDataRemoveMaster {
     pub deviceid: DeviceId,
     pub return_mode: ChangeMode,
@@ -9499,6 +9660,7 @@ impl Serialize for HierarchyChangeDataRemoveMaster {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyChangeDataAttachSlave {
     pub deviceid: DeviceId,
     pub master: DeviceId,
@@ -9530,6 +9692,7 @@ impl Serialize for HierarchyChangeDataAttachSlave {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyChangeDataDetachSlave {
     pub deviceid: DeviceId,
 }
@@ -9559,6 +9722,7 @@ impl Serialize for HierarchyChangeDataDetachSlave {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum HierarchyChangeData {
     AddMaster(HierarchyChangeDataAddMaster),
     RemoveMaster(HierarchyChangeDataRemoveMaster),
@@ -9666,6 +9830,7 @@ impl HierarchyChangeData {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyChange {
     pub len: u16,
     pub data: HierarchyChangeData,
@@ -9698,6 +9863,7 @@ impl Serialize for HierarchyChange {
 /// Opcode for the XIChangeHierarchy request
 pub const XI_CHANGE_HIERARCHY_REQUEST: u8 = 43;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIChangeHierarchyRequest<'input> {
     pub changes: Cow<'input, [HierarchyChange]>,
 }
@@ -9763,6 +9929,7 @@ impl<'input> crate::x11_utils::VoidRequest for XIChangeHierarchyRequest<'input> 
 /// Opcode for the XISetClientPointer request
 pub const XI_SET_CLIENT_POINTER_REQUEST: u8 = 44;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XISetClientPointerRequest {
     pub window: xproto::Window,
     pub deviceid: DeviceId,
@@ -9824,6 +9991,7 @@ impl crate::x11_utils::VoidRequest for XISetClientPointerRequest {
 /// Opcode for the XIGetClientPointer request
 pub const XI_GET_CLIENT_POINTER_REQUEST: u8 = 45;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetClientPointerRequest {
     pub window: xproto::Window,
 }
@@ -9875,6 +10043,7 @@ impl crate::x11_utils::ReplyRequest for XIGetClientPointerRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetClientPointerReply {
     pub sequence: u16,
     pub length: u32,
@@ -9904,6 +10073,7 @@ impl TryParse for XIGetClientPointerReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIEventMask(u32);
 impl XIEventMask {
     pub const DEVICE_CHANGED: Self = Self(1 << 1);
@@ -9999,6 +10169,7 @@ impl core::fmt::Debug for XIEventMask  {
 bitmask_binop!(XIEventMask, u32);
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EventMask {
     pub deviceid: DeviceId,
     pub mask: Vec<u32>,
@@ -10046,6 +10217,7 @@ impl EventMask {
 /// Opcode for the XISelectEvents request
 pub const XI_SELECT_EVENTS_REQUEST: u8 = 46;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XISelectEventsRequest<'input> {
     pub window: xproto::Window,
     pub masks: Cow<'input, [EventMask]>,
@@ -10120,6 +10292,7 @@ impl<'input> crate::x11_utils::VoidRequest for XISelectEventsRequest<'input> {
 /// Opcode for the XIQueryVersion request
 pub const XI_QUERY_VERSION_REQUEST: u8 = 47;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIQueryVersionRequest {
     pub major_version: u16,
     pub minor_version: u16,
@@ -10175,6 +10348,7 @@ impl crate::x11_utils::ReplyRequest for XIQueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIQueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -10203,6 +10377,7 @@ impl TryParse for XIQueryVersionReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClassType(u16);
 impl DeviceClassType {
     pub const KEY: Self = Self(0);
@@ -10261,6 +10436,7 @@ impl core::fmt::Debug for DeviceClassType  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceType(u16);
 impl DeviceType {
     pub const MASTER_POINTER: Self = Self(1);
@@ -10319,6 +10495,7 @@ impl core::fmt::Debug for DeviceType  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScrollFlags(u8);
 impl ScrollFlags {
     pub const NO_EMULATION: Self = Self(1 << 0);
@@ -10378,6 +10555,7 @@ impl core::fmt::Debug for ScrollFlags  {
 bitmask_binop!(ScrollFlags, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScrollType(u16);
 impl ScrollType {
     pub const VERTICAL: Self = Self(1);
@@ -10430,6 +10608,7 @@ impl core::fmt::Debug for ScrollType  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TouchMode(u8);
 impl TouchMode {
     pub const DIRECT: Self = Self(1);
@@ -10488,6 +10667,7 @@ impl core::fmt::Debug for TouchMode  {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ButtonClass {
     pub type_: DeviceClassType,
     pub len: u16,
@@ -10544,6 +10724,7 @@ impl ButtonClass {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyClass {
     pub type_: DeviceClassType,
     pub len: u16,
@@ -10596,6 +10777,7 @@ impl KeyClass {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScrollClass {
     pub type_: DeviceClassType,
     pub len: u16,
@@ -10672,6 +10854,7 @@ impl Serialize for ScrollClass {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TouchClass {
     pub type_: DeviceClassType,
     pub len: u16,
@@ -10722,6 +10905,7 @@ impl Serialize for TouchClass {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValuatorClass {
     pub type_: DeviceClassType,
     pub len: u16,
@@ -10830,6 +11014,7 @@ impl Serialize for ValuatorClass {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClassDataKey {
     pub keys: Vec<u32>,
 }
@@ -10870,6 +11055,7 @@ impl DeviceClassDataKey {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClassDataButton {
     pub state: Vec<u32>,
     pub labels: Vec<xproto::Atom>,
@@ -10914,6 +11100,7 @@ impl DeviceClassDataButton {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClassDataValuator {
     pub number: u16,
     pub label: xproto::Atom,
@@ -11002,6 +11189,7 @@ impl Serialize for DeviceClassDataValuator {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClassDataScroll {
     pub number: u16,
     pub scroll_type: ScrollType,
@@ -11058,6 +11246,7 @@ impl Serialize for DeviceClassDataScroll {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClassDataTouch {
     pub mode: TouchMode,
     pub num_touches: u8,
@@ -11088,6 +11277,7 @@ impl Serialize for DeviceClassDataTouch {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceClassData {
     Key(DeviceClassDataKey),
     Button(DeviceClassDataButton),
@@ -11210,6 +11400,7 @@ impl DeviceClassData {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClass {
     pub len: u16,
     pub sourceid: DeviceId,
@@ -11243,6 +11434,7 @@ impl Serialize for DeviceClass {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIDeviceInfo {
     pub deviceid: DeviceId,
     pub type_: DeviceType,
@@ -11328,6 +11520,7 @@ impl XIDeviceInfo {
 /// Opcode for the XIQueryDevice request
 pub const XI_QUERY_DEVICE_REQUEST: u8 = 48;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIQueryDeviceRequest {
     pub deviceid: DeviceId,
 }
@@ -11380,6 +11573,7 @@ impl crate::x11_utils::ReplyRequest for XIQueryDeviceRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIQueryDeviceReply {
     pub sequence: u16,
     pub length: u32,
@@ -11424,6 +11618,7 @@ impl XIQueryDeviceReply {
 /// Opcode for the XISetFocus request
 pub const XI_SET_FOCUS_REQUEST: u8 = 49;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XISetFocusRequest {
     pub window: xproto::Window,
     pub time: xproto::Timestamp,
@@ -11493,6 +11688,7 @@ impl crate::x11_utils::VoidRequest for XISetFocusRequest {
 /// Opcode for the XIGetFocus request
 pub const XI_GET_FOCUS_REQUEST: u8 = 50;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetFocusRequest {
     pub deviceid: DeviceId,
 }
@@ -11545,6 +11741,7 @@ impl crate::x11_utils::ReplyRequest for XIGetFocusRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetFocusReply {
     pub sequence: u16,
     pub length: u32,
@@ -11571,6 +11768,7 @@ impl TryParse for XIGetFocusReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabOwner(bool);
 impl GrabOwner {
     pub const NO_OWNER: Self = Self(false);
@@ -11643,6 +11841,7 @@ impl core::fmt::Debug for GrabOwner  {
 /// Opcode for the XIGrabDevice request
 pub const XI_GRAB_DEVICE_REQUEST: u8 = 51;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGrabDeviceRequest<'input> {
     pub window: xproto::Window,
     pub time: xproto::Timestamp,
@@ -11761,6 +11960,7 @@ impl<'input> crate::x11_utils::ReplyRequest for XIGrabDeviceRequest<'input> {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGrabDeviceReply {
     pub sequence: u16,
     pub length: u32,
@@ -11790,6 +11990,7 @@ impl TryParse for XIGrabDeviceReply {
 /// Opcode for the XIUngrabDevice request
 pub const XI_UNGRAB_DEVICE_REQUEST: u8 = 52;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIUngrabDeviceRequest {
     pub time: xproto::Timestamp,
     pub deviceid: DeviceId,
@@ -11849,6 +12050,7 @@ impl crate::x11_utils::VoidRequest for XIUngrabDeviceRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EventMode(u8);
 impl EventMode {
     pub const ASYNC_DEVICE: Self = Self(0);
@@ -11921,6 +12123,7 @@ impl core::fmt::Debug for EventMode  {
 /// Opcode for the XIAllowEvents request
 pub const XI_ALLOW_EVENTS_REQUEST: u8 = 53;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIAllowEventsRequest {
     pub time: xproto::Timestamp,
     pub deviceid: DeviceId,
@@ -12001,6 +12204,7 @@ impl crate::x11_utils::VoidRequest for XIAllowEventsRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabMode22(u8);
 impl GrabMode22 {
     pub const SYNC: Self = Self(0);
@@ -12061,6 +12265,7 @@ impl core::fmt::Debug for GrabMode22  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabType(u8);
 impl GrabType {
     pub const BUTTON: Self = Self(0);
@@ -12125,6 +12330,7 @@ impl core::fmt::Debug for GrabType  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModifierMask(u32);
 impl ModifierMask {
     pub const ANY: Self = Self(1 << 31);
@@ -12170,6 +12376,7 @@ impl core::fmt::Debug for ModifierMask  {
 bitmask_binop!(ModifierMask, u32);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabModifierInfo {
     pub modifiers: u32,
     pub status: xproto::GrabStatus,
@@ -12211,6 +12418,7 @@ impl Serialize for GrabModifierInfo {
 /// Opcode for the XIPassiveGrabDevice request
 pub const XI_PASSIVE_GRAB_DEVICE_REQUEST: u8 = 54;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIPassiveGrabDeviceRequest<'input> {
     pub time: xproto::Timestamp,
     pub grab_window: xproto::Window,
@@ -12357,6 +12565,7 @@ impl<'input> crate::x11_utils::ReplyRequest for XIPassiveGrabDeviceRequest<'inpu
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIPassiveGrabDeviceReply {
     pub sequence: u16,
     pub length: u32,
@@ -12401,6 +12610,7 @@ impl XIPassiveGrabDeviceReply {
 /// Opcode for the XIPassiveUngrabDevice request
 pub const XI_PASSIVE_UNGRAB_DEVICE_REQUEST: u8 = 55;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIPassiveUngrabDeviceRequest<'input> {
     pub grab_window: xproto::Window,
     pub detail: u32,
@@ -12499,6 +12709,7 @@ impl<'input> crate::x11_utils::VoidRequest for XIPassiveUngrabDeviceRequest<'inp
 /// Opcode for the XIListProperties request
 pub const XI_LIST_PROPERTIES_REQUEST: u8 = 56;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIListPropertiesRequest {
     pub deviceid: DeviceId,
 }
@@ -12551,6 +12762,7 @@ impl crate::x11_utils::ReplyRequest for XIListPropertiesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIListPropertiesReply {
     pub sequence: u16,
     pub length: u32,
@@ -12593,6 +12805,7 @@ impl XIListPropertiesReply {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum XIChangePropertyAux {
     Data8(Vec<u8>),
     Data16(Vec<u16>),
@@ -12712,6 +12925,7 @@ impl XIChangePropertyAux {
 /// Opcode for the XIChangeProperty request
 pub const XI_CHANGE_PROPERTY_REQUEST: u8 = 57;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIChangePropertyRequest<'input> {
     pub deviceid: DeviceId,
     pub mode: xproto::PropMode,
@@ -12814,6 +13028,7 @@ impl<'input> crate::x11_utils::VoidRequest for XIChangePropertyRequest<'input> {
 /// Opcode for the XIDeleteProperty request
 pub const XI_DELETE_PROPERTY_REQUEST: u8 = 58;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIDeletePropertyRequest {
     pub deviceid: DeviceId,
     pub property: xproto::Atom,
@@ -12875,6 +13090,7 @@ impl crate::x11_utils::VoidRequest for XIDeletePropertyRequest {
 /// Opcode for the XIGetProperty request
 pub const XI_GET_PROPERTY_REQUEST: u8 = 59;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetPropertyRequest {
     pub deviceid: DeviceId,
     pub delete: bool,
@@ -12963,6 +13179,7 @@ impl crate::x11_utils::ReplyRequest for XIGetPropertyRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum XIGetPropertyItems {
     Data8(Vec<u8>),
     Data16(Vec<u16>),
@@ -13042,6 +13259,7 @@ impl XIGetPropertyItems {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetPropertyReply {
     pub sequence: u16,
     pub length: u32,
@@ -13077,6 +13295,7 @@ impl TryParse for XIGetPropertyReply {
 /// Opcode for the XIGetSelectedEvents request
 pub const XI_GET_SELECTED_EVENTS_REQUEST: u8 = 60;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetSelectedEventsRequest {
     pub window: xproto::Window,
 }
@@ -13128,6 +13347,7 @@ impl crate::x11_utils::ReplyRequest for XIGetSelectedEventsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetSelectedEventsReply {
     pub sequence: u16,
     pub length: u32,
@@ -13170,6 +13390,7 @@ impl XIGetSelectedEventsReply {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BarrierReleasePointerInfo {
     pub deviceid: DeviceId,
     pub barrier: xfixes::Barrier,
@@ -13218,6 +13439,7 @@ impl Serialize for BarrierReleasePointerInfo {
 /// Opcode for the XIBarrierReleasePointer request
 pub const XI_BARRIER_RELEASE_POINTER_REQUEST: u8 = 61;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIBarrierReleasePointerRequest<'input> {
     pub barriers: Cow<'input, [BarrierReleasePointerInfo]>,
 }
@@ -13282,6 +13504,7 @@ impl<'input> crate::x11_utils::VoidRequest for XIBarrierReleasePointerRequest<'i
 /// Opcode for the DeviceValuator event
 pub const DEVICE_VALUATOR_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceValuatorEvent {
     pub response_type: u8,
     pub device_id: u8,
@@ -13378,6 +13601,7 @@ impl From<DeviceValuatorEvent> for [u8; 32] {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MoreEventsMask(u8);
 impl MoreEventsMask {
     pub const MORE_EVENTS: Self = Self(1 << 7);
@@ -13437,6 +13661,7 @@ bitmask_binop!(MoreEventsMask, u8);
 /// Opcode for the DeviceKeyPress event
 pub const DEVICE_KEY_PRESS_EVENT: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceKeyPressEvent {
     pub response_type: u8,
     pub detail: u8,
@@ -13554,6 +13779,7 @@ pub type DeviceMotionNotifyEvent = DeviceKeyPressEvent;
 /// Opcode for the DeviceFocusIn event
 pub const DEVICE_FOCUS_IN_EVENT: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceFocusInEvent {
     pub response_type: u8,
     pub detail: xproto::NotifyDetail,
@@ -13647,6 +13873,7 @@ pub const PROXIMITY_OUT_EVENT: u8 = 9;
 pub type ProximityOutEvent = DeviceKeyPressEvent;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClassesReportedMask(u8);
 impl ClassesReportedMask {
     pub const OUT_OF_PROXIMITY: Self = Self(1 << 7);
@@ -13714,6 +13941,7 @@ bitmask_binop!(ClassesReportedMask, u8);
 /// Opcode for the DeviceStateNotify event
 pub const DEVICE_STATE_NOTIFY_EVENT: u8 = 10;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceStateNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
@@ -13815,6 +14043,7 @@ impl From<DeviceStateNotifyEvent> for [u8; 32] {
 /// Opcode for the DeviceMappingNotify event
 pub const DEVICE_MAPPING_NOTIFY_EVENT: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceMappingNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
@@ -13896,6 +14125,7 @@ impl From<DeviceMappingNotifyEvent> for [u8; 32] {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDevice(u8);
 impl ChangeDevice {
     pub const NEW_POINTER: Self = Self(0);
@@ -13956,6 +14186,7 @@ impl core::fmt::Debug for ChangeDevice  {
 /// Opcode for the ChangeDeviceNotify event
 pub const CHANGE_DEVICE_NOTIFY_EVENT: u8 = 12;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDeviceNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
@@ -14032,6 +14263,7 @@ impl From<ChangeDeviceNotifyEvent> for [u8; 32] {
 /// Opcode for the DeviceKeyStateNotify event
 pub const DEVICE_KEY_STATE_NOTIFY_EVENT: u8 = 13;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceKeyStateNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
@@ -14103,6 +14335,7 @@ impl From<DeviceKeyStateNotifyEvent> for [u8; 32] {
 /// Opcode for the DeviceButtonStateNotify event
 pub const DEVICE_BUTTON_STATE_NOTIFY_EVENT: u8 = 14;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceButtonStateNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
@@ -14172,6 +14405,7 @@ impl From<DeviceButtonStateNotifyEvent> for [u8; 32] {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceChange(u8);
 impl DeviceChange {
     pub const ADDED: Self = Self(0);
@@ -14240,6 +14474,7 @@ impl core::fmt::Debug for DeviceChange  {
 /// Opcode for the DevicePresenceNotify event
 pub const DEVICE_PRESENCE_NOTIFY_EVENT: u8 = 15;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DevicePresenceNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -14320,6 +14555,7 @@ impl From<DevicePresenceNotifyEvent> for [u8; 32] {
 /// Opcode for the DevicePropertyNotify event
 pub const DEVICE_PROPERTY_NOTIFY_EVENT: u8 = 16;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DevicePropertyNotifyEvent {
     pub response_type: u8,
     pub state: xproto::Property,
@@ -14397,6 +14633,7 @@ impl From<DevicePropertyNotifyEvent> for [u8; 32] {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeReason(u8);
 impl ChangeReason {
     pub const SLAVE_SWITCH: Self = Self(1);
@@ -14457,6 +14694,7 @@ impl core::fmt::Debug for ChangeReason  {
 /// Opcode for the DeviceChanged event
 pub const DEVICE_CHANGED_EVENT: u16 = 1;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceChangedEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -14509,6 +14747,7 @@ impl DeviceChangedEvent {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyEventFlags(u32);
 impl KeyEventFlags {
     pub const KEY_REPEAT: Self = Self(1 << 16);
@@ -14556,6 +14795,7 @@ bitmask_binop!(KeyEventFlags, u32);
 /// Opcode for the KeyPress event
 pub const KEY_PRESS_EVENT: u16 = 2;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyPressEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -14649,6 +14889,7 @@ pub const KEY_RELEASE_EVENT: u16 = 3;
 pub type KeyReleaseEvent = KeyPressEvent;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PointerEventFlags(u32);
 impl PointerEventFlags {
     pub const POINTER_EMULATED: Self = Self(1 << 16);
@@ -14696,6 +14937,7 @@ bitmask_binop!(PointerEventFlags, u32);
 /// Opcode for the ButtonPress event
 pub const BUTTON_PRESS_EVENT: u16 = 4;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ButtonPressEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -14793,6 +15035,7 @@ pub const MOTION_EVENT: u16 = 6;
 pub type MotionEvent = ButtonPressEvent;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyMode(u8);
 impl NotifyMode {
     pub const NORMAL: Self = Self(0);
@@ -14859,6 +15102,7 @@ impl core::fmt::Debug for NotifyMode  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyDetail(u8);
 impl NotifyDetail {
     pub const ANCESTOR: Self = Self(0);
@@ -14931,6 +15175,7 @@ impl core::fmt::Debug for NotifyDetail  {
 /// Opcode for the Enter event
 pub const ENTER_EVENT: u16 = 7;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnterEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15019,6 +15264,7 @@ pub const FOCUS_OUT_EVENT: u16 = 10;
 pub type FocusOutEvent = EnterEvent;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyMask(u8);
 impl HierarchyMask {
     pub const MASTER_ADDED: Self = Self(1 << 0);
@@ -15090,6 +15336,7 @@ impl core::fmt::Debug for HierarchyMask  {
 bitmask_binop!(HierarchyMask, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyInfo {
     pub deviceid: DeviceId,
     pub attachment: DeviceId,
@@ -15147,6 +15394,7 @@ impl Serialize for HierarchyInfo {
 /// Opcode for the Hierarchy event
 pub const HIERARCHY_EVENT: u16 = 11;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15196,6 +15444,7 @@ impl HierarchyEvent {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PropertyFlag(u8);
 impl PropertyFlag {
     pub const DELETED: Self = Self(0);
@@ -15258,6 +15507,7 @@ impl core::fmt::Debug for PropertyFlag  {
 /// Opcode for the Property event
 pub const PROPERTY_EVENT: u16 = 12;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PropertyEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15294,6 +15544,7 @@ impl TryParse for PropertyEvent {
 /// Opcode for the RawKeyPress event
 pub const RAW_KEY_PRESS_EVENT: u16 = 13;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RawKeyPressEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15357,6 +15608,7 @@ pub type RawKeyReleaseEvent = RawKeyPressEvent;
 /// Opcode for the RawButtonPress event
 pub const RAW_BUTTON_PRESS_EVENT: u16 = 15;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RawButtonPressEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15422,6 +15674,7 @@ pub const RAW_MOTION_EVENT: u16 = 17;
 pub type RawMotionEvent = RawButtonPressEvent;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TouchEventFlags(u32);
 impl TouchEventFlags {
     pub const TOUCH_PENDING_END: Self = Self(1 << 16);
@@ -15471,6 +15724,7 @@ bitmask_binop!(TouchEventFlags, u32);
 /// Opcode for the TouchBegin event
 pub const TOUCH_BEGIN_EVENT: u16 = 18;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TouchBeginEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15568,6 +15822,7 @@ pub const TOUCH_END_EVENT: u16 = 20;
 pub type TouchEndEvent = TouchBeginEvent;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TouchOwnershipFlags(u32);
 impl TouchOwnershipFlags {
     pub const NONE: Self = Self(0);
@@ -15614,6 +15869,7 @@ impl core::fmt::Debug for TouchOwnershipFlags  {
 /// Opcode for the TouchOwnership event
 pub const TOUCH_OWNERSHIP_EVENT: u16 = 21;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TouchOwnershipEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15659,6 +15915,7 @@ impl TryParse for TouchOwnershipEvent {
 /// Opcode for the RawTouchBegin event
 pub const RAW_TOUCH_BEGIN_EVENT: u16 = 22;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RawTouchBeginEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15724,6 +15981,7 @@ pub const RAW_TOUCH_END_EVENT: u16 = 24;
 pub type RawTouchEndEvent = RawTouchBeginEvent;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BarrierFlags(u8);
 impl BarrierFlags {
     pub const POINTER_RELEASED: Self = Self(1 << 0);
@@ -15785,6 +16043,7 @@ bitmask_binop!(BarrierFlags, u8);
 /// Opcode for the BarrierHit event
 pub const BARRIER_HIT_EVENT: u16 = 25;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BarrierHitEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -15840,6 +16099,7 @@ pub const BARRIER_LEAVE_EVENT: u16 = 26;
 pub type BarrierLeaveEvent = BarrierHitEvent;
 
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EventForSend([u8; 32]);
 impl EventForSend {
     pub fn as_device_valuator_event(&self) -> DeviceValuatorEvent {
@@ -16051,6 +16311,7 @@ impl From<&DevicePropertyNotifyEvent> for EventForSend {
 /// Opcode for the SendExtensionEvent request
 pub const SEND_EXTENSION_EVENT_REQUEST: u8 = 31;
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SendExtensionEventRequest<'input> {
     pub destination: xproto::Window,
     pub device_id: u8,

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -35,6 +35,7 @@ pub const X11_EXTENSION_NAME: &str = "XKEYBOARD";
 pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Const(u8);
 impl Const {
     pub const MAX_LEGAL_KEY_CODE: Self = Self(255);
@@ -95,6 +96,7 @@ impl core::fmt::Debug for Const  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EventType(u16);
 impl EventType {
     pub const NEW_KEYBOARD_NOTIFY: Self = Self(1 << 0);
@@ -168,6 +170,7 @@ impl core::fmt::Debug for EventType  {
 bitmask_binop!(EventType, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NKNDetail(u8);
 impl NKNDetail {
     pub const KEYCODES: Self = Self(1 << 0);
@@ -229,6 +232,7 @@ impl core::fmt::Debug for NKNDetail  {
 bitmask_binop!(NKNDetail, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AXNDetail(u8);
 impl AXNDetail {
     pub const SK_PRESS: Self = Self(1 << 0);
@@ -298,6 +302,7 @@ impl core::fmt::Debug for AXNDetail  {
 bitmask_binop!(AXNDetail, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapPart(u8);
 impl MapPart {
     pub const KEY_TYPES: Self = Self(1 << 0);
@@ -369,6 +374,7 @@ impl core::fmt::Debug for MapPart  {
 bitmask_binop!(MapPart, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetMapFlags(u8);
 impl SetMapFlags {
     pub const RESIZE_TYPES: Self = Self(1 << 0);
@@ -428,6 +434,7 @@ impl core::fmt::Debug for SetMapFlags  {
 bitmask_binop!(SetMapFlags, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StatePart(u16);
 impl StatePart {
     pub const MODIFIER_STATE: Self = Self(1 << 0);
@@ -505,6 +512,7 @@ impl core::fmt::Debug for StatePart  {
 bitmask_binop!(StatePart, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BoolCtrl(u16);
 impl BoolCtrl {
     pub const REPEAT_KEYS: Self = Self(1 << 0);
@@ -580,6 +588,7 @@ impl core::fmt::Debug for BoolCtrl  {
 bitmask_binop!(BoolCtrl, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Control(u32);
 impl Control {
     pub const GROUPS_WRAP: Self = Self(1 << 27);
@@ -633,6 +642,7 @@ impl core::fmt::Debug for Control  {
 bitmask_binop!(Control, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AXOption(u16);
 impl AXOption {
     pub const SK_PRESS_FB: Self = Self(1 << 0);
@@ -708,6 +718,7 @@ bitmask_binop!(AXOption, u16);
 pub type DeviceSpec = u16;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LedClassResult(u16);
 impl LedClassResult {
     pub const KBD_FEEDBACK_CLASS: Self = Self(0);
@@ -760,6 +771,7 @@ impl core::fmt::Debug for LedClassResult  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LedClass(u16);
 impl LedClass {
     pub const KBD_FEEDBACK_CLASS: Self = Self(0);
@@ -818,6 +830,7 @@ impl core::fmt::Debug for LedClass  {
 pub type LedClassSpec = u16;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BellClassResult(u8);
 impl BellClassResult {
     pub const KBD_FEEDBACK_CLASS: Self = Self(0);
@@ -876,6 +889,7 @@ impl core::fmt::Debug for BellClassResult  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BellClass(u16);
 impl BellClass {
     pub const KBD_FEEDBACK_CLASS: Self = Self(0);
@@ -932,6 +946,7 @@ impl core::fmt::Debug for BellClass  {
 pub type BellClassSpec = u16;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ID(u16);
 impl ID {
     pub const USE_CORE_KBD: Self = Self(256);
@@ -996,6 +1011,7 @@ impl core::fmt::Debug for ID  {
 pub type IDSpec = u16;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Group(u8);
 impl Group {
     pub const M1: Self = Self(0);
@@ -1058,6 +1074,7 @@ impl core::fmt::Debug for Group  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Groups(u8);
 impl Groups {
     pub const ANY: Self = Self(254);
@@ -1116,6 +1133,7 @@ impl core::fmt::Debug for Groups  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetOfGroup(u8);
 impl SetOfGroup {
     pub const GROUP1: Self = Self(1 << 0);
@@ -1179,6 +1197,7 @@ impl core::fmt::Debug for SetOfGroup  {
 bitmask_binop!(SetOfGroup, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetOfGroups(u8);
 impl SetOfGroups {
     pub const ANY: Self = Self(1 << 7);
@@ -1236,6 +1255,7 @@ impl core::fmt::Debug for SetOfGroups  {
 bitmask_binop!(SetOfGroups, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GroupsWrap(u8);
 impl GroupsWrap {
     pub const WRAP_INTO_RANGE: Self = Self(0);
@@ -1297,6 +1317,7 @@ impl core::fmt::Debug for GroupsWrap  {
 bitmask_binop!(GroupsWrap, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VModsHigh(u8);
 impl VModsHigh {
     pub const M15: Self = Self(1 << 7);
@@ -1368,6 +1389,7 @@ impl core::fmt::Debug for VModsHigh  {
 bitmask_binop!(VModsHigh, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VModsLow(u8);
 impl VModsLow {
     pub const M7: Self = Self(1 << 7);
@@ -1439,6 +1461,7 @@ impl core::fmt::Debug for VModsLow  {
 bitmask_binop!(VModsLow, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VMod(u16);
 impl VMod {
     pub const M15: Self = Self(1 << 15);
@@ -1520,6 +1543,7 @@ impl core::fmt::Debug for VMod  {
 bitmask_binop!(VMod, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Explicit(u8);
 impl Explicit {
     pub const V_MOD_MAP: Self = Self(1 << 7);
@@ -1591,6 +1615,7 @@ impl core::fmt::Debug for Explicit  {
 bitmask_binop!(Explicit, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SymInterpretMatch(u8);
 impl SymInterpretMatch {
     pub const NONE_OF: Self = Self(0);
@@ -1655,6 +1680,7 @@ impl core::fmt::Debug for SymInterpretMatch  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SymInterpMatch(u8);
 impl SymInterpMatch {
     pub const LEVEL_ONE_ONLY: Self = Self(1 << 7);
@@ -1713,6 +1739,7 @@ impl core::fmt::Debug for SymInterpMatch  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IMFlag(u8);
 impl IMFlag {
     pub const NO_EXPLICIT: Self = Self(1 << 7);
@@ -1774,6 +1801,7 @@ impl core::fmt::Debug for IMFlag  {
 bitmask_binop!(IMFlag, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IMModsWhich(u8);
 impl IMModsWhich {
     pub const USE_COMPAT: Self = Self(1 << 4);
@@ -1839,6 +1867,7 @@ impl core::fmt::Debug for IMModsWhich  {
 bitmask_binop!(IMModsWhich, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IMGroupsWhich(u8);
 impl IMGroupsWhich {
     pub const USE_COMPAT: Self = Self(1 << 4);
@@ -1904,6 +1933,7 @@ impl core::fmt::Debug for IMGroupsWhich  {
 bitmask_binop!(IMGroupsWhich, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndicatorMap {
     pub flags: IMFlag,
     pub which_groups: IMGroupsWhich,
@@ -1972,6 +2002,7 @@ impl Serialize for IndicatorMap {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CMDetail(u8);
 impl CMDetail {
     pub const SYM_INTERP: Self = Self(1 << 0);
@@ -2031,6 +2062,7 @@ impl core::fmt::Debug for CMDetail  {
 bitmask_binop!(CMDetail, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NameDetail(u16);
 impl NameDetail {
     pub const KEYCODES: Self = Self(1 << 0);
@@ -2108,6 +2140,7 @@ impl core::fmt::Debug for NameDetail  {
 bitmask_binop!(NameDetail, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GBNDetail(u8);
 impl GBNDetail {
     pub const TYPES: Self = Self(1 << 0);
@@ -2179,6 +2212,7 @@ impl core::fmt::Debug for GBNDetail  {
 bitmask_binop!(GBNDetail, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIFeature(u8);
 impl XIFeature {
     pub const KEYBOARDS: Self = Self(1 << 0);
@@ -2244,6 +2278,7 @@ impl core::fmt::Debug for XIFeature  {
 bitmask_binop!(XIFeature, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PerClientFlag(u8);
 impl PerClientFlag {
     pub const DETECTABLE_AUTO_REPEAT: Self = Self(1 << 0);
@@ -2309,6 +2344,7 @@ impl core::fmt::Debug for PerClientFlag  {
 bitmask_binop!(PerClientFlag, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModDef {
     pub mask: u8,
     pub real_mods: u8,
@@ -2345,6 +2381,7 @@ impl Serialize for ModDef {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyName {
     pub name: [u8; 4],
 }
@@ -2373,6 +2410,7 @@ impl Serialize for KeyName {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyAlias {
     pub real: [u8; 4],
     pub alias: [u8; 4],
@@ -2409,6 +2447,7 @@ impl Serialize for KeyAlias {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CountedString16 {
     pub string: Vec<u8>,
     pub alignment_pad: Vec<u8>,
@@ -2456,6 +2495,7 @@ impl CountedString16 {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KTMapEntry {
     pub active: bool,
     pub mods_mask: u8,
@@ -2506,6 +2546,7 @@ impl Serialize for KTMapEntry {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyType {
     pub mods_mask: u8,
     pub mods_mods: u8,
@@ -2569,6 +2610,7 @@ impl KeyType {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeySymMap {
     pub kt_index: [u8; 4],
     pub group_info: u8,
@@ -2621,6 +2663,7 @@ impl KeySymMap {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CommonBehavior {
     pub type_: u8,
     pub data: u8,
@@ -2651,6 +2694,7 @@ impl Serialize for CommonBehavior {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DefaultBehavior {
     pub type_: u8,
 }
@@ -2681,6 +2725,7 @@ impl Serialize for DefaultBehavior {
 pub type LockBehavior = DefaultBehavior;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RadioGroupBehavior {
     pub type_: u8,
     pub group: u8,
@@ -2711,6 +2756,7 @@ impl Serialize for RadioGroupBehavior {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OverlayBehavior {
     pub type_: u8,
     pub key: xproto::Keycode,
@@ -2747,6 +2793,7 @@ pub type PermamentRadioGroupBehavior = RadioGroupBehavior;
 pub type PermamentOverlayBehavior = OverlayBehavior;
 
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Behavior([u8; 2]);
 impl Behavior {
     pub fn as_common(&self) -> CommonBehavior {
@@ -2893,6 +2940,7 @@ impl From<u8> for Behavior {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BehaviorType(u8);
 impl BehaviorType {
     pub const DEFAULT: Self = Self(0);
@@ -2965,6 +3013,7 @@ impl core::fmt::Debug for BehaviorType  {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetBehavior {
     pub keycode: xproto::Keycode,
     pub behavior: Behavior,
@@ -2999,6 +3048,7 @@ impl Serialize for SetBehavior {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetExplicit {
     pub keycode: xproto::Keycode,
     pub explicit: u8,
@@ -3029,6 +3079,7 @@ impl Serialize for SetExplicit {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyModMap {
     pub keycode: xproto::Keycode,
     pub mods: u8,
@@ -3059,6 +3110,7 @@ impl Serialize for KeyModMap {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyVModMap {
     pub keycode: xproto::Keycode,
     pub vmods: u16,
@@ -3093,6 +3145,7 @@ impl Serialize for KeyVModMap {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KTSetMapEntry {
     pub level: u8,
     pub real_mods: u8,
@@ -3129,6 +3182,7 @@ impl Serialize for KTSetMapEntry {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetKeyType {
     pub mask: u8,
     pub real_mods: u8,
@@ -3194,6 +3248,7 @@ impl SetKeyType {
 pub type String8 = u8;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Outline {
     pub corner_radius: u8,
     pub points: Vec<xproto::Point>,
@@ -3241,6 +3296,7 @@ impl Outline {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Shape {
     pub name: xproto::Atom,
     pub primary_ndx: u8,
@@ -3294,6 +3350,7 @@ impl Shape {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Key {
     pub name: [String8; 4],
     pub gap: i16,
@@ -3338,6 +3395,7 @@ impl Serialize for Key {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OverlayKey {
     pub over: [String8; 4],
     pub under: [String8; 4],
@@ -3374,6 +3432,7 @@ impl Serialize for OverlayKey {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OverlayRow {
     pub row_under: u8,
     pub keys: Vec<OverlayKey>,
@@ -3421,6 +3480,7 @@ impl OverlayRow {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Overlay {
     pub name: xproto::Atom,
     pub rows: Vec<OverlayRow>,
@@ -3468,6 +3528,7 @@ impl Overlay {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Row {
     pub top: i16,
     pub left: i16,
@@ -3521,6 +3582,7 @@ impl Row {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DoodadType(u8);
 impl DoodadType {
     pub const OUTLINE: Self = Self(1);
@@ -3585,6 +3647,7 @@ impl core::fmt::Debug for DoodadType  {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Listing {
     pub flags: u16,
     pub string: Vec<String8>,
@@ -3637,6 +3700,7 @@ impl Listing {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceLedInfo {
     pub led_class: LedClass,
     pub led_id: IDSpec,
@@ -3685,6 +3749,7 @@ impl Serialize for DeviceLedInfo {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Error(u8);
 impl Error {
     pub const BAD_DEVICE: Self = Self(255);
@@ -3748,6 +3813,7 @@ impl core::fmt::Debug for Error  {
 pub const KEYBOARD_ERROR: u8 = 0;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SA(u8);
 impl SA {
     pub const CLEAR_LOCKS: Self = Self(1 << 0);
@@ -3811,6 +3877,7 @@ impl core::fmt::Debug for SA  {
 bitmask_binop!(SA, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAType(u8);
 impl SAType {
     pub const NO_ACTION: Self = Self(0);
@@ -3907,6 +3974,7 @@ impl core::fmt::Debug for SAType  {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SANoAction {
     pub type_: SAType,
 }
@@ -3942,6 +4010,7 @@ impl Serialize for SANoAction {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetMods {
     pub type_: SAType,
     pub flags: u8,
@@ -4001,6 +4070,7 @@ pub type SALatchMods = SASetMods;
 pub type SALockMods = SASetMods;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetGroup {
     pub type_: SAType,
     pub flags: u8,
@@ -4048,6 +4118,7 @@ pub type SALatchGroup = SASetGroup;
 pub type SALockGroup = SASetGroup;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAMovePtrFlag(u8);
 impl SAMovePtrFlag {
     pub const NO_ACCELERATION: Self = Self(1 << 0);
@@ -4109,6 +4180,7 @@ impl core::fmt::Debug for SAMovePtrFlag  {
 bitmask_binop!(SAMovePtrFlag, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAMovePtr {
     pub type_: SAType,
     pub flags: u8,
@@ -4164,6 +4236,7 @@ impl Serialize for SAMovePtr {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAPtrBtn {
     pub type_: SAType,
     pub flags: u8,
@@ -4211,6 +4284,7 @@ impl Serialize for SAPtrBtn {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SALockPtrBtn {
     pub type_: SAType,
     pub flags: u8,
@@ -4256,6 +4330,7 @@ impl Serialize for SALockPtrBtn {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetPtrDfltFlag(u8);
 impl SASetPtrDfltFlag {
     pub const DFLT_BTN_ABSOLUTE: Self = Self(1 << 2);
@@ -4315,6 +4390,7 @@ impl core::fmt::Debug for SASetPtrDfltFlag  {
 bitmask_binop!(SASetPtrDfltFlag, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetPtrDflt {
     pub type_: SAType,
     pub flags: u8,
@@ -4362,6 +4438,7 @@ impl Serialize for SASetPtrDflt {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAIsoLockFlag(u8);
 impl SAIsoLockFlag {
     pub const NO_LOCK: Self = Self(1 << 0);
@@ -4427,6 +4504,7 @@ impl core::fmt::Debug for SAIsoLockFlag  {
 bitmask_binop!(SAIsoLockFlag, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAIsoLockNoAffect(u8);
 impl SAIsoLockNoAffect {
     pub const CTRLS: Self = Self(1 << 3);
@@ -4490,6 +4568,7 @@ impl core::fmt::Debug for SAIsoLockNoAffect  {
 bitmask_binop!(SAIsoLockNoAffect, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAIsoLock {
     pub type_: SAType,
     pub flags: u8,
@@ -4551,6 +4630,7 @@ impl Serialize for SAIsoLock {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SATerminate {
     pub type_: SAType,
 }
@@ -4586,6 +4666,7 @@ impl Serialize for SATerminate {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwitchScreenFlag(u8);
 impl SwitchScreenFlag {
     pub const APPLICATION: Self = Self(1 << 0);
@@ -4645,6 +4726,7 @@ impl core::fmt::Debug for SwitchScreenFlag  {
 bitmask_binop!(SwitchScreenFlag, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASwitchScreen {
     pub type_: SAType,
     pub flags: u8,
@@ -4688,6 +4770,7 @@ impl Serialize for SASwitchScreen {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BoolCtrlsHigh(u8);
 impl BoolCtrlsHigh {
     pub const ACCESS_X_FEEDBACK: Self = Self(1 << 0);
@@ -4753,6 +4836,7 @@ impl core::fmt::Debug for BoolCtrlsHigh  {
 bitmask_binop!(BoolCtrlsHigh, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BoolCtrlsLow(u8);
 impl BoolCtrlsLow {
     pub const REPEAT_KEYS: Self = Self(1 << 0);
@@ -4824,6 +4908,7 @@ impl core::fmt::Debug for BoolCtrlsLow  {
 bitmask_binop!(BoolCtrlsLow, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetControls {
     pub type_: SAType,
     pub bool_ctrls_high: u8,
@@ -4871,6 +4956,7 @@ impl Serialize for SASetControls {
 pub type SALockControls = SASetControls;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ActionMessageFlag(u8);
 impl ActionMessageFlag {
     pub const ON_PRESS: Self = Self(1 << 0);
@@ -4932,6 +5018,7 @@ impl core::fmt::Debug for ActionMessageFlag  {
 bitmask_binop!(ActionMessageFlag, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAActionMessage {
     pub type_: SAType,
     pub flags: u8,
@@ -4973,6 +5060,7 @@ impl Serialize for SAActionMessage {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SARedirectKey {
     pub type_: SAType,
     pub newkey: xproto::Keycode,
@@ -5034,6 +5122,7 @@ impl Serialize for SARedirectKey {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SADeviceBtn {
     pub type_: SAType,
     pub flags: u8,
@@ -5085,6 +5174,7 @@ impl Serialize for SADeviceBtn {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LockDeviceFlags(u8);
 impl LockDeviceFlags {
     pub const NO_LOCK: Self = Self(1 << 0);
@@ -5144,6 +5234,7 @@ impl core::fmt::Debug for LockDeviceFlags  {
 bitmask_binop!(LockDeviceFlags, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SALockDeviceBtn {
     pub type_: SAType,
     pub flags: u8,
@@ -5193,6 +5284,7 @@ impl Serialize for SALockDeviceBtn {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAValWhat(u8);
 impl SAValWhat {
     pub const IGNORE_VAL: Self = Self(0);
@@ -5259,6 +5351,7 @@ impl core::fmt::Debug for SAValWhat  {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SADeviceValuator {
     pub type_: SAType,
     pub device: u8,
@@ -5322,6 +5415,7 @@ impl Serialize for SADeviceValuator {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SIAction {
     pub type_: SAType,
     pub data: [u8; 7],
@@ -5359,6 +5453,7 @@ impl Serialize for SIAction {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SymInterpret {
     pub sym: xproto::Keysym,
     pub mods: u8,
@@ -5419,6 +5514,7 @@ impl Serialize for SymInterpret {
 }
 
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Action([u8; 8]);
 impl Action {
     pub fn as_noaction(&self) -> SANoAction {
@@ -5734,6 +5830,7 @@ impl From<SAType> for Action {
 /// Opcode for the UseExtension request
 pub const USE_EXTENSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UseExtensionRequest {
     pub wanted_major: u16,
     pub wanted_minor: u16,
@@ -5789,6 +5886,7 @@ impl crate::x11_utils::ReplyRequest for UseExtensionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UseExtensionReply {
     pub supported: bool,
     pub sequence: u16,
@@ -5818,6 +5916,7 @@ impl TryParse for UseExtensionReply {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase1 {
     pub affect_new_keyboard: u16,
     pub new_keyboard_details: u16,
@@ -5849,6 +5948,7 @@ impl Serialize for SelectEventsAuxBitcase1 {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase2 {
     pub affect_state: u16,
     pub state_details: u16,
@@ -5880,6 +5980,7 @@ impl Serialize for SelectEventsAuxBitcase2 {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase3 {
     pub affect_ctrls: u32,
     pub ctrl_details: u32,
@@ -5915,6 +6016,7 @@ impl Serialize for SelectEventsAuxBitcase3 {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase4 {
     pub affect_indicator_state: u32,
     pub indicator_state_details: u32,
@@ -5950,6 +6052,7 @@ impl Serialize for SelectEventsAuxBitcase4 {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase5 {
     pub affect_indicator_map: u32,
     pub indicator_map_details: u32,
@@ -5985,6 +6088,7 @@ impl Serialize for SelectEventsAuxBitcase5 {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase6 {
     pub affect_names: u16,
     pub names_details: u16,
@@ -6016,6 +6120,7 @@ impl Serialize for SelectEventsAuxBitcase6 {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase7 {
     pub affect_compat: u8,
     pub compat_details: u8,
@@ -6045,6 +6150,7 @@ impl Serialize for SelectEventsAuxBitcase7 {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase8 {
     pub affect_bell: u8,
     pub bell_details: u8,
@@ -6074,6 +6180,7 @@ impl Serialize for SelectEventsAuxBitcase8 {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase9 {
     pub affect_msg_details: u8,
     pub msg_details: u8,
@@ -6103,6 +6210,7 @@ impl Serialize for SelectEventsAuxBitcase9 {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase10 {
     pub affect_access_x: u16,
     pub access_x_details: u16,
@@ -6134,6 +6242,7 @@ impl Serialize for SelectEventsAuxBitcase10 {
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase11 {
     pub affect_ext_dev: u16,
     pub extdev_details: u16,
@@ -6166,6 +6275,7 @@ impl Serialize for SelectEventsAuxBitcase11 {
 }
 /// Auxiliary and optional information for the `select_events` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAux {
     pub bitcase1: Option<SelectEventsAuxBitcase1>,
     pub bitcase2: Option<SelectEventsAuxBitcase2>,
@@ -6423,6 +6533,7 @@ impl SelectEventsAux {
 /// Opcode for the SelectEvents request
 pub const SELECT_EVENTS_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsRequest<'input> {
     pub device_spec: DeviceSpec,
     pub clear: u16,
@@ -6520,6 +6631,7 @@ impl<'input> crate::x11_utils::VoidRequest for SelectEventsRequest<'input> {
 /// Opcode for the Bell request
 pub const BELL_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BellRequest {
     pub device_spec: DeviceSpec,
     pub bell_class: BellClassSpec,
@@ -6630,6 +6742,7 @@ impl crate::x11_utils::VoidRequest for BellRequest {
 /// Opcode for the GetState request
 pub const GET_STATE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStateRequest {
     pub device_spec: DeviceSpec,
 }
@@ -6682,6 +6795,7 @@ impl crate::x11_utils::ReplyRequest for GetStateRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStateReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -6740,6 +6854,7 @@ impl TryParse for GetStateReply {
 /// Opcode for the LatchLockState request
 pub const LATCH_LOCK_STATE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LatchLockStateRequest {
     pub device_spec: DeviceSpec,
     pub affect_mod_locks: u8,
@@ -6831,6 +6946,7 @@ impl crate::x11_utils::VoidRequest for LatchLockStateRequest {
 /// Opcode for the GetControls request
 pub const GET_CONTROLS_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetControlsRequest {
     pub device_spec: DeviceSpec,
 }
@@ -6883,6 +6999,7 @@ impl crate::x11_utils::ReplyRequest for GetControlsRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetControlsReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -6964,6 +7081,7 @@ impl TryParse for GetControlsReply {
 /// Opcode for the SetControls request
 pub const SET_CONTROLS_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetControlsRequest<'input> {
     pub device_spec: DeviceSpec,
     pub affect_internal_real_mods: u8,
@@ -7229,6 +7347,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetControlsRequest<'input> {
 /// Opcode for the GetMap request
 pub const GET_MAP_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapRequest {
     pub device_spec: DeviceSpec,
     pub full: u16,
@@ -7369,6 +7488,7 @@ impl crate::x11_utils::ReplyRequest for GetMapRequest {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapMapBitcase3 {
     pub acts_rtrn_count: Vec<u8>,
     pub acts_rtrn_acts: Vec<Action>,
@@ -7388,6 +7508,7 @@ impl GetMapMapBitcase3 {
     }
 }
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapMap {
     pub types_rtrn: Option<Vec<KeyType>>,
     pub syms_rtrn: Option<Vec<KeySymMap>>,
@@ -7487,6 +7608,7 @@ impl GetMapMap {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -7564,6 +7686,7 @@ impl TryParse for GetMapReply {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetMapAuxBitcase3 {
     pub actions_count: Vec<u8>,
     pub actions: Vec<Action>,
@@ -7599,6 +7722,7 @@ impl SetMapAuxBitcase3 {
 }
 /// Auxiliary and optional information for the `set_map` function
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetMapAux {
     pub types: Option<Vec<SetKeyType>>,
     pub syms: Option<Vec<KeySymMap>>,
@@ -7817,6 +7941,7 @@ impl SetMapAux {
 /// Opcode for the SetMap request
 pub const SET_MAP_REQUEST: u8 = 9;
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetMapRequest<'input> {
     pub device_spec: DeviceSpec,
     pub flags: u16,
@@ -8034,6 +8159,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetMapRequest<'input> {
 /// Opcode for the GetCompatMap request
 pub const GET_COMPAT_MAP_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCompatMapRequest {
     pub device_spec: DeviceSpec,
     pub groups: u8,
@@ -8105,6 +8231,7 @@ impl crate::x11_utils::ReplyRequest for GetCompatMapRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCompatMapReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -8159,6 +8286,7 @@ impl GetCompatMapReply {
 /// Opcode for the SetCompatMap request
 pub const SET_COMPAT_MAP_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCompatMapRequest<'input> {
     pub device_spec: DeviceSpec,
     pub recompute_actions: bool,
@@ -8265,6 +8393,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetCompatMapRequest<'input> {
 /// Opcode for the GetIndicatorState request
 pub const GET_INDICATOR_STATE_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetIndicatorStateRequest {
     pub device_spec: DeviceSpec,
 }
@@ -8317,6 +8446,7 @@ impl crate::x11_utils::ReplyRequest for GetIndicatorStateRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetIndicatorStateReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -8346,6 +8476,7 @@ impl TryParse for GetIndicatorStateReply {
 /// Opcode for the GetIndicatorMap request
 pub const GET_INDICATOR_MAP_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetIndicatorMapRequest {
     pub device_spec: DeviceSpec,
     pub which: u32,
@@ -8406,6 +8537,7 @@ impl crate::x11_utils::ReplyRequest for GetIndicatorMapRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetIndicatorMapReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -8441,6 +8573,7 @@ impl TryParse for GetIndicatorMapReply {
 /// Opcode for the SetIndicatorMap request
 pub const SET_INDICATOR_MAP_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetIndicatorMapRequest<'input> {
     pub device_spec: DeviceSpec,
     pub which: u32,
@@ -8518,6 +8651,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetIndicatorMapRequest<'input> {
 /// Opcode for the GetNamedIndicator request
 pub const GET_NAMED_INDICATOR_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamedIndicatorRequest {
     pub device_spec: DeviceSpec,
     pub led_class: LedClass,
@@ -8591,6 +8725,7 @@ impl crate::x11_utils::ReplyRequest for GetNamedIndicatorRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamedIndicatorReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -8646,6 +8781,7 @@ impl TryParse for GetNamedIndicatorReply {
 /// Opcode for the SetNamedIndicator request
 pub const SET_NAMED_INDICATOR_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetNamedIndicatorRequest {
     pub device_spec: DeviceSpec,
     pub led_class: LedClass,
@@ -8781,6 +8917,7 @@ impl crate::x11_utils::VoidRequest for SetNamedIndicatorRequest {
 /// Opcode for the GetNames request
 pub const GET_NAMES_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamesRequest {
     pub device_spec: DeviceSpec,
     pub which: u32,
@@ -8841,6 +8978,7 @@ impl crate::x11_utils::ReplyRequest for GetNamesRequest {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamesValueListBitcase8 {
     pub n_levels_per_type: Vec<u8>,
     pub kt_level_names: Vec<xproto::Atom>,
@@ -8860,6 +8998,7 @@ impl GetNamesValueListBitcase8 {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamesValueList {
     pub keycodes_name: Option<xproto::Atom>,
     pub geometry_name: Option<xproto::Atom>,
@@ -8997,6 +9136,7 @@ impl GetNamesValueList {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamesReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -9047,6 +9187,7 @@ impl TryParse for GetNamesReply {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetNamesAuxBitcase8 {
     pub n_levels_per_type: Vec<u8>,
     pub kt_level_names: Vec<xproto::Atom>,
@@ -9082,6 +9223,7 @@ impl SetNamesAuxBitcase8 {
 }
 /// Auxiliary and optional information for the `set_names` function
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetNamesAux {
     pub keycodes_name: Option<xproto::Atom>,
     pub geometry_name: Option<xproto::Atom>,
@@ -9419,6 +9561,7 @@ impl SetNamesAux {
 /// Opcode for the SetNames request
 pub const SET_NAMES_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetNamesRequest<'input> {
     pub device_spec: DeviceSpec,
     pub virtual_mods: u16,
@@ -9569,6 +9712,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetNamesRequest<'input> {
 /// Opcode for the PerClientFlags request
 pub const PER_CLIENT_FLAGS_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PerClientFlagsRequest {
     pub device_spec: DeviceSpec,
     pub change: u32,
@@ -9661,6 +9805,7 @@ impl crate::x11_utils::ReplyRequest for PerClientFlagsRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PerClientFlagsReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -9696,6 +9841,7 @@ impl TryParse for PerClientFlagsReply {
 /// Opcode for the ListComponents request
 pub const LIST_COMPONENTS_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListComponentsRequest {
     pub device_spec: DeviceSpec,
     pub max_names: u16,
@@ -9751,6 +9897,7 @@ impl crate::x11_utils::ReplyRequest for ListComponentsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListComponentsReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -9878,6 +10025,7 @@ impl ListComponentsReply {
 /// Opcode for the GetKbdByName request
 pub const GET_KBD_BY_NAME_REQUEST: u8 = 23;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRequest {
     pub device_spec: DeviceSpec,
     pub need: u16,
@@ -9946,6 +10094,7 @@ impl crate::x11_utils::ReplyRequest for GetKbdByNameRequest {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesTypesMapBitcase3 {
     pub acts_rtrn_count: Vec<u8>,
     pub acts_rtrn_acts: Vec<Action>,
@@ -9965,6 +10114,7 @@ impl GetKbdByNameRepliesTypesMapBitcase3 {
     }
 }
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesTypesMap {
     pub types_rtrn: Option<Vec<KeyType>>,
     pub syms_rtrn: Option<Vec<KeySymMap>>,
@@ -10064,6 +10214,7 @@ impl GetKbdByNameRepliesTypesMap {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesTypes {
     pub getmap_type: u8,
     pub type_device_id: u8,
@@ -10134,6 +10285,7 @@ impl TryParse for GetKbdByNameRepliesTypes {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesCompatMap {
     pub compatmap_type: u8,
     pub compat_device_id: u8,
@@ -10179,6 +10331,7 @@ impl GetKbdByNameRepliesCompatMap {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesIndicatorMaps {
     pub indicatormap_type: u8,
     pub indicator_device_id: u8,
@@ -10219,6 +10372,7 @@ impl GetKbdByNameRepliesIndicatorMaps {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesKeyNamesValueListBitcase8 {
     pub n_levels_per_type: Vec<u8>,
     pub kt_level_names: Vec<xproto::Atom>,
@@ -10238,6 +10392,7 @@ impl GetKbdByNameRepliesKeyNamesValueListBitcase8 {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesKeyNamesValueList {
     pub keycodes_name: Option<xproto::Atom>,
     pub geometry_name: Option<xproto::Atom>,
@@ -10375,6 +10530,7 @@ impl GetKbdByNameRepliesKeyNamesValueList {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesKeyNames {
     pub keyname_type: u8,
     pub key_device_id: u8,
@@ -10418,6 +10574,7 @@ impl TryParse for GetKbdByNameRepliesKeyNames {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesGeometry {
     pub geometry_type: u8,
     pub geometry_device_id: u8,
@@ -10462,6 +10619,7 @@ impl TryParse for GetKbdByNameRepliesGeometry {
     }
 }
 #[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameReplies {
     pub types: Option<GetKbdByNameRepliesTypes>,
     pub compat_map: Option<GetKbdByNameRepliesCompatMap>,
@@ -10514,6 +10672,7 @@ impl GetKbdByNameReplies {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -10555,6 +10714,7 @@ impl TryParse for GetKbdByNameReply {
 /// Opcode for the GetDeviceInfo request
 pub const GET_DEVICE_INFO_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceInfoRequest {
     pub device_spec: DeviceSpec,
     pub wanted: u16,
@@ -10640,6 +10800,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceInfoRequest {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceInfoReply {
     pub device_id: u8,
     pub sequence: u16,
@@ -10745,6 +10906,7 @@ impl GetDeviceInfoReply {
 /// Opcode for the SetDeviceInfo request
 pub const SET_DEVICE_INFO_REQUEST: u8 = 25;
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceInfoRequest<'input> {
     pub device_spec: DeviceSpec,
     pub first_btn: u8,
@@ -10837,6 +10999,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetDeviceInfoRequest<'input> {
 /// Opcode for the SetDebuggingFlags request
 pub const SET_DEBUGGING_FLAGS_REQUEST: u8 = 101;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDebuggingFlagsRequest<'input> {
     pub affect_flags: u32,
     pub flags: u32,
@@ -10936,6 +11099,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetDebuggingFlagsRequest<'input>
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDebuggingFlagsReply {
     pub sequence: u16,
     pub length: u32,
@@ -10970,6 +11134,7 @@ impl TryParse for SetDebuggingFlagsReply {
 /// Opcode for the NewKeyboardNotify event
 pub const NEW_KEYBOARD_NOTIFY_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NewKeyboardNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11069,6 +11234,7 @@ impl From<NewKeyboardNotifyEvent> for [u8; 32] {
 /// Opcode for the MapNotify event
 pub const MAP_NOTIFY_EVENT: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11201,6 +11367,7 @@ impl From<MapNotifyEvent> for [u8; 32] {
 /// Opcode for the StateNotify event
 pub const STATE_NOTIFY_EVENT: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StateNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11334,6 +11501,7 @@ impl From<StateNotifyEvent> for [u8; 32] {
 /// Opcode for the ControlsNotify event
 pub const CONTROLS_NOTIFY_EVENT: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ControlsNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11434,6 +11602,7 @@ impl From<ControlsNotifyEvent> for [u8; 32] {
 /// Opcode for the IndicatorStateNotify event
 pub const INDICATOR_STATE_NOTIFY_EVENT: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndicatorStateNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11516,6 +11685,7 @@ impl From<IndicatorStateNotifyEvent> for [u8; 32] {
 /// Opcode for the IndicatorMapNotify event
 pub const INDICATOR_MAP_NOTIFY_EVENT: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndicatorMapNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11598,6 +11768,7 @@ impl From<IndicatorMapNotifyEvent> for [u8; 32] {
 /// Opcode for the NamesNotify event
 pub const NAMES_NOTIFY_EVENT: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NamesNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11711,6 +11882,7 @@ impl From<NamesNotifyEvent> for [u8; 32] {
 /// Opcode for the CompatMapNotify event
 pub const COMPAT_MAP_NOTIFY_EVENT: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompatMapNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11798,6 +11970,7 @@ impl From<CompatMapNotifyEvent> for [u8; 32] {
 /// Opcode for the BellNotify event
 pub const BELL_NOTIFY_EVENT: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BellNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11898,6 +12071,7 @@ impl From<BellNotifyEvent> for [u8; 32] {
 /// Opcode for the ActionMessage event
 pub const ACTION_MESSAGE_EVENT: u8 = 9;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ActionMessageEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -11992,6 +12166,7 @@ impl From<ActionMessageEvent> for [u8; 32] {
 /// Opcode for the AccessXNotify event
 pub const ACCESS_X_NOTIFY_EVENT: u8 = 10;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AccessXNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,
@@ -12079,6 +12254,7 @@ impl From<AccessXNotifyEvent> for [u8; 32] {
 /// Opcode for the ExtensionDeviceNotify event
 pub const EXTENSION_DEVICE_NOTIFY_EVENT: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtensionDeviceNotifyEvent {
     pub response_type: u8,
     pub xkb_type: u8,

--- a/x11rb-protocol/src/protocol/xprint.rs
+++ b/x11rb-protocol/src/protocol/xprint.rs
@@ -37,6 +37,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 pub type String8 = u8;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Printer {
     pub name: Vec<String8>,
     pub description: Vec<String8>,
@@ -112,6 +113,7 @@ impl Printer {
 pub type Pcontext = u32;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDoc(bool);
 impl GetDoc {
     pub const FINISHED: Self = Self(false);
@@ -182,6 +184,7 @@ impl core::fmt::Debug for GetDoc  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EvMask(u8);
 impl EvMask {
     pub const NO_EVENT_MASK: Self = Self(0);
@@ -243,6 +246,7 @@ impl core::fmt::Debug for EvMask  {
 bitmask_binop!(EvMask, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Detail(u8);
 impl Detail {
     pub const START_JOB_NOTIFY: Self = Self(1);
@@ -309,6 +313,7 @@ impl core::fmt::Debug for Detail  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Attr(u8);
 impl Attr {
     pub const JOB_ATTR: Self = Self(1);
@@ -379,6 +384,7 @@ impl core::fmt::Debug for Attr  {
 /// Opcode for the PrintQueryVersion request
 pub const PRINT_QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintQueryVersionRequest;
 impl PrintQueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -421,6 +427,7 @@ impl crate::x11_utils::ReplyRequest for PrintQueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintQueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -450,6 +457,7 @@ impl TryParse for PrintQueryVersionReply {
 /// Opcode for the PrintGetPrinterList request
 pub const PRINT_GET_PRINTER_LIST_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetPrinterListRequest<'input> {
     pub printer_name: Cow<'input, [String8]>,
     pub locale: Cow<'input, [String8]>,
@@ -524,6 +532,7 @@ impl<'input> crate::x11_utils::ReplyRequest for PrintGetPrinterListRequest<'inpu
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetPrinterListReply {
     pub sequence: u16,
     pub length: u32,
@@ -568,6 +577,7 @@ impl PrintGetPrinterListReply {
 /// Opcode for the PrintRehashPrinterList request
 pub const PRINT_REHASH_PRINTER_LIST_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintRehashPrinterListRequest;
 impl PrintRehashPrinterListRequest {
     /// Serialize this request into bytes for the provided connection
@@ -611,6 +621,7 @@ impl crate::x11_utils::VoidRequest for PrintRehashPrinterListRequest {
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextRequest<'input> {
     pub context_id: u32,
     pub printer_name: Cow<'input, [String8]>,
@@ -695,6 +706,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateContextRequest<'input> {
 /// Opcode for the PrintSetContext request
 pub const PRINT_SET_CONTEXT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintSetContextRequest {
     pub context: u32,
 }
@@ -747,6 +759,7 @@ impl crate::x11_utils::VoidRequest for PrintSetContextRequest {
 /// Opcode for the PrintGetContext request
 pub const PRINT_GET_CONTEXT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetContextRequest;
 impl PrintGetContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -789,6 +802,7 @@ impl crate::x11_utils::ReplyRequest for PrintGetContextRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -816,6 +830,7 @@ impl TryParse for PrintGetContextReply {
 /// Opcode for the PrintDestroyContext request
 pub const PRINT_DESTROY_CONTEXT_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintDestroyContextRequest {
     pub context: u32,
 }
@@ -868,6 +883,7 @@ impl crate::x11_utils::VoidRequest for PrintDestroyContextRequest {
 /// Opcode for the PrintGetScreenOfContext request
 pub const PRINT_GET_SCREEN_OF_CONTEXT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetScreenOfContextRequest;
 impl PrintGetScreenOfContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -910,6 +926,7 @@ impl crate::x11_utils::ReplyRequest for PrintGetScreenOfContextRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetScreenOfContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -937,6 +954,7 @@ impl TryParse for PrintGetScreenOfContextReply {
 /// Opcode for the PrintStartJob request
 pub const PRINT_START_JOB_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintStartJobRequest {
     pub output_mode: u8,
 }
@@ -989,6 +1007,7 @@ impl crate::x11_utils::VoidRequest for PrintStartJobRequest {
 /// Opcode for the PrintEndJob request
 pub const PRINT_END_JOB_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintEndJobRequest {
     pub cancel: bool,
 }
@@ -1041,6 +1060,7 @@ impl crate::x11_utils::VoidRequest for PrintEndJobRequest {
 /// Opcode for the PrintStartDoc request
 pub const PRINT_START_DOC_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintStartDocRequest {
     pub driver_mode: u8,
 }
@@ -1093,6 +1113,7 @@ impl crate::x11_utils::VoidRequest for PrintStartDocRequest {
 /// Opcode for the PrintEndDoc request
 pub const PRINT_END_DOC_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintEndDocRequest {
     pub cancel: bool,
 }
@@ -1145,6 +1166,7 @@ impl crate::x11_utils::VoidRequest for PrintEndDocRequest {
 /// Opcode for the PrintPutDocumentData request
 pub const PRINT_PUT_DOCUMENT_DATA_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintPutDocumentDataRequest<'input> {
     pub drawable: xproto::Drawable,
     pub data: Cow<'input, [u8]>,
@@ -1237,6 +1259,7 @@ impl<'input> crate::x11_utils::VoidRequest for PrintPutDocumentDataRequest<'inpu
 /// Opcode for the PrintGetDocumentData request
 pub const PRINT_GET_DOCUMENT_DATA_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetDocumentDataRequest {
     pub context: Pcontext,
     pub max_bytes: u32,
@@ -1296,6 +1319,7 @@ impl crate::x11_utils::ReplyRequest for PrintGetDocumentDataRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetDocumentDataReply {
     pub sequence: u16,
     pub length: u32,
@@ -1345,6 +1369,7 @@ impl PrintGetDocumentDataReply {
 /// Opcode for the PrintStartPage request
 pub const PRINT_START_PAGE_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintStartPageRequest {
     pub window: xproto::Window,
 }
@@ -1397,6 +1422,7 @@ impl crate::x11_utils::VoidRequest for PrintStartPageRequest {
 /// Opcode for the PrintEndPage request
 pub const PRINT_END_PAGE_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintEndPageRequest {
     pub cancel: bool,
 }
@@ -1450,6 +1476,7 @@ impl crate::x11_utils::VoidRequest for PrintEndPageRequest {
 /// Opcode for the PrintSelectInput request
 pub const PRINT_SELECT_INPUT_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintSelectInputRequest {
     pub context: Pcontext,
     pub event_mask: u32,
@@ -1510,6 +1537,7 @@ impl crate::x11_utils::VoidRequest for PrintSelectInputRequest {
 /// Opcode for the PrintInputSelected request
 pub const PRINT_INPUT_SELECTED_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintInputSelectedRequest {
     pub context: Pcontext,
 }
@@ -1561,6 +1589,7 @@ impl crate::x11_utils::ReplyRequest for PrintInputSelectedRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintInputSelectedReply {
     pub sequence: u16,
     pub length: u32,
@@ -1590,6 +1619,7 @@ impl TryParse for PrintInputSelectedReply {
 /// Opcode for the PrintGetAttributes request
 pub const PRINT_GET_ATTRIBUTES_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetAttributesRequest {
     pub context: Pcontext,
     pub pool: u8,
@@ -1650,6 +1680,7 @@ impl crate::x11_utils::ReplyRequest for PrintGetAttributesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetAttributesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1695,6 +1726,7 @@ impl PrintGetAttributesReply {
 /// Opcode for the PrintGetOneAttributes request
 pub const PRINT_GET_ONE_ATTRIBUTES_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetOneAttributesRequest<'input> {
     pub context: Pcontext,
     pub pool: u8,
@@ -1776,6 +1808,7 @@ impl<'input> crate::x11_utils::ReplyRequest for PrintGetOneAttributesRequest<'in
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetOneAttributesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1821,6 +1854,7 @@ impl PrintGetOneAttributesReply {
 /// Opcode for the PrintSetAttributes request
 pub const PRINT_SET_ATTRIBUTES_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintSetAttributesRequest<'input> {
     pub context: Pcontext,
     pub string_len: u32,
@@ -1910,6 +1944,7 @@ impl<'input> crate::x11_utils::VoidRequest for PrintSetAttributesRequest<'input>
 /// Opcode for the PrintGetPageDimensions request
 pub const PRINT_GET_PAGE_DIMENSIONS_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetPageDimensionsRequest {
     pub context: Pcontext,
 }
@@ -1961,6 +1996,7 @@ impl crate::x11_utils::ReplyRequest for PrintGetPageDimensionsRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetPageDimensionsReply {
     pub sequence: u16,
     pub length: u32,
@@ -1998,6 +2034,7 @@ impl TryParse for PrintGetPageDimensionsReply {
 /// Opcode for the PrintQueryScreens request
 pub const PRINT_QUERY_SCREENS_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintQueryScreensRequest;
 impl PrintQueryScreensRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2040,6 +2077,7 @@ impl crate::x11_utils::ReplyRequest for PrintQueryScreensRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintQueryScreensReply {
     pub sequence: u16,
     pub length: u32,
@@ -2084,6 +2122,7 @@ impl PrintQueryScreensReply {
 /// Opcode for the PrintSetImageResolution request
 pub const PRINT_SET_IMAGE_RESOLUTION_REQUEST: u8 = 23;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintSetImageResolutionRequest {
     pub context: Pcontext,
     pub image_resolution: u16,
@@ -2143,6 +2182,7 @@ impl crate::x11_utils::ReplyRequest for PrintSetImageResolutionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintSetImageResolutionReply {
     pub status: bool,
     pub sequence: u16,
@@ -2171,6 +2211,7 @@ impl TryParse for PrintSetImageResolutionReply {
 /// Opcode for the PrintGetImageResolution request
 pub const PRINT_GET_IMAGE_RESOLUTION_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetImageResolutionRequest {
     pub context: Pcontext,
 }
@@ -2222,6 +2263,7 @@ impl crate::x11_utils::ReplyRequest for PrintGetImageResolutionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetImageResolutionReply {
     pub sequence: u16,
     pub length: u32,
@@ -2249,6 +2291,7 @@ impl TryParse for PrintGetImageResolutionReply {
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyEvent {
     pub response_type: u8,
     pub detail: u8,
@@ -2324,6 +2367,7 @@ impl From<NotifyEvent> for [u8; 32] {
 /// Opcode for the AttributNotify event
 pub const ATTRIBUT_NOTIFY_EVENT: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttributNotifyEvent {
     pub response_type: u8,
     pub detail: u8,

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -27,6 +27,7 @@ use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Char2b {
     pub byte1: u8,
     pub byte2: u8,
@@ -89,6 +90,7 @@ pub type Keycode32 = u32;
 pub type Button = u8;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Point {
     pub x: i16,
     pub y: i16,
@@ -121,6 +123,7 @@ impl Serialize for Point {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rectangle {
     pub x: i16,
     pub y: i16,
@@ -165,6 +168,7 @@ impl Serialize for Rectangle {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Arc {
     pub x: i16,
     pub y: i16,
@@ -221,6 +225,7 @@ impl Serialize for Arc {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Format {
     pub depth: u8,
     pub bits_per_pixel: u8,
@@ -263,6 +268,7 @@ impl Serialize for Format {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VisualClass(u8);
 impl VisualClass {
     pub const STATIC_GRAY: Self = Self(0);
@@ -329,6 +335,7 @@ impl core::fmt::Debug for VisualClass  {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Visualtype {
     pub visual_id: Visualid,
     pub class: VisualClass,
@@ -404,6 +411,7 @@ impl Serialize for Visualtype {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Depth {
     pub depth: u8,
     pub visuals: Vec<Visualtype>,
@@ -453,6 +461,7 @@ impl Depth {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EventMask(u32);
 impl EventMask {
     pub const NO_EVENT: Self = Self(0);
@@ -548,6 +557,7 @@ impl core::fmt::Debug for EventMask  {
 bitmask_binop!(EventMask, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BackingStore(u32);
 impl BackingStore {
     pub const NOT_USEFUL: Self = Self(0);
@@ -596,6 +606,7 @@ impl core::fmt::Debug for BackingStore  {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Screen {
     pub root: Window,
     pub default_colormap: Colormap,
@@ -684,6 +695,7 @@ impl Screen {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetupRequest {
     pub byte_order: u8,
     pub protocol_major_version: u16,
@@ -771,6 +783,7 @@ impl SetupRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetupFailed {
     pub status: u8,
     pub protocol_major_version: u16,
@@ -826,6 +839,7 @@ impl SetupFailed {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetupAuthenticate {
     pub status: u8,
     pub reason: Vec<u8>,
@@ -876,6 +890,7 @@ impl SetupAuthenticate {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageOrder(u8);
 impl ImageOrder {
     pub const LSB_FIRST: Self = Self(0);
@@ -934,6 +949,7 @@ impl core::fmt::Debug for ImageOrder  {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Setup {
     pub status: u8,
     pub protocol_major_version: u16,
@@ -1072,6 +1088,7 @@ impl Setup {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModMask(u16);
 impl ModMask {
     pub const SHIFT: Self = Self(1 << 0);
@@ -1139,6 +1156,7 @@ impl core::fmt::Debug for ModMask  {
 bitmask_binop!(ModMask, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyButMask(u16);
 impl KeyButMask {
     pub const SHIFT: Self = Self(1 << 0);
@@ -1214,6 +1232,7 @@ impl core::fmt::Debug for KeyButMask  {
 bitmask_binop!(KeyButMask, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowEnum(u8);
 impl WindowEnum {
     pub const NONE: Self = Self(0);
@@ -1296,6 +1315,7 @@ pub const KEY_PRESS_EVENT: u8 = 2;
 /// * `GrabKey`: request
 /// * `GrabKeyboard`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyPressEvent {
     pub response_type: u8,
     pub detail: Keycode,
@@ -1397,6 +1417,7 @@ pub const KEY_RELEASE_EVENT: u8 = 3;
 pub type KeyReleaseEvent = KeyPressEvent;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ButtonMask(u16);
 impl ButtonMask {
     pub const M1: Self = Self(1 << 8);
@@ -1484,6 +1505,7 @@ pub const BUTTON_PRESS_EVENT: u8 = 4;
 /// * `GrabButton`: request
 /// * `GrabPointer`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ButtonPressEvent {
     pub response_type: u8,
     pub detail: Button,
@@ -1585,6 +1607,7 @@ pub const BUTTON_RELEASE_EVENT: u8 = 5;
 pub type ButtonReleaseEvent = ButtonPressEvent;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Motion(u8);
 impl Motion {
     pub const NORMAL: Self = Self(0);
@@ -1669,6 +1692,7 @@ pub const MOTION_NOTIFY_EVENT: u8 = 6;
 /// * `GrabKey`: request
 /// * `GrabKeyboard`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MotionNotifyEvent {
     pub response_type: u8,
     pub detail: Motion,
@@ -1767,6 +1791,7 @@ impl From<MotionNotifyEvent> for [u8; 32] {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyDetail(u8);
 impl NotifyDetail {
     pub const ANCESTOR: Self = Self(0);
@@ -1837,6 +1862,7 @@ impl core::fmt::Debug for NotifyDetail  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyMode(u8);
 impl NotifyMode {
     pub const NORMAL: Self = Self(0);
@@ -1916,6 +1942,7 @@ pub const ENTER_NOTIFY_EVENT: u8 = 7;
 /// relative to the event window's origin.
 /// * `mode` -
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnterNotifyEvent {
     pub response_type: u8,
     pub detail: NotifyDetail,
@@ -2031,6 +2058,7 @@ pub const FOCUS_IN_EVENT: u8 = 9;
 /// * `detail` -
 /// * `mode` -
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FocusInEvent {
     pub response_type: u8,
     pub detail: NotifyDetail,
@@ -2113,6 +2141,7 @@ pub type FocusOutEvent = FocusInEvent;
 /// Opcode for the KeymapNotify event
 pub const KEYMAP_NOTIFY_EVENT: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeymapNotifyEvent {
     pub response_type: u8,
     pub keys: [u8; 31],
@@ -2193,6 +2222,7 @@ pub const EXPOSE_EVENT: u8 = 12;
 /// can just ignore all Expose events with nonzero counts and perform full
 /// redisplays on events with zero counts.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExposeEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2279,6 +2309,7 @@ impl From<ExposeEvent> for [u8; 32] {
 /// Opcode for the GraphicsExposure event
 pub const GRAPHICS_EXPOSURE_EVENT: u8 = 13;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GraphicsExposureEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2371,6 +2402,7 @@ impl From<GraphicsExposureEvent> for [u8; 32] {
 /// Opcode for the NoExposure event
 pub const NO_EXPOSURE_EVENT: u8 = 14;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NoExposureEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2446,6 +2478,7 @@ impl From<NoExposureEvent> for [u8; 32] {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Visibility(u8);
 impl Visibility {
     pub const UNOBSCURED: Self = Self(0);
@@ -2508,6 +2541,7 @@ impl core::fmt::Debug for Visibility  {
 /// Opcode for the VisibilityNotify event
 pub const VISIBILITY_NOTIFY_EVENT: u8 = 15;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VisibilityNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2583,6 +2617,7 @@ impl From<VisibilityNotifyEvent> for [u8; 32] {
 /// Opcode for the CreateNotify event
 pub const CREATE_NOTIFY_EVENT: u8 = 16;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2686,6 +2721,7 @@ pub const DESTROY_NOTIFY_EVENT: u8 = 17;
 ///
 /// * `DestroyWindow`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2772,6 +2808,7 @@ pub const UNMAP_NOTIFY_EVENT: u8 = 18;
 ///
 /// * `UnmapWindow`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnmapNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2861,6 +2898,7 @@ pub const MAP_NOTIFY_EVENT: u8 = 19;
 ///
 /// * `MapWindow`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -2948,6 +2986,7 @@ pub const MAP_REQUEST_EVENT: u8 = 20;
 ///
 /// * `MapWindow`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapRequestEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3021,6 +3060,7 @@ impl From<MapRequestEvent> for [u8; 32] {
 /// Opcode for the ReparentNotify event
 pub const REPARENT_NOTIFY_EVENT: u8 = 21;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReparentNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3129,6 +3169,7 @@ pub const CONFIGURE_NOTIFY_EVENT: u8 = 22;
 ///
 /// * `FreeColormap`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3224,6 +3265,7 @@ impl From<ConfigureNotifyEvent> for [u8; 32] {
 /// Opcode for the ConfigureRequest event
 pub const CONFIGURE_REQUEST_EVENT: u8 = 23;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureRequestEvent {
     pub response_type: u8,
     pub stack_mode: StackMode,
@@ -3321,6 +3363,7 @@ impl From<ConfigureRequestEvent> for [u8; 32] {
 /// Opcode for the GravityNotify event
 pub const GRAVITY_NOTIFY_EVENT: u8 = 24;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GravityNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3400,6 +3443,7 @@ impl From<GravityNotifyEvent> for [u8; 32] {
 /// Opcode for the ResizeRequest event
 pub const RESIZE_REQUEST_EVENT: u8 = 25;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResizeRequestEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3478,6 +3522,7 @@ impl From<ResizeRequestEvent> for [u8; 32] {
 /// * `OnTop` - The window is now on top of all siblings.
 /// * `OnBottom` - The window is now below all siblings.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Place(u8);
 impl Place {
     pub const ON_TOP: Self = Self(0);
@@ -3550,6 +3595,7 @@ pub const CIRCULATE_NOTIFY_EVENT: u8 = 26;
 ///
 /// * `CirculateWindow`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CirculateNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3631,6 +3677,7 @@ pub const CIRCULATE_REQUEST_EVENT: u8 = 27;
 pub type CirculateRequestEvent = CirculateNotifyEvent;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Property(u8);
 impl Property {
     pub const NEW_VALUE: Self = Self(0);
@@ -3703,6 +3750,7 @@ pub const PROPERTY_NOTIFY_EVENT: u8 = 28;
 ///
 /// * `ChangeProperty`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PropertyNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3784,6 +3832,7 @@ impl From<PropertyNotifyEvent> for [u8; 32] {
 /// Opcode for the SelectionClear event
 pub const SELECTION_CLEAR_EVENT: u8 = 29;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectionClearEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -3858,6 +3907,7 @@ impl From<SelectionClearEvent> for [u8; 32] {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Time(u8);
 impl Time {
     pub const CURRENT_TIME: Self = Self(0);
@@ -3914,6 +3964,7 @@ impl core::fmt::Debug for Time  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AtomEnum(u8);
 impl AtomEnum {
     pub const NONE: Self = Self(0);
@@ -4110,6 +4161,7 @@ impl core::fmt::Debug for AtomEnum  {
 /// Opcode for the SelectionRequest event
 pub const SELECTION_REQUEST_EVENT: u8 = 30;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectionRequestEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -4195,6 +4247,7 @@ impl From<SelectionRequestEvent> for [u8; 32] {
 /// Opcode for the SelectionNotify event
 pub const SELECTION_NOTIFY_EVENT: u8 = 31;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectionNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -4279,6 +4332,7 @@ impl From<SelectionNotifyEvent> for [u8; 32] {
 /// * `Uninstalled` - The colormap was uninstalled.
 /// * `Installed` - The colormap was installed.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColormapState(u8);
 impl ColormapState {
     pub const UNINSTALLED: Self = Self(0);
@@ -4337,6 +4391,7 @@ impl core::fmt::Debug for ColormapState  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColormapEnum(u8);
 impl ColormapEnum {
     pub const NONE: Self = Self(0);
@@ -4408,6 +4463,7 @@ pub const COLORMAP_NOTIFY_EVENT: u8 = 32;
 ///
 /// * `FreeColormap`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColormapNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -4487,6 +4543,7 @@ impl From<ColormapNotifyEvent> for [u8; 32] {
 }
 
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientMessageData([u8; 20]);
 impl ClientMessageData {
     pub fn as_data8(&self) -> [u8; 20] {
@@ -4661,6 +4718,7 @@ pub const CLIENT_MESSAGE_EVENT: u8 = 33;
 ///
 /// * `SendEvent`: request
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientMessageEvent {
     pub response_type: u8,
     pub format: u8,
@@ -4756,6 +4814,7 @@ impl ClientMessageEvent {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Mapping(u8);
 impl Mapping {
     pub const MODIFIER: Self = Self(0);
@@ -4825,6 +4884,7 @@ pub const MAPPING_NOTIFY_EVENT: u8 = 34;
 /// * `first_keycode` - The first number in the range of the altered mapping.
 /// * `count` - The number of keycodes altered.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MappingNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -4910,6 +4970,7 @@ pub const GE_GENERIC_EVENT: u8 = 35;
 /// * `length` - The amount (in 4-byte units) of data beyond 32 bytes
 /// * `evtype` - The extension-specific event type
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GeGenericEvent {
     pub response_type: u8,
     pub extension: u8,
@@ -4986,6 +5047,7 @@ pub const LENGTH_ERROR: u8 = 16;
 pub const IMPLEMENTATION_ERROR: u8 = 17;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WindowClass(u16);
 impl WindowClass {
     pub const COPY_FROM_PARENT: Self = Self(0);
@@ -5110,6 +5172,7 @@ impl core::fmt::Debug for WindowClass  {
 /// fied, the parent's cursor will be used when the pointer is in the window, and any change in the
 /// parent's cursor will cause an immediate change in the displayed cursor.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CW(u16);
 impl CW {
     pub const BACK_PIXMAP: Self = Self(1 << 0);
@@ -5189,6 +5252,7 @@ impl core::fmt::Debug for CW  {
 bitmask_binop!(CW, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BackPixmap(bool);
 impl BackPixmap {
     pub const NONE: Self = Self(false);
@@ -5259,6 +5323,7 @@ impl core::fmt::Debug for BackPixmap  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Gravity(u32);
 impl Gravity {
     pub const BIT_FORGET: Self = Self(0);
@@ -5326,6 +5391,7 @@ impl core::fmt::Debug for Gravity  {
 
 /// Auxiliary and optional information for the `create_window` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateWindowAux {
     pub background_pixmap: Option<Pixmap>,
     pub background_pixel: Option<u32>,
@@ -5735,6 +5801,7 @@ pub const CREATE_WINDOW_REQUEST: u8 = 1;
 /// * `MapWindow`: request
 /// * `CreateNotify`: event
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateWindowRequest<'input> {
     pub depth: u8,
     pub wid: Window,
@@ -5875,6 +5942,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateWindowRequest<'input> {
 
 /// Auxiliary and optional information for the `change_window_attributes` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeWindowAttributesAux {
     pub background_pixmap: Option<Pixmap>,
     pub background_pixel: Option<u32>,
@@ -6250,6 +6318,7 @@ pub const CHANGE_WINDOW_ATTRIBUTES_REQUEST: u8 = 2;
 /// * `Value` - TODO: reasons?
 /// * `Window` - The specified `window` does not exist.
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeWindowAttributesRequest<'input> {
     pub window: Window,
     pub value_list: Cow<'input, ChangeWindowAttributesAux>,
@@ -6324,6 +6393,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeWindowAttributesRequest<'in
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapState(u8);
 impl MapState {
     pub const UNMAPPED: Self = Self(0);
@@ -6398,6 +6468,7 @@ pub const GET_WINDOW_ATTRIBUTES_REQUEST: u8 = 3;
 /// * `Window` - The specified `window` does not exist.
 /// * `Drawable` - TODO: reasons?
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowAttributesRequest {
     pub window: Window,
 }
@@ -6468,6 +6539,7 @@ impl crate::x11_utils::ReplyRequest for GetWindowAttributesRequest {
 /// * `win_gravity` -
 /// * `map_state` -
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowAttributesReply {
     pub backing_store: BackingStore,
     pub sequence: u16,
@@ -6550,6 +6622,7 @@ pub const DESTROY_WINDOW_REQUEST: u8 = 4;
 /// * `MapWindow`: request
 /// * `UnmapWindow`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyWindowRequest {
     pub window: Window,
 }
@@ -6605,6 +6678,7 @@ impl crate::x11_utils::VoidRequest for DestroyWindowRequest {
 /// Opcode for the DestroySubwindows request
 pub const DESTROY_SUBWINDOWS_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroySubwindowsRequest {
     pub window: Window,
 }
@@ -6658,6 +6732,7 @@ impl crate::x11_utils::VoidRequest for DestroySubwindowsRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetMode(u8);
 impl SetMode {
     pub const INSERT: Self = Self(0);
@@ -6740,6 +6815,7 @@ pub const CHANGE_SAVE_SET_REQUEST: u8 = 6;
 ///
 /// * `ReparentWindow`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeSaveSetRequest {
     pub mode: SetMode,
     pub window: Window,
@@ -6831,6 +6907,7 @@ pub const REPARENT_WINDOW_REQUEST: u8 = 7;
 /// * `MapWindow`: request
 /// * `UnmapWindow`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReparentWindowRequest {
     pub window: Window,
     pub parent: Window,
@@ -6941,6 +7018,7 @@ pub const MAP_WINDOW_REQUEST: u8 = 8;
 /// * `Expose`: event
 /// * `UnmapWindow`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapWindowRequest {
     pub window: Window,
 }
@@ -6996,6 +7074,7 @@ impl crate::x11_utils::VoidRequest for MapWindowRequest {
 /// Opcode for the MapSubwindows request
 pub const MAP_SUBWINDOWS_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapSubwindowsRequest {
     pub window: Window,
 }
@@ -7072,6 +7151,7 @@ pub const UNMAP_WINDOW_REQUEST: u8 = 10;
 /// * `Expose`: event
 /// * `MapWindow`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnmapWindowRequest {
     pub window: Window,
 }
@@ -7127,6 +7207,7 @@ impl crate::x11_utils::VoidRequest for UnmapWindowRequest {
 /// Opcode for the UnmapSubwindows request
 pub const UNMAP_SUBWINDOWS_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnmapSubwindowsRequest {
     pub window: Window,
 }
@@ -7180,6 +7261,7 @@ impl crate::x11_utils::VoidRequest for UnmapSubwindowsRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigWindow(u8);
 impl ConfigWindow {
     pub const X: Self = Self(1 << 0);
@@ -7249,6 +7331,7 @@ impl core::fmt::Debug for ConfigWindow  {
 bitmask_binop!(ConfigWindow, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StackMode(u32);
 impl StackMode {
     pub const ABOVE: Self = Self(0);
@@ -7302,6 +7385,7 @@ impl core::fmt::Debug for StackMode  {
 
 /// Auxiliary and optional information for the `configure_window` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureWindowAux {
     pub x: Option<i32>,
     pub y: Option<i32>,
@@ -7568,6 +7652,7 @@ pub const CONFIGURE_WINDOW_REQUEST: u8 = 12;
 /// }
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureWindowRequest<'input> {
     pub window: Window,
     pub value_list: Cow<'input, ConfigureWindowAux>,
@@ -7643,6 +7728,7 @@ impl<'input> crate::x11_utils::VoidRequest for ConfigureWindowRequest<'input> {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Circulate(u8);
 impl Circulate {
     pub const RAISE_LOWEST: Self = Self(0);
@@ -7720,6 +7806,7 @@ pub const CIRCULATE_WINDOW_REQUEST: u8 = 13;
 /// * `Window` - The specified `window` does not exist.
 /// * `Value` - The specified `direction` is invalid.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CirculateWindowRequest {
     pub direction: Circulate,
     pub window: Window,
@@ -7815,6 +7902,7 @@ pub const GET_GEOMETRY_REQUEST: u8 = 14;
 /// }
 /// ```
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGeometryRequest {
     pub drawable: Drawable,
 }
@@ -7882,6 +7970,7 @@ impl crate::x11_utils::ReplyRequest for GetGeometryRequest {
 /// * `border_width` - The border width (in pixels).
 /// * `depth` - The depth of the drawable (bits per pixel for the object).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGeometryReply {
     pub depth: u8,
     pub sequence: u16,
@@ -7958,6 +8047,7 @@ pub const QUERY_TREE_REQUEST: u8 = 15;
 /// }
 /// ```
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryTreeRequest {
     pub window: Window,
 }
@@ -8016,6 +8106,7 @@ impl crate::x11_utils::ReplyRequest for QueryTreeRequest {
 /// * `root` - The root window of `window`.
 /// * `parent` - The parent window of `window`.
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryTreeReply {
     pub sequence: u16,
     pub length: u32,
@@ -8108,6 +8199,7 @@ pub const INTERN_ATOM_REQUEST: u8 = 16;
 /// }
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InternAtomRequest<'input> {
     pub only_if_exists: bool,
     pub name: Cow<'input, [u8]>,
@@ -8178,6 +8270,7 @@ impl<'input> crate::x11_utils::ReplyRequest for InternAtomRequest<'input> {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InternAtomReply {
     pub sequence: u16,
     pub length: u32,
@@ -8205,6 +8298,7 @@ impl TryParse for InternAtomReply {
 /// Opcode for the GetAtomName request
 pub const GET_ATOM_NAME_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetAtomNameRequest {
     pub atom: Atom,
 }
@@ -8259,6 +8353,7 @@ impl crate::x11_utils::ReplyRequest for GetAtomNameRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetAtomNameReply {
     pub sequence: u16,
     pub length: u32,
@@ -8311,6 +8406,7 @@ impl GetAtomNameReply {
 /// match existing property value. If the property is undefined, it is treated as
 /// defined with the correct type and format with zero-length data.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PropMode(u8);
 impl PropMode {
     pub const REPLACE: Self = Self(0);
@@ -8424,6 +8520,7 @@ pub const CHANGE_PROPERTY_REQUEST: u8 = 18;
 /// }
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangePropertyRequest<'input> {
     pub mode: PropMode,
     pub window: Window,
@@ -8535,6 +8632,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangePropertyRequest<'input> {
 /// Opcode for the DeleteProperty request
 pub const DELETE_PROPERTY_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeletePropertyRequest {
     pub window: Window,
     pub property: Atom,
@@ -8596,6 +8694,7 @@ impl crate::x11_utils::VoidRequest for DeletePropertyRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyType(u8);
 impl GetPropertyType {
     pub const ANY: Self = Self(0);
@@ -8722,6 +8821,7 @@ pub const GET_PROPERTY_REQUEST: u8 = 20;
 /// }
 /// ```
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyRequest {
     pub delete: bool,
     pub window: Window,
@@ -8978,6 +9078,7 @@ impl GetPropertyReply {
 /// * `value_len` - The length of value. You should use the corresponding accessor instead of this
 /// field.
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyReply {
     pub format: u8,
     pub sequence: u16,
@@ -9014,6 +9115,7 @@ impl TryParse for GetPropertyReply {
 /// Opcode for the ListProperties request
 pub const LIST_PROPERTIES_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListPropertiesRequest {
     pub window: Window,
 }
@@ -9068,6 +9170,7 @@ impl crate::x11_utils::ReplyRequest for ListPropertiesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListPropertiesReply {
     pub sequence: u16,
     pub length: u32,
@@ -9141,6 +9244,7 @@ pub const SET_SELECTION_OWNER_REQUEST: u8 = 22;
 ///
 /// * `SetSelectionOwner`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetSelectionOwnerRequest {
     pub owner: Window,
     pub selection: Atom,
@@ -9229,6 +9333,7 @@ pub const GET_SELECTION_OWNER_REQUEST: u8 = 23;
 ///
 /// * `SetSelectionOwner`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionOwnerRequest {
     pub selection: Atom,
 }
@@ -9286,6 +9391,7 @@ impl crate::x11_utils::ReplyRequest for GetSelectionOwnerRequest {
 ///
 /// * `owner` - The current selection owner window.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionOwnerReply {
     pub sequence: u16,
     pub length: u32,
@@ -9313,6 +9419,7 @@ impl TryParse for GetSelectionOwnerReply {
 /// Opcode for the ConvertSelection request
 pub const CONVERT_SELECTION_REQUEST: u8 = 24;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConvertSelectionRequest {
     pub requestor: Window,
     pub selection: Atom,
@@ -9398,6 +9505,7 @@ impl crate::x11_utils::VoidRequest for ConvertSelectionRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SendEventDest(bool);
 impl SendEventDest {
     pub const POINTER_WINDOW: Self = Self(false);
@@ -9543,6 +9651,7 @@ pub const SEND_EVENT_REQUEST: u8 = 25;
 /// }
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SendEventRequest<'input> {
     pub propagate: bool,
     pub destination: Window,
@@ -9627,6 +9736,7 @@ impl<'input> crate::x11_utils::VoidRequest for SendEventRequest<'input> {
 /// `AllowEvents` request or until the keyboard grab is released.
 /// * `Async` - Keyboard event processing continues normally.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabMode(u8);
 impl GrabMode {
     pub const SYNC: Self = Self(0);
@@ -9685,6 +9795,7 @@ impl core::fmt::Debug for GrabMode  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabStatus(u8);
 impl GrabStatus {
     pub const SUCCESS: Self = Self(0);
@@ -9749,6 +9860,7 @@ impl core::fmt::Debug for GrabStatus  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorEnum(u8);
 impl CursorEnum {
     pub const NONE: Self = Self(0);
@@ -9878,6 +9990,7 @@ pub const GRAB_POINTER_REQUEST: u8 = 26;
 /// }
 /// ```
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabPointerRequest {
     pub owner_events: bool,
     pub grab_window: Window,
@@ -9977,6 +10090,7 @@ impl crate::x11_utils::ReplyRequest for GrabPointerRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabPointerReply {
     pub status: GrabStatus,
     pub sequence: u16,
@@ -10027,6 +10141,7 @@ pub const UNGRAB_POINTER_REQUEST: u8 = 27;
 /// * `EnterNotify`: event
 /// * `LeaveNotify`: event
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabPointerRequest {
     pub time: Timestamp,
 }
@@ -10088,6 +10203,7 @@ impl crate::x11_utils::VoidRequest for UngrabPointerRequest {
 /// * `4` - Scroll wheel. TODO: direction?
 /// * `5` - Scroll wheel. TODO: direction?
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ButtonIndex(u8);
 impl ButtonIndex {
     pub const ANY: Self = Self(0);
@@ -10223,6 +10339,7 @@ pub const GRAB_BUTTON_REQUEST: u8 = 28;
 /// * `Cursor` - The specified `cursor` does not exist.
 /// * `Window` - The specified `window` does not exist.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabButtonRequest {
     pub owner_events: bool,
     pub grab_window: Window,
@@ -10329,6 +10446,7 @@ impl crate::x11_utils::VoidRequest for GrabButtonRequest {
 /// Opcode for the UngrabButton request
 pub const UNGRAB_BUTTON_REQUEST: u8 = 29;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabButtonRequest {
     pub button: ButtonIndex,
     pub grab_window: Window,
@@ -10397,6 +10515,7 @@ impl crate::x11_utils::VoidRequest for UngrabButtonRequest {
 /// Opcode for the ChangeActivePointerGrab request
 pub const CHANGE_ACTIVE_POINTER_GRAB_REQUEST: u8 = 30;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeActivePointerGrabRequest {
     pub cursor: Cursor,
     pub time: Timestamp,
@@ -10531,6 +10650,7 @@ pub const GRAB_KEYBOARD_REQUEST: u8 = 31;
 /// }
 /// ```
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabKeyboardRequest {
     pub owner_events: bool,
     pub grab_window: Window,
@@ -10611,6 +10731,7 @@ impl crate::x11_utils::ReplyRequest for GrabKeyboardRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabKeyboardReply {
     pub status: GrabStatus,
     pub sequence: u16,
@@ -10638,6 +10759,7 @@ impl TryParse for GrabKeyboardReply {
 /// Opcode for the UngrabKeyboard request
 pub const UNGRAB_KEYBOARD_REQUEST: u8 = 32;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabKeyboardRequest {
     pub time: Timestamp,
 }
@@ -10691,6 +10813,7 @@ impl crate::x11_utils::VoidRequest for UngrabKeyboardRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Grab(u8);
 impl Grab {
     pub const ANY: Self = Self(0);
@@ -10809,6 +10932,7 @@ pub const GRAB_KEY_REQUEST: u8 = 33;
 ///
 /// * `GrabKeyboard`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabKeyRequest {
     pub owner_events: bool,
     pub grab_window: Window,
@@ -10919,6 +11043,7 @@ pub const UNGRAB_KEY_REQUEST: u8 = 34;
 /// * `GrabKey`: request
 /// * `xev`: program
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabKeyRequest {
     pub key: Keycode,
     pub grab_window: Window,
@@ -11043,6 +11168,7 @@ impl crate::x11_utils::VoidRequest for UngrabKeyRequest {
 /// the client on behalf of two separate grabs, AsyncBoth thaws for both. AsyncBoth
 /// has no effect unless both pointer and keyboard are frozen by the client.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Allow(u8);
 impl Allow {
     pub const ASYNC_POINTER: Self = Self(0);
@@ -11133,6 +11259,7 @@ pub const ALLOW_EVENTS_REQUEST: u8 = 35;
 ///
 /// * `Value` - You specified an invalid `mode`.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllowEventsRequest {
     pub mode: Allow,
     pub time: Timestamp,
@@ -11192,6 +11319,7 @@ impl crate::x11_utils::VoidRequest for AllowEventsRequest {
 /// Opcode for the GrabServer request
 pub const GRAB_SERVER_REQUEST: u8 = 36;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabServerRequest;
 impl GrabServerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11238,6 +11366,7 @@ impl crate::x11_utils::VoidRequest for GrabServerRequest {
 /// Opcode for the UngrabServer request
 pub const UNGRAB_SERVER_REQUEST: u8 = 37;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabServerRequest;
 impl UngrabServerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11297,6 +11426,7 @@ pub const QUERY_POINTER_REQUEST: u8 = 38;
 ///
 /// * `Window` - The specified `window` does not exist.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPointerRequest {
     pub window: Window,
 }
@@ -11370,6 +11500,7 @@ impl crate::x11_utils::ReplyRequest for QueryPointerRequest {
 /// logical state of a device (as seen by means of the protocol) may lag the
 /// physical state if device event processing is frozen.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPointerReply {
     pub same_screen: bool,
     pub sequence: u16,
@@ -11409,6 +11540,7 @@ impl TryParse for QueryPointerReply {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Timecoord {
     pub time: Timestamp,
     pub x: i16,
@@ -11451,6 +11583,7 @@ impl Serialize for Timecoord {
 /// Opcode for the GetMotionEvents request
 pub const GET_MOTION_EVENTS_REQUEST: u8 = 39;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMotionEventsRequest {
     pub window: Window,
     pub start: Timestamp,
@@ -11521,6 +11654,7 @@ impl crate::x11_utils::ReplyRequest for GetMotionEventsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMotionEventsReply {
     pub sequence: u16,
     pub length: u32,
@@ -11565,6 +11699,7 @@ impl GetMotionEventsReply {
 /// Opcode for the TranslateCoordinates request
 pub const TRANSLATE_COORDINATES_REQUEST: u8 = 40;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TranslateCoordinatesRequest {
     pub src_window: Window,
     pub dst_window: Window,
@@ -11639,6 +11774,7 @@ impl crate::x11_utils::ReplyRequest for TranslateCoordinatesRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TranslateCoordinatesReply {
     pub same_screen: bool,
     pub sequence: u16,
@@ -11703,6 +11839,7 @@ pub const WARP_POINTER_REQUEST: u8 = 41;
 ///
 /// * `SetInputFocus`: request
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WarpPointerRequest {
     pub src_window: Window,
     pub dst_window: Window,
@@ -11809,6 +11946,7 @@ impl crate::x11_utils::VoidRequest for WarpPointerRequest {
 /// revert_to value is `XCB_INPUT_FOCUS_NONE`.
 /// * `FollowKeyboard` - NOT YET DOCUMENTED. Only relevant for the xinput extension.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputFocus(u8);
 impl InputFocus {
     pub const NONE: Self = Self(0);
@@ -11908,6 +12046,7 @@ pub const SET_INPUT_FOCUS_REQUEST: u8 = 42;
 /// * `FocusIn`: event
 /// * `FocusOut`: event
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetInputFocusRequest {
     pub revert_to: InputFocus,
     pub focus: Window,
@@ -11975,6 +12114,7 @@ impl crate::x11_utils::VoidRequest for SetInputFocusRequest {
 /// Opcode for the GetInputFocus request
 pub const GET_INPUT_FOCUS_REQUEST: u8 = 43;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetInputFocusRequest;
 impl GetInputFocusRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12020,6 +12160,7 @@ impl crate::x11_utils::ReplyRequest for GetInputFocusRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetInputFocusReply {
     pub revert_to: InputFocus,
     pub sequence: u16,
@@ -12049,6 +12190,7 @@ impl TryParse for GetInputFocusReply {
 /// Opcode for the QueryKeymap request
 pub const QUERY_KEYMAP_REQUEST: u8 = 44;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryKeymapRequest;
 impl QueryKeymapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12094,6 +12236,7 @@ impl crate::x11_utils::ReplyRequest for QueryKeymapRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryKeymapReply {
     pub sequence: u16,
     pub length: u32,
@@ -12141,6 +12284,7 @@ pub const OPEN_FONT_REQUEST: u8 = 45;
 ///
 /// * `xcb_generate_id`: function
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenFontRequest<'input> {
     pub fid: Font,
     pub name: Cow<'input, [u8]>,
@@ -12217,6 +12361,7 @@ impl<'input> crate::x11_utils::VoidRequest for OpenFontRequest<'input> {
 /// Opcode for the CloseFont request
 pub const CLOSE_FONT_REQUEST: u8 = 46;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CloseFontRequest {
     pub font: Font,
 }
@@ -12270,6 +12415,7 @@ impl crate::x11_utils::VoidRequest for CloseFontRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FontDraw(u8);
 impl FontDraw {
     pub const LEFT_TO_RIGHT: Self = Self(0);
@@ -12328,6 +12474,7 @@ impl core::fmt::Debug for FontDraw  {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Fontprop {
     pub name: Atom,
     pub value: u32,
@@ -12364,6 +12511,7 @@ impl Serialize for Fontprop {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Charinfo {
     pub left_side_bearing: i16,
     pub right_side_bearing: i16,
@@ -12429,6 +12577,7 @@ pub const QUERY_FONT_REQUEST: u8 = 47;
 ///
 /// * `font` - The fontable (Font or Graphics Context) to query.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryFontRequest {
     pub font: Fontable,
 }
@@ -12494,6 +12643,7 @@ impl crate::x11_utils::ReplyRequest for QueryFontRequest {
 /// * `font_descent` - baseline to bottom edge of raster
 /// * `draw_direction` -
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryFontReply {
     pub sequence: u16,
     pub length: u32,
@@ -12612,6 +12762,7 @@ pub const QUERY_TEXT_EXTENTS_REQUEST: u8 = 48;
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Font` - The specified `font` does not exist.
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryTextExtentsRequest<'input> {
     pub font: Fontable,
     pub string: Cow<'input, [Char2b]>,
@@ -12696,6 +12847,7 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryTextExtentsRequest<'input> 
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryTextExtentsReply {
     pub draw_direction: FontDraw,
     pub sequence: u16,
@@ -12735,6 +12887,7 @@ impl TryParse for QueryTextExtentsReply {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Str {
     pub name: Vec<u8>,
 }
@@ -12791,6 +12944,7 @@ pub const LIST_FONTS_REQUEST: u8 = 49;
 /// not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListFontsRequest<'input> {
     pub max_names: u16,
     pub pattern: Cow<'input, [u8]>,
@@ -12863,6 +13017,7 @@ impl<'input> crate::x11_utils::ReplyRequest for ListFontsRequest<'input> {
 /// # Fields
 ///
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListFontsReply {
     pub sequence: u16,
     pub length: u32,
@@ -12919,6 +13074,7 @@ pub const LIST_FONTS_WITH_INFO_REQUEST: u8 = 50;
 /// not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListFontsWithInfoRequest<'input> {
     pub max_names: u16,
     pub pattern: Cow<'input, [u8]>,
@@ -13003,6 +13159,7 @@ impl<'input> crate::x11_utils::ReplyRequest for ListFontsWithInfoRequest<'input>
 /// value does not guarantee that no more fonts will be returned.
 /// * `draw_direction` -
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListFontsWithInfoReply {
     pub sequence: u16,
     pub length: u32,
@@ -13089,6 +13246,7 @@ impl ListFontsWithInfoReply {
 /// Opcode for the SetFontPath request
 pub const SET_FONT_PATH_REQUEST: u8 = 51;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetFontPathRequest<'input> {
     pub font: Cow<'input, [Str]>,
 }
@@ -13157,6 +13315,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetFontPathRequest<'input> {
 /// Opcode for the GetFontPath request
 pub const GET_FONT_PATH_REQUEST: u8 = 52;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFontPathRequest;
 impl GetFontPathRequest {
     /// Serialize this request into bytes for the provided connection
@@ -13202,6 +13361,7 @@ impl crate::x11_utils::ReplyRequest for GetFontPathRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFontPathReply {
     pub sequence: u16,
     pub length: u32,
@@ -13269,6 +13429,7 @@ pub const CREATE_PIXMAP_REQUEST: u8 = 53;
 ///
 /// * `xcb_generate_id`: function
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePixmapRequest {
     pub depth: u8,
     pub pid: Pixmap,
@@ -13359,6 +13520,7 @@ pub const FREE_PIXMAP_REQUEST: u8 = 54;
 ///
 /// * `Pixmap` - The specified pixmap does not exist.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreePixmapRequest {
     pub pixmap: Pixmap,
 }
@@ -13514,6 +13676,7 @@ impl crate::x11_utils::VoidRequest for FreePixmapRequest {
 /// * `DashList` - TODO
 /// * `ArcMode` - TODO
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GC(u32);
 impl GC {
     pub const FUNCTION: Self = Self(1 << 0);
@@ -13603,6 +13766,7 @@ impl core::fmt::Debug for GC  {
 bitmask_binop!(GC, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GX(u32);
 impl GX {
     pub const CLEAR: Self = Self(0);
@@ -13677,6 +13841,7 @@ impl core::fmt::Debug for GX  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LineStyle(u32);
 impl LineStyle {
     pub const SOLID: Self = Self(0);
@@ -13725,6 +13890,7 @@ impl core::fmt::Debug for LineStyle  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CapStyle(u32);
 impl CapStyle {
     pub const NOT_LAST: Self = Self(0);
@@ -13775,6 +13941,7 @@ impl core::fmt::Debug for CapStyle  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct JoinStyle(u32);
 impl JoinStyle {
     pub const MITER: Self = Self(0);
@@ -13823,6 +13990,7 @@ impl core::fmt::Debug for JoinStyle  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FillStyle(u32);
 impl FillStyle {
     pub const SOLID: Self = Self(0);
@@ -13873,6 +14041,7 @@ impl core::fmt::Debug for FillStyle  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FillRule(u32);
 impl FillRule {
     pub const EVEN_ODD: Self = Self(0);
@@ -13919,6 +14088,7 @@ impl core::fmt::Debug for FillRule  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SubwindowMode(u32);
 impl SubwindowMode {
     pub const CLIP_BY_CHILDREN: Self = Self(0);
@@ -13965,6 +14135,7 @@ impl core::fmt::Debug for SubwindowMode  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ArcMode(u32);
 impl ArcMode {
     pub const CHORD: Self = Self(0);
@@ -14012,6 +14183,7 @@ impl core::fmt::Debug for ArcMode  {
 
 /// Auxiliary and optional information for the `create_gc` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateGCAux {
     pub function: Option<GX>,
     pub plane_mask: Option<u32>,
@@ -14563,6 +14735,7 @@ pub const CREATE_GC_REQUEST: u8 = 55;
 ///
 /// * `xcb_generate_id`: function
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateGCRequest<'input> {
     pub cid: Gcontext,
     pub drawable: Drawable,
@@ -14647,6 +14820,7 @@ impl<'input> crate::x11_utils::VoidRequest for CreateGCRequest<'input> {
 
 /// Auxiliary and optional information for the `change_gc` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeGCAux {
     pub function: Option<GX>,
     pub plane_mask: Option<u32>,
@@ -15219,6 +15393,7 @@ pub const CHANGE_GC_REQUEST: u8 = 56;
 /// }
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeGCRequest<'input> {
     pub gc: Gcontext,
     pub value_list: Cow<'input, ChangeGCAux>,
@@ -15295,6 +15470,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeGCRequest<'input> {
 /// Opcode for the CopyGC request
 pub const COPY_GC_REQUEST: u8 = 57;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyGCRequest {
     pub src_gc: Gcontext,
     pub dst_gc: Gcontext,
@@ -15366,6 +15542,7 @@ impl crate::x11_utils::VoidRequest for CopyGCRequest {
 /// Opcode for the SetDashes request
 pub const SET_DASHES_REQUEST: u8 = 58;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDashesRequest<'input> {
     pub gc: Gcontext,
     pub dash_offset: u16,
@@ -15444,6 +15621,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetDashesRequest<'input> {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClipOrdering(u8);
 impl ClipOrdering {
     pub const UNSORTED: Self = Self(0);
@@ -15508,6 +15686,7 @@ impl core::fmt::Debug for ClipOrdering  {
 /// Opcode for the SetClipRectangles request
 pub const SET_CLIP_RECTANGLES_REQUEST: u8 = 59;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetClipRectanglesRequest<'input> {
     pub ordering: ClipOrdering,
     pub gc: Gcontext,
@@ -15614,6 +15793,7 @@ pub const FREE_GC_REQUEST: u8 = 60;
 ///
 /// * `GContext` - The specified graphics context does not exist.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeGCRequest {
     pub gc: Gcontext,
 }
@@ -15669,6 +15849,7 @@ impl crate::x11_utils::VoidRequest for FreeGCRequest {
 /// Opcode for the ClearArea request
 pub const CLEAR_AREA_REQUEST: u8 = 61;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClearAreaRequest {
     pub exposures: bool,
     pub window: Window,
@@ -15772,6 +15953,7 @@ pub const COPY_AREA_REQUEST: u8 = 62;
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Match` - `src_drawable` has a different root or depth than `dst_drawable`.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyAreaRequest {
     pub src_drawable: Drawable,
     pub dst_drawable: Drawable,
@@ -15879,6 +16061,7 @@ impl crate::x11_utils::VoidRequest for CopyAreaRequest {
 /// Opcode for the CopyPlane request
 pub const COPY_PLANE_REQUEST: u8 = 63;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyPlaneRequest {
     pub src_drawable: Drawable,
     pub dst_drawable: Drawable,
@@ -15996,6 +16179,7 @@ impl crate::x11_utils::VoidRequest for CopyPlaneRequest {
 /// * `Origin` - Treats all coordinates as relative to the origin.
 /// * `Previous` - Treats all coordinates after the first as relative to the previous coordinate.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CoordMode(u8);
 impl CoordMode {
     pub const ORIGIN: Self = Self(0);
@@ -16056,6 +16240,7 @@ impl core::fmt::Debug for CoordMode  {
 /// Opcode for the PolyPoint request
 pub const POLY_POINT_REQUEST: u8 = 64;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyPointRequest<'input> {
     pub coordinate_mode: CoordMode,
     pub drawable: Drawable,
@@ -16185,6 +16370,7 @@ pub const POLY_LINE_REQUEST: u8 = 65;
 /// }
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyLineRequest<'input> {
     pub coordinate_mode: CoordMode,
     pub drawable: Drawable,
@@ -16273,6 +16459,7 @@ impl<'input> crate::x11_utils::VoidRequest for PolyLineRequest<'input> {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Segment {
     pub x1: i16,
     pub y1: i16,
@@ -16345,6 +16532,7 @@ pub const POLY_SEGMENT_REQUEST: u8 = 66;
 /// * `GContext` - The specified `gc` does not exist.
 /// * `Match` - TODO: reasons?
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolySegmentRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -16430,6 +16618,7 @@ impl<'input> crate::x11_utils::VoidRequest for PolySegmentRequest<'input> {
 /// Opcode for the PolyRectangle request
 pub const POLY_RECTANGLE_REQUEST: u8 = 67;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyRectangleRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -16515,6 +16704,7 @@ impl<'input> crate::x11_utils::VoidRequest for PolyRectangleRequest<'input> {
 /// Opcode for the PolyArc request
 pub const POLY_ARC_REQUEST: u8 = 68;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyArcRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -16598,6 +16788,7 @@ impl<'input> crate::x11_utils::VoidRequest for PolyArcRequest<'input> {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyShape(u8);
 impl PolyShape {
     pub const COMPLEX: Self = Self(0);
@@ -16660,6 +16851,7 @@ impl core::fmt::Debug for PolyShape  {
 /// Opcode for the FillPoly request
 pub const FILL_POLY_REQUEST: u8 = 69;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FillPolyRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -16787,6 +16979,7 @@ pub const POLY_FILL_RECTANGLE_REQUEST: u8 = 70;
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Match` - TODO: reasons?
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyFillRectangleRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -16872,6 +17065,7 @@ impl<'input> crate::x11_utils::VoidRequest for PolyFillRectangleRequest<'input> 
 /// Opcode for the PolyFillArc request
 pub const POLY_FILL_ARC_REQUEST: u8 = 71;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyFillArcRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -16955,6 +17149,7 @@ impl<'input> crate::x11_utils::VoidRequest for PolyFillArcRequest<'input> {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageFormat(u8);
 impl ImageFormat {
     pub const XY_BITMAP: Self = Self(0);
@@ -17017,6 +17212,7 @@ impl core::fmt::Debug for ImageFormat  {
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 72;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PutImageRequest<'input> {
     pub format: ImageFormat,
     pub drawable: Drawable,
@@ -17142,6 +17338,7 @@ impl<'input> crate::x11_utils::VoidRequest for PutImageRequest<'input> {
 /// Opcode for the GetImage request
 pub const GET_IMAGE_REQUEST: u8 = 73;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetImageRequest {
     pub format: ImageFormat,
     pub drawable: Drawable,
@@ -17232,6 +17429,7 @@ impl crate::x11_utils::ReplyRequest for GetImageRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetImageReply {
     pub depth: u8,
     pub sequence: u16,
@@ -17279,6 +17477,7 @@ impl GetImageReply {
 /// Opcode for the PolyText8 request
 pub const POLY_TEXT8_REQUEST: u8 = 74;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyText8Request<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -17370,6 +17569,7 @@ impl<'input> crate::x11_utils::VoidRequest for PolyText8Request<'input> {
 /// Opcode for the PolyText16 request
 pub const POLY_TEXT16_REQUEST: u8 = 75;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyText16Request<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -17493,6 +17693,7 @@ pub const IMAGE_TEXT8_REQUEST: u8 = 76;
 ///
 /// * `ImageText16`: request
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageText8Request<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -17619,6 +17820,7 @@ pub const IMAGE_TEXT16_REQUEST: u8 = 77;
 ///
 /// * `ImageText8`: request
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageText16Request<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
@@ -17711,6 +17913,7 @@ impl<'input> crate::x11_utils::VoidRequest for ImageText16Request<'input> {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColormapAlloc(u8);
 impl ColormapAlloc {
     pub const NONE: Self = Self(0);
@@ -17771,6 +17974,7 @@ impl core::fmt::Debug for ColormapAlloc  {
 /// Opcode for the CreateColormap request
 pub const CREATE_COLORMAP_REQUEST: u8 = 78;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateColormapRequest {
     pub alloc: ColormapAlloc,
     pub mid: Colormap,
@@ -17846,6 +18050,7 @@ impl crate::x11_utils::VoidRequest for CreateColormapRequest {
 /// Opcode for the FreeColormap request
 pub const FREE_COLORMAP_REQUEST: u8 = 79;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeColormapRequest {
     pub cmap: Colormap,
 }
@@ -17901,6 +18106,7 @@ impl crate::x11_utils::VoidRequest for FreeColormapRequest {
 /// Opcode for the CopyColormapAndFree request
 pub const COPY_COLORMAP_AND_FREE_REQUEST: u8 = 80;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyColormapAndFreeRequest {
     pub mid: Colormap,
     pub src_cmap: Colormap,
@@ -17964,6 +18170,7 @@ impl crate::x11_utils::VoidRequest for CopyColormapAndFreeRequest {
 /// Opcode for the InstallColormap request
 pub const INSTALL_COLORMAP_REQUEST: u8 = 81;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InstallColormapRequest {
     pub cmap: Colormap,
 }
@@ -18019,6 +18226,7 @@ impl crate::x11_utils::VoidRequest for InstallColormapRequest {
 /// Opcode for the UninstallColormap request
 pub const UNINSTALL_COLORMAP_REQUEST: u8 = 82;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UninstallColormapRequest {
     pub cmap: Colormap,
 }
@@ -18074,6 +18282,7 @@ impl crate::x11_utils::VoidRequest for UninstallColormapRequest {
 /// Opcode for the ListInstalledColormaps request
 pub const LIST_INSTALLED_COLORMAPS_REQUEST: u8 = 83;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListInstalledColormapsRequest {
     pub window: Window,
 }
@@ -18128,6 +18337,7 @@ impl crate::x11_utils::ReplyRequest for ListInstalledColormapsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListInstalledColormapsReply {
     pub sequence: u16,
     pub length: u32,
@@ -18190,6 +18400,7 @@ pub const ALLOC_COLOR_REQUEST: u8 = 84;
 ///
 /// * `Colormap` - The specified colormap `cmap` does not exist.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocColorRequest {
     pub cmap: Colormap,
     pub red: u16,
@@ -18265,6 +18476,7 @@ impl crate::x11_utils::ReplyRequest for AllocColorRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocColorReply {
     pub sequence: u16,
     pub length: u32,
@@ -18299,6 +18511,7 @@ impl TryParse for AllocColorReply {
 /// Opcode for the AllocNamedColor request
 pub const ALLOC_NAMED_COLOR_REQUEST: u8 = 85;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocNamedColorRequest<'input> {
     pub cmap: Colormap,
     pub name: Cow<'input, [u8]>,
@@ -18374,6 +18587,7 @@ impl<'input> crate::x11_utils::ReplyRequest for AllocNamedColorRequest<'input> {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocNamedColorReply {
     pub sequence: u16,
     pub length: u32,
@@ -18413,6 +18627,7 @@ impl TryParse for AllocNamedColorReply {
 /// Opcode for the AllocColorCells request
 pub const ALLOC_COLOR_CELLS_REQUEST: u8 = 86;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocColorCellsRequest {
     pub contiguous: bool,
     pub cmap: Colormap,
@@ -18482,6 +18697,7 @@ impl crate::x11_utils::ReplyRequest for AllocColorCellsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocColorCellsReply {
     pub sequence: u16,
     pub length: u32,
@@ -18542,6 +18758,7 @@ impl AllocColorCellsReply {
 /// Opcode for the AllocColorPlanes request
 pub const ALLOC_COLOR_PLANES_REQUEST: u8 = 87;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocColorPlanesRequest {
     pub contiguous: bool,
     pub cmap: Colormap,
@@ -18623,6 +18840,7 @@ impl crate::x11_utils::ReplyRequest for AllocColorPlanesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocColorPlanesReply {
     pub sequence: u16,
     pub length: u32,
@@ -18674,6 +18892,7 @@ impl AllocColorPlanesReply {
 /// Opcode for the FreeColors request
 pub const FREE_COLORS_REQUEST: u8 = 88;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeColorsRequest<'input> {
     pub cmap: Colormap,
     pub plane_mask: u32,
@@ -18757,6 +18976,7 @@ impl<'input> crate::x11_utils::VoidRequest for FreeColorsRequest<'input> {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColorFlag(u8);
 impl ColorFlag {
     pub const RED: Self = Self(1 << 0);
@@ -18818,6 +19038,7 @@ impl core::fmt::Debug for ColorFlag  {
 bitmask_binop!(ColorFlag, u8);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Coloritem {
     pub pixel: u32,
     pub red: u16,
@@ -18874,6 +19095,7 @@ impl Serialize for Coloritem {
 /// Opcode for the StoreColors request
 pub const STORE_COLORS_REQUEST: u8 = 89;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StoreColorsRequest<'input> {
     pub cmap: Colormap,
     pub items: Cow<'input, [Coloritem]>,
@@ -18950,6 +19172,7 @@ impl<'input> crate::x11_utils::VoidRequest for StoreColorsRequest<'input> {
 /// Opcode for the StoreNamedColor request
 pub const STORE_NAMED_COLOR_REQUEST: u8 = 90;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StoreNamedColorRequest<'input> {
     pub flags: u8,
     pub cmap: Colormap,
@@ -19037,6 +19260,7 @@ impl<'input> crate::x11_utils::VoidRequest for StoreNamedColorRequest<'input> {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rgb {
     pub red: u16,
     pub green: u16,
@@ -19081,6 +19305,7 @@ impl Serialize for Rgb {
 /// Opcode for the QueryColors request
 pub const QUERY_COLORS_REQUEST: u8 = 91;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryColorsRequest<'input> {
     pub cmap: Colormap,
     pub pixels: Cow<'input, [u32]>,
@@ -19156,6 +19381,7 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryColorsRequest<'input> {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryColorsReply {
     pub sequence: u16,
     pub length: u32,
@@ -19200,6 +19426,7 @@ impl QueryColorsReply {
 /// Opcode for the LookupColor request
 pub const LOOKUP_COLOR_REQUEST: u8 = 92;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LookupColorRequest<'input> {
     pub cmap: Colormap,
     pub name: Cow<'input, [u8]>,
@@ -19275,6 +19502,7 @@ impl<'input> crate::x11_utils::ReplyRequest for LookupColorRequest<'input> {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LookupColorReply {
     pub sequence: u16,
     pub length: u32,
@@ -19310,6 +19538,7 @@ impl TryParse for LookupColorReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PixmapEnum(u8);
 impl PixmapEnum {
     pub const NONE: Self = Self(0);
@@ -19368,6 +19597,7 @@ impl core::fmt::Debug for PixmapEnum  {
 /// Opcode for the CreateCursor request
 pub const CREATE_CURSOR_REQUEST: u8 = 93;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateCursorRequest {
     pub cid: Cursor,
     pub source: Pixmap,
@@ -19485,6 +19715,7 @@ impl crate::x11_utils::VoidRequest for CreateCursorRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FontEnum(u8);
 impl FontEnum {
     pub const NONE: Self = Self(0);
@@ -19576,6 +19807,7 @@ pub const CREATE_GLYPH_CURSOR_REQUEST: u8 = 94;
 /// * `Font` - The specified `source_font` or `mask_font` does not exist.
 /// * `Value` - Either `source_char` or `mask_char` are not defined in `source_font` or `mask_font`, respectively.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateGlyphCursorRequest {
     pub cid: Cursor,
     pub source_font: Font,
@@ -19707,6 +19939,7 @@ pub const FREE_CURSOR_REQUEST: u8 = 95;
 ///
 /// * `Cursor` - The specified cursor does not exist.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeCursorRequest {
     pub cursor: Cursor,
 }
@@ -19762,6 +19995,7 @@ impl crate::x11_utils::VoidRequest for FreeCursorRequest {
 /// Opcode for the RecolorCursor request
 pub const RECOLOR_CURSOR_REQUEST: u8 = 96;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RecolorCursorRequest {
     pub cursor: Cursor,
     pub fore_red: u16,
@@ -19851,6 +20085,7 @@ impl crate::x11_utils::VoidRequest for RecolorCursorRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryShapeOf(u8);
 impl QueryShapeOf {
     pub const LARGEST_CURSOR: Self = Self(0);
@@ -19913,6 +20148,7 @@ impl core::fmt::Debug for QueryShapeOf  {
 /// Opcode for the QueryBestSize request
 pub const QUERY_BEST_SIZE_REQUEST: u8 = 97;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryBestSizeRequest {
     pub class: QueryShapeOf,
     pub drawable: Drawable,
@@ -19983,6 +20219,7 @@ impl crate::x11_utils::ReplyRequest for QueryBestSizeRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryBestSizeReply {
     pub sequence: u16,
     pub length: u32,
@@ -20033,6 +20270,7 @@ pub const QUERY_EXTENSION_REQUEST: u8 = 98;
 /// * `xdpyinfo`: program
 /// * `xcb_get_extension_data`: function
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionRequest<'input> {
     pub name: Cow<'input, [u8]>,
 }
@@ -20105,6 +20343,7 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryExtensionRequest<'input> {
 /// * `first_event` - The first event code, if any.
 /// * `first_error` - The first error code, if any.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionReply {
     pub sequence: u16,
     pub length: u32,
@@ -20138,6 +20377,7 @@ impl TryParse for QueryExtensionReply {
 /// Opcode for the ListExtensions request
 pub const LIST_EXTENSIONS_REQUEST: u8 = 99;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListExtensionsRequest;
 impl ListExtensionsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -20183,6 +20423,7 @@ impl crate::x11_utils::ReplyRequest for ListExtensionsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListExtensionsReply {
     pub sequence: u16,
     pub length: u32,
@@ -20226,6 +20467,7 @@ impl ListExtensionsReply {
 /// Opcode for the ChangeKeyboardMapping request
 pub const CHANGE_KEYBOARD_MAPPING_REQUEST: u8 = 100;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeKeyboardMappingRequest<'input> {
     pub keycode_count: u8,
     pub first_keycode: Keycode,
@@ -20306,6 +20548,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeKeyboardMappingRequest<'inp
 /// Opcode for the GetKeyboardMapping request
 pub const GET_KEYBOARD_MAPPING_REQUEST: u8 = 101;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKeyboardMappingRequest {
     pub first_keycode: Keycode,
     pub count: u8,
@@ -20364,6 +20607,7 @@ impl crate::x11_utils::ReplyRequest for GetKeyboardMappingRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKeyboardMappingReply {
     pub keysyms_per_keycode: u8,
     pub sequence: u16,
@@ -20405,6 +20649,7 @@ impl GetKeyboardMappingReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KB(u8);
 impl KB {
     pub const KEY_CLICK_PERCENT: Self = Self(1 << 0);
@@ -20476,6 +20721,7 @@ impl core::fmt::Debug for KB  {
 bitmask_binop!(KB, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LedMode(u32);
 impl LedMode {
     pub const OFF: Self = Self(0);
@@ -20522,6 +20768,7 @@ impl core::fmt::Debug for LedMode  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AutoRepeatMode(u32);
 impl AutoRepeatMode {
     pub const OFF: Self = Self(0);
@@ -20571,6 +20818,7 @@ impl core::fmt::Debug for AutoRepeatMode  {
 
 /// Auxiliary and optional information for the `change_keyboard_control` function
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeKeyboardControlAux {
     pub key_click_percent: Option<i32>,
     pub bell_percent: Option<i32>,
@@ -20778,6 +21026,7 @@ impl ChangeKeyboardControlAux {
 /// Opcode for the ChangeKeyboardControl request
 pub const CHANGE_KEYBOARD_CONTROL_REQUEST: u8 = 102;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeKeyboardControlRequest<'input> {
     pub value_list: Cow<'input, ChangeKeyboardControlAux>,
 }
@@ -20845,6 +21094,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeKeyboardControlRequest<'inp
 /// Opcode for the GetKeyboardControl request
 pub const GET_KEYBOARD_CONTROL_REQUEST: u8 = 103;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKeyboardControlRequest;
 impl GetKeyboardControlRequest {
     /// Serialize this request into bytes for the provided connection
@@ -20890,6 +21140,7 @@ impl crate::x11_utils::ReplyRequest for GetKeyboardControlRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKeyboardControlReply {
     pub global_auto_repeat: AutoRepeatMode,
     pub sequence: u16,
@@ -20931,6 +21182,7 @@ impl TryParse for GetKeyboardControlReply {
 /// Opcode for the Bell request
 pub const BELL_REQUEST: u8 = 104;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BellRequest {
     pub percent: i8,
 }
@@ -20981,6 +21233,7 @@ impl crate::x11_utils::VoidRequest for BellRequest {
 /// Opcode for the ChangePointerControl request
 pub const CHANGE_POINTER_CONTROL_REQUEST: u8 = 105;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangePointerControlRequest {
     pub acceleration_numerator: i16,
     pub acceleration_denominator: i16,
@@ -21056,6 +21309,7 @@ impl crate::x11_utils::VoidRequest for ChangePointerControlRequest {
 /// Opcode for the GetPointerControl request
 pub const GET_POINTER_CONTROL_REQUEST: u8 = 106;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPointerControlRequest;
 impl GetPointerControlRequest {
     /// Serialize this request into bytes for the provided connection
@@ -21101,6 +21355,7 @@ impl crate::x11_utils::ReplyRequest for GetPointerControlRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPointerControlReply {
     pub sequence: u16,
     pub length: u32,
@@ -21131,6 +21386,7 @@ impl TryParse for GetPointerControlReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Blanking(u8);
 impl Blanking {
     pub const NOT_PREFERRED: Self = Self(0);
@@ -21191,6 +21447,7 @@ impl core::fmt::Debug for Blanking  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Exposures(u8);
 impl Exposures {
     pub const NOT_ALLOWED: Self = Self(0);
@@ -21253,6 +21510,7 @@ impl core::fmt::Debug for Exposures  {
 /// Opcode for the SetScreenSaver request
 pub const SET_SCREEN_SAVER_REQUEST: u8 = 107;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetScreenSaverRequest {
     pub timeout: i16,
     pub interval: i16,
@@ -21326,6 +21584,7 @@ impl crate::x11_utils::VoidRequest for SetScreenSaverRequest {
 /// Opcode for the GetScreenSaver request
 pub const GET_SCREEN_SAVER_REQUEST: u8 = 108;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSaverRequest;
 impl GetScreenSaverRequest {
     /// Serialize this request into bytes for the provided connection
@@ -21371,6 +21630,7 @@ impl crate::x11_utils::ReplyRequest for GetScreenSaverRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSaverReply {
     pub sequence: u16,
     pub length: u32,
@@ -21405,6 +21665,7 @@ impl TryParse for GetScreenSaverReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HostMode(u8);
 impl HostMode {
     pub const INSERT: Self = Self(0);
@@ -21463,6 +21724,7 @@ impl core::fmt::Debug for HostMode  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Family(u8);
 impl Family {
     pub const INTERNET: Self = Self(0);
@@ -21529,6 +21791,7 @@ impl core::fmt::Debug for Family  {
 /// Opcode for the ChangeHosts request
 pub const CHANGE_HOSTS_REQUEST: u8 = 109;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeHostsRequest<'input> {
     pub mode: HostMode,
     pub family: Family,
@@ -21605,6 +21868,7 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeHostsRequest<'input> {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Host {
     pub family: Family,
     pub address: Vec<u8>,
@@ -21662,6 +21926,7 @@ impl Host {
 /// Opcode for the ListHosts request
 pub const LIST_HOSTS_REQUEST: u8 = 110;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListHostsRequest;
 impl ListHostsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -21707,6 +21972,7 @@ impl crate::x11_utils::ReplyRequest for ListHostsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListHostsReply {
     pub mode: AccessControl,
     pub sequence: u16,
@@ -21751,6 +22017,7 @@ impl ListHostsReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AccessControl(u8);
 impl AccessControl {
     pub const DISABLE: Self = Self(0);
@@ -21811,6 +22078,7 @@ impl core::fmt::Debug for AccessControl  {
 /// Opcode for the SetAccessControl request
 pub const SET_ACCESS_CONTROL_REQUEST: u8 = 111;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetAccessControlRequest {
     pub mode: AccessControl,
 }
@@ -21860,6 +22128,7 @@ impl crate::x11_utils::VoidRequest for SetAccessControlRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CloseDown(u8);
 impl CloseDown {
     pub const DESTROY_ALL: Self = Self(0);
@@ -21922,6 +22191,7 @@ impl core::fmt::Debug for CloseDown  {
 /// Opcode for the SetCloseDownMode request
 pub const SET_CLOSE_DOWN_MODE_REQUEST: u8 = 112;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCloseDownModeRequest {
     pub mode: CloseDown,
 }
@@ -21971,6 +22241,7 @@ impl crate::x11_utils::VoidRequest for SetCloseDownModeRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Kill(u8);
 impl Kill {
     pub const ALL_TEMPORARY: Self = Self(0);
@@ -22048,6 +22319,7 @@ pub const KILL_CLIENT_REQUEST: u8 = 113;
 ///
 /// * `xkill`: program
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KillClientRequest {
     pub resource: u32,
 }
@@ -22103,6 +22375,7 @@ impl crate::x11_utils::VoidRequest for KillClientRequest {
 /// Opcode for the RotateProperties request
 pub const ROTATE_PROPERTIES_REQUEST: u8 = 114;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RotatePropertiesRequest<'input> {
     pub window: Window,
     pub delta: i16,
@@ -22182,6 +22455,7 @@ impl<'input> crate::x11_utils::VoidRequest for RotatePropertiesRequest<'input> {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScreenSaver(u8);
 impl ScreenSaver {
     pub const RESET: Self = Self(0);
@@ -22242,6 +22516,7 @@ impl core::fmt::Debug for ScreenSaver  {
 /// Opcode for the ForceScreenSaver request
 pub const FORCE_SCREEN_SAVER_REQUEST: u8 = 115;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ForceScreenSaverRequest {
     pub mode: ScreenSaver,
 }
@@ -22291,6 +22566,7 @@ impl crate::x11_utils::VoidRequest for ForceScreenSaverRequest {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MappingStatus(u8);
 impl MappingStatus {
     pub const SUCCESS: Self = Self(0);
@@ -22353,6 +22629,7 @@ impl core::fmt::Debug for MappingStatus  {
 /// Opcode for the SetPointerMapping request
 pub const SET_POINTER_MAPPING_REQUEST: u8 = 116;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPointerMappingRequest<'input> {
     pub map: Cow<'input, [u8]>,
 }
@@ -22413,6 +22690,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetPointerMappingRequest<'input>
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPointerMappingReply {
     pub status: MappingStatus,
     pub sequence: u16,
@@ -22440,6 +22718,7 @@ impl TryParse for SetPointerMappingReply {
 /// Opcode for the GetPointerMapping request
 pub const GET_POINTER_MAPPING_REQUEST: u8 = 117;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPointerMappingRequest;
 impl GetPointerMappingRequest {
     /// Serialize this request into bytes for the provided connection
@@ -22485,6 +22764,7 @@ impl crate::x11_utils::ReplyRequest for GetPointerMappingRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPointerMappingReply {
     pub sequence: u16,
     pub length: u32,
@@ -22527,6 +22807,7 @@ impl GetPointerMappingReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapIndex(u8);
 impl MapIndex {
     pub const SHIFT: Self = Self(0);
@@ -22599,6 +22880,7 @@ impl core::fmt::Debug for MapIndex  {
 /// Opcode for the SetModifierMapping request
 pub const SET_MODIFIER_MAPPING_REQUEST: u8 = 118;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetModifierMappingRequest<'input> {
     pub keycodes: Cow<'input, [Keycode]>,
 }
@@ -22660,6 +22942,7 @@ impl<'input> crate::x11_utils::ReplyRequest for SetModifierMappingRequest<'input
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetModifierMappingReply {
     pub status: MappingStatus,
     pub sequence: u16,
@@ -22687,6 +22970,7 @@ impl TryParse for SetModifierMappingReply {
 /// Opcode for the GetModifierMapping request
 pub const GET_MODIFIER_MAPPING_REQUEST: u8 = 119;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetModifierMappingRequest;
 impl GetModifierMappingRequest {
     /// Serialize this request into bytes for the provided connection
@@ -22732,6 +23016,7 @@ impl crate::x11_utils::ReplyRequest for GetModifierMappingRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetModifierMappingReply {
     pub sequence: u16,
     pub length: u32,
@@ -22777,6 +23062,7 @@ impl GetModifierMappingReply {
 /// Opcode for the NoOperation request
 pub const NO_OPERATION_REQUEST: u8 = 127;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NoOperationRequest;
 impl NoOperationRequest {
     /// Serialize this request into bytes for the provided connection

--- a/x11rb-protocol/src/protocol/xselinux.rs
+++ b/x11rb-protocol/src/protocol/xselinux.rs
@@ -37,6 +37,7 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major: u8,
     pub client_minor: u8,
@@ -92,6 +93,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -121,6 +123,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the SetDeviceCreateContext request
 pub const SET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
@@ -184,6 +187,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetDeviceCreateContextRequest<'in
 /// Opcode for the GetDeviceCreateContext request
 pub const GET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceCreateContextRequest;
 impl GetDeviceCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -226,6 +230,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceCreateContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceCreateContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -271,6 +276,7 @@ impl GetDeviceCreateContextReply {
 /// Opcode for the SetDeviceContext request
 pub const SET_DEVICE_CONTEXT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceContextRequest<'input> {
     pub device: u32,
     pub context: Cow<'input, [u8]>,
@@ -343,6 +349,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetDeviceContextRequest<'input> {
 /// Opcode for the GetDeviceContext request
 pub const GET_DEVICE_CONTEXT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceContextRequest {
     pub device: u32,
 }
@@ -394,6 +401,7 @@ impl crate::x11_utils::ReplyRequest for GetDeviceContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -439,6 +447,7 @@ impl GetDeviceContextReply {
 /// Opcode for the SetWindowCreateContext request
 pub const SET_WINDOW_CREATE_CONTEXT_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetWindowCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
@@ -502,6 +511,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetWindowCreateContextRequest<'in
 /// Opcode for the GetWindowCreateContext request
 pub const GET_WINDOW_CREATE_CONTEXT_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowCreateContextRequest;
 impl GetWindowCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -544,6 +554,7 @@ impl crate::x11_utils::ReplyRequest for GetWindowCreateContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowCreateContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -589,6 +600,7 @@ impl GetWindowCreateContextReply {
 /// Opcode for the GetWindowContext request
 pub const GET_WINDOW_CONTEXT_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowContextRequest {
     pub window: xproto::Window,
 }
@@ -640,6 +652,7 @@ impl crate::x11_utils::ReplyRequest for GetWindowContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -683,6 +696,7 @@ impl GetWindowContextReply {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListItem {
     pub name: xproto::Atom,
     pub object_context: Vec<u8>,
@@ -762,6 +776,7 @@ impl ListItem {
 /// Opcode for the SetPropertyCreateContext request
 pub const SET_PROPERTY_CREATE_CONTEXT_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPropertyCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
@@ -825,6 +840,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetPropertyCreateContextRequest<'
 /// Opcode for the GetPropertyCreateContext request
 pub const GET_PROPERTY_CREATE_CONTEXT_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyCreateContextRequest;
 impl GetPropertyCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -867,6 +883,7 @@ impl crate::x11_utils::ReplyRequest for GetPropertyCreateContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyCreateContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -912,6 +929,7 @@ impl GetPropertyCreateContextReply {
 /// Opcode for the SetPropertyUseContext request
 pub const SET_PROPERTY_USE_CONTEXT_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPropertyUseContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
@@ -975,6 +993,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetPropertyUseContextRequest<'inp
 /// Opcode for the GetPropertyUseContext request
 pub const GET_PROPERTY_USE_CONTEXT_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyUseContextRequest;
 impl GetPropertyUseContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1017,6 +1036,7 @@ impl crate::x11_utils::ReplyRequest for GetPropertyUseContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyUseContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1062,6 +1082,7 @@ impl GetPropertyUseContextReply {
 /// Opcode for the GetPropertyContext request
 pub const GET_PROPERTY_CONTEXT_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyContextRequest {
     pub window: xproto::Window,
     pub property: xproto::Atom,
@@ -1121,6 +1142,7 @@ impl crate::x11_utils::ReplyRequest for GetPropertyContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1166,6 +1188,7 @@ impl GetPropertyContextReply {
 /// Opcode for the GetPropertyDataContext request
 pub const GET_PROPERTY_DATA_CONTEXT_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyDataContextRequest {
     pub window: xproto::Window,
     pub property: xproto::Atom,
@@ -1225,6 +1248,7 @@ impl crate::x11_utils::ReplyRequest for GetPropertyDataContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyDataContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1270,6 +1294,7 @@ impl GetPropertyDataContextReply {
 /// Opcode for the ListProperties request
 pub const LIST_PROPERTIES_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListPropertiesRequest {
     pub window: xproto::Window,
 }
@@ -1321,6 +1346,7 @@ impl crate::x11_utils::ReplyRequest for ListPropertiesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListPropertiesReply {
     pub sequence: u16,
     pub length: u32,
@@ -1365,6 +1391,7 @@ impl ListPropertiesReply {
 /// Opcode for the SetSelectionCreateContext request
 pub const SET_SELECTION_CREATE_CONTEXT_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetSelectionCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
@@ -1428,6 +1455,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetSelectionCreateContextRequest<
 /// Opcode for the GetSelectionCreateContext request
 pub const GET_SELECTION_CREATE_CONTEXT_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionCreateContextRequest;
 impl GetSelectionCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1470,6 +1498,7 @@ impl crate::x11_utils::ReplyRequest for GetSelectionCreateContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionCreateContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1515,6 +1544,7 @@ impl GetSelectionCreateContextReply {
 /// Opcode for the SetSelectionUseContext request
 pub const SET_SELECTION_USE_CONTEXT_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetSelectionUseContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
@@ -1578,6 +1608,7 @@ impl<'input> crate::x11_utils::VoidRequest for SetSelectionUseContextRequest<'in
 /// Opcode for the GetSelectionUseContext request
 pub const GET_SELECTION_USE_CONTEXT_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionUseContextRequest;
 impl GetSelectionUseContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1620,6 +1651,7 @@ impl crate::x11_utils::ReplyRequest for GetSelectionUseContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionUseContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1665,6 +1697,7 @@ impl GetSelectionUseContextReply {
 /// Opcode for the GetSelectionContext request
 pub const GET_SELECTION_CONTEXT_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionContextRequest {
     pub selection: xproto::Atom,
 }
@@ -1716,6 +1749,7 @@ impl crate::x11_utils::ReplyRequest for GetSelectionContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1761,6 +1795,7 @@ impl GetSelectionContextReply {
 /// Opcode for the GetSelectionDataContext request
 pub const GET_SELECTION_DATA_CONTEXT_REQUEST: u8 = 20;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionDataContextRequest {
     pub selection: xproto::Atom,
 }
@@ -1812,6 +1847,7 @@ impl crate::x11_utils::ReplyRequest for GetSelectionDataContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionDataContextReply {
     pub sequence: u16,
     pub length: u32,
@@ -1857,6 +1893,7 @@ impl GetSelectionDataContextReply {
 /// Opcode for the ListSelections request
 pub const LIST_SELECTIONS_REQUEST: u8 = 21;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSelectionsRequest;
 impl ListSelectionsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1899,6 +1936,7 @@ impl crate::x11_utils::ReplyRequest for ListSelectionsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSelectionsReply {
     pub sequence: u16,
     pub length: u32,
@@ -1943,6 +1981,7 @@ impl ListSelectionsReply {
 /// Opcode for the GetClientContext request
 pub const GET_CLIENT_CONTEXT_REQUEST: u8 = 22;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClientContextRequest {
     pub resource: u32,
 }
@@ -1994,6 +2033,7 @@ impl crate::x11_utils::ReplyRequest for GetClientContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClientContextReply {
     pub sequence: u16,
     pub length: u32,

--- a/x11rb-protocol/src/protocol/xtest.rs
+++ b/x11rb-protocol/src/protocol/xtest.rs
@@ -37,6 +37,7 @@ pub const X11_XML_VERSION: (u32, u32) = (2, 2);
 /// Opcode for the GetVersion request
 pub const GET_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVersionRequest {
     pub major_version: u8,
     pub minor_version: u16,
@@ -93,6 +94,7 @@ impl crate::x11_utils::ReplyRequest for GetVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVersionReply {
     pub major_version: u8,
     pub sequence: u16,
@@ -119,6 +121,7 @@ impl TryParse for GetVersionReply {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cursor(bool);
 impl Cursor {
     pub const NONE: Self = Self(false);
@@ -191,6 +194,7 @@ impl core::fmt::Debug for Cursor  {
 /// Opcode for the CompareCursor request
 pub const COMPARE_CURSOR_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompareCursorRequest {
     pub window: xproto::Window,
     pub cursor: xproto::Cursor,
@@ -250,6 +254,7 @@ impl crate::x11_utils::ReplyRequest for CompareCursorRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompareCursorReply {
     pub same: bool,
     pub sequence: u16,
@@ -276,6 +281,7 @@ impl TryParse for CompareCursorReply {
 /// Opcode for the FakeInput request
 pub const FAKE_INPUT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FakeInputRequest {
     pub type_: u8,
     pub detail: u8,
@@ -383,6 +389,7 @@ impl crate::x11_utils::VoidRequest for FakeInputRequest {
 /// Opcode for the GrabControl request
 pub const GRAB_CONTROL_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabControlRequest {
     pub impervious: bool,
 }

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -41,6 +41,7 @@ pub type Port = u32;
 pub type Encoding = u32;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Type(u8);
 impl Type {
     pub const INPUT_MASK: Self = Self(1 << 0);
@@ -106,6 +107,7 @@ impl core::fmt::Debug for Type  {
 bitmask_binop!(Type, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageFormatInfoType(u8);
 impl ImageFormatInfoType {
     pub const RGB: Self = Self(0);
@@ -164,6 +166,7 @@ impl core::fmt::Debug for ImageFormatInfoType  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageFormatInfoFormat(u8);
 impl ImageFormatInfoFormat {
     pub const PACKED: Self = Self(0);
@@ -222,6 +225,7 @@ impl core::fmt::Debug for ImageFormatInfoFormat  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttributeFlag(u8);
 impl AttributeFlag {
     pub const GETTABLE: Self = Self(1 << 0);
@@ -281,6 +285,7 @@ impl core::fmt::Debug for AttributeFlag  {
 bitmask_binop!(AttributeFlag, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VideoNotifyReason(u8);
 impl VideoNotifyReason {
     pub const STARTED: Self = Self(0);
@@ -345,6 +350,7 @@ impl core::fmt::Debug for VideoNotifyReason  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScanlineOrder(u8);
 impl ScanlineOrder {
     pub const TOP_TO_BOTTOM: Self = Self(0);
@@ -403,6 +409,7 @@ impl core::fmt::Debug for ScanlineOrder  {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabPortStatus(u8);
 impl GrabPortStatus {
     pub const SUCCESS: Self = Self(0);
@@ -469,6 +476,7 @@ impl core::fmt::Debug for GrabPortStatus  {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rational {
     pub numerator: i32,
     pub denominator: i32,
@@ -505,6 +513,7 @@ impl Serialize for Rational {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Format {
     pub visual: xproto::Visualid,
     pub depth: u8,
@@ -543,6 +552,7 @@ impl Serialize for Format {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AdaptorInfo {
     pub base_id: Port,
     pub num_ports: u16,
@@ -622,6 +632,7 @@ impl AdaptorInfo {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EncodingInfo {
     pub encoding: Encoding,
     pub width: u16,
@@ -685,6 +696,7 @@ impl EncodingInfo {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Image {
     pub id: u32,
     pub width: u16,
@@ -760,6 +772,7 @@ impl Image {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttributeInfo {
     pub flags: u32,
     pub min: i32,
@@ -818,6 +831,7 @@ impl AttributeInfo {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageFormatInfo {
     pub id: u32,
     pub type_: ImageFormatInfoType,
@@ -1079,6 +1093,7 @@ pub const BAD_CONTROL_ERROR: u8 = 2;
 /// Opcode for the VideoNotify event
 pub const VIDEO_NOTIFY_EVENT: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VideoNotifyEvent {
     pub response_type: u8,
     pub reason: VideoNotifyReason,
@@ -1158,6 +1173,7 @@ impl From<VideoNotifyEvent> for [u8; 32] {
 /// Opcode for the PortNotify event
 pub const PORT_NOTIFY_EVENT: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PortNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
@@ -1237,6 +1253,7 @@ impl From<PortNotifyEvent> for [u8; 32] {
 /// Opcode for the QueryExtension request
 pub const QUERY_EXTENSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionRequest;
 impl QueryExtensionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1279,6 +1296,7 @@ impl crate::x11_utils::ReplyRequest for QueryExtensionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionReply {
     pub sequence: u16,
     pub length: u32,
@@ -1308,6 +1326,7 @@ impl TryParse for QueryExtensionReply {
 /// Opcode for the QueryAdaptors request
 pub const QUERY_ADAPTORS_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryAdaptorsRequest {
     pub window: xproto::Window,
 }
@@ -1359,6 +1378,7 @@ impl crate::x11_utils::ReplyRequest for QueryAdaptorsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryAdaptorsReply {
     pub sequence: u16,
     pub length: u32,
@@ -1403,6 +1423,7 @@ impl QueryAdaptorsReply {
 /// Opcode for the QueryEncodings request
 pub const QUERY_ENCODINGS_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryEncodingsRequest {
     pub port: Port,
 }
@@ -1454,6 +1475,7 @@ impl crate::x11_utils::ReplyRequest for QueryEncodingsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryEncodingsReply {
     pub sequence: u16,
     pub length: u32,
@@ -1498,6 +1520,7 @@ impl QueryEncodingsReply {
 /// Opcode for the GrabPort request
 pub const GRAB_PORT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabPortRequest {
     pub port: Port,
     pub time: xproto::Timestamp,
@@ -1557,6 +1580,7 @@ impl crate::x11_utils::ReplyRequest for GrabPortRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabPortReply {
     pub result: GrabPortStatus,
     pub sequence: u16,
@@ -1584,6 +1608,7 @@ impl TryParse for GrabPortReply {
 /// Opcode for the UngrabPort request
 pub const UNGRAB_PORT_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabPortRequest {
     pub port: Port,
     pub time: xproto::Timestamp,
@@ -1644,6 +1669,7 @@ impl crate::x11_utils::VoidRequest for UngrabPortRequest {
 /// Opcode for the PutVideo request
 pub const PUT_VIDEO_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PutVideoRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
@@ -1760,6 +1786,7 @@ impl crate::x11_utils::VoidRequest for PutVideoRequest {
 /// Opcode for the PutStill request
 pub const PUT_STILL_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PutStillRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
@@ -1876,6 +1903,7 @@ impl crate::x11_utils::VoidRequest for PutStillRequest {
 /// Opcode for the GetVideo request
 pub const GET_VIDEO_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVideoRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
@@ -1992,6 +2020,7 @@ impl crate::x11_utils::VoidRequest for GetVideoRequest {
 /// Opcode for the GetStill request
 pub const GET_STILL_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStillRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
@@ -2108,6 +2137,7 @@ impl crate::x11_utils::VoidRequest for GetStillRequest {
 /// Opcode for the StopVideo request
 pub const STOP_VIDEO_REQUEST: u8 = 9;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StopVideoRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
@@ -2168,6 +2198,7 @@ impl crate::x11_utils::VoidRequest for StopVideoRequest {
 /// Opcode for the SelectVideoNotify request
 pub const SELECT_VIDEO_NOTIFY_REQUEST: u8 = 10;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectVideoNotifyRequest {
     pub drawable: xproto::Drawable,
     pub onoff: bool,
@@ -2229,6 +2260,7 @@ impl crate::x11_utils::VoidRequest for SelectVideoNotifyRequest {
 /// Opcode for the SelectPortNotify request
 pub const SELECT_PORT_NOTIFY_REQUEST: u8 = 11;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectPortNotifyRequest {
     pub port: Port,
     pub onoff: bool,
@@ -2290,6 +2322,7 @@ impl crate::x11_utils::VoidRequest for SelectPortNotifyRequest {
 /// Opcode for the QueryBestSize request
 pub const QUERY_BEST_SIZE_REQUEST: u8 = 12;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryBestSizeRequest {
     pub port: Port,
     pub vid_w: u16,
@@ -2374,6 +2407,7 @@ impl crate::x11_utils::ReplyRequest for QueryBestSizeRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryBestSizeReply {
     pub sequence: u16,
     pub length: u32,
@@ -2403,6 +2437,7 @@ impl TryParse for QueryBestSizeReply {
 /// Opcode for the SetPortAttribute request
 pub const SET_PORT_ATTRIBUTE_REQUEST: u8 = 13;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPortAttributeRequest {
     pub port: Port,
     pub attribute: xproto::Atom,
@@ -2471,6 +2506,7 @@ impl crate::x11_utils::VoidRequest for SetPortAttributeRequest {
 /// Opcode for the GetPortAttribute request
 pub const GET_PORT_ATTRIBUTE_REQUEST: u8 = 14;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPortAttributeRequest {
     pub port: Port,
     pub attribute: xproto::Atom,
@@ -2530,6 +2566,7 @@ impl crate::x11_utils::ReplyRequest for GetPortAttributeRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPortAttributeReply {
     pub sequence: u16,
     pub length: u32,
@@ -2557,6 +2594,7 @@ impl TryParse for GetPortAttributeReply {
 /// Opcode for the QueryPortAttributes request
 pub const QUERY_PORT_ATTRIBUTES_REQUEST: u8 = 15;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPortAttributesRequest {
     pub port: Port,
 }
@@ -2608,6 +2646,7 @@ impl crate::x11_utils::ReplyRequest for QueryPortAttributesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPortAttributesReply {
     pub sequence: u16,
     pub length: u32,
@@ -2654,6 +2693,7 @@ impl QueryPortAttributesReply {
 /// Opcode for the ListImageFormats request
 pub const LIST_IMAGE_FORMATS_REQUEST: u8 = 16;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListImageFormatsRequest {
     pub port: Port,
 }
@@ -2705,6 +2745,7 @@ impl crate::x11_utils::ReplyRequest for ListImageFormatsRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListImageFormatsReply {
     pub sequence: u16,
     pub length: u32,
@@ -2749,6 +2790,7 @@ impl ListImageFormatsReply {
 /// Opcode for the QueryImageAttributes request
 pub const QUERY_IMAGE_ATTRIBUTES_REQUEST: u8 = 17;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryImageAttributesRequest {
     pub port: Port,
     pub id: u32,
@@ -2820,6 +2862,7 @@ impl crate::x11_utils::ReplyRequest for QueryImageAttributesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryImageAttributesReply {
     pub sequence: u16,
     pub length: u32,
@@ -2872,6 +2915,7 @@ impl QueryImageAttributesReply {
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 18;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PutImageRequest<'input> {
     pub port: Port,
     pub drawable: xproto::Drawable,
@@ -3034,6 +3078,7 @@ impl<'input> crate::x11_utils::VoidRequest for PutImageRequest<'input> {
 /// Opcode for the ShmPutImage request
 pub const SHM_PUT_IMAGE_REQUEST: u8 = 19;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ShmPutImageRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,

--- a/x11rb-protocol/src/protocol/xvmc.rs
+++ b/x11rb-protocol/src/protocol/xvmc.rs
@@ -41,6 +41,7 @@ pub type Surface = u32;
 pub type Subpicture = u32;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SurfaceInfo {
     pub id: Surface,
     pub chroma_format: u16,
@@ -123,6 +124,7 @@ impl Serialize for SurfaceInfo {
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -165,6 +167,7 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
@@ -194,6 +197,7 @@ impl TryParse for QueryVersionReply {
 /// Opcode for the ListSurfaceTypes request
 pub const LIST_SURFACE_TYPES_REQUEST: u8 = 1;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSurfaceTypesRequest {
     pub port_id: xv::Port,
 }
@@ -245,6 +249,7 @@ impl crate::x11_utils::ReplyRequest for ListSurfaceTypesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSurfaceTypesReply {
     pub sequence: u16,
     pub length: u32,
@@ -289,6 +294,7 @@ impl ListSurfaceTypesReply {
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 2;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextRequest {
     pub context_id: Context,
     pub port_id: xv::Port,
@@ -376,6 +382,7 @@ impl crate::x11_utils::ReplyRequest for CreateContextRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextReply {
     pub sequence: u16,
     pub width_actual: u16,
@@ -424,6 +431,7 @@ impl CreateContextReply {
 /// Opcode for the DestroyContext request
 pub const DESTROY_CONTEXT_REQUEST: u8 = 3;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyContextRequest {
     pub context_id: Context,
 }
@@ -476,6 +484,7 @@ impl crate::x11_utils::VoidRequest for DestroyContextRequest {
 /// Opcode for the CreateSurface request
 pub const CREATE_SURFACE_REQUEST: u8 = 4;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateSurfaceRequest {
     pub surface_id: Surface,
     pub context_id: Context,
@@ -535,6 +544,7 @@ impl crate::x11_utils::ReplyRequest for CreateSurfaceRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateSurfaceReply {
     pub sequence: u16,
     pub priv_data: Vec<u32>,
@@ -577,6 +587,7 @@ impl CreateSurfaceReply {
 /// Opcode for the DestroySurface request
 pub const DESTROY_SURFACE_REQUEST: u8 = 5;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroySurfaceRequest {
     pub surface_id: Surface,
 }
@@ -629,6 +640,7 @@ impl crate::x11_utils::VoidRequest for DestroySurfaceRequest {
 /// Opcode for the CreateSubpicture request
 pub const CREATE_SUBPICTURE_REQUEST: u8 = 6;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateSubpictureRequest {
     pub subpicture_id: Subpicture,
     pub context: Context,
@@ -708,6 +720,7 @@ impl crate::x11_utils::ReplyRequest for CreateSubpictureRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateSubpictureReply {
     pub sequence: u16,
     pub width_actual: u16,
@@ -761,6 +774,7 @@ impl CreateSubpictureReply {
 /// Opcode for the DestroySubpicture request
 pub const DESTROY_SUBPICTURE_REQUEST: u8 = 7;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroySubpictureRequest {
     pub subpicture_id: Subpicture,
 }
@@ -813,6 +827,7 @@ impl crate::x11_utils::VoidRequest for DestroySubpictureRequest {
 /// Opcode for the ListSubpictureTypes request
 pub const LIST_SUBPICTURE_TYPES_REQUEST: u8 = 8;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSubpictureTypesRequest {
     pub port_id: xv::Port,
     pub surface_id: Surface,
@@ -872,6 +887,7 @@ impl crate::x11_utils::ReplyRequest for ListSubpictureTypesRequest {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSubpictureTypesReply {
     pub sequence: u16,
     pub length: u32,


### PR DESCRIPTION
It's generally recommended that objects derive `serde` traits. This PR adds the optional `serde` feature, which derives `serde::Serialize` and `serde::Deserialize` for all protocol objects that don't contain raw FDs.