### PR TITLE
Try to stabilise code coverage reports

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
   MOST_FEATURES: all-extensions cursor image
+  # According to code coverage changes, sometimes $XENVIRONMENT is set and
+  # sometimes not. Try to make this consistent to stabilise coverage reports.
+  # Example: https://app.codecov.io/gh/psychon/x11rb/compare/726/changes
+  XENVIRONMENT: this/file/does/not/exit
 
 jobs:
   code_gen:


### PR DESCRIPTION
We got some flaky code coverage results. The resource database code
sometimes takes different paths. Apparently, $XENVIRONMENT is sometimes
set and sometimes is not.

This commit tries to get rid of the noise in coverage reports by simply
always setting $XENVIRONMENT to a file that does not exist.

Time will tell if this works properly. No idea how to test this.

Signed-off-by: Uli Schlachter <psychon@znc.in>