### PR TITLE
Disable nix default features

### DIFF
--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -19,8 +19,11 @@ serde = { version = "1", features = ["derive"], optional = true }
 [dev-dependencies]
 criterion = "0.3"
 
-[target.'cfg(unix)'.dependencies]
-nix = { version = "0.24", optional = true }
+[target.'cfg(unix)'.dependencies.nix]
+version = "0.24"
+default-features = false
+features = ["fs"]
+optional = true
 
 [features]
 default = ["std"]

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -26,8 +26,10 @@ libloading = { version = "0.7.0", optional = true }
 once_cell = { version = "1.8.0", optional = true }
 gethostname = "0.2.1"
 
-[target.'cfg(unix)'.dependencies]
-nix = "0.24"
+[target.'cfg(unix)'.dependencies.nix]
+version = "0.24"
+default-features = false
+features = ["socket", "uio", "poll"]
 
 [target.'cfg(windows)'.dependencies]
 winapi-wsapoll = "0.1.1"


### PR DESCRIPTION
I just noticed that since version 0.24.0, the nix crate has features. By
default, everything is enabled.

This commit disables default features and then re-enables features until
things compile again.

Signed-off-by: Uli Schlachter <psychon@znc.in>