### PR TITLE
Remove some unused code in the code generator

### DIFF
--- a/xcbgen-rs/src/defs/expression.rs
+++ b/xcbgen-rs/src/defs/expression.rs
@@ -172,7 +172,7 @@ pub struct ParamRefExpr {
     pub field_name: String,
 
     /// The type of the referenced field.
-    pub type_: NamedTypeRef,
+    pub(crate) type_: NamedTypeRef,
 }
 
 /// An expression referencing a value from an enumeration.

--- a/xcbgen-rs/src/defs/fields.rs
+++ b/xcbgen-rs/src/defs/fields.rs
@@ -56,7 +56,7 @@ impl FieldDef {
     /// * For `<field>`s and `<exprfield>`s, this returns the type of the field.
     /// * For `<list>`s, this returns the element type of the list.
     /// * For virtual length fields, this returns the type of the length, which is a `CARD32`.
-    pub fn value_type(&self) -> Option<&FieldValueType> {
+    pub(crate) fn value_type(&self) -> Option<&FieldValueType> {
         match self {
             Self::Pad(_) => None,
             Self::Normal(normal_field) => Some(&normal_field.type_),
@@ -229,7 +229,7 @@ pub struct SwitchCase {
     pub exprs: Vec<Expression>,
 
     /// The value of the `<required_start_align>` child, if any.
-    pub required_start_align: Option<Alignment>,
+    pub(crate) required_start_align: Option<Alignment>,
 
     /// Alignment information about this case.
     ///
@@ -324,7 +324,7 @@ pub struct VirtualLenField {
     pub name: String,
 
     /// The type of the field.
-    pub type_: FieldValueType,
+    pub(crate) type_: FieldValueType,
 
     /// The name of the referenced list.
     pub list_name: String,
@@ -443,7 +443,7 @@ pub enum BuiltInType {
 
 impl BuiltInType {
     /// Get the size in bytes of this type on the wire.
-    pub fn size(self) -> u32 {
+    pub(crate) fn size(self) -> u32 {
         match self {
             Self::Card8 => 1,
             Self::Card16 => 2,

--- a/xcbgen-rs/src/defs/top_level.rs
+++ b/xcbgen-rs/src/defs/top_level.rs
@@ -549,16 +549,11 @@ impl NamedEventRef {
             .expect("named event reference already resolved")
     }
 
-    /// Returns the resolved event, or `None` if not set.
-    #[inline]
-    fn try_get_resolved(&self) -> Option<&EventRef> {
-        self.def.get()
-    }
-
     /// Returns the resolved event, or panics if not set.
     #[inline]
     pub fn get_resolved(&self) -> &EventRef {
-        self.try_get_resolved()
+        self.def
+            .get()
             .expect("named event reference has not been resolved")
     }
 }
@@ -647,16 +642,11 @@ impl NamedErrorRef {
             .expect("named error reference already resolved")
     }
 
-    /// Returns the resolved error, or `None` if not set.
-    #[inline]
-    fn try_get_resolved(&self) -> Option<&ErrorRef> {
-        self.def.get()
-    }
-
     /// Returns the resolved error, or panics if not set.
     #[inline]
     fn get_resolved(&self) -> &ErrorRef {
-        self.try_get_resolved()
+        self.def
+            .get()
             .expect("named error reference has not been resolved")
     }
 }
@@ -745,16 +735,11 @@ impl NamedTypeRef {
             .expect("named type reference already resolved")
     }
 
-    /// Returns the resolved type, or `None` if not set.
-    #[inline]
-    fn try_get_resolved(&self) -> Option<&TypeRef> {
-        self.def.get()
-    }
-
     /// Returns the resolved type, or panics if not set.
     #[inline]
     pub fn get_resolved(&self) -> &TypeRef {
-        self.try_get_resolved()
+        self.def
+            .get()
             .expect("named type reference has not been resolved")
     }
 }

--- a/xcbgen-rs/src/parser.rs
+++ b/xcbgen-rs/src/parser.rs
@@ -83,13 +83,11 @@ impl Parser {
             .attribute("extension-xname")
             .map::<Result<defs::ExtInfo, ParseError>, _>(|xname| {
                 let name = get_attr(node, "extension-name")?;
-                let multiword = try_get_attr_parsed(node, "extension-multiword")?.unwrap_or(false);
                 let major_version = get_attr_parsed(node, "major-version")?;
                 let minor_version = get_attr_parsed(node, "minor-version")?;
                 Ok(defs::ExtInfo {
                     xname: xname.into(),
                     name: name.into(),
-                    multiword,
                     major_version,
                     minor_version,
                 })


### PR DESCRIPTION
What should I say? It's weekend, it's hot outside, I removed all occurrences of `pub ` from xcbgen-rs and made the result compile again by re-adding first `pub(crate)`, then `pub`. The goal of the exercise was to give the dead code lint something to complain about, but I guess changing some `pub` to `pub(crate)` is also not the worst thing. This PR is the result.