### PR TITLE
Use `MSG_CMSG_CLOEXEC` for the `recvmsg()` calls

### DIFF
--- a/x11rb/src/rust_connection/stream.rs
+++ b/x11rb/src/rust_connection/stream.rs
@@ -420,7 +420,7 @@ impl Stream for DefaultStream {
 
             let fd = self.as_raw_fd();
             let msg = loop {
-                match recvmsg::<()>(fd, &mut iov, Some(&mut cmsg), MsgFlags::empty()) {
+                match recvmsg::<()>(fd, &mut iov, Some(&mut cmsg), MsgFlags::MSG_CMSG_CLOEXEC) {
                     Ok(msg) => break msg,
                     // try again
                     Err(nix::Error::EINTR) => {}


### PR DESCRIPTION
Resolves #641, and probably a good idea anyways, since `CLOEXEC` is the default state for all Unix socket types in Rust