### PR TITLE
Ignore examples for code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+ignore:
+  # Coverage for examples is not interesting, so exclude examples
+  - "x11rb/examples"
+  - "cairo-example"
+  - "xtrace-example"


### PR DESCRIPTION
Tracking code coverage for examples is not interesting. No one should
write tests for them.

Also, if we were to include the execution of these examples (easily
possible!), this would also consider all code in x11rb and
x11rb-protocol that is used by these examples to be covered. I consider
the examples "too light a test" to really count the code they use as
properly tested.

Signed-off-by: Uli Schlachter <psychon@znc.in>

Edit: `cat codecov.yml | curl --data-binary @- https://codecov.io/validate` says this yml is valid and I think I got the file name right. I guess we will see if this worked when codecov leaves a comment on this PR. That comment should show an increase in code coverage, because there is now less lines that are *not* covered, so the lines that are covered should result in a higher percentage value. Right?