### PR TITLE
Move xtrace-example to x11rb-protocol

### DIFF
--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -29,6 +29,37 @@ std = ["nix"]
 # resource databases.
 resource_manager = ["std"]
 
+# Enable this feature to enable all the X11 extensions
+all-extensions = [
+    "composite",
+    "damage",
+    "dpms",
+    "dri2",
+    "dri3",
+    "glx",
+    "present",
+    "randr",
+    "record",
+    "render",
+    "res",
+    "screensaver",
+    "shape",
+    "shm",
+    "sync",
+    "xevie",
+    "xf86dri",
+    "xf86vidmode",
+    "xfixes",
+    "xinerama",
+    "xinput",
+    "xkb",
+    "xprint",
+    "xselinux",
+    "xtest",
+    "xv",
+    "xvmc",
+]
+
 # Features to enable individual X11 extensions
 composite = ["xfixes"]
 damage = ["xfixes"]

--- a/x11rb-protocol/src/x11_utils.rs
+++ b/x11rb-protocol/src/x11_utils.rs
@@ -507,3 +507,45 @@ impl TryIntoUSize for i8 {}
 impl TryIntoUSize for i16 {}
 impl TryIntoUSize for i32 {}
 impl TryIntoUSize for i64 {}
+
+/// Has the BigRequests extension been enabled?
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BigRequests {
+    /// The BigRequests extension has been enabled.
+    Enabled,
+    /// The BigRequests extension has not been enabled.
+    NotEnabled,
+}
+
+/// Parse the given input for a RequestHeader and the remaining input.
+pub fn parse_request_header(
+    input: &[u8],
+    big_requests_enabled: BigRequests,
+) -> Result<(RequestHeader, &[u8]), ParseError> {
+    let (major_opcode, remaining) = u8::try_parse(input)?;
+    let (minor_opcode, remaining) = u8::try_parse(remaining)?;
+    let (length, remaining) = u16::try_parse(remaining)?;
+    let (remaining_length, finally_remaining) = if length == 0 {
+        if big_requests_enabled == BigRequests::NotEnabled {
+            return Err(ParseError::InvalidValue);
+        }
+
+        let (length, remaining) = u32::try_parse(remaining)?;
+        if length < 2 {
+            return Err(ParseError::InvalidValue);
+        }
+        // Adjust length for the size of this header (two 4 byte units).
+        (length - 2, remaining)
+    } else {
+        // Adjust length for the size of this header (one 4 byte unit).
+        (u32::from(length) - 1, remaining)
+    };
+    Ok((
+        RequestHeader {
+            major_opcode,
+            minor_opcode,
+            remaining_length,
+        },
+        finally_remaining,
+    ))
+}

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -55,6 +55,7 @@ dl-libxcb = ["allow-unsafe-code", "libloading", "once_cell"]
 
 # Enable this feature to enable all the X11 extensions
 all-extensions = [
+    "x11rb-protocol/all-extensions",
     "composite",
     "damage",
     "dpms",

--- a/x11rb/src/x11_utils.rs
+++ b/x11rb/src/x11_utils.rs
@@ -1,52 +1,9 @@
 //! Some utilities for working with X11.
 
-use x11rb_protocol::errors::ParseError;
 pub use x11rb_protocol::x11_utils::{
-    ExtInfoProvider, ExtensionInformation, ReplyParsingFunction, Request, RequestHeader, Serialize,
-    TryParse, TryParseFd, X11Error,
+    parse_request_header, BigRequests, ExtInfoProvider, ExtensionInformation, ReplyParsingFunction,
+    Request, RequestHeader, Serialize, TryParse, TryParseFd, X11Error,
 };
-
-/// Has the BigRequests extension been enabled?
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BigRequests {
-    /// The BigRequests extension has been enabled.
-    Enabled,
-    /// The BigRequests extension has not been enabled.
-    NotEnabled,
-}
-
-/// Parse the given input for a RequestHeader and the remaining input.
-pub fn parse_request_header(
-    input: &[u8],
-    big_requests_enabled: BigRequests,
-) -> Result<(RequestHeader, &[u8]), ParseError> {
-    let (major_opcode, remaining) = u8::try_parse(input)?;
-    let (minor_opcode, remaining) = u8::try_parse(remaining)?;
-    let (length, remaining) = u16::try_parse(remaining)?;
-    let (remaining_length, finally_remaining) = if length == 0 {
-        if big_requests_enabled == BigRequests::NotEnabled {
-            return Err(ParseError::InvalidValue);
-        }
-
-        let (length, remaining) = u32::try_parse(remaining)?;
-        if length < 2 {
-            return Err(ParseError::InvalidValue);
-        }
-        // Adjust length for the size of this header (two 4 byte units).
-        (length - 2, remaining)
-    } else {
-        // Adjust length for the size of this header (one 4 byte unit).
-        (u32::from(length) - 1, remaining)
-    };
-    Ok((
-        RequestHeader {
-            major_opcode,
-            minor_opcode,
-            remaining_length,
-        },
-        finally_remaining,
-    ))
-}
 
 /// A helper macro for managing atoms
 ///

--- a/xtrace-example/Cargo.toml
+++ b/xtrace-example/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 [dependencies]
 smol = "1.2.5"
 
-[dependencies.x11rb]
-path = "../x11rb"
+[dependencies.x11rb-protocol]
+path = "../x11rb-protocol"
 features = ["all-extensions"]
 
 [dependencies.futures-util]

--- a/xtrace-example/src/connection.rs
+++ b/xtrace-example/src/connection.rs
@@ -4,7 +4,7 @@ use std::convert::{TryFrom, TryInto};
 use std::io::Result as IOResult;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-use x11rb::protocol::xproto::GE_GENERIC_EVENT;
+use x11rb_protocol::protocol::xproto::GE_GENERIC_EVENT;
 
 use crate::connection_inner::ConnectionInner;
 use crate::forwarder::forward_with_callback;

--- a/xtrace-example/src/connection_inner.rs
+++ b/xtrace-example/src/connection_inner.rs
@@ -1,6 +1,6 @@
-use x11rb::errors::ParseError;
-use x11rb::protocol::{xproto, Event, Reply, Request};
-use x11rb::x11_utils::{
+use x11rb_protocol::errors::ParseError;
+use x11rb_protocol::protocol::{xproto, Event, Reply, Request};
+use x11rb_protocol::x11_utils::{
     parse_request_header, BigRequests, ExtInfoProvider, ExtensionInformation, ReplyParsingFunction,
     TryParse, X11Error,
 };


### PR DESCRIPTION
This commit makes the xtrace-example depend on x11rb-protocol instead of
x11rb. To make this possible, some more stuff is moved from x11rb to
x11rb-protocol:

* The all-extensions feature now also exists in x11rb-protocol
* x11_utils::BigRequests and the parse_request_header() function are
  moved over and re-exports are left behind to avoid an API break

Signed-off-by: Uli Schlachter <psychon@znc.in>