### PR TITLE
Document abstract unix socket use

### DIFF
--- a/x11rb/src/rust_connection/stream.rs
+++ b/x11rb/src/rust_connection/stream.rs
@@ -196,6 +196,9 @@ impl DefaultStream {
             }
             #[cfg(unix)]
             ConnectAddress::Socket(path) => {
+                // TODO: Try abstract socket (file name with prepended '\0')
+                // Not supported on Rust right now: https://github.com/rust-lang/rust/issues/42048
+
                 // connect over Unix domain socket
                 let stream = UnixStream::connect(path)?;
                 Self::from_unix_stream(stream)
@@ -208,6 +211,10 @@ impl DefaultStream {
                     "Unix domain sockets are not supported on Windows",
                 ))
             }
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "The given address family is not implemented",
+            )),
         }
     }
 


### PR DESCRIPTION
We already have ConnectAddress::Socket that means "the given file name
is a unix socket to connect to". Abstract unix sockets work the same
name, only that the file should be looked up in the abstract namespace
instead of the filesystem.

Thus, this commit changes the docs of x11rb-protocol accordingly and
moves the "TODO" for implementing this from x11rb-protocol to x11rb.

Additionally, this marks ConnectAddress as #[non_exhaustive] so that we
may add new cases in the future. One might think "this will never happen
/ be necessary", but here is a merge request trying to add a new case to
libxcb:
https://gitlab.freedesktop.org/xorg/lib/libxcb/-/merge_requests/27

Signed-off-by: Uli Schlachter <psychon@znc.in>