### PR TITLE
Run the code generator with coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -143,6 +143,14 @@ jobs:
       run: ./run_examples --features "$MOST_FEATURES libc allow-unsafe-code"
     - name: run examples with XCBConnection and dl-libxcb
       run: ./run_examples --features "$MOST_FEATURES libc allow-unsafe-code dl-libxcb"
+
+    # run code generator in nightly builds for coverage
+    - name: Run code generator
+      if: matrix.rust == 'nightly'
+      run: make
+      env:
+        LLVM_PROFILE_FILE: coverage-%m.profraw
+
     - name: Prepare coverage information for upload
       if: matrix.rust == 'nightly'
       run: grcov $(find ./ -type f -name "coverage-*.profraw") -s . --binary-path ./target/debug --branch --ignore-not-existing --ignore 'tests/*' -t coveralls+ --token ? -o ./coveralls.json


### PR DESCRIPTION
The code generator is included in the stats by codecov, but is never
executed with coverage enabled. This commit "simply" runs the code
generator in the coverage build.

Signed-off-by: Uli Schlachter <psychon@znc.in>