### PR TITLE
Fix two doc links

### DIFF
--- a/x11rb-protocol/src/connect.rs
+++ b/x11rb-protocol/src/connect.rs
@@ -168,7 +168,7 @@ impl Connect {
 
     /// Returns the buffer that needs to be filled with incoming data from the server.
     ///
-    /// After filling this buffer (using a method like `Read::read`), call [`advance`] with
+    /// After filling this buffer (using a method like `Read::read`), call [`Self::advance`] with
     /// the number of bytes read to indicate that the buffer has been filled.
     pub fn buffer(&mut self) -> &mut [u8] {
         &mut self.buffer[self.advanced..]

--- a/x11rb-protocol/src/xauth.rs
+++ b/x11rb-protocol/src/xauth.rs
@@ -12,7 +12,7 @@ const MIT_MAGIC_COOKIE_1: &[u8] = b"MIT-MAGIC-COOKIE-1";
 
 /// A family describes how to interpret some bytes as an address in an `AuthEntry`.
 ///
-/// Compared to [`x11rb_protocol::protocol::xproto::Family`], this is a `u16` and not an `u8` since
+/// Compared to [`super::protocol::xproto::Family`], this is a `u16` and not an `u8` since
 /// that's what is used in `~/.Xauthority` files.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Family(u16);


### PR DESCRIPTION
"cargo doc" had the following two complaints. There are still, others,
but these two are easily fixed:
```
warning: unresolved link to `advance`
   --> x11rb-protocol/src/connect.rs:171:78
    |
171 |     /// After filling this buffer (using a method like `Read::read`), call [`advance`] with
    |                                                                              ^^^^^^^ no item named `advance` in scope
    |
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
    = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

warning: unresolved link to `x11rb_protocol::protocol::xproto::Family`
  --> x11rb-protocol/src/xauth.rs:15:19
   |
15 | /// Compared to [`x11rb_protocol::protocol::xproto::Family`], this is a `u16` and not an `u8` since
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `x11rb_protocol` in scope
```
Signed-off-by: Uli Schlachter <psychon@znc.in>