### PR TITLE
Ensure that Unix behavior works on all Unixes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -172,3 +172,16 @@ jobs:
       run: cargo install cross --force
     - name: cargo test
       run: cross test --target "$CROSS_TARGET" --verbose --package x11rb --features "$MOST_FEATURES"
+
+  # future-proof against issue #721
+  non-linux-unix-test:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Run tests
+      run: cargo test --verbose --package x11rb --features "$MOST_FEATURES"


### PR DESCRIPTION
This PR does three things:

- Fixes #721 by locking abstract sockets behind a Linux cfg guard.
- While fixing this, I realized that `MSG_CMSG_CLOEXEC` is not available on all Unixes. I also cfg guard this, and manually set CLOEXEC on OSes that don’t support it.
- I add a `macOS` build to the CI to hopefully serve as a canary for when non-Linux Unixes break in the future.