### PR TITLE
Add serialization options for replies and events

### DIFF
--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -211,7 +211,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             false,
             true,
             size_constraint,
-            false,
+            true,
             true,
             event_full_def.doc.as_ref(),
             out,

--- a/generator/src/generator/namespace/request.rs
+++ b/generator/src/generator/namespace/request.rs
@@ -276,8 +276,8 @@ pub(super) fn generate_request(
             false,
             true,
             StructSizeConstraint::EmbeddedLength { minimum: 32 },
-            false,
-            false,
+            true,
+            true,
             reply.doc.as_ref(),
             proto_out,
         );

--- a/generator/src/generator/namespace/switch.rs
+++ b/generator/src/generator/namespace/switch.rs
@@ -808,7 +808,24 @@ fn emit_variable_size_switch_serialize(
             ext_params_arg_defs
         );
         out.indented(|out| {
-            serialize::emit_assert_for_switch_serialize(generator, switch, switch_expr_type, out);
+            // TODO: emit an assertion checking that the switch case has
+            // been set properly
+            //
+            // omitted here because some expressions do not have a
+            // `switch_expr()` function
+            let _ = switch_expr_type;
+
+            // eat the parameters for now
+            if !external_params.is_empty() {
+                for external_param in external_params.iter() {
+                    outln!(
+                        out,
+                        "let _ = {};",
+                        to_rust_variable_name(&external_param.name)
+                    );
+                }
+            }
+
             if switch.kind == xcbdefs::SwitchKind::BitCase {
                 for (case, case_info) in switch.cases.iter().zip(case_infos.iter()) {
                     match case_info {

--- a/x11rb-protocol/src/protocol/bigreq.rs
+++ b/x11rb-protocol/src/protocol/bigreq.rs
@@ -102,4 +102,36 @@ impl TryParse for EnableReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for EnableReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let maximum_request_length_bytes = self.maximum_request_length.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            maximum_request_length_bytes[0],
+            maximum_request_length_bytes[1],
+            maximum_request_length_bytes[2],
+            maximum_request_length_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.maximum_request_length.serialize_into(bytes);
+    }
+}
 

--- a/x11rb-protocol/src/protocol/composite.rs
+++ b/x11rb-protocol/src/protocol/composite.rs
@@ -185,6 +185,61 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_version_bytes[0],
+            major_version_bytes[1],
+            major_version_bytes[2],
+            major_version_bytes[3],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+            minor_version_bytes[2],
+            minor_version_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major_version.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+    }
+}
 
 /// Opcode for the RedirectWindow request
 pub const REDIRECT_WINDOW_REQUEST: u8 = 1;
@@ -638,6 +693,59 @@ impl TryParse for GetOverlayWindowReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetOverlayWindowReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let overlay_win_bytes = self.overlay_win.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            overlay_win_bytes[0],
+            overlay_win_bytes[1],
+            overlay_win_bytes[2],
+            overlay_win_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.overlay_win.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
     }
 }
 

--- a/x11rb-protocol/src/protocol/damage.rs
+++ b/x11rb-protocol/src/protocol/damage.rs
@@ -194,6 +194,61 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_version_bytes[0],
+            major_version_bytes[1],
+            major_version_bytes[2],
+            major_version_bytes[3],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+            minor_version_bytes[2],
+            minor_version_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major_version.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+    }
+}
 
 /// Opcode for the Create request
 pub const CREATE_REQUEST: u8 = 1;
@@ -480,6 +535,64 @@ impl TryParse for NotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for NotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let level_bytes = u8::from(self.level).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let damage_bytes = self.damage.serialize();
+        let timestamp_bytes = self.timestamp.serialize();
+        let area_bytes = self.area.serialize();
+        let geometry_bytes = self.geometry.serialize();
+        [
+            response_type_bytes[0],
+            level_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            damage_bytes[0],
+            damage_bytes[1],
+            damage_bytes[2],
+            damage_bytes[3],
+            timestamp_bytes[0],
+            timestamp_bytes[1],
+            timestamp_bytes[2],
+            timestamp_bytes[3],
+            area_bytes[0],
+            area_bytes[1],
+            area_bytes[2],
+            area_bytes[3],
+            area_bytes[4],
+            area_bytes[5],
+            area_bytes[6],
+            area_bytes[7],
+            geometry_bytes[0],
+            geometry_bytes[1],
+            geometry_bytes[2],
+            geometry_bytes[3],
+            geometry_bytes[4],
+            geometry_bytes[5],
+            geometry_bytes[6],
+            geometry_bytes[7],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        u8::from(self.level).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.drawable.serialize_into(bytes);
+        self.damage.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        self.area.serialize_into(bytes);
+        self.geometry.serialize_into(bytes);
     }
 }
 impl From<&NotifyEvent> for [u8; 32] {

--- a/x11rb-protocol/src/protocol/dpms.rs
+++ b/x11rb-protocol/src/protocol/dpms.rs
@@ -117,6 +117,40 @@ impl TryParse for GetVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetVersionReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let server_major_version_bytes = self.server_major_version.serialize();
+        let server_minor_version_bytes = self.server_minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            server_major_version_bytes[0],
+            server_major_version_bytes[1],
+            server_minor_version_bytes[0],
+            server_minor_version_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.server_major_version.serialize_into(bytes);
+        self.server_minor_version.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the Capable request
 pub const CAPABLE_REQUEST: u8 = 1;
@@ -187,6 +221,59 @@ impl TryParse for CapableReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for CapableReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let capable_bytes = self.capable.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            capable_bytes[0],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.capable.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 23]);
     }
 }
 
@@ -263,6 +350,63 @@ impl TryParse for GetTimeoutsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetTimeoutsReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let standby_timeout_bytes = self.standby_timeout.serialize();
+        let suspend_timeout_bytes = self.suspend_timeout.serialize();
+        let off_timeout_bytes = self.off_timeout.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            standby_timeout_bytes[0],
+            standby_timeout_bytes[1],
+            suspend_timeout_bytes[0],
+            suspend_timeout_bytes[1],
+            off_timeout_bytes[0],
+            off_timeout_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.standby_timeout.serialize_into(bytes);
+        self.suspend_timeout.serialize_into(bytes);
+        self.off_timeout.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 18]);
     }
 }
 
@@ -602,6 +746,61 @@ impl TryParse for InfoReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for InfoReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let power_level_bytes = u16::from(self.power_level).serialize();
+        let state_bytes = self.state.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            power_level_bytes[0],
+            power_level_bytes[1],
+            state_bytes[0],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        u16::from(self.power_level).serialize_into(bytes);
+        self.state.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 21]);
     }
 }
 

--- a/x11rb-protocol/src/protocol/dri3.rs
+++ b/x11rb-protocol/src/protocol/dri3.rs
@@ -123,6 +123,44 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_version_bytes[0],
+            major_version_bytes[1],
+            major_version_bytes[2],
+            major_version_bytes[3],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+            minor_version_bytes[2],
+            minor_version_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major_version.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the Open request
 pub const OPEN_REQUEST: u8 = 1;
@@ -211,6 +249,58 @@ impl TryParseFd for OpenReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for OpenReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let nfd_bytes = self.nfd.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            nfd_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.nfd.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
     }
 }
 
@@ -407,6 +497,70 @@ impl TryParseFd for BufferFromPixmapReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for BufferFromPixmapReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let nfd_bytes = self.nfd.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let size_bytes = self.size.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let stride_bytes = self.stride.serialize();
+        let depth_bytes = self.depth.serialize();
+        let bpp_bytes = self.bpp.serialize();
+        [
+            response_type_bytes[0],
+            nfd_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            size_bytes[0],
+            size_bytes[1],
+            size_bytes[2],
+            size_bytes[3],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            stride_bytes[0],
+            stride_bytes[1],
+            depth_bytes[0],
+            bpp_bytes[0],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.nfd.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.size.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.stride.serialize_into(bytes);
+        self.depth.serialize_into(bytes);
+        self.bpp.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+    }
+}
 
 /// Opcode for the FenceFromFD request
 pub const FENCE_FROM_FD_REQUEST: u8 = 4;
@@ -570,6 +724,58 @@ impl TryParseFd for FDFromFenceReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for FDFromFenceReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let nfd_bytes = self.nfd.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            nfd_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.nfd.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+    }
+}
 
 /// Opcode for the GetSupportedModifiers request
 pub const GET_SUPPORTED_MODIFIERS_REQUEST: u8 = 6;
@@ -666,6 +872,29 @@ impl TryParse for GetSupportedModifiersReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetSupportedModifiersReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let num_window_modifiers = u32::try_from(self.window_modifiers.len()).expect("`window_modifiers` has too many elements");
+        num_window_modifiers.serialize_into(bytes);
+        let num_screen_modifiers = u32::try_from(self.screen_modifiers.len()).expect("`screen_modifiers` has too many elements");
+        num_screen_modifiers.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+        self.window_modifiers.serialize_into(bytes);
+        self.screen_modifiers.serialize_into(bytes);
     }
 }
 impl GetSupportedModifiersReply {
@@ -967,6 +1196,34 @@ impl TryParseFd for BuffersFromPixmapReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for BuffersFromPixmapReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        let nfd = u8::try_from(self.strides.len()).expect("`strides` has too many elements");
+        nfd.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        self.modifier.serialize_into(bytes);
+        self.depth.serialize_into(bytes);
+        self.bpp.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 6]);
+        self.strides.serialize_into(bytes);
+        assert_eq!(self.offsets.len(), usize::try_from(nfd).unwrap(), "`offsets` has an incorrect length");
+        self.offsets.serialize_into(bytes);
+        assert_eq!(self.buffers.len(), usize::try_from(nfd).unwrap(), "`buffers` has an incorrect length");
     }
 }
 impl BuffersFromPixmapReply {

--- a/x11rb-protocol/src/protocol/ge.rs
+++ b/x11rb-protocol/src/protocol/ge.rs
@@ -118,4 +118,59 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_version_bytes[0],
+            major_version_bytes[1],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major_version.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+    }
+}
 

--- a/x11rb-protocol/src/protocol/glx.rs
+++ b/x11rb-protocol/src/protocol/glx.rs
@@ -139,6 +139,74 @@ impl TryParse for PbufferClobberEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for PbufferClobberEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let event_type_bytes = self.event_type.serialize();
+        let draw_type_bytes = self.draw_type.serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let b_mask_bytes = self.b_mask.serialize();
+        let aux_buffer_bytes = self.aux_buffer.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let count_bytes = self.count.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            event_type_bytes[0],
+            event_type_bytes[1],
+            draw_type_bytes[0],
+            draw_type_bytes[1],
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            b_mask_bytes[0],
+            b_mask_bytes[1],
+            b_mask_bytes[2],
+            b_mask_bytes[3],
+            aux_buffer_bytes[0],
+            aux_buffer_bytes[1],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            count_bytes[0],
+            count_bytes[1],
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.event_type.serialize_into(bytes);
+        self.draw_type.serialize_into(bytes);
+        self.drawable.serialize_into(bytes);
+        self.b_mask.serialize_into(bytes);
+        self.aux_buffer.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.count.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+    }
+}
 impl From<&PbufferClobberEvent> for [u8; 32] {
     fn from(input: &PbufferClobberEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -229,6 +297,68 @@ impl TryParse for BufferSwapCompleteEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for BufferSwapCompleteEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let event_type_bytes = self.event_type.serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let ust_hi_bytes = self.ust_hi.serialize();
+        let ust_lo_bytes = self.ust_lo.serialize();
+        let msc_hi_bytes = self.msc_hi.serialize();
+        let msc_lo_bytes = self.msc_lo.serialize();
+        let sbc_bytes = self.sbc.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            event_type_bytes[0],
+            event_type_bytes[1],
+            0,
+            0,
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            ust_hi_bytes[0],
+            ust_hi_bytes[1],
+            ust_hi_bytes[2],
+            ust_hi_bytes[3],
+            ust_lo_bytes[0],
+            ust_lo_bytes[1],
+            ust_lo_bytes[2],
+            ust_lo_bytes[3],
+            msc_hi_bytes[0],
+            msc_hi_bytes[1],
+            msc_hi_bytes[2],
+            msc_hi_bytes[3],
+            msc_lo_bytes[0],
+            msc_lo_bytes[1],
+            msc_lo_bytes[2],
+            msc_lo_bytes[3],
+            sbc_bytes[0],
+            sbc_bytes[1],
+            sbc_bytes[2],
+            sbc_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.event_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.drawable.serialize_into(bytes);
+        self.ust_hi.serialize_into(bytes);
+        self.ust_lo.serialize_into(bytes);
+        self.msc_hi.serialize_into(bytes);
+        self.msc_lo.serialize_into(bytes);
+        self.sbc.serialize_into(bytes);
     }
 }
 impl From<&BufferSwapCompleteEvent> for [u8; 32] {
@@ -778,6 +908,59 @@ impl TryParse for MakeCurrentReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for MakeCurrentReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let context_tag_bytes = self.context_tag.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            context_tag_bytes[0],
+            context_tag_bytes[1],
+            context_tag_bytes[2],
+            context_tag_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.context_tag.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+    }
+}
 
 /// Opcode for the IsDirect request
 pub const IS_DIRECT_REQUEST: u8 = 6;
@@ -857,6 +1040,59 @@ impl TryParse for IsDirectReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for IsDirectReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let is_direct_bytes = self.is_direct.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            is_direct_bytes[0],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.is_direct.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 23]);
     }
 }
 
@@ -948,6 +1184,61 @@ impl TryParse for QueryVersionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_version_bytes[0],
+            major_version_bytes[1],
+            major_version_bytes[2],
+            major_version_bytes[3],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+            minor_version_bytes[2],
+            minor_version_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major_version.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
     }
 }
 
@@ -1525,6 +1816,27 @@ impl TryParse for GetVisualConfigsReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetVisualConfigsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        let length = u32::try_from(self.property_list.len()).expect("`property_list` has too many elements");
+        length.serialize_into(bytes);
+        self.num_visuals.serialize_into(bytes);
+        self.num_properties.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+        self.property_list.serialize_into(bytes);
+    }
+}
 impl GetVisualConfigsReply {
     /// Get the value of the `length` field.
     ///
@@ -1775,6 +2087,27 @@ impl TryParse for VendorPrivateWithReplyReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for VendorPrivateWithReplyReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(36);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        assert_eq!(self.data2.len() % 4, 0, "`data2` has an incorrect length, must be a multiple of 4");
+        let length = u32::try_from(self.data2.len() / 4).expect("`data2` has too many elements");
+        length.serialize_into(bytes);
+        self.retval.serialize_into(bytes);
+        bytes.extend_from_slice(&self.data1);
+        bytes.extend_from_slice(&self.data2);
+    }
+}
 impl VendorPrivateWithReplyReply {
     /// Get the value of the `length` field.
     ///
@@ -1873,6 +2206,60 @@ impl TryParse for QueryExtensionsStringReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryExtensionsStringReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let n_bytes = self.n.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            n_bytes[0],
+            n_bytes[1],
+            n_bytes[2],
+            n_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        self.n.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+    }
+}
 
 /// Opcode for the QueryServerString request
 pub const QUERY_SERVER_STRING_REQUEST: u8 = 19;
@@ -1963,6 +2350,27 @@ impl TryParse for QueryServerStringReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryServerStringReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let str_len = u32::try_from(self.string.len()).expect("`string` has too many elements");
+        str_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+        bytes.extend_from_slice(&self.string);
     }
 }
 impl QueryServerStringReply {
@@ -2144,6 +2552,27 @@ impl TryParse for GetFBConfigsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetFBConfigsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        let length = u32::try_from(self.property_list.len()).expect("`property_list` has too many elements");
+        length.serialize_into(bytes);
+        self.num_fb_configs.serialize_into(bytes);
+        self.num_properties.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+        self.property_list.serialize_into(bytes);
     }
 }
 impl GetFBConfigsReply {
@@ -2492,6 +2921,27 @@ impl TryParse for QueryContextReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        assert_eq!(self.attribs.len() % 2, 0, "`attribs` has an incorrect length, must be a multiple of 2");
+        let num_attribs = u32::try_from(self.attribs.len() / 2).expect("`attribs` has too many elements");
+        num_attribs.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.attribs.serialize_into(bytes);
+    }
+}
 impl QueryContextReply {
     /// Get the value of the `num_attribs` field.
     ///
@@ -2611,6 +3061,59 @@ impl TryParse for MakeContextCurrentReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for MakeContextCurrentReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let context_tag_bytes = self.context_tag.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            context_tag_bytes[0],
+            context_tag_bytes[1],
+            context_tag_bytes[2],
+            context_tag_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.context_tag.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
     }
 }
 
@@ -2839,6 +3342,27 @@ impl TryParse for GetDrawableAttributesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetDrawableAttributesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        assert_eq!(self.attribs.len() % 2, 0, "`attribs` has an incorrect length, must be a multiple of 2");
+        let num_attribs = u32::try_from(self.attribs.len() / 2).expect("`attribs` has too many elements");
+        num_attribs.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.attribs.serialize_into(bytes);
     }
 }
 impl GetDrawableAttributesReply {
@@ -3694,6 +4218,38 @@ impl TryParse for GenListsReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GenListsReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let ret_val_bytes = self.ret_val.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            ret_val_bytes[0],
+            ret_val_bytes[1],
+            ret_val_bytes[2],
+            ret_val_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.ret_val.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the FeedbackBuffer request
 pub const FEEDBACK_BUFFER_REQUEST: u8 = 105;
@@ -3918,6 +4474,28 @@ impl TryParse for RenderModeReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for RenderModeReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.ret_val.serialize_into(bytes);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.new_mode.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl RenderModeReply {
     /// Get the value of the `n` field.
     ///
@@ -4064,6 +4642,32 @@ impl TryParse for FinishReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for FinishReply {
+    type Bytes = [u8; 8];
+    fn serialize(&self) -> [u8; 8] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(8);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
     }
 }
 
@@ -4345,6 +4949,26 @@ impl TryParse for ReadPixelsReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for ReadPixelsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        assert_eq!(self.data.len() % 4, 0, "`data` has an incorrect length, must be a multiple of 4");
+        let length = u32::try_from(self.data.len() / 4).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+        bytes.extend_from_slice(&self.data);
+    }
+}
 impl ReadPixelsReply {
     /// Get the value of the `length` field.
     ///
@@ -4454,6 +5078,28 @@ impl TryParse for GetBooleanvReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetBooleanvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 15]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetBooleanvReply {
     /// Get the value of the `n` field.
     ///
@@ -4555,6 +5201,25 @@ impl TryParse for GetClipPlaneReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetClipPlaneReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        let length = u32::try_from(self.data.len()).ok().and_then(|len| len.checked_mul(2)).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetClipPlaneReply {
@@ -4666,6 +5331,28 @@ impl TryParse for GetDoublevReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetDoublevReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetDoublevReply {
     /// Get the value of the `n` field.
     ///
@@ -4761,6 +5448,38 @@ impl TryParse for GetErrorReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetErrorReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let error_bytes = self.error.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            error_bytes[0],
+            error_bytes[1],
+            error_bytes[2],
+            error_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.error.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the GetFloatv request
 pub const GET_FLOATV_REQUEST: u8 = 116;
@@ -4852,6 +5571,28 @@ impl TryParse for GetFloatvReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetFloatvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetFloatvReply {
@@ -4960,6 +5701,28 @@ impl TryParse for GetIntegervReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetIntegervReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetIntegervReply {
@@ -5078,6 +5841,28 @@ impl TryParse for GetLightfvReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetLightfvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetLightfvReply {
     /// Get the value of the `n` field.
     ///
@@ -5192,6 +5977,28 @@ impl TryParse for GetLightivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetLightivReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetLightivReply {
@@ -5310,6 +6117,28 @@ impl TryParse for GetMapdvReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetMapdvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetMapdvReply {
     /// Get the value of the `n` field.
     ///
@@ -5424,6 +6253,28 @@ impl TryParse for GetMapfvReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetMapfvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetMapfvReply {
@@ -5542,6 +6393,28 @@ impl TryParse for GetMapivReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetMapivReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetMapivReply {
     /// Get the value of the `n` field.
     ///
@@ -5656,6 +6529,28 @@ impl TryParse for GetMaterialfvReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetMaterialfvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetMaterialfvReply {
@@ -5774,6 +6669,28 @@ impl TryParse for GetMaterialivReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetMaterialivReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetMaterialivReply {
     /// Get the value of the `n` field.
     ///
@@ -5880,6 +6797,28 @@ impl TryParse for GetPixelMapfvReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetPixelMapfvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetPixelMapfvReply {
@@ -5990,6 +6929,28 @@ impl TryParse for GetPixelMapuivReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetPixelMapuivReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetPixelMapuivReply {
     /// Get the value of the `n` field.
     ///
@@ -6098,6 +7059,28 @@ impl TryParse for GetPixelMapusvReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetPixelMapusvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(34);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetPixelMapusvReply {
     /// Get the value of the `n` field.
     ///
@@ -6200,6 +7183,26 @@ impl TryParse for GetPolygonStippleReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetPolygonStippleReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        assert_eq!(self.data.len() % 4, 0, "`data` has an incorrect length, must be a multiple of 4");
+        let length = u32::try_from(self.data.len() / 4).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+        bytes.extend_from_slice(&self.data);
     }
 }
 impl GetPolygonStippleReply {
@@ -6308,6 +7311,27 @@ impl TryParse for GetStringReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetStringReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.string.len()).expect("`string` has too many elements");
+        n.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+        bytes.extend_from_slice(&self.string);
     }
 }
 impl GetStringReply {
@@ -6426,6 +7450,28 @@ impl TryParse for GetTexEnvfvReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetTexEnvfvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetTexEnvfvReply {
     /// Get the value of the `n` field.
     ///
@@ -6540,6 +7586,28 @@ impl TryParse for GetTexEnvivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetTexEnvivReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetTexEnvivReply {
@@ -6658,6 +7726,28 @@ impl TryParse for GetTexGendvReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetTexGendvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetTexGendvReply {
     /// Get the value of the `n` field.
     ///
@@ -6774,6 +7864,28 @@ impl TryParse for GetTexGenfvReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetTexGenfvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetTexGenfvReply {
     /// Get the value of the `n` field.
     ///
@@ -6888,6 +8000,28 @@ impl TryParse for GetTexGenivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetTexGenivReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetTexGenivReply {
@@ -7033,6 +8167,30 @@ impl TryParse for GetTexImageReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetTexImageReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        assert_eq!(self.data.len() % 4, 0, "`data` has an incorrect length, must be a multiple of 4");
+        let length = u32::try_from(self.data.len() / 4).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.depth.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        bytes.extend_from_slice(&self.data);
+    }
+}
 impl GetTexImageReply {
     /// Get the value of the `length` field.
     ///
@@ -7150,6 +8308,28 @@ impl TryParse for GetTexParameterfvReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetTexParameterfvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetTexParameterfvReply {
     /// Get the value of the `n` field.
     ///
@@ -7264,6 +8444,28 @@ impl TryParse for GetTexParameterivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetTexParameterivReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetTexParameterivReply {
@@ -7390,6 +8592,28 @@ impl TryParse for GetTexLevelParameterfvReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetTexLevelParameterfvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetTexLevelParameterfvReply {
     /// Get the value of the `n` field.
     ///
@@ -7514,6 +8738,28 @@ impl TryParse for GetTexLevelParameterivReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetTexLevelParameterivReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetTexLevelParameterivReply {
     /// Get the value of the `n` field.
     ///
@@ -7617,6 +8863,38 @@ impl TryParse for IsEnabledReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for IsEnabledReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let ret_val_bytes = self.ret_val.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            ret_val_bytes[0],
+            ret_val_bytes[1],
+            ret_val_bytes[2],
+            ret_val_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.ret_val.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the IsList request
 pub const IS_LIST_REQUEST: u8 = 141;
@@ -7703,6 +8981,38 @@ impl TryParse for IsListReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for IsListReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let ret_val_bytes = self.ret_val.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            ret_val_bytes[0],
+            ret_val_bytes[1],
+            ret_val_bytes[2],
+            ret_val_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.ret_val.serialize_into(bytes);
     }
 }
 
@@ -7859,6 +9169,27 @@ impl TryParse for AreTexturesResidentReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for AreTexturesResidentReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        assert_eq!(self.data.len() % 4, 0, "`data` has an incorrect length, must be a multiple of 4");
+        let length = u32::try_from(self.data.len() / 4).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        self.ret_val.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.data.serialize_into(bytes);
     }
 }
 impl AreTexturesResidentReply {
@@ -8039,6 +9370,25 @@ impl TryParse for GenTexturesReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GenTexturesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        let length = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GenTexturesReply {
     /// Get the value of the `length` field.
     ///
@@ -8140,6 +9490,38 @@ impl TryParse for IsTextureReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for IsTextureReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let ret_val_bytes = self.ret_val.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            ret_val_bytes[0],
+            ret_val_bytes[1],
+            ret_val_bytes[2],
+            ret_val_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.ret_val.serialize_into(bytes);
     }
 }
 
@@ -8256,6 +9638,28 @@ impl TryParse for GetColorTableReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetColorTableReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        assert_eq!(self.data.len() % 4, 0, "`data` has an incorrect length, must be a multiple of 4");
+        let length = u32::try_from(self.data.len() / 4).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.width.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        bytes.extend_from_slice(&self.data);
     }
 }
 impl GetColorTableReply {
@@ -8375,6 +9779,28 @@ impl TryParse for GetColorTableParameterfvReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetColorTableParameterfvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetColorTableParameterfvReply {
     /// Get the value of the `n` field.
     ///
@@ -8489,6 +9915,28 @@ impl TryParse for GetColorTableParameterivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetColorTableParameterivReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetColorTableParameterivReply {
@@ -8624,6 +10072,29 @@ impl TryParse for GetConvolutionFilterReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetConvolutionFilterReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        assert_eq!(self.data.len() % 4, 0, "`data` has an incorrect length, must be a multiple of 4");
+        let length = u32::try_from(self.data.len() / 4).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        bytes.extend_from_slice(&self.data);
+    }
+}
 impl GetConvolutionFilterReply {
     /// Get the value of the `length` field.
     ///
@@ -8741,6 +10212,28 @@ impl TryParse for GetConvolutionParameterfvReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetConvolutionParameterfvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetConvolutionParameterfvReply {
     /// Get the value of the `n` field.
     ///
@@ -8855,6 +10348,28 @@ impl TryParse for GetConvolutionParameterivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetConvolutionParameterivReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetConvolutionParameterivReply {
@@ -8988,6 +10503,29 @@ impl TryParse for GetSeparableFilterReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetSeparableFilterReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        assert_eq!(self.rows_and_cols.len() % 4, 0, "`rows_and_cols` has an incorrect length, must be a multiple of 4");
+        let length = u32::try_from(self.rows_and_cols.len() / 4).expect("`rows_and_cols` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.row_w.serialize_into(bytes);
+        self.col_h.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        bytes.extend_from_slice(&self.rows_and_cols);
     }
 }
 impl GetSeparableFilterReply {
@@ -9126,6 +10664,28 @@ impl TryParse for GetHistogramReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetHistogramReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        assert_eq!(self.data.len() % 4, 0, "`data` has an incorrect length, must be a multiple of 4");
+        let length = u32::try_from(self.data.len() / 4).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.width.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        bytes.extend_from_slice(&self.data);
+    }
+}
 impl GetHistogramReply {
     /// Get the value of the `length` field.
     ///
@@ -9243,6 +10803,28 @@ impl TryParse for GetHistogramParameterfvReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetHistogramParameterfvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetHistogramParameterfvReply {
     /// Get the value of the `n` field.
     ///
@@ -9357,6 +10939,28 @@ impl TryParse for GetHistogramParameterivReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetHistogramParameterivReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetHistogramParameterivReply {
@@ -9491,6 +11095,26 @@ impl TryParse for GetMinmaxReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetMinmaxReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        assert_eq!(self.data.len() % 4, 0, "`data` has an incorrect length, must be a multiple of 4");
+        let length = u32::try_from(self.data.len() / 4).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+        bytes.extend_from_slice(&self.data);
+    }
+}
 impl GetMinmaxReply {
     /// Get the value of the `length` field.
     ///
@@ -9606,6 +11230,28 @@ impl TryParse for GetMinmaxParameterfvReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetMinmaxParameterfvReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetMinmaxParameterfvReply {
@@ -9724,6 +11370,28 @@ impl TryParse for GetMinmaxParameterivReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetMinmaxParameterivReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetMinmaxParameterivReply {
     /// Get the value of the `n` field.
     ///
@@ -9837,6 +11505,28 @@ impl TryParse for GetCompressedTexImageARBReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetCompressedTexImageARBReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        assert_eq!(self.data.len() % 4, 0, "`data` has an incorrect length, must be a multiple of 4");
+        let length = u32::try_from(self.data.len() / 4).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.size.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        bytes.extend_from_slice(&self.data);
     }
 }
 impl GetCompressedTexImageARBReply {
@@ -10017,6 +11707,25 @@ impl TryParse for GenQueriesARBReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GenQueriesARBReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        let length = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GenQueriesARBReply {
     /// Get the value of the `length` field.
     ///
@@ -10120,6 +11829,38 @@ impl TryParse for IsQueryARBReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for IsQueryARBReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let ret_val_bytes = self.ret_val.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            ret_val_bytes[0],
+            ret_val_bytes[1],
+            ret_val_bytes[2],
+            ret_val_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.ret_val.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the GetQueryivARB request
 pub const GET_QUERYIV_ARB_REQUEST: u8 = 164;
@@ -10219,6 +11960,28 @@ impl TryParse for GetQueryivARBReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetQueryivARBReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetQueryivARBReply {
@@ -10337,6 +12100,28 @@ impl TryParse for GetQueryObjectivARBReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetQueryObjectivARBReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
+    }
+}
 impl GetQueryObjectivARBReply {
     /// Get the value of the `n` field.
     ///
@@ -10451,6 +12236,28 @@ impl TryParse for GetQueryObjectuivARBReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetQueryObjectuivARBReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let n = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        n.serialize_into(bytes);
+        self.datum.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.data.serialize_into(bytes);
     }
 }
 impl GetQueryObjectuivARBReply {

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -547,6 +547,44 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_version_bytes[0],
+            major_version_bytes[1],
+            major_version_bytes[2],
+            major_version_bytes[3],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+            minor_version_bytes[2],
+            minor_version_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major_version.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the Pixmap request
 pub const PIXMAP_REQUEST: u8 = 1;
@@ -1004,6 +1042,38 @@ impl TryParse for QueryCapabilitiesReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryCapabilitiesReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let capabilities_bytes = self.capabilities.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            capabilities_bytes[0],
+            capabilities_bytes[1],
+            capabilities_bytes[2],
+            capabilities_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.capabilities.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the Generic event
 pub const GENERIC_EVENT: u8 = 0;
@@ -1032,6 +1102,45 @@ impl TryParse for GenericEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GenericEvent {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = self.response_type.serialize();
+        let extension_bytes = self.extension.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let evtype_bytes = self.evtype.serialize();
+        let event_bytes = self.event.serialize();
+        [
+            response_type_bytes[0],
+            extension_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            evtype_bytes[0],
+            evtype_bytes[1],
+            0,
+            0,
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        self.response_type.serialize_into(bytes);
+        self.extension.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.evtype.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.event.serialize_into(bytes);
     }
 }
 impl From<&GenericEvent> for [u8; 32] {
@@ -1134,6 +1243,89 @@ impl TryParse for ConfigureNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for ConfigureNotifyEvent {
+    type Bytes = [u8; 40];
+    fn serialize(&self) -> [u8; 40] {
+        let response_type_bytes = self.response_type.serialize();
+        let extension_bytes = self.extension.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let event_type_bytes = self.event_type.serialize();
+        let event_bytes = self.event.serialize();
+        let window_bytes = self.window.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let off_x_bytes = self.off_x.serialize();
+        let off_y_bytes = self.off_y.serialize();
+        let pixmap_width_bytes = self.pixmap_width.serialize();
+        let pixmap_height_bytes = self.pixmap_height.serialize();
+        let pixmap_flags_bytes = self.pixmap_flags.serialize();
+        [
+            response_type_bytes[0],
+            extension_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            event_type_bytes[0],
+            event_type_bytes[1],
+            0,
+            0,
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            off_x_bytes[0],
+            off_x_bytes[1],
+            off_y_bytes[0],
+            off_y_bytes[1],
+            pixmap_width_bytes[0],
+            pixmap_width_bytes[1],
+            pixmap_height_bytes[0],
+            pixmap_height_bytes[1],
+            pixmap_flags_bytes[0],
+            pixmap_flags_bytes[1],
+            pixmap_flags_bytes[2],
+            pixmap_flags_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(40);
+        self.response_type.serialize_into(bytes);
+        self.extension.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.event_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.event.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.off_x.serialize_into(bytes);
+        self.off_y.serialize_into(bytes);
+        self.pixmap_width.serialize_into(bytes);
+        self.pixmap_height.serialize_into(bytes);
+        self.pixmap_flags.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the CompleteNotify event
 pub const COMPLETE_NOTIFY_EVENT: u16 = 1;
@@ -1177,6 +1369,80 @@ impl TryParse for CompleteNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for CompleteNotifyEvent {
+    type Bytes = [u8; 40];
+    fn serialize(&self) -> [u8; 40] {
+        let response_type_bytes = self.response_type.serialize();
+        let extension_bytes = self.extension.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let event_type_bytes = self.event_type.serialize();
+        let kind_bytes = u8::from(self.kind).serialize();
+        let mode_bytes = u8::from(self.mode).serialize();
+        let event_bytes = self.event.serialize();
+        let window_bytes = self.window.serialize();
+        let serial_bytes = self.serial.serialize();
+        let ust_bytes = self.ust.serialize();
+        let msc_bytes = self.msc.serialize();
+        [
+            response_type_bytes[0],
+            extension_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            event_type_bytes[0],
+            event_type_bytes[1],
+            kind_bytes[0],
+            mode_bytes[0],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            serial_bytes[0],
+            serial_bytes[1],
+            serial_bytes[2],
+            serial_bytes[3],
+            ust_bytes[0],
+            ust_bytes[1],
+            ust_bytes[2],
+            ust_bytes[3],
+            ust_bytes[4],
+            ust_bytes[5],
+            ust_bytes[6],
+            ust_bytes[7],
+            msc_bytes[0],
+            msc_bytes[1],
+            msc_bytes[2],
+            msc_bytes[3],
+            msc_bytes[4],
+            msc_bytes[5],
+            msc_bytes[6],
+            msc_bytes[7],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(40);
+        self.response_type.serialize_into(bytes);
+        self.extension.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.event_type.serialize_into(bytes);
+        u8::from(self.kind).serialize_into(bytes);
+        u8::from(self.mode).serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.serial.serialize_into(bytes);
+        self.ust.serialize_into(bytes);
+        self.msc.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the IdleNotify event
 pub const IDLE_NOTIFY_EVENT: u16 = 2;
@@ -1213,6 +1479,69 @@ impl TryParse for IdleNotifyEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for IdleNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let extension_bytes = self.extension.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let event_type_bytes = self.event_type.serialize();
+        let event_bytes = self.event.serialize();
+        let window_bytes = self.window.serialize();
+        let serial_bytes = self.serial.serialize();
+        let pixmap_bytes = self.pixmap.serialize();
+        let idle_fence_bytes = self.idle_fence.serialize();
+        [
+            response_type_bytes[0],
+            extension_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            event_type_bytes[0],
+            event_type_bytes[1],
+            0,
+            0,
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            serial_bytes[0],
+            serial_bytes[1],
+            serial_bytes[2],
+            serial_bytes[3],
+            pixmap_bytes[0],
+            pixmap_bytes[1],
+            pixmap_bytes[2],
+            pixmap_bytes[3],
+            idle_fence_bytes[0],
+            idle_fence_bytes[1],
+            idle_fence_bytes[2],
+            idle_fence_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.extension.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.event_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.event.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.serial.serialize_into(bytes);
+        self.pixmap.serialize_into(bytes);
+        self.idle_fence.serialize_into(bytes);
     }
 }
 
@@ -1289,6 +1618,47 @@ impl TryParse for RedirectNotifyEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for RedirectNotifyEvent {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(104);
+        self.response_type.serialize_into(bytes);
+        self.extension.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.event_type.serialize_into(bytes);
+        self.update_window.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.event.serialize_into(bytes);
+        self.event_window.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.pixmap.serialize_into(bytes);
+        self.serial.serialize_into(bytes);
+        self.valid_region.serialize_into(bytes);
+        self.update_region.serialize_into(bytes);
+        self.valid_rect.serialize_into(bytes);
+        self.update_rect.serialize_into(bytes);
+        self.x_off.serialize_into(bytes);
+        self.y_off.serialize_into(bytes);
+        self.target_crtc.serialize_into(bytes);
+        self.wait_fence.serialize_into(bytes);
+        self.idle_fence.serialize_into(bytes);
+        self.options.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        self.target_msc.serialize_into(bytes);
+        self.divisor.serialize_into(bytes);
+        self.remainder.serialize_into(bytes);
+        self.notifies.serialize_into(bytes);
+        let notifies_len_bytes = u32::try_from(self.notifies.len()).unwrap();
+        let notifies_len_bytes = notifies_len_bytes.to_ne_bytes();
+        bytes.extend_from_slice(&notifies_len_bytes);
     }
 }
 

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -303,6 +303,61 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_version_bytes[0],
+            major_version_bytes[1],
+            major_version_bytes[2],
+            major_version_bytes[3],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+            minor_version_bytes[2],
+            minor_version_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major_version.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+    }
+}
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -491,6 +546,66 @@ impl TryParse for SetScreenConfigReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for SetScreenConfigReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let status_bytes = u8::from(self.status).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let new_timestamp_bytes = self.new_timestamp.serialize();
+        let config_timestamp_bytes = self.config_timestamp.serialize();
+        let root_bytes = self.root.serialize();
+        let subpixel_order_bytes = (u32::from(self.subpixel_order) as u16).serialize();
+        [
+            response_type_bytes[0],
+            status_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            new_timestamp_bytes[0],
+            new_timestamp_bytes[1],
+            new_timestamp_bytes[2],
+            new_timestamp_bytes[3],
+            config_timestamp_bytes[0],
+            config_timestamp_bytes[1],
+            config_timestamp_bytes[2],
+            config_timestamp_bytes[3],
+            root_bytes[0],
+            root_bytes[1],
+            root_bytes[2],
+            root_bytes[3],
+            subpixel_order_bytes[0],
+            subpixel_order_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.status).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.new_timestamp.serialize_into(bytes);
+        self.config_timestamp.serialize_into(bytes);
+        self.root.serialize_into(bytes);
+        (u32::from(self.subpixel_order) as u16).serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 10]);
     }
 }
 
@@ -726,6 +841,35 @@ impl TryParse for GetScreenInfoReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetScreenInfoReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.rotations.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.root.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        self.config_timestamp.serialize_into(bytes);
+        let n_sizes = u16::try_from(self.sizes.len()).expect("`sizes` has too many elements");
+        n_sizes.serialize_into(bytes);
+        self.size_id.serialize_into(bytes);
+        self.rotation.serialize_into(bytes);
+        self.rate.serialize_into(bytes);
+        self.n_info.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.sizes.serialize_into(bytes);
+        assert_eq!(self.rates.len(), usize::try_from(u32::from(self.n_info).checked_sub(u32::from(n_sizes)).unwrap()).unwrap(), "`rates` has an incorrect length");
+        self.rates.serialize_into(bytes);
+    }
+}
 impl GetScreenInfoReply {
     /// Get the value of the `nSizes` field.
     ///
@@ -826,6 +970,65 @@ impl TryParse for GetScreenSizeRangeReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetScreenSizeRangeReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let min_width_bytes = self.min_width.serialize();
+        let min_height_bytes = self.min_height.serialize();
+        let max_width_bytes = self.max_width.serialize();
+        let max_height_bytes = self.max_height.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            min_width_bytes[0],
+            min_width_bytes[1],
+            min_height_bytes[0],
+            min_height_bytes[1],
+            max_width_bytes[0],
+            max_width_bytes[1],
+            max_height_bytes[0],
+            max_height_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.min_width.serialize_into(bytes);
+        self.min_height.serialize_into(bytes);
+        self.max_width.serialize_into(bytes);
+        self.max_height.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
     }
 }
 
@@ -1188,6 +1391,37 @@ impl TryParse for GetScreenResourcesReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetScreenResourcesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        self.config_timestamp.serialize_into(bytes);
+        let num_crtcs = u16::try_from(self.crtcs.len()).expect("`crtcs` has too many elements");
+        num_crtcs.serialize_into(bytes);
+        let num_outputs = u16::try_from(self.outputs.len()).expect("`outputs` has too many elements");
+        num_outputs.serialize_into(bytes);
+        let num_modes = u16::try_from(self.modes.len()).expect("`modes` has too many elements");
+        num_modes.serialize_into(bytes);
+        let names_len = u16::try_from(self.names.len()).expect("`names` has too many elements");
+        names_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.crtcs.serialize_into(bytes);
+        self.outputs.serialize_into(bytes);
+        self.modes.serialize_into(bytes);
+        bytes.extend_from_slice(&self.names);
+    }
+}
 impl GetScreenResourcesReply {
     /// Get the value of the `num_crtcs` field.
     ///
@@ -1420,6 +1654,41 @@ impl TryParse for GetOutputInfoReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetOutputInfoReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(36);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.status).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        self.crtc.serialize_into(bytes);
+        self.mm_width.serialize_into(bytes);
+        self.mm_height.serialize_into(bytes);
+        u8::from(self.connection).serialize_into(bytes);
+        (u32::from(self.subpixel_order) as u8).serialize_into(bytes);
+        let num_crtcs = u16::try_from(self.crtcs.len()).expect("`crtcs` has too many elements");
+        num_crtcs.serialize_into(bytes);
+        let num_modes = u16::try_from(self.modes.len()).expect("`modes` has too many elements");
+        num_modes.serialize_into(bytes);
+        self.num_preferred.serialize_into(bytes);
+        let num_clones = u16::try_from(self.clones.len()).expect("`clones` has too many elements");
+        num_clones.serialize_into(bytes);
+        let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        name_len.serialize_into(bytes);
+        self.crtcs.serialize_into(bytes);
+        self.modes.serialize_into(bytes);
+        self.clones.serialize_into(bytes);
+        bytes.extend_from_slice(&self.name);
+    }
+}
 impl GetOutputInfoReply {
     /// Get the value of the `num_crtcs` field.
     ///
@@ -1556,6 +1825,26 @@ impl TryParse for ListOutputPropertiesReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for ListOutputPropertiesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let num_atoms = u16::try_from(self.atoms.len()).expect("`atoms` has too many elements");
+        num_atoms.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 22]);
+        self.atoms.serialize_into(bytes);
+    }
+}
 impl ListOutputPropertiesReply {
     /// Get the value of the `num_atoms` field.
     ///
@@ -1663,6 +1952,28 @@ impl TryParse for QueryOutputPropertyReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryOutputPropertyReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        let length = u32::try_from(self.valid_values.len()).expect("`valid_values` has too many elements");
+        length.serialize_into(bytes);
+        self.pending.serialize_into(bytes);
+        self.range.serialize_into(bytes);
+        self.immutable.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 21]);
+        self.valid_values.serialize_into(bytes);
     }
 }
 impl QueryOutputPropertyReply {
@@ -2083,6 +2394,28 @@ impl TryParse for GetOutputPropertyReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetOutputPropertyReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.format.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.type_.serialize_into(bytes);
+        self.bytes_after.serialize_into(bytes);
+        self.num_items.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        assert_eq!(self.data.len(), usize::try_from(self.num_items.checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`data` has an incorrect length");
+        bytes.extend_from_slice(&self.data);
+    }
+}
 
 /// Opcode for the CreateMode request
 pub const CREATE_MODE_REQUEST: u8 = 16;
@@ -2212,6 +2545,59 @@ impl TryParse for CreateModeReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for CreateModeReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let mode_bytes = self.mode.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            mode_bytes[0],
+            mode_bytes[1],
+            mode_bytes[2],
+            mode_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.mode.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
     }
 }
 
@@ -2499,6 +2885,36 @@ impl TryParse for GetCrtcInfoReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetCrtcInfoReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.status).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.mode.serialize_into(bytes);
+        self.rotation.serialize_into(bytes);
+        self.rotations.serialize_into(bytes);
+        let num_outputs = u16::try_from(self.outputs.len()).expect("`outputs` has too many elements");
+        num_outputs.serialize_into(bytes);
+        let num_possible_outputs = u16::try_from(self.possible.len()).expect("`possible` has too many elements");
+        num_possible_outputs.serialize_into(bytes);
+        self.outputs.serialize_into(bytes);
+        self.possible.serialize_into(bytes);
+    }
+}
 impl GetCrtcInfoReply {
     /// Get the value of the `num_outputs` field.
     ///
@@ -2682,6 +3098,60 @@ impl TryParse for SetCrtcConfigReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for SetCrtcConfigReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let status_bytes = u8::from(self.status).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let timestamp_bytes = self.timestamp.serialize();
+        [
+            response_type_bytes[0],
+            status_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            timestamp_bytes[0],
+            timestamp_bytes[1],
+            timestamp_bytes[2],
+            timestamp_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.status).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+    }
+}
 
 /// Opcode for the GetCrtcGammaSize request
 pub const GET_CRTC_GAMMA_SIZE_REQUEST: u8 = 22;
@@ -2761,6 +3231,59 @@ impl TryParse for GetCrtcGammaSizeReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetCrtcGammaSizeReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let size_bytes = self.size.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            size_bytes[0],
+            size_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.size.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 22]);
     }
 }
 
@@ -2847,6 +3370,30 @@ impl TryParse for GetCrtcGammaReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetCrtcGammaReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let size = u16::try_from(self.red.len()).expect("`red` has too many elements");
+        size.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 22]);
+        self.red.serialize_into(bytes);
+        assert_eq!(self.green.len(), usize::try_from(size).unwrap(), "`green` has an incorrect length");
+        self.green.serialize_into(bytes);
+        assert_eq!(self.blue.len(), usize::try_from(size).unwrap(), "`blue` has an incorrect length");
+        self.blue.serialize_into(bytes);
     }
 }
 impl GetCrtcGammaReply {
@@ -3047,6 +3594,37 @@ impl TryParse for GetScreenResourcesCurrentReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetScreenResourcesCurrentReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        self.config_timestamp.serialize_into(bytes);
+        let num_crtcs = u16::try_from(self.crtcs.len()).expect("`crtcs` has too many elements");
+        num_crtcs.serialize_into(bytes);
+        let num_outputs = u16::try_from(self.outputs.len()).expect("`outputs` has too many elements");
+        num_outputs.serialize_into(bytes);
+        let num_modes = u16::try_from(self.modes.len()).expect("`modes` has too many elements");
+        num_modes.serialize_into(bytes);
+        let names_len = u16::try_from(self.names.len()).expect("`names` has too many elements");
+        names_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.crtcs.serialize_into(bytes);
+        self.outputs.serialize_into(bytes);
+        self.modes.serialize_into(bytes);
+        bytes.extend_from_slice(&self.names);
     }
 }
 impl GetScreenResourcesCurrentReply {
@@ -3410,6 +3988,41 @@ impl TryParse for GetCrtcTransformReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetCrtcTransformReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(96);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.pending_transform.serialize_into(bytes);
+        self.has_transforms.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 3]);
+        self.current_transform.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        let pending_len = u16::try_from(self.pending_filter_name.len()).expect("`pending_filter_name` has too many elements");
+        pending_len.serialize_into(bytes);
+        let pending_nparams = u16::try_from(self.pending_params.len()).expect("`pending_params` has too many elements");
+        pending_nparams.serialize_into(bytes);
+        let current_len = u16::try_from(self.current_filter_name.len()).expect("`current_filter_name` has too many elements");
+        current_len.serialize_into(bytes);
+        let current_nparams = u16::try_from(self.current_params.len()).expect("`current_params` has too many elements");
+        current_nparams.serialize_into(bytes);
+        bytes.extend_from_slice(&self.pending_filter_name);
+        bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        self.pending_params.serialize_into(bytes);
+        bytes.extend_from_slice(&self.current_filter_name);
+        bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        self.current_params.serialize_into(bytes);
+    }
+}
 impl GetCrtcTransformReply {
     /// Get the value of the `pending_len` field.
     ///
@@ -3568,6 +4181,87 @@ impl TryParse for GetPanningReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetPanningReply {
+    type Bytes = [u8; 36];
+    fn serialize(&self) -> [u8; 36] {
+        let response_type_bytes = &[1];
+        let status_bytes = u8::from(self.status).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let timestamp_bytes = self.timestamp.serialize();
+        let left_bytes = self.left.serialize();
+        let top_bytes = self.top.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let track_left_bytes = self.track_left.serialize();
+        let track_top_bytes = self.track_top.serialize();
+        let track_width_bytes = self.track_width.serialize();
+        let track_height_bytes = self.track_height.serialize();
+        let border_left_bytes = self.border_left.serialize();
+        let border_top_bytes = self.border_top.serialize();
+        let border_right_bytes = self.border_right.serialize();
+        let border_bottom_bytes = self.border_bottom.serialize();
+        [
+            response_type_bytes[0],
+            status_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            timestamp_bytes[0],
+            timestamp_bytes[1],
+            timestamp_bytes[2],
+            timestamp_bytes[3],
+            left_bytes[0],
+            left_bytes[1],
+            top_bytes[0],
+            top_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            track_left_bytes[0],
+            track_left_bytes[1],
+            track_top_bytes[0],
+            track_top_bytes[1],
+            track_width_bytes[0],
+            track_width_bytes[1],
+            track_height_bytes[0],
+            track_height_bytes[1],
+            border_left_bytes[0],
+            border_left_bytes[1],
+            border_top_bytes[0],
+            border_top_bytes[1],
+            border_right_bytes[0],
+            border_right_bytes[1],
+            border_bottom_bytes[0],
+            border_bottom_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(36);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.status).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        self.left.serialize_into(bytes);
+        self.top.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.track_left.serialize_into(bytes);
+        self.track_top.serialize_into(bytes);
+        self.track_width.serialize_into(bytes);
+        self.track_height.serialize_into(bytes);
+        self.border_left.serialize_into(bytes);
+        self.border_top.serialize_into(bytes);
+        self.border_right.serialize_into(bytes);
+        self.border_bottom.serialize_into(bytes);
     }
 }
 
@@ -3732,6 +4426,39 @@ impl TryParse for SetPanningReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for SetPanningReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let status_bytes = u8::from(self.status).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let timestamp_bytes = self.timestamp.serialize();
+        [
+            response_type_bytes[0],
+            status_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            timestamp_bytes[0],
+            timestamp_bytes[1],
+            timestamp_bytes[2],
+            timestamp_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.status).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the SetOutputPrimary request
 pub const SET_OUTPUT_PRIMARY_REQUEST: u8 = 30;
@@ -3873,6 +4600,38 @@ impl TryParse for GetOutputPrimaryReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetOutputPrimaryReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let output_bytes = self.output.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            output_bytes[0],
+            output_bytes[1],
+            output_bytes[2],
+            output_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.output.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the GetProviders request
 pub const GET_PROVIDERS_REQUEST: u8 = 32;
@@ -3955,6 +4714,27 @@ impl TryParse for GetProvidersReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetProvidersReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        let num_providers = u16::try_from(self.providers.len()).expect("`providers` has too many elements");
+        num_providers.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 18]);
+        self.providers.serialize_into(bytes);
     }
 }
 impl GetProvidersReply {
@@ -4141,6 +4921,39 @@ impl TryParse for GetProviderInfoReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetProviderInfoReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.status.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        self.capabilities.serialize_into(bytes);
+        let num_crtcs = u16::try_from(self.crtcs.len()).expect("`crtcs` has too many elements");
+        num_crtcs.serialize_into(bytes);
+        let num_outputs = u16::try_from(self.outputs.len()).expect("`outputs` has too many elements");
+        num_outputs.serialize_into(bytes);
+        let num_associated_providers = u16::try_from(self.associated_providers.len()).expect("`associated_providers` has too many elements");
+        num_associated_providers.serialize_into(bytes);
+        let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        name_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.crtcs.serialize_into(bytes);
+        self.outputs.serialize_into(bytes);
+        self.associated_providers.serialize_into(bytes);
+        assert_eq!(self.associated_capability.len(), usize::try_from(num_associated_providers).unwrap(), "`associated_capability` has an incorrect length");
+        self.associated_capability.serialize_into(bytes);
+        bytes.extend_from_slice(&self.name);
     }
 }
 impl GetProviderInfoReply {
@@ -4417,6 +5230,26 @@ impl TryParse for ListProviderPropertiesReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for ListProviderPropertiesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let num_atoms = u16::try_from(self.atoms.len()).expect("`atoms` has too many elements");
+        num_atoms.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 22]);
+        self.atoms.serialize_into(bytes);
+    }
+}
 impl ListProviderPropertiesReply {
     /// Get the value of the `num_atoms` field.
     ///
@@ -4524,6 +5357,28 @@ impl TryParse for QueryProviderPropertyReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryProviderPropertyReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        let length = u32::try_from(self.valid_values.len()).expect("`valid_values` has too many elements");
+        length.serialize_into(bytes);
+        self.pending.serialize_into(bytes);
+        self.range.serialize_into(bytes);
+        self.immutable.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 21]);
+        self.valid_values.serialize_into(bytes);
     }
 }
 impl QueryProviderPropertyReply {
@@ -4943,6 +5798,28 @@ impl TryParse for GetProviderPropertyReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetProviderPropertyReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.format.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.type_.serialize_into(bytes);
+        self.bytes_after.serialize_into(bytes);
+        self.num_items.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        assert_eq!(self.data.len(), usize::try_from(self.num_items.checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`data` has an incorrect length");
+        bytes.extend_from_slice(&self.data);
+    }
+}
 
 /// Opcode for the ScreenChangeNotify event
 pub const SCREEN_CHANGE_NOTIFY_EVENT: u8 = 0;
@@ -4985,6 +5862,74 @@ impl TryParse for ScreenChangeNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ScreenChangeNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let rotation_bytes = self.rotation.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let timestamp_bytes = self.timestamp.serialize();
+        let config_timestamp_bytes = self.config_timestamp.serialize();
+        let root_bytes = self.root.serialize();
+        let request_window_bytes = self.request_window.serialize();
+        let size_id_bytes = self.size_id.serialize();
+        let subpixel_order_bytes = (u32::from(self.subpixel_order) as u16).serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let mwidth_bytes = self.mwidth.serialize();
+        let mheight_bytes = self.mheight.serialize();
+        [
+            response_type_bytes[0],
+            rotation_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            timestamp_bytes[0],
+            timestamp_bytes[1],
+            timestamp_bytes[2],
+            timestamp_bytes[3],
+            config_timestamp_bytes[0],
+            config_timestamp_bytes[1],
+            config_timestamp_bytes[2],
+            config_timestamp_bytes[3],
+            root_bytes[0],
+            root_bytes[1],
+            root_bytes[2],
+            root_bytes[3],
+            request_window_bytes[0],
+            request_window_bytes[1],
+            request_window_bytes[2],
+            request_window_bytes[3],
+            size_id_bytes[0],
+            size_id_bytes[1],
+            subpixel_order_bytes[0],
+            subpixel_order_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            mwidth_bytes[0],
+            mwidth_bytes[1],
+            mheight_bytes[0],
+            mheight_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.rotation.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        self.config_timestamp.serialize_into(bytes);
+        self.root.serialize_into(bytes);
+        self.request_window.serialize_into(bytes);
+        self.size_id.serialize_into(bytes);
+        (u32::from(self.subpixel_order) as u16).serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.mwidth.serialize_into(bytes);
+        self.mheight.serialize_into(bytes);
     }
 }
 impl From<&ScreenChangeNotifyEvent> for [u8; 32] {
@@ -5715,6 +6660,28 @@ impl TryParse for GetMonitorsReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetMonitorsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        let n_monitors = u32::try_from(self.monitors.len()).expect("`monitors` has too many elements");
+        n_monitors.serialize_into(bytes);
+        self.n_outputs.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        self.monitors.serialize_into(bytes);
+    }
+}
 impl GetMonitorsReply {
     /// Get the value of the `nMonitors` field.
     ///
@@ -5970,6 +6937,58 @@ impl TryParseFd for CreateLeaseReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for CreateLeaseReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let nfd_bytes = self.nfd.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            nfd_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.nfd.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
     }
 }
 
@@ -6247,6 +7266,56 @@ impl TryParse for NotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for NotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let sub_code_bytes = u8::from(self.sub_code).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let u_bytes = self.u.serialize();
+        [
+            response_type_bytes[0],
+            sub_code_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            u_bytes[0],
+            u_bytes[1],
+            u_bytes[2],
+            u_bytes[3],
+            u_bytes[4],
+            u_bytes[5],
+            u_bytes[6],
+            u_bytes[7],
+            u_bytes[8],
+            u_bytes[9],
+            u_bytes[10],
+            u_bytes[11],
+            u_bytes[12],
+            u_bytes[13],
+            u_bytes[14],
+            u_bytes[15],
+            u_bytes[16],
+            u_bytes[17],
+            u_bytes[18],
+            u_bytes[19],
+            u_bytes[20],
+            u_bytes[21],
+            u_bytes[22],
+            u_bytes[23],
+            u_bytes[24],
+            u_bytes[25],
+            u_bytes[26],
+            u_bytes[27],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        u8::from(self.sub_code).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.u.serialize_into(bytes);
     }
 }
 impl From<&NotifyEvent> for [u8; 32] {

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -1347,6 +1347,61 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_version_bytes[0],
+            major_version_bytes[1],
+            major_version_bytes[2],
+            major_version_bytes[3],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+            minor_version_bytes[2],
+            minor_version_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major_version.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+    }
+}
 
 /// Opcode for the QueryPictFormats request
 pub const QUERY_PICT_FORMATS_REQUEST: u8 = 1;
@@ -1436,6 +1491,36 @@ impl TryParse for QueryPictFormatsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryPictFormatsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let num_formats = u32::try_from(self.formats.len()).expect("`formats` has too many elements");
+        num_formats.serialize_into(bytes);
+        let num_screens = u32::try_from(self.screens.len()).expect("`screens` has too many elements");
+        num_screens.serialize_into(bytes);
+        self.num_depths.serialize_into(bytes);
+        self.num_visuals.serialize_into(bytes);
+        let num_subpixel = u32::try_from(self.subpixels.len()).expect("`subpixels` has too many elements");
+        num_subpixel.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        self.formats.serialize_into(bytes);
+        self.screens.serialize_into(bytes);
+        for element in self.subpixels.iter().copied() {
+            u32::from(element).serialize_into(bytes);
+        }
     }
 }
 impl QueryPictFormatsReply {
@@ -1559,6 +1644,26 @@ impl TryParse for QueryPictIndexValuesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryPictIndexValuesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let num_values = u32::try_from(self.values.len()).expect("`values` has too many elements");
+        num_values.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.values.serialize_into(bytes);
     }
 }
 impl QueryPictIndexValuesReply {
@@ -1719,7 +1824,7 @@ impl CreatePictureAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
+        let _ = value_mask;
         if let Some(repeat) = self.repeat {
             u32::from(repeat).serialize_into(bytes);
         }
@@ -2125,7 +2230,7 @@ impl ChangePictureAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
+        let _ = value_mask;
         if let Some(repeat) = self.repeat {
             u32::from(repeat).serialize_into(bytes);
         }
@@ -4235,6 +4340,29 @@ impl TryParse for QueryFiltersReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryFiltersReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let num_aliases = u32::try_from(self.aliases.len()).expect("`aliases` has too many elements");
+        num_aliases.serialize_into(bytes);
+        let num_filters = u32::try_from(self.filters.len()).expect("`filters` has too many elements");
+        num_filters.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+        self.aliases.serialize_into(bytes);
+        self.filters.serialize_into(bytes);
     }
 }
 impl QueryFiltersReply {

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -477,6 +477,40 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let server_major_bytes = self.server_major.serialize();
+        let server_minor_bytes = self.server_minor.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            server_major_bytes[0],
+            server_major_bytes[1],
+            server_minor_bytes[0],
+            server_minor_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.server_major.serialize_into(bytes);
+        self.server_minor.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the QueryClients request
 pub const QUERY_CLIENTS_REQUEST: u8 = 1;
@@ -548,6 +582,26 @@ impl TryParse for QueryClientsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryClientsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let num_clients = u32::try_from(self.clients.len()).expect("`clients` has too many elements");
+        num_clients.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.clients.serialize_into(bytes);
     }
 }
 impl QueryClientsReply {
@@ -647,6 +701,26 @@ impl TryParse for QueryClientResourcesReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryClientResourcesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let num_types = u32::try_from(self.types.len()).expect("`types` has too many elements");
+        num_types.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.types.serialize_into(bytes);
+    }
+}
 impl QueryClientResourcesReply {
     /// Get the value of the `num_types` field.
     ///
@@ -744,6 +818,44 @@ impl TryParse for QueryClientPixmapBytesReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryClientPixmapBytesReply {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let bytes_bytes = self.bytes.serialize();
+        let bytes_overflow_bytes = self.bytes_overflow.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            bytes_bytes[0],
+            bytes_bytes[1],
+            bytes_bytes[2],
+            bytes_bytes[3],
+            bytes_overflow_bytes[0],
+            bytes_overflow_bytes[1],
+            bytes_overflow_bytes[2],
+            bytes_overflow_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.bytes.serialize_into(bytes);
+        self.bytes_overflow.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the QueryClientIds request
 pub const QUERY_CLIENT_IDS_REQUEST: u8 = 4;
@@ -836,6 +948,26 @@ impl TryParse for QueryClientIdsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryClientIdsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let num_ids = u32::try_from(self.ids.len()).expect("`ids` has too many elements");
+        num_ids.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.ids.serialize_into(bytes);
     }
 }
 impl QueryClientIdsReply {
@@ -954,6 +1086,26 @@ impl TryParse for QueryResourceBytesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryResourceBytesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let num_sizes = u32::try_from(self.sizes.len()).expect("`sizes` has too many elements");
+        num_sizes.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.sizes.serialize_into(bytes);
     }
 }
 impl QueryResourceBytesReply {

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -305,6 +305,61 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let server_major_version_bytes = self.server_major_version.serialize();
+        let server_minor_version_bytes = self.server_minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            server_major_version_bytes[0],
+            server_major_version_bytes[1],
+            server_minor_version_bytes[0],
+            server_minor_version_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.server_major_version.serialize_into(bytes);
+        self.server_minor_version.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+    }
+}
 
 /// Opcode for the QueryInfo request
 pub const QUERY_INFO_REQUEST: u8 = 1;
@@ -394,6 +449,68 @@ impl TryParse for QueryInfoReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryInfoReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let state_bytes = self.state.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let saver_window_bytes = self.saver_window.serialize();
+        let ms_until_server_bytes = self.ms_until_server.serialize();
+        let ms_since_user_input_bytes = self.ms_since_user_input.serialize();
+        let event_mask_bytes = self.event_mask.serialize();
+        let kind_bytes = u8::from(self.kind).serialize();
+        [
+            response_type_bytes[0],
+            state_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            saver_window_bytes[0],
+            saver_window_bytes[1],
+            saver_window_bytes[2],
+            saver_window_bytes[3],
+            ms_until_server_bytes[0],
+            ms_until_server_bytes[1],
+            ms_until_server_bytes[2],
+            ms_until_server_bytes[3],
+            ms_since_user_input_bytes[0],
+            ms_since_user_input_bytes[1],
+            ms_since_user_input_bytes[2],
+            ms_since_user_input_bytes[3],
+            event_mask_bytes[0],
+            event_mask_bytes[1],
+            event_mask_bytes[2],
+            event_mask_bytes[3],
+            kind_bytes[0],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.state.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.saver_window.serialize_into(bytes);
+        self.ms_until_server.serialize_into(bytes);
+        self.ms_since_user_input.serialize_into(bytes);
+        self.event_mask.serialize_into(bytes);
+        u8::from(self.kind).serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 7]);
     }
 }
 
@@ -617,7 +734,7 @@ impl SetAttributesAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
+        let _ = value_mask;
         if let Some(background_pixmap) = self.background_pixmap {
             background_pixmap.serialize_into(bytes);
         }
@@ -1083,6 +1200,65 @@ impl TryParse for NotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for NotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let state_bytes = u8::from(self.state).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let root_bytes = self.root.serialize();
+        let window_bytes = self.window.serialize();
+        let kind_bytes = u8::from(self.kind).serialize();
+        let forced_bytes = self.forced.serialize();
+        [
+            response_type_bytes[0],
+            state_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            root_bytes[0],
+            root_bytes[1],
+            root_bytes[2],
+            root_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            kind_bytes[0],
+            forced_bytes[0],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        u8::from(self.state).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.root.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        u8::from(self.kind).serialize_into(bytes);
+        self.forced.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 14]);
     }
 }
 impl From<&NotifyEvent> for [u8; 32] {

--- a/x11rb-protocol/src/protocol/shape.rs
+++ b/x11rb-protocol/src/protocol/shape.rs
@@ -202,6 +202,69 @@ impl TryParse for NotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for NotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let shape_kind_bytes = Kind::from(self.shape_kind).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let affected_window_bytes = self.affected_window.serialize();
+        let extents_x_bytes = self.extents_x.serialize();
+        let extents_y_bytes = self.extents_y.serialize();
+        let extents_width_bytes = self.extents_width.serialize();
+        let extents_height_bytes = self.extents_height.serialize();
+        let server_time_bytes = self.server_time.serialize();
+        let shaped_bytes = self.shaped.serialize();
+        [
+            response_type_bytes[0],
+            shape_kind_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            affected_window_bytes[0],
+            affected_window_bytes[1],
+            affected_window_bytes[2],
+            affected_window_bytes[3],
+            extents_x_bytes[0],
+            extents_x_bytes[1],
+            extents_y_bytes[0],
+            extents_y_bytes[1],
+            extents_width_bytes[0],
+            extents_width_bytes[1],
+            extents_height_bytes[0],
+            extents_height_bytes[1],
+            server_time_bytes[0],
+            server_time_bytes[1],
+            server_time_bytes[2],
+            server_time_bytes[3],
+            shaped_bytes[0],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        Kind::from(self.shape_kind).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.affected_window.serialize_into(bytes);
+        self.extents_x.serialize_into(bytes);
+        self.extents_y.serialize_into(bytes);
+        self.extents_width.serialize_into(bytes);
+        self.extents_height.serialize_into(bytes);
+        self.server_time.serialize_into(bytes);
+        self.shaped.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 11]);
+    }
+}
 impl From<&NotifyEvent> for [u8; 32] {
     fn from(input: &NotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -326,6 +389,40 @@ impl TryParse for QueryVersionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_version_bytes[0],
+            major_version_bytes[1],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major_version.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
     }
 }
 
@@ -794,6 +891,73 @@ impl TryParse for QueryExtentsReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryExtentsReply {
+    type Bytes = [u8; 28];
+    fn serialize(&self) -> [u8; 28] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let bounding_shaped_bytes = self.bounding_shaped.serialize();
+        let clip_shaped_bytes = self.clip_shaped.serialize();
+        let bounding_shape_extents_x_bytes = self.bounding_shape_extents_x.serialize();
+        let bounding_shape_extents_y_bytes = self.bounding_shape_extents_y.serialize();
+        let bounding_shape_extents_width_bytes = self.bounding_shape_extents_width.serialize();
+        let bounding_shape_extents_height_bytes = self.bounding_shape_extents_height.serialize();
+        let clip_shape_extents_x_bytes = self.clip_shape_extents_x.serialize();
+        let clip_shape_extents_y_bytes = self.clip_shape_extents_y.serialize();
+        let clip_shape_extents_width_bytes = self.clip_shape_extents_width.serialize();
+        let clip_shape_extents_height_bytes = self.clip_shape_extents_height.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            bounding_shaped_bytes[0],
+            clip_shaped_bytes[0],
+            0,
+            0,
+            bounding_shape_extents_x_bytes[0],
+            bounding_shape_extents_x_bytes[1],
+            bounding_shape_extents_y_bytes[0],
+            bounding_shape_extents_y_bytes[1],
+            bounding_shape_extents_width_bytes[0],
+            bounding_shape_extents_width_bytes[1],
+            bounding_shape_extents_height_bytes[0],
+            bounding_shape_extents_height_bytes[1],
+            clip_shape_extents_x_bytes[0],
+            clip_shape_extents_x_bytes[1],
+            clip_shape_extents_y_bytes[0],
+            clip_shape_extents_y_bytes[1],
+            clip_shape_extents_width_bytes[0],
+            clip_shape_extents_width_bytes[1],
+            clip_shape_extents_height_bytes[0],
+            clip_shape_extents_height_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(28);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.bounding_shaped.serialize_into(bytes);
+        self.clip_shaped.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.bounding_shape_extents_x.serialize_into(bytes);
+        self.bounding_shape_extents_y.serialize_into(bytes);
+        self.bounding_shape_extents_width.serialize_into(bytes);
+        self.bounding_shape_extents_height.serialize_into(bytes);
+        self.clip_shape_extents_x.serialize_into(bytes);
+        self.clip_shape_extents_y.serialize_into(bytes);
+        self.clip_shape_extents_width.serialize_into(bytes);
+        self.clip_shape_extents_height.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 6;
@@ -935,6 +1099,33 @@ impl TryParse for InputSelectedReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for InputSelectedReply {
+    type Bytes = [u8; 8];
+    fn serialize(&self) -> [u8; 8] {
+        let response_type_bytes = &[1];
+        let enabled_bytes = self.enabled.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            enabled_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(8);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.enabled.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the GetRectangles request
 pub const GET_RECTANGLES_REQUEST: u8 = 8;
@@ -1027,6 +1218,26 @@ impl TryParse for GetRectanglesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetRectanglesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.ordering).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let rectangles_len = u32::try_from(self.rectangles.len()).expect("`rectangles` has too many elements");
+        rectangles_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.rectangles.serialize_into(bytes);
     }
 }
 impl GetRectanglesReply {

--- a/x11rb-protocol/src/protocol/shm.rs
+++ b/x11rb-protocol/src/protocol/shm.rs
@@ -68,6 +68,52 @@ impl TryParse for CompletionEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for CompletionEvent {
+    type Bytes = [u8; 20];
+    fn serialize(&self) -> [u8; 20] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let minor_event_bytes = self.minor_event.serialize();
+        let major_event_bytes = self.major_event.serialize();
+        let shmseg_bytes = self.shmseg.serialize();
+        let offset_bytes = self.offset.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            minor_event_bytes[0],
+            minor_event_bytes[1],
+            major_event_bytes[0],
+            0,
+            shmseg_bytes[0],
+            shmseg_bytes[1],
+            shmseg_bytes[2],
+            shmseg_bytes[3],
+            offset_bytes[0],
+            offset_bytes[1],
+            offset_bytes[2],
+            offset_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(20);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.drawable.serialize_into(bytes);
+        self.minor_event.serialize_into(bytes);
+        self.major_event.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.shmseg.serialize_into(bytes);
+        self.offset.serialize_into(bytes);
+    }
+}
 impl From<&CompletionEvent> for [u8; 32] {
     fn from(input: &CompletionEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -201,6 +247,68 @@ impl TryParse for QueryVersionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let shared_pixmaps_bytes = self.shared_pixmaps.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        let uid_bytes = self.uid.serialize();
+        let gid_bytes = self.gid.serialize();
+        let pixmap_format_bytes = self.pixmap_format.serialize();
+        [
+            response_type_bytes[0],
+            shared_pixmaps_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_version_bytes[0],
+            major_version_bytes[1],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+            uid_bytes[0],
+            uid_bytes[1],
+            gid_bytes[0],
+            gid_bytes[1],
+            pixmap_format_bytes[0],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.shared_pixmaps.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major_version.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
+        self.uid.serialize_into(bytes);
+        self.gid.serialize_into(bytes);
+        self.pixmap_format.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 15]);
     }
 }
 
@@ -608,6 +716,45 @@ impl TryParse for GetImageReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetImageReply {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = &[1];
+        let depth_bytes = self.depth.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let visual_bytes = self.visual.serialize();
+        let size_bytes = self.size.serialize();
+        [
+            response_type_bytes[0],
+            depth_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            visual_bytes[0],
+            visual_bytes[1],
+            visual_bytes[2],
+            visual_bytes[3],
+            size_bytes[0],
+            size_bytes[1],
+            size_bytes[2],
+            size_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.depth.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.visual.serialize_into(bytes);
+        self.size.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the CreatePixmap request
 pub const CREATE_PIXMAP_REQUEST: u8 = 5;
@@ -868,6 +1015,58 @@ impl TryParseFd for CreateSegmentReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for CreateSegmentReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let nfd_bytes = self.nfd.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            nfd_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.nfd.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
     }
 }
 

--- a/x11rb-protocol/src/protocol/xc_misc.rs
+++ b/x11rb-protocol/src/protocol/xc_misc.rs
@@ -117,6 +117,40 @@ impl TryParse for GetVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetVersionReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let server_major_version_bytes = self.server_major_version.serialize();
+        let server_minor_version_bytes = self.server_minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            server_major_version_bytes[0],
+            server_major_version_bytes[1],
+            server_minor_version_bytes[0],
+            server_minor_version_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.server_major_version.serialize_into(bytes);
+        self.server_minor_version.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the GetXIDRange request
 pub const GET_XID_RANGE_REQUEST: u8 = 1;
@@ -188,6 +222,44 @@ impl TryParse for GetXIDRangeReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetXIDRangeReply {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let start_id_bytes = self.start_id.serialize();
+        let count_bytes = self.count.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            start_id_bytes[0],
+            start_id_bytes[1],
+            start_id_bytes[2],
+            start_id_bytes[3],
+            count_bytes[0],
+            count_bytes[1],
+            count_bytes[2],
+            count_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.start_id.serialize_into(bytes);
+        self.count.serialize_into(bytes);
     }
 }
 
@@ -270,6 +342,26 @@ impl TryParse for GetXIDListReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetXIDListReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let ids_len = u32::try_from(self.ids.len()).expect("`ids` has too many elements");
+        ids_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.ids.serialize_into(bytes);
     }
 }
 impl GetXIDListReply {

--- a/x11rb-protocol/src/protocol/xevie.rs
+++ b/x11rb-protocol/src/protocol/xevie.rs
@@ -118,6 +118,61 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let server_major_version_bytes = self.server_major_version.serialize();
+        let server_minor_version_bytes = self.server_minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            server_major_version_bytes[0],
+            server_major_version_bytes[1],
+            server_minor_version_bytes[0],
+            server_minor_version_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.server_major_version.serialize_into(bytes);
+        self.server_minor_version.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+    }
+}
 
 /// Opcode for the Start request
 pub const START_REQUEST: u8 = 1;
@@ -197,6 +252,57 @@ impl TryParse for StartReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for StartReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+    }
+}
 
 /// Opcode for the End request
 pub const END_REQUEST: u8 = 2;
@@ -274,6 +380,57 @@ impl TryParse for EndReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for EndReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
     }
 }
 
@@ -582,6 +739,57 @@ impl TryParse for SendReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for SendReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+    }
+}
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 4;
@@ -659,6 +867,57 @@ impl TryParse for SelectInputReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for SelectInputReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
     }
 }
 

--- a/x11rb-protocol/src/protocol/xf86dri.rs
+++ b/x11rb-protocol/src/protocol/xf86dri.rs
@@ -151,6 +151,46 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let dri_major_version_bytes = self.dri_major_version.serialize();
+        let dri_minor_version_bytes = self.dri_minor_version.serialize();
+        let dri_minor_patch_bytes = self.dri_minor_patch.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            dri_major_version_bytes[0],
+            dri_major_version_bytes[1],
+            dri_minor_version_bytes[0],
+            dri_minor_version_bytes[1],
+            dri_minor_patch_bytes[0],
+            dri_minor_patch_bytes[1],
+            dri_minor_patch_bytes[2],
+            dri_minor_patch_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.dri_major_version.serialize_into(bytes);
+        self.dri_minor_version.serialize_into(bytes);
+        self.dri_minor_patch.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the QueryDirectRenderingCapable request
 pub const QUERY_DIRECT_RENDERING_CAPABLE_REQUEST: u8 = 1;
@@ -229,6 +269,35 @@ impl TryParse for QueryDirectRenderingCapableReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryDirectRenderingCapableReply {
+    type Bytes = [u8; 9];
+    fn serialize(&self) -> [u8; 9] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let is_capable_bytes = self.is_capable.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            is_capable_bytes[0],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(9);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.is_capable.serialize_into(bytes);
     }
 }
 
@@ -316,6 +385,28 @@ impl TryParse for OpenConnectionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for OpenConnectionReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.sarea_handle_low.serialize_into(bytes);
+        self.sarea_handle_high.serialize_into(bytes);
+        let bus_id_len = u32::try_from(self.bus_id.len()).expect("`bus_id` has too many elements");
+        bus_id_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        bytes.extend_from_slice(&self.bus_id);
     }
 }
 impl OpenConnectionReply {
@@ -475,6 +566,29 @@ impl TryParse for GetClientDriverNameReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetClientDriverNameReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.client_driver_major_version.serialize_into(bytes);
+        self.client_driver_minor_version.serialize_into(bytes);
+        self.client_driver_patch_version.serialize_into(bytes);
+        let client_driver_name_len = u32::try_from(self.client_driver_name.len()).expect("`client_driver_name` has too many elements");
+        client_driver_name_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        bytes.extend_from_slice(&self.client_driver_name);
+    }
+}
 impl GetClientDriverNameReply {
     /// Get the value of the `client_driver_name_len` field.
     ///
@@ -584,6 +698,38 @@ impl TryParse for CreateContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for CreateContextReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let hw_context_bytes = self.hw_context.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            hw_context_bytes[0],
+            hw_context_bytes[1],
+            hw_context_bytes[2],
+            hw_context_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.hw_context.serialize_into(bytes);
     }
 }
 
@@ -733,6 +879,38 @@ impl TryParse for CreateDrawableReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for CreateDrawableReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let hw_drawable_handle_bytes = self.hw_drawable_handle.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            hw_drawable_handle_bytes[0],
+            hw_drawable_handle_bytes[1],
+            hw_drawable_handle_bytes[2],
+            hw_drawable_handle_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.hw_drawable_handle.serialize_into(bytes);
     }
 }
 
@@ -904,6 +1082,36 @@ impl TryParse for GetDrawableInfoReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetDrawableInfoReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(36);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.drawable_table_index.serialize_into(bytes);
+        self.drawable_table_stamp.serialize_into(bytes);
+        self.drawable_origin_x.serialize_into(bytes);
+        self.drawable_origin_y.serialize_into(bytes);
+        self.drawable_size_w.serialize_into(bytes);
+        self.drawable_size_h.serialize_into(bytes);
+        let num_clip_rects = u32::try_from(self.clip_rects.len()).expect("`clip_rects` has too many elements");
+        num_clip_rects.serialize_into(bytes);
+        self.back_x.serialize_into(bytes);
+        self.back_y.serialize_into(bytes);
+        let num_back_clip_rects = u32::try_from(self.back_clip_rects.len()).expect("`back_clip_rects` has too many elements");
+        num_back_clip_rects.serialize_into(bytes);
+        self.clip_rects.serialize_into(bytes);
+        self.back_clip_rects.serialize_into(bytes);
+    }
+}
 impl GetDrawableInfoReply {
     /// Get the value of the `num_clip_rects` field.
     ///
@@ -1023,6 +1231,30 @@ impl TryParse for GetDeviceInfoReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetDeviceInfoReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.framebuffer_handle_low.serialize_into(bytes);
+        self.framebuffer_handle_high.serialize_into(bytes);
+        self.framebuffer_origin_offset.serialize_into(bytes);
+        self.framebuffer_size.serialize_into(bytes);
+        self.framebuffer_stride.serialize_into(bytes);
+        let device_private_size = u32::try_from(self.device_private.len()).expect("`device_private` has too many elements");
+        device_private_size.serialize_into(bytes);
+        self.device_private.serialize_into(bytes);
+    }
+}
 impl GetDeviceInfoReply {
     /// Get the value of the `device_private_size` field.
     ///
@@ -1124,6 +1356,38 @@ impl TryParse for AuthConnectionReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for AuthConnectionReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let authenticated_bytes = self.authenticated.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            authenticated_bytes[0],
+            authenticated_bytes[1],
+            authenticated_bytes[2],
+            authenticated_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.authenticated.serialize_into(bytes);
     }
 }
 

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -128,6 +128,61 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_version_bytes[0],
+            major_version_bytes[1],
+            major_version_bytes[2],
+            major_version_bytes[3],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+            minor_version_bytes[2],
+            minor_version_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major_version.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+    }
+}
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -536,6 +591,65 @@ impl TryParse for SelectionNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for SelectionNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let subtype_bytes = u8::from(self.subtype).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let window_bytes = self.window.serialize();
+        let owner_bytes = self.owner.serialize();
+        let selection_bytes = self.selection.serialize();
+        let timestamp_bytes = self.timestamp.serialize();
+        let selection_timestamp_bytes = self.selection_timestamp.serialize();
+        [
+            response_type_bytes[0],
+            subtype_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            owner_bytes[0],
+            owner_bytes[1],
+            owner_bytes[2],
+            owner_bytes[3],
+            selection_bytes[0],
+            selection_bytes[1],
+            selection_bytes[2],
+            selection_bytes[3],
+            timestamp_bytes[0],
+            timestamp_bytes[1],
+            timestamp_bytes[2],
+            timestamp_bytes[3],
+            selection_timestamp_bytes[0],
+            selection_timestamp_bytes[1],
+            selection_timestamp_bytes[2],
+            selection_timestamp_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        u8::from(self.subtype).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.owner.serialize_into(bytes);
+        self.selection.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        self.selection_timestamp.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+    }
+}
 impl From<&SelectionNotifyEvent> for [u8; 32] {
     fn from(input: &SelectionNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -804,6 +918,63 @@ impl TryParse for CursorNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for CursorNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let subtype_bytes = u8::from(self.subtype).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let window_bytes = self.window.serialize();
+        let cursor_serial_bytes = self.cursor_serial.serialize();
+        let timestamp_bytes = self.timestamp.serialize();
+        let name_bytes = self.name.serialize();
+        [
+            response_type_bytes[0],
+            subtype_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            cursor_serial_bytes[0],
+            cursor_serial_bytes[1],
+            cursor_serial_bytes[2],
+            cursor_serial_bytes[3],
+            timestamp_bytes[0],
+            timestamp_bytes[1],
+            timestamp_bytes[2],
+            timestamp_bytes[3],
+            name_bytes[0],
+            name_bytes[1],
+            name_bytes[2],
+            name_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        u8::from(self.subtype).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.cursor_serial.serialize_into(bytes);
+        self.timestamp.serialize_into(bytes);
+        self.name.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+    }
+}
 impl From<&CursorNotifyEvent> for [u8; 32] {
     fn from(input: &CursorNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -999,6 +1170,32 @@ impl TryParse for GetCursorImageReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetCursorImageReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.xhot.serialize_into(bytes);
+        self.yhot.serialize_into(bytes);
+        self.cursor_serial.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        assert_eq!(self.cursor_image.len(), usize::try_from(u32::from(self.width).checked_mul(u32::from(self.height)).unwrap()).unwrap(), "`cursor_image` has an incorrect length");
+        self.cursor_image.serialize_into(bytes);
     }
 }
 
@@ -2067,6 +2264,26 @@ impl TryParse for FetchRegionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for FetchRegionReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        let length = u32::try_from(self.rectangles.len()).ok().and_then(|len| len.checked_mul(2)).expect("`rectangles` has too many elements");
+        length.serialize_into(bytes);
+        self.extents.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+        self.rectangles.serialize_into(bytes);
+    }
+}
 impl FetchRegionReply {
     /// Get the value of the `length` field.
     ///
@@ -2471,6 +2688,27 @@ impl TryParse for GetCursorNameReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetCursorNameReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.atom.serialize_into(bytes);
+        let nbytes = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        nbytes.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 18]);
+        bytes.extend_from_slice(&self.name);
+    }
+}
 impl GetCursorNameReply {
     /// Get the value of the `nbytes` field.
     ///
@@ -2576,6 +2814,36 @@ impl TryParse for GetCursorImageAndNameReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetCursorImageAndNameReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.xhot.serialize_into(bytes);
+        self.yhot.serialize_into(bytes);
+        self.cursor_serial.serialize_into(bytes);
+        self.cursor_atom.serialize_into(bytes);
+        let nbytes = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        nbytes.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        assert_eq!(self.cursor_image.len(), usize::try_from(u32::from(self.width).checked_mul(u32::from(self.height)).unwrap()).unwrap(), "`cursor_image` has an incorrect length");
+        self.cursor_image.serialize_into(bytes);
+        bytes.extend_from_slice(&self.name);
     }
 }
 impl GetCursorImageAndNameReply {

--- a/x11rb-protocol/src/protocol/xinerama.rs
+++ b/x11rb-protocol/src/protocol/xinerama.rs
@@ -164,6 +164,40 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_bytes = self.major.serialize();
+        let minor_bytes = self.minor.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_bytes[0],
+            major_bytes[1],
+            minor_bytes[0],
+            minor_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major.serialize_into(bytes);
+        self.minor.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the GetState request
 pub const GET_STATE_REQUEST: u8 = 1;
@@ -245,6 +279,39 @@ impl TryParse for GetStateReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetStateReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let state_bytes = self.state.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let window_bytes = self.window.serialize();
+        [
+            response_type_bytes[0],
+            state_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.state.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the GetScreenCount request
 pub const GET_SCREEN_COUNT_REQUEST: u8 = 2;
@@ -324,6 +391,39 @@ impl TryParse for GetScreenCountReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetScreenCountReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let screen_count_bytes = self.screen_count.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let window_bytes = self.window.serialize();
+        [
+            response_type_bytes[0],
+            screen_count_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.screen_count.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.window.serialize_into(bytes);
     }
 }
 
@@ -420,6 +520,56 @@ impl TryParse for GetScreenSizeReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetScreenSizeReply {
+    type Bytes = [u8; 24];
+    fn serialize(&self) -> [u8; 24] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let window_bytes = self.window.serialize();
+        let screen_bytes = self.screen.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            width_bytes[0],
+            width_bytes[1],
+            width_bytes[2],
+            width_bytes[3],
+            height_bytes[0],
+            height_bytes[1],
+            height_bytes[2],
+            height_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            screen_bytes[0],
+            screen_bytes[1],
+            screen_bytes[2],
+            screen_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(24);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.screen.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the IsActive request
 pub const IS_ACTIVE_REQUEST: u8 = 4;
@@ -489,6 +639,38 @@ impl TryParse for IsActiveReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for IsActiveReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let state_bytes = self.state.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            state_bytes[0],
+            state_bytes[1],
+            state_bytes[2],
+            state_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.state.serialize_into(bytes);
     }
 }
 
@@ -562,6 +744,26 @@ impl TryParse for QueryScreensReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryScreensReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let number = u32::try_from(self.screen_info.len()).expect("`screen_info` has too many elements");
+        number.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.screen_info.serialize_into(bytes);
     }
 }
 impl QueryScreensReply {

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -5914,6 +5914,62 @@ impl TryParse for UseExtensionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for UseExtensionReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let supported_bytes = self.supported.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let server_major_bytes = self.server_major.serialize();
+        let server_minor_bytes = self.server_minor.serialize();
+        [
+            response_type_bytes[0],
+            supported_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            server_major_bytes[0],
+            server_major_bytes[1],
+            server_minor_bytes[0],
+            server_minor_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.supported.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.server_major.serialize_into(bytes);
+        self.server_minor.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -6382,7 +6438,9 @@ impl SelectEventsAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, affect_which: u16, clear: u16, select_all: u16) {
-        assert_eq!(self.switch_expr(), affect_which & ((!clear) & (!select_all)), "switch `details` has an inconsistent discriminant");
+        let _ = affect_which;
+        let _ = clear;
+        let _ = select_all;
         if let Some(ref bitcase1) = self.bitcase1 {
             bitcase1.serialize_into(bytes);
         }
@@ -6850,6 +6908,87 @@ impl TryParse for GetStateReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetStateReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let device_id_bytes = self.device_id.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let mods_bytes = self.mods.serialize();
+        let base_mods_bytes = self.base_mods.serialize();
+        let latched_mods_bytes = self.latched_mods.serialize();
+        let locked_mods_bytes = self.locked_mods.serialize();
+        let group_bytes = u8::from(self.group).serialize();
+        let locked_group_bytes = u8::from(self.locked_group).serialize();
+        let base_group_bytes = self.base_group.serialize();
+        let latched_group_bytes = self.latched_group.serialize();
+        let compat_state_bytes = self.compat_state.serialize();
+        let grab_mods_bytes = self.grab_mods.serialize();
+        let compat_grab_mods_bytes = self.compat_grab_mods.serialize();
+        let lookup_mods_bytes = self.lookup_mods.serialize();
+        let compat_lookup_mods_bytes = self.compat_lookup_mods.serialize();
+        let ptr_btn_state_bytes = self.ptr_btn_state.serialize();
+        [
+            response_type_bytes[0],
+            device_id_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            mods_bytes[0],
+            base_mods_bytes[0],
+            latched_mods_bytes[0],
+            locked_mods_bytes[0],
+            group_bytes[0],
+            locked_group_bytes[0],
+            base_group_bytes[0],
+            base_group_bytes[1],
+            latched_group_bytes[0],
+            latched_group_bytes[1],
+            compat_state_bytes[0],
+            grab_mods_bytes[0],
+            compat_grab_mods_bytes[0],
+            lookup_mods_bytes[0],
+            compat_lookup_mods_bytes[0],
+            0,
+            ptr_btn_state_bytes[0],
+            ptr_btn_state_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.device_id.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.mods.serialize_into(bytes);
+        self.base_mods.serialize_into(bytes);
+        self.latched_mods.serialize_into(bytes);
+        self.locked_mods.serialize_into(bytes);
+        u8::from(self.group).serialize_into(bytes);
+        u8::from(self.locked_group).serialize_into(bytes);
+        self.base_group.serialize_into(bytes);
+        self.latched_group.serialize_into(bytes);
+        self.compat_state.serialize_into(bytes);
+        self.grab_mods.serialize_into(bytes);
+        self.compat_grab_mods.serialize_into(bytes);
+        self.lookup_mods.serialize_into(bytes);
+        self.compat_lookup_mods.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.ptr_btn_state.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 6]);
+    }
+}
 
 /// Opcode for the LatchLockState request
 pub const LATCH_LOCK_STATE_REQUEST: u8 = 5;
@@ -7075,6 +7214,170 @@ impl TryParse for GetControlsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetControlsReply {
+    type Bytes = [u8; 92];
+    fn serialize(&self) -> [u8; 92] {
+        let response_type_bytes = &[1];
+        let device_id_bytes = self.device_id.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let mouse_keys_dflt_btn_bytes = self.mouse_keys_dflt_btn.serialize();
+        let num_groups_bytes = self.num_groups.serialize();
+        let groups_wrap_bytes = self.groups_wrap.serialize();
+        let internal_mods_mask_bytes = self.internal_mods_mask.serialize();
+        let ignore_lock_mods_mask_bytes = self.ignore_lock_mods_mask.serialize();
+        let internal_mods_real_mods_bytes = self.internal_mods_real_mods.serialize();
+        let ignore_lock_mods_real_mods_bytes = self.ignore_lock_mods_real_mods.serialize();
+        let internal_mods_vmods_bytes = self.internal_mods_vmods.serialize();
+        let ignore_lock_mods_vmods_bytes = self.ignore_lock_mods_vmods.serialize();
+        let repeat_delay_bytes = self.repeat_delay.serialize();
+        let repeat_interval_bytes = self.repeat_interval.serialize();
+        let slow_keys_delay_bytes = self.slow_keys_delay.serialize();
+        let debounce_delay_bytes = self.debounce_delay.serialize();
+        let mouse_keys_delay_bytes = self.mouse_keys_delay.serialize();
+        let mouse_keys_interval_bytes = self.mouse_keys_interval.serialize();
+        let mouse_keys_time_to_max_bytes = self.mouse_keys_time_to_max.serialize();
+        let mouse_keys_max_speed_bytes = self.mouse_keys_max_speed.serialize();
+        let mouse_keys_curve_bytes = self.mouse_keys_curve.serialize();
+        let access_x_option_bytes = self.access_x_option.serialize();
+        let access_x_timeout_bytes = self.access_x_timeout.serialize();
+        let access_x_timeout_options_mask_bytes = self.access_x_timeout_options_mask.serialize();
+        let access_x_timeout_options_values_bytes = self.access_x_timeout_options_values.serialize();
+        let access_x_timeout_mask_bytes = self.access_x_timeout_mask.serialize();
+        let access_x_timeout_values_bytes = self.access_x_timeout_values.serialize();
+        let enabled_controls_bytes = self.enabled_controls.serialize();
+        [
+            response_type_bytes[0],
+            device_id_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            mouse_keys_dflt_btn_bytes[0],
+            num_groups_bytes[0],
+            groups_wrap_bytes[0],
+            internal_mods_mask_bytes[0],
+            ignore_lock_mods_mask_bytes[0],
+            internal_mods_real_mods_bytes[0],
+            ignore_lock_mods_real_mods_bytes[0],
+            0,
+            internal_mods_vmods_bytes[0],
+            internal_mods_vmods_bytes[1],
+            ignore_lock_mods_vmods_bytes[0],
+            ignore_lock_mods_vmods_bytes[1],
+            repeat_delay_bytes[0],
+            repeat_delay_bytes[1],
+            repeat_interval_bytes[0],
+            repeat_interval_bytes[1],
+            slow_keys_delay_bytes[0],
+            slow_keys_delay_bytes[1],
+            debounce_delay_bytes[0],
+            debounce_delay_bytes[1],
+            mouse_keys_delay_bytes[0],
+            mouse_keys_delay_bytes[1],
+            mouse_keys_interval_bytes[0],
+            mouse_keys_interval_bytes[1],
+            mouse_keys_time_to_max_bytes[0],
+            mouse_keys_time_to_max_bytes[1],
+            mouse_keys_max_speed_bytes[0],
+            mouse_keys_max_speed_bytes[1],
+            mouse_keys_curve_bytes[0],
+            mouse_keys_curve_bytes[1],
+            access_x_option_bytes[0],
+            access_x_option_bytes[1],
+            access_x_timeout_bytes[0],
+            access_x_timeout_bytes[1],
+            access_x_timeout_options_mask_bytes[0],
+            access_x_timeout_options_mask_bytes[1],
+            access_x_timeout_options_values_bytes[0],
+            access_x_timeout_options_values_bytes[1],
+            0,
+            0,
+            access_x_timeout_mask_bytes[0],
+            access_x_timeout_mask_bytes[1],
+            access_x_timeout_mask_bytes[2],
+            access_x_timeout_mask_bytes[3],
+            access_x_timeout_values_bytes[0],
+            access_x_timeout_values_bytes[1],
+            access_x_timeout_values_bytes[2],
+            access_x_timeout_values_bytes[3],
+            enabled_controls_bytes[0],
+            enabled_controls_bytes[1],
+            enabled_controls_bytes[2],
+            enabled_controls_bytes[3],
+            self.per_key_repeat[0],
+            self.per_key_repeat[1],
+            self.per_key_repeat[2],
+            self.per_key_repeat[3],
+            self.per_key_repeat[4],
+            self.per_key_repeat[5],
+            self.per_key_repeat[6],
+            self.per_key_repeat[7],
+            self.per_key_repeat[8],
+            self.per_key_repeat[9],
+            self.per_key_repeat[10],
+            self.per_key_repeat[11],
+            self.per_key_repeat[12],
+            self.per_key_repeat[13],
+            self.per_key_repeat[14],
+            self.per_key_repeat[15],
+            self.per_key_repeat[16],
+            self.per_key_repeat[17],
+            self.per_key_repeat[18],
+            self.per_key_repeat[19],
+            self.per_key_repeat[20],
+            self.per_key_repeat[21],
+            self.per_key_repeat[22],
+            self.per_key_repeat[23],
+            self.per_key_repeat[24],
+            self.per_key_repeat[25],
+            self.per_key_repeat[26],
+            self.per_key_repeat[27],
+            self.per_key_repeat[28],
+            self.per_key_repeat[29],
+            self.per_key_repeat[30],
+            self.per_key_repeat[31],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(92);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.device_id.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.mouse_keys_dflt_btn.serialize_into(bytes);
+        self.num_groups.serialize_into(bytes);
+        self.groups_wrap.serialize_into(bytes);
+        self.internal_mods_mask.serialize_into(bytes);
+        self.ignore_lock_mods_mask.serialize_into(bytes);
+        self.internal_mods_real_mods.serialize_into(bytes);
+        self.ignore_lock_mods_real_mods.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.internal_mods_vmods.serialize_into(bytes);
+        self.ignore_lock_mods_vmods.serialize_into(bytes);
+        self.repeat_delay.serialize_into(bytes);
+        self.repeat_interval.serialize_into(bytes);
+        self.slow_keys_delay.serialize_into(bytes);
+        self.debounce_delay.serialize_into(bytes);
+        self.mouse_keys_delay.serialize_into(bytes);
+        self.mouse_keys_interval.serialize_into(bytes);
+        self.mouse_keys_time_to_max.serialize_into(bytes);
+        self.mouse_keys_max_speed.serialize_into(bytes);
+        self.mouse_keys_curve.serialize_into(bytes);
+        self.access_x_option.serialize_into(bytes);
+        self.access_x_timeout.serialize_into(bytes);
+        self.access_x_timeout_options_mask.serialize_into(bytes);
+        self.access_x_timeout_options_values.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.access_x_timeout_mask.serialize_into(bytes);
+        self.access_x_timeout_values.serialize_into(bytes);
+        self.enabled_controls.serialize_into(bytes);
+        bytes.extend_from_slice(&self.per_key_repeat);
     }
 }
 
@@ -7507,6 +7810,21 @@ impl GetMapMapBitcase3 {
         Ok((result, remaining))
     }
 }
+impl GetMapMapBitcase3 {
+    #[allow(dead_code)]
+    fn serialize(&self, n_key_actions: u8, total_actions: u16) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result, n_key_actions, total_actions);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>, n_key_actions: u8, total_actions: u16) {
+        assert_eq!(self.acts_rtrn_count.len(), usize::try_from(n_key_actions).unwrap(), "`acts_rtrn_count` has an incorrect length");
+        bytes.extend_from_slice(&self.acts_rtrn_count);
+        bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        assert_eq!(self.acts_rtrn_acts.len(), usize::try_from(total_actions).unwrap(), "`acts_rtrn_acts` has an incorrect length");
+        self.acts_rtrn_acts.serialize_into(bytes);
+    }
+}
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapMap {
@@ -7606,6 +7924,90 @@ impl GetMapMap {
         Ok((result, outer_remaining))
     }
 }
+impl GetMapMap {
+    #[allow(dead_code)]
+    fn serialize(&self, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) {
+        let _ = present;
+        let _ = n_types;
+        let _ = n_key_syms;
+        let _ = n_key_actions;
+        let _ = total_actions;
+        let _ = total_key_behaviors;
+        let _ = virtual_mods;
+        let _ = total_key_explicit;
+        let _ = total_mod_map_keys;
+        let _ = total_v_mod_map_keys;
+        if let Some(ref types_rtrn) = self.types_rtrn {
+            assert_eq!(types_rtrn.len(), usize::try_from(n_types).unwrap(), "`types_rtrn` has an incorrect length");
+            types_rtrn.serialize_into(bytes);
+        }
+        if let Some(ref syms_rtrn) = self.syms_rtrn {
+            assert_eq!(syms_rtrn.len(), usize::try_from(n_key_syms).unwrap(), "`syms_rtrn` has an incorrect length");
+            syms_rtrn.serialize_into(bytes);
+        }
+        if let Some(ref bitcase3) = self.bitcase3 {
+            bitcase3.serialize_into(bytes, n_key_actions, total_actions);
+        }
+        if let Some(ref behaviors_rtrn) = self.behaviors_rtrn {
+            assert_eq!(behaviors_rtrn.len(), usize::try_from(total_key_behaviors).unwrap(), "`behaviors_rtrn` has an incorrect length");
+            behaviors_rtrn.serialize_into(bytes);
+        }
+        if let Some(ref vmods_rtrn) = self.vmods_rtrn {
+            assert_eq!(vmods_rtrn.len(), usize::try_from(virtual_mods.count_ones()).unwrap(), "`vmods_rtrn` has an incorrect length");
+            bytes.extend_from_slice(&vmods_rtrn);
+            bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        }
+        if let Some(ref explicit_rtrn) = self.explicit_rtrn {
+            assert_eq!(explicit_rtrn.len(), usize::try_from(total_key_explicit).unwrap(), "`explicit_rtrn` has an incorrect length");
+            explicit_rtrn.serialize_into(bytes);
+            bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        }
+        if let Some(ref modmap_rtrn) = self.modmap_rtrn {
+            assert_eq!(modmap_rtrn.len(), usize::try_from(total_mod_map_keys).unwrap(), "`modmap_rtrn` has an incorrect length");
+            modmap_rtrn.serialize_into(bytes);
+            bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        }
+        if let Some(ref vmodmap_rtrn) = self.vmodmap_rtrn {
+            assert_eq!(vmodmap_rtrn.len(), usize::try_from(total_v_mod_map_keys).unwrap(), "`vmodmap_rtrn` has an incorrect length");
+            vmodmap_rtrn.serialize_into(bytes);
+        }
+    }
+}
+impl GetMapMap {
+    fn switch_expr(&self) -> u16 {
+        let mut expr_value = 0;
+        if self.types_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::KEY_TYPES);
+        }
+        if self.syms_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::KEY_SYMS);
+        }
+        if self.bitcase3.is_some() {
+            expr_value |= u16::from(MapPart::KEY_ACTIONS);
+        }
+        if self.behaviors_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::KEY_BEHAVIORS);
+        }
+        if self.vmods_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::VIRTUAL_MODS);
+        }
+        if self.explicit_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::EXPLICIT_COMPONENTS);
+        }
+        if self.modmap_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::MODIFIER_MAP);
+        }
+        if self.vmodmap_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::VIRTUAL_MOD_MAP);
+        }
+        expr_value
+    }
+}
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -7682,6 +8084,51 @@ impl TryParse for GetMapReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetMapReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(40);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.device_id.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.min_key_code.serialize_into(bytes);
+        self.max_key_code.serialize_into(bytes);
+        let present: u16 = self.map.switch_expr();
+        present.serialize_into(bytes);
+        self.first_type.serialize_into(bytes);
+        self.n_types.serialize_into(bytes);
+        self.total_types.serialize_into(bytes);
+        self.first_key_sym.serialize_into(bytes);
+        self.total_syms.serialize_into(bytes);
+        self.n_key_syms.serialize_into(bytes);
+        self.first_key_action.serialize_into(bytes);
+        self.total_actions.serialize_into(bytes);
+        self.n_key_actions.serialize_into(bytes);
+        self.first_key_behavior.serialize_into(bytes);
+        self.n_key_behaviors.serialize_into(bytes);
+        self.total_key_behaviors.serialize_into(bytes);
+        self.first_key_explicit.serialize_into(bytes);
+        self.n_key_explicit.serialize_into(bytes);
+        self.total_key_explicit.serialize_into(bytes);
+        self.first_mod_map_key.serialize_into(bytes);
+        self.n_mod_map_keys.serialize_into(bytes);
+        self.total_mod_map_keys.serialize_into(bytes);
+        self.first_v_mod_map_key.serialize_into(bytes);
+        self.n_v_mod_map_keys.serialize_into(bytes);
+        self.total_v_mod_map_keys.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.virtual_mods.serialize_into(bytes);
+        self.map.serialize_into(bytes, present, self.n_types, self.n_key_syms, self.n_key_actions, self.total_actions, self.total_key_behaviors, self.virtual_mods, self.total_key_explicit, self.total_mod_map_keys, self.total_v_mod_map_keys);
     }
 }
 
@@ -7818,7 +8265,16 @@ impl SetMapAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) {
-        assert_eq!(self.switch_expr(), present, "switch `values` has an inconsistent discriminant");
+        let _ = present;
+        let _ = n_types;
+        let _ = n_key_syms;
+        let _ = n_key_actions;
+        let _ = total_actions;
+        let _ = total_key_behaviors;
+        let _ = virtual_mods;
+        let _ = total_key_explicit;
+        let _ = total_mod_map_keys;
+        let _ = total_v_mod_map_keys;
         if let Some(ref types) = self.types {
             assert_eq!(types.len(), usize::try_from(n_types).unwrap(), "`types` has an incorrect length");
             types.serialize_into(bytes);
@@ -8267,6 +8723,32 @@ impl TryParse for GetCompatMapReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetCompatMapReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.device_id.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.groups_rtrn.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.first_si_rtrn.serialize_into(bytes);
+        let n_si_rtrn = u16::try_from(self.si_rtrn.len()).expect("`si_rtrn` has too many elements");
+        n_si_rtrn.serialize_into(bytes);
+        self.n_total_si.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+        self.si_rtrn.serialize_into(bytes);
+        assert_eq!(self.group_rtrn.len(), usize::try_from(self.groups_rtrn.count_ones()).unwrap(), "`group_rtrn` has an incorrect length");
+        self.group_rtrn.serialize_into(bytes);
+    }
+}
 impl GetCompatMapReply {
     /// Get the value of the `nSIRtrn` field.
     ///
@@ -8472,6 +8954,60 @@ impl TryParse for GetIndicatorStateReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetIndicatorStateReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let device_id_bytes = self.device_id.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let state_bytes = self.state.serialize();
+        [
+            response_type_bytes[0],
+            device_id_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            state_bytes[0],
+            state_bytes[1],
+            state_bytes[2],
+            state_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.device_id.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.state.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+    }
+}
 
 /// Opcode for the GetIndicatorMap request
 pub const GET_INDICATOR_MAP_REQUEST: u8 = 13;
@@ -8567,6 +9103,28 @@ impl TryParse for GetIndicatorMapReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetIndicatorMapReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.device_id.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.which.serialize_into(bytes);
+        self.real_indicators.serialize_into(bytes);
+        self.n_indicators.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 15]);
+        assert_eq!(self.maps.len(), usize::try_from(self.which.count_ones()).unwrap(), "`maps` has an incorrect length");
+        self.maps.serialize_into(bytes);
     }
 }
 
@@ -8775,6 +9333,86 @@ impl TryParse for GetNamedIndicatorReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetNamedIndicatorReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let device_id_bytes = self.device_id.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let indicator_bytes = self.indicator.serialize();
+        let found_bytes = self.found.serialize();
+        let on_bytes = self.on.serialize();
+        let real_indicator_bytes = self.real_indicator.serialize();
+        let ndx_bytes = self.ndx.serialize();
+        let map_flags_bytes = self.map_flags.serialize();
+        let map_which_groups_bytes = self.map_which_groups.serialize();
+        let map_groups_bytes = self.map_groups.serialize();
+        let map_which_mods_bytes = self.map_which_mods.serialize();
+        let map_mods_bytes = self.map_mods.serialize();
+        let map_real_mods_bytes = self.map_real_mods.serialize();
+        let map_vmod_bytes = self.map_vmod.serialize();
+        let map_ctrls_bytes = self.map_ctrls.serialize();
+        let supported_bytes = self.supported.serialize();
+        [
+            response_type_bytes[0],
+            device_id_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            indicator_bytes[0],
+            indicator_bytes[1],
+            indicator_bytes[2],
+            indicator_bytes[3],
+            found_bytes[0],
+            on_bytes[0],
+            real_indicator_bytes[0],
+            ndx_bytes[0],
+            map_flags_bytes[0],
+            map_which_groups_bytes[0],
+            map_groups_bytes[0],
+            map_which_mods_bytes[0],
+            map_mods_bytes[0],
+            map_real_mods_bytes[0],
+            map_vmod_bytes[0],
+            map_vmod_bytes[1],
+            map_ctrls_bytes[0],
+            map_ctrls_bytes[1],
+            map_ctrls_bytes[2],
+            map_ctrls_bytes[3],
+            supported_bytes[0],
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.device_id.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.indicator.serialize_into(bytes);
+        self.found.serialize_into(bytes);
+        self.on.serialize_into(bytes);
+        self.real_indicator.serialize_into(bytes);
+        self.ndx.serialize_into(bytes);
+        self.map_flags.serialize_into(bytes);
+        self.map_which_groups.serialize_into(bytes);
+        self.map_groups.serialize_into(bytes);
+        self.map_which_mods.serialize_into(bytes);
+        self.map_mods.serialize_into(bytes);
+        self.map_real_mods.serialize_into(bytes);
+        self.map_vmod.serialize_into(bytes);
+        self.map_ctrls.serialize_into(bytes);
+        self.supported.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 3]);
     }
 }
 
@@ -8997,6 +9635,21 @@ impl GetNamesValueListBitcase8 {
         Ok((result, remaining))
     }
 }
+impl GetNamesValueListBitcase8 {
+    #[allow(dead_code)]
+    fn serialize(&self, n_types: u8) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result, n_types);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>, n_types: u8) {
+        assert_eq!(self.n_levels_per_type.len(), usize::try_from(n_types).unwrap(), "`n_levels_per_type` has an incorrect length");
+        bytes.extend_from_slice(&self.n_levels_per_type);
+        bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        assert_eq!(self.kt_level_names.len(), usize::try_from(self.n_levels_per_type.iter().fold(0u32, |acc, x| acc.checked_add(u32::from(*x)).unwrap())).unwrap(), "`kt_level_names` has an incorrect length");
+        self.kt_level_names.serialize_into(bytes);
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamesValueList {
@@ -9134,6 +9787,121 @@ impl GetNamesValueList {
         Ok((result, outer_remaining))
     }
 }
+impl GetNamesValueList {
+    #[allow(dead_code)]
+    fn serialize(&self, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result, which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) {
+        let _ = which;
+        let _ = n_types;
+        let _ = indicators;
+        let _ = virtual_mods;
+        let _ = group_names;
+        let _ = n_keys;
+        let _ = n_key_aliases;
+        let _ = n_radio_groups;
+        if let Some(keycodes_name) = self.keycodes_name {
+            keycodes_name.serialize_into(bytes);
+        }
+        if let Some(geometry_name) = self.geometry_name {
+            geometry_name.serialize_into(bytes);
+        }
+        if let Some(symbols_name) = self.symbols_name {
+            symbols_name.serialize_into(bytes);
+        }
+        if let Some(phys_symbols_name) = self.phys_symbols_name {
+            phys_symbols_name.serialize_into(bytes);
+        }
+        if let Some(types_name) = self.types_name {
+            types_name.serialize_into(bytes);
+        }
+        if let Some(compat_name) = self.compat_name {
+            compat_name.serialize_into(bytes);
+        }
+        if let Some(ref type_names) = self.type_names {
+            assert_eq!(type_names.len(), usize::try_from(n_types).unwrap(), "`type_names` has an incorrect length");
+            type_names.serialize_into(bytes);
+        }
+        if let Some(ref bitcase8) = self.bitcase8 {
+            bitcase8.serialize_into(bytes, n_types);
+        }
+        if let Some(ref indicator_names) = self.indicator_names {
+            assert_eq!(indicator_names.len(), usize::try_from(indicators.count_ones()).unwrap(), "`indicator_names` has an incorrect length");
+            indicator_names.serialize_into(bytes);
+        }
+        if let Some(ref virtual_mod_names) = self.virtual_mod_names {
+            assert_eq!(virtual_mod_names.len(), usize::try_from(virtual_mods.count_ones()).unwrap(), "`virtual_mod_names` has an incorrect length");
+            virtual_mod_names.serialize_into(bytes);
+        }
+        if let Some(ref groups) = self.groups {
+            assert_eq!(groups.len(), usize::try_from(group_names.count_ones()).unwrap(), "`groups` has an incorrect length");
+            groups.serialize_into(bytes);
+        }
+        if let Some(ref key_names) = self.key_names {
+            assert_eq!(key_names.len(), usize::try_from(n_keys).unwrap(), "`key_names` has an incorrect length");
+            key_names.serialize_into(bytes);
+        }
+        if let Some(ref key_aliases) = self.key_aliases {
+            assert_eq!(key_aliases.len(), usize::try_from(n_key_aliases).unwrap(), "`key_aliases` has an incorrect length");
+            key_aliases.serialize_into(bytes);
+        }
+        if let Some(ref radio_group_names) = self.radio_group_names {
+            assert_eq!(radio_group_names.len(), usize::try_from(n_radio_groups).unwrap(), "`radio_group_names` has an incorrect length");
+            radio_group_names.serialize_into(bytes);
+        }
+    }
+}
+impl GetNamesValueList {
+    fn switch_expr(&self) -> u32 {
+        let mut expr_value = 0;
+        if self.keycodes_name.is_some() {
+            expr_value |= u32::from(NameDetail::KEYCODES);
+        }
+        if self.geometry_name.is_some() {
+            expr_value |= u32::from(NameDetail::GEOMETRY);
+        }
+        if self.symbols_name.is_some() {
+            expr_value |= u32::from(NameDetail::SYMBOLS);
+        }
+        if self.phys_symbols_name.is_some() {
+            expr_value |= u32::from(NameDetail::PHYS_SYMBOLS);
+        }
+        if self.types_name.is_some() {
+            expr_value |= u32::from(NameDetail::TYPES);
+        }
+        if self.compat_name.is_some() {
+            expr_value |= u32::from(NameDetail::COMPAT);
+        }
+        if self.type_names.is_some() {
+            expr_value |= u32::from(NameDetail::KEY_TYPE_NAMES);
+        }
+        if self.bitcase8.is_some() {
+            expr_value |= u32::from(NameDetail::KT_LEVEL_NAMES);
+        }
+        if self.indicator_names.is_some() {
+            expr_value |= u32::from(NameDetail::INDICATOR_NAMES);
+        }
+        if self.virtual_mod_names.is_some() {
+            expr_value |= u32::from(NameDetail::VIRTUAL_MOD_NAMES);
+        }
+        if self.groups.is_some() {
+            expr_value |= u32::from(NameDetail::GROUP_NAMES);
+        }
+        if self.key_names.is_some() {
+            expr_value |= u32::from(NameDetail::KEY_NAMES);
+        }
+        if self.key_aliases.is_some() {
+            expr_value |= u32::from(NameDetail::KEY_ALIASES);
+        }
+        if self.radio_group_names.is_some() {
+            expr_value |= u32::from(NameDetail::RG_NAMES);
+        }
+        expr_value
+    }
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -9183,6 +9951,37 @@ impl TryParse for GetNamesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetNamesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.device_id.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let which: u32 = self.value_list.switch_expr();
+        which.serialize_into(bytes);
+        self.min_key_code.serialize_into(bytes);
+        self.max_key_code.serialize_into(bytes);
+        self.n_types.serialize_into(bytes);
+        self.group_names.serialize_into(bytes);
+        self.virtual_mods.serialize_into(bytes);
+        self.first_key.serialize_into(bytes);
+        self.n_keys.serialize_into(bytes);
+        self.indicators.serialize_into(bytes);
+        self.n_radio_groups.serialize_into(bytes);
+        self.n_key_aliases.serialize_into(bytes);
+        self.n_kt_levels.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        self.value_list.serialize_into(bytes, which, self.n_types, self.indicators, self.virtual_mods, self.group_names, self.n_keys, self.n_key_aliases, self.n_radio_groups);
     }
 }
 
@@ -9367,7 +10166,14 @@ impl SetNamesAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) {
-        assert_eq!(self.switch_expr(), which, "switch `values` has an inconsistent discriminant");
+        let _ = which;
+        let _ = n_types;
+        let _ = indicators;
+        let _ = virtual_mods;
+        let _ = group_names;
+        let _ = n_keys;
+        let _ = n_key_aliases;
+        let _ = n_radio_groups;
         if let Some(keycodes_name) = self.keycodes_name {
             keycodes_name.serialize_into(bytes);
         }
@@ -9837,6 +10643,66 @@ impl TryParse for PerClientFlagsReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for PerClientFlagsReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let device_id_bytes = self.device_id.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let supported_bytes = self.supported.serialize();
+        let value_bytes = self.value.serialize();
+        let auto_ctrls_bytes = self.auto_ctrls.serialize();
+        let auto_ctrls_values_bytes = self.auto_ctrls_values.serialize();
+        [
+            response_type_bytes[0],
+            device_id_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            supported_bytes[0],
+            supported_bytes[1],
+            supported_bytes[2],
+            supported_bytes[3],
+            value_bytes[0],
+            value_bytes[1],
+            value_bytes[2],
+            value_bytes[3],
+            auto_ctrls_bytes[0],
+            auto_ctrls_bytes[1],
+            auto_ctrls_bytes[2],
+            auto_ctrls_bytes[3],
+            auto_ctrls_values_bytes[0],
+            auto_ctrls_values_bytes[1],
+            auto_ctrls_values_bytes[2],
+            auto_ctrls_values_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.device_id.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.supported.serialize_into(bytes);
+        self.value.serialize_into(bytes);
+        self.auto_ctrls.serialize_into(bytes);
+        self.auto_ctrls_values.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+    }
+}
 
 /// Opcode for the ListComponents request
 pub const LIST_COMPONENTS_REQUEST: u8 = 22;
@@ -9939,6 +10805,42 @@ impl TryParse for ListComponentsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ListComponentsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.device_id.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let n_keymaps = u16::try_from(self.keymaps.len()).expect("`keymaps` has too many elements");
+        n_keymaps.serialize_into(bytes);
+        let n_keycodes = u16::try_from(self.keycodes.len()).expect("`keycodes` has too many elements");
+        n_keycodes.serialize_into(bytes);
+        let n_types = u16::try_from(self.types.len()).expect("`types` has too many elements");
+        n_types.serialize_into(bytes);
+        let n_compat_maps = u16::try_from(self.compat_maps.len()).expect("`compat_maps` has too many elements");
+        n_compat_maps.serialize_into(bytes);
+        let n_symbols = u16::try_from(self.symbols.len()).expect("`symbols` has too many elements");
+        n_symbols.serialize_into(bytes);
+        let n_geometries = u16::try_from(self.geometries.len()).expect("`geometries` has too many elements");
+        n_geometries.serialize_into(bytes);
+        self.extra.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 10]);
+        self.keymaps.serialize_into(bytes);
+        self.keycodes.serialize_into(bytes);
+        self.types.serialize_into(bytes);
+        self.compat_maps.serialize_into(bytes);
+        self.symbols.serialize_into(bytes);
+        self.geometries.serialize_into(bytes);
     }
 }
 impl ListComponentsReply {
@@ -10113,6 +11015,21 @@ impl GetKbdByNameRepliesTypesMapBitcase3 {
         Ok((result, remaining))
     }
 }
+impl GetKbdByNameRepliesTypesMapBitcase3 {
+    #[allow(dead_code)]
+    fn serialize(&self, n_key_actions: u8, total_actions: u16) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result, n_key_actions, total_actions);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>, n_key_actions: u8, total_actions: u16) {
+        assert_eq!(self.acts_rtrn_count.len(), usize::try_from(n_key_actions).unwrap(), "`acts_rtrn_count` has an incorrect length");
+        bytes.extend_from_slice(&self.acts_rtrn_count);
+        bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        assert_eq!(self.acts_rtrn_acts.len(), usize::try_from(total_actions).unwrap(), "`acts_rtrn_acts` has an incorrect length");
+        self.acts_rtrn_acts.serialize_into(bytes);
+    }
+}
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesTypesMap {
@@ -10212,6 +11129,90 @@ impl GetKbdByNameRepliesTypesMap {
         Ok((result, outer_remaining))
     }
 }
+impl GetKbdByNameRepliesTypesMap {
+    #[allow(dead_code)]
+    fn serialize(&self, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) {
+        let _ = present;
+        let _ = n_types;
+        let _ = n_key_syms;
+        let _ = n_key_actions;
+        let _ = total_actions;
+        let _ = total_key_behaviors;
+        let _ = virtual_mods;
+        let _ = total_key_explicit;
+        let _ = total_mod_map_keys;
+        let _ = total_v_mod_map_keys;
+        if let Some(ref types_rtrn) = self.types_rtrn {
+            assert_eq!(types_rtrn.len(), usize::try_from(n_types).unwrap(), "`types_rtrn` has an incorrect length");
+            types_rtrn.serialize_into(bytes);
+        }
+        if let Some(ref syms_rtrn) = self.syms_rtrn {
+            assert_eq!(syms_rtrn.len(), usize::try_from(n_key_syms).unwrap(), "`syms_rtrn` has an incorrect length");
+            syms_rtrn.serialize_into(bytes);
+        }
+        if let Some(ref bitcase3) = self.bitcase3 {
+            bitcase3.serialize_into(bytes, n_key_actions, total_actions);
+        }
+        if let Some(ref behaviors_rtrn) = self.behaviors_rtrn {
+            assert_eq!(behaviors_rtrn.len(), usize::try_from(total_key_behaviors).unwrap(), "`behaviors_rtrn` has an incorrect length");
+            behaviors_rtrn.serialize_into(bytes);
+        }
+        if let Some(ref vmods_rtrn) = self.vmods_rtrn {
+            assert_eq!(vmods_rtrn.len(), usize::try_from(virtual_mods.count_ones()).unwrap(), "`vmods_rtrn` has an incorrect length");
+            bytes.extend_from_slice(&vmods_rtrn);
+            bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        }
+        if let Some(ref explicit_rtrn) = self.explicit_rtrn {
+            assert_eq!(explicit_rtrn.len(), usize::try_from(total_key_explicit).unwrap(), "`explicit_rtrn` has an incorrect length");
+            explicit_rtrn.serialize_into(bytes);
+            bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        }
+        if let Some(ref modmap_rtrn) = self.modmap_rtrn {
+            assert_eq!(modmap_rtrn.len(), usize::try_from(total_mod_map_keys).unwrap(), "`modmap_rtrn` has an incorrect length");
+            modmap_rtrn.serialize_into(bytes);
+            bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        }
+        if let Some(ref vmodmap_rtrn) = self.vmodmap_rtrn {
+            assert_eq!(vmodmap_rtrn.len(), usize::try_from(total_v_mod_map_keys).unwrap(), "`vmodmap_rtrn` has an incorrect length");
+            vmodmap_rtrn.serialize_into(bytes);
+        }
+    }
+}
+impl GetKbdByNameRepliesTypesMap {
+    fn switch_expr(&self) -> u16 {
+        let mut expr_value = 0;
+        if self.types_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::KEY_TYPES);
+        }
+        if self.syms_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::KEY_SYMS);
+        }
+        if self.bitcase3.is_some() {
+            expr_value |= u16::from(MapPart::KEY_ACTIONS);
+        }
+        if self.behaviors_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::KEY_BEHAVIORS);
+        }
+        if self.vmods_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::VIRTUAL_MODS);
+        }
+        if self.explicit_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::EXPLICIT_COMPONENTS);
+        }
+        if self.modmap_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::MODIFIER_MAP);
+        }
+        if self.vmodmap_rtrn.is_some() {
+            expr_value |= u16::from(MapPart::VIRTUAL_MOD_MAP);
+        }
+        expr_value
+    }
+}
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -10284,6 +11285,50 @@ impl TryParse for GetKbdByNameRepliesTypes {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetKbdByNameRepliesTypes {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(40);
+        self.getmap_type.serialize_into(bytes);
+        self.type_device_id.serialize_into(bytes);
+        self.getmap_sequence.serialize_into(bytes);
+        self.getmap_length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.type_min_key_code.serialize_into(bytes);
+        self.type_max_key_code.serialize_into(bytes);
+        let present: u16 = self.map.switch_expr();
+        present.serialize_into(bytes);
+        self.first_type.serialize_into(bytes);
+        self.n_types.serialize_into(bytes);
+        self.total_types.serialize_into(bytes);
+        self.first_key_sym.serialize_into(bytes);
+        self.total_syms.serialize_into(bytes);
+        self.n_key_syms.serialize_into(bytes);
+        self.first_key_action.serialize_into(bytes);
+        self.total_actions.serialize_into(bytes);
+        self.n_key_actions.serialize_into(bytes);
+        self.first_key_behavior.serialize_into(bytes);
+        self.n_key_behaviors.serialize_into(bytes);
+        self.total_key_behaviors.serialize_into(bytes);
+        self.first_key_explicit.serialize_into(bytes);
+        self.n_key_explicit.serialize_into(bytes);
+        self.total_key_explicit.serialize_into(bytes);
+        self.first_mod_map_key.serialize_into(bytes);
+        self.n_mod_map_keys.serialize_into(bytes);
+        self.total_mod_map_keys.serialize_into(bytes);
+        self.first_v_mod_map_key.serialize_into(bytes);
+        self.n_v_mod_map_keys.serialize_into(bytes);
+        self.total_v_mod_map_keys.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.virtual_mods.serialize_into(bytes);
+        self.map.serialize_into(bytes, present, self.n_types, self.n_key_syms, self.n_key_actions, self.total_actions, self.total_key_behaviors, self.virtual_mods, self.total_key_explicit, self.total_mod_map_keys, self.total_v_mod_map_keys);
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesCompatMap {
@@ -10313,6 +11358,31 @@ impl TryParse for GetKbdByNameRepliesCompatMap {
         let (group_rtrn, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, groups_rtrn.count_ones().try_to_usize()?)?;
         let result = GetKbdByNameRepliesCompatMap { compatmap_type, compat_device_id, compatmap_sequence, compatmap_length, groups_rtrn, first_si_rtrn, n_total_si, si_rtrn, group_rtrn };
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetKbdByNameRepliesCompatMap {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.compatmap_type.serialize_into(bytes);
+        self.compat_device_id.serialize_into(bytes);
+        self.compatmap_sequence.serialize_into(bytes);
+        self.compatmap_length.serialize_into(bytes);
+        self.groups_rtrn.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.first_si_rtrn.serialize_into(bytes);
+        let n_si_rtrn = u16::try_from(self.si_rtrn.len()).expect("`si_rtrn` has too many elements");
+        n_si_rtrn.serialize_into(bytes);
+        self.n_total_si.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+        self.si_rtrn.serialize_into(bytes);
+        assert_eq!(self.group_rtrn.len(), usize::try_from(self.groups_rtrn.count_ones()).unwrap(), "`group_rtrn` has an incorrect length");
+        self.group_rtrn.serialize_into(bytes);
     }
 }
 impl GetKbdByNameRepliesCompatMap {
@@ -10356,6 +11426,27 @@ impl TryParse for GetKbdByNameRepliesIndicatorMaps {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetKbdByNameRepliesIndicatorMaps {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.indicatormap_type.serialize_into(bytes);
+        self.indicator_device_id.serialize_into(bytes);
+        self.indicatormap_sequence.serialize_into(bytes);
+        self.indicatormap_length.serialize_into(bytes);
+        self.which.serialize_into(bytes);
+        self.real_indicators.serialize_into(bytes);
+        let n_indicators = u8::try_from(self.maps.len()).expect("`maps` has too many elements");
+        n_indicators.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 15]);
+        self.maps.serialize_into(bytes);
+    }
+}
 impl GetKbdByNameRepliesIndicatorMaps {
     /// Get the value of the `nIndicators` field.
     ///
@@ -10389,6 +11480,21 @@ impl GetKbdByNameRepliesKeyNamesValueListBitcase8 {
         let (kt_level_names, remaining) = crate::x11_utils::parse_list::<xproto::Atom>(remaining, n_levels_per_type.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x)).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
         let result = GetKbdByNameRepliesKeyNamesValueListBitcase8 { n_levels_per_type, kt_level_names };
         Ok((result, remaining))
+    }
+}
+impl GetKbdByNameRepliesKeyNamesValueListBitcase8 {
+    #[allow(dead_code)]
+    fn serialize(&self, n_types: u8) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result, n_types);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>, n_types: u8) {
+        assert_eq!(self.n_levels_per_type.len(), usize::try_from(n_types).unwrap(), "`n_levels_per_type` has an incorrect length");
+        bytes.extend_from_slice(&self.n_levels_per_type);
+        bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        assert_eq!(self.kt_level_names.len(), usize::try_from(self.n_levels_per_type.iter().fold(0u32, |acc, x| acc.checked_add(u32::from(*x)).unwrap())).unwrap(), "`kt_level_names` has an incorrect length");
+        self.kt_level_names.serialize_into(bytes);
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -10528,6 +11634,121 @@ impl GetKbdByNameRepliesKeyNamesValueList {
         Ok((result, outer_remaining))
     }
 }
+impl GetKbdByNameRepliesKeyNamesValueList {
+    #[allow(dead_code)]
+    fn serialize(&self, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result, which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) {
+        let _ = which;
+        let _ = n_types;
+        let _ = indicators;
+        let _ = virtual_mods;
+        let _ = group_names;
+        let _ = n_keys;
+        let _ = n_key_aliases;
+        let _ = n_radio_groups;
+        if let Some(keycodes_name) = self.keycodes_name {
+            keycodes_name.serialize_into(bytes);
+        }
+        if let Some(geometry_name) = self.geometry_name {
+            geometry_name.serialize_into(bytes);
+        }
+        if let Some(symbols_name) = self.symbols_name {
+            symbols_name.serialize_into(bytes);
+        }
+        if let Some(phys_symbols_name) = self.phys_symbols_name {
+            phys_symbols_name.serialize_into(bytes);
+        }
+        if let Some(types_name) = self.types_name {
+            types_name.serialize_into(bytes);
+        }
+        if let Some(compat_name) = self.compat_name {
+            compat_name.serialize_into(bytes);
+        }
+        if let Some(ref type_names) = self.type_names {
+            assert_eq!(type_names.len(), usize::try_from(n_types).unwrap(), "`type_names` has an incorrect length");
+            type_names.serialize_into(bytes);
+        }
+        if let Some(ref bitcase8) = self.bitcase8 {
+            bitcase8.serialize_into(bytes, n_types);
+        }
+        if let Some(ref indicator_names) = self.indicator_names {
+            assert_eq!(indicator_names.len(), usize::try_from(indicators.count_ones()).unwrap(), "`indicator_names` has an incorrect length");
+            indicator_names.serialize_into(bytes);
+        }
+        if let Some(ref virtual_mod_names) = self.virtual_mod_names {
+            assert_eq!(virtual_mod_names.len(), usize::try_from(virtual_mods.count_ones()).unwrap(), "`virtual_mod_names` has an incorrect length");
+            virtual_mod_names.serialize_into(bytes);
+        }
+        if let Some(ref groups) = self.groups {
+            assert_eq!(groups.len(), usize::try_from(group_names.count_ones()).unwrap(), "`groups` has an incorrect length");
+            groups.serialize_into(bytes);
+        }
+        if let Some(ref key_names) = self.key_names {
+            assert_eq!(key_names.len(), usize::try_from(n_keys).unwrap(), "`key_names` has an incorrect length");
+            key_names.serialize_into(bytes);
+        }
+        if let Some(ref key_aliases) = self.key_aliases {
+            assert_eq!(key_aliases.len(), usize::try_from(n_key_aliases).unwrap(), "`key_aliases` has an incorrect length");
+            key_aliases.serialize_into(bytes);
+        }
+        if let Some(ref radio_group_names) = self.radio_group_names {
+            assert_eq!(radio_group_names.len(), usize::try_from(n_radio_groups).unwrap(), "`radio_group_names` has an incorrect length");
+            radio_group_names.serialize_into(bytes);
+        }
+    }
+}
+impl GetKbdByNameRepliesKeyNamesValueList {
+    fn switch_expr(&self) -> u32 {
+        let mut expr_value = 0;
+        if self.keycodes_name.is_some() {
+            expr_value |= u32::from(NameDetail::KEYCODES);
+        }
+        if self.geometry_name.is_some() {
+            expr_value |= u32::from(NameDetail::GEOMETRY);
+        }
+        if self.symbols_name.is_some() {
+            expr_value |= u32::from(NameDetail::SYMBOLS);
+        }
+        if self.phys_symbols_name.is_some() {
+            expr_value |= u32::from(NameDetail::PHYS_SYMBOLS);
+        }
+        if self.types_name.is_some() {
+            expr_value |= u32::from(NameDetail::TYPES);
+        }
+        if self.compat_name.is_some() {
+            expr_value |= u32::from(NameDetail::COMPAT);
+        }
+        if self.type_names.is_some() {
+            expr_value |= u32::from(NameDetail::KEY_TYPE_NAMES);
+        }
+        if self.bitcase8.is_some() {
+            expr_value |= u32::from(NameDetail::KT_LEVEL_NAMES);
+        }
+        if self.indicator_names.is_some() {
+            expr_value |= u32::from(NameDetail::INDICATOR_NAMES);
+        }
+        if self.virtual_mod_names.is_some() {
+            expr_value |= u32::from(NameDetail::VIRTUAL_MOD_NAMES);
+        }
+        if self.groups.is_some() {
+            expr_value |= u32::from(NameDetail::GROUP_NAMES);
+        }
+        if self.key_names.is_some() {
+            expr_value |= u32::from(NameDetail::KEY_NAMES);
+        }
+        if self.key_aliases.is_some() {
+            expr_value |= u32::from(NameDetail::KEY_ALIASES);
+        }
+        if self.radio_group_names.is_some() {
+            expr_value |= u32::from(NameDetail::RG_NAMES);
+        }
+        expr_value
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -10573,6 +11794,36 @@ impl TryParse for GetKbdByNameRepliesKeyNames {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetKbdByNameRepliesKeyNames {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.keyname_type.serialize_into(bytes);
+        self.key_device_id.serialize_into(bytes);
+        self.keyname_sequence.serialize_into(bytes);
+        self.keyname_length.serialize_into(bytes);
+        let which: u32 = self.value_list.switch_expr();
+        which.serialize_into(bytes);
+        self.key_min_key_code.serialize_into(bytes);
+        self.key_max_key_code.serialize_into(bytes);
+        self.n_types.serialize_into(bytes);
+        self.group_names.serialize_into(bytes);
+        self.virtual_mods.serialize_into(bytes);
+        self.first_key.serialize_into(bytes);
+        self.n_keys.serialize_into(bytes);
+        self.indicators.serialize_into(bytes);
+        self.n_radio_groups.serialize_into(bytes);
+        self.n_key_aliases.serialize_into(bytes);
+        self.n_kt_levels.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        self.value_list.serialize_into(bytes, which, self.n_types, self.indicators, self.virtual_mods, self.group_names, self.n_keys, self.n_key_aliases, self.n_radio_groups);
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesGeometry {
@@ -10616,6 +11867,35 @@ impl TryParse for GetKbdByNameRepliesGeometry {
         let (label_font, remaining) = CountedString16::try_parse(remaining)?;
         let result = GetKbdByNameRepliesGeometry { geometry_type, geometry_device_id, geometry_sequence, geometry_length, name, geometry_found, width_mm, height_mm, n_properties, n_colors, n_shapes, n_sections, n_doodads, n_key_aliases, base_color_ndx, label_color_ndx, label_font };
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetKbdByNameRepliesGeometry {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.geometry_type.serialize_into(bytes);
+        self.geometry_device_id.serialize_into(bytes);
+        self.geometry_sequence.serialize_into(bytes);
+        self.geometry_length.serialize_into(bytes);
+        self.name.serialize_into(bytes);
+        self.geometry_found.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.width_mm.serialize_into(bytes);
+        self.height_mm.serialize_into(bytes);
+        self.n_properties.serialize_into(bytes);
+        self.n_colors.serialize_into(bytes);
+        self.n_shapes.serialize_into(bytes);
+        self.n_sections.serialize_into(bytes);
+        self.n_doodads.serialize_into(bytes);
+        self.n_key_aliases.serialize_into(bytes);
+        self.base_color_ndx.serialize_into(bytes);
+        self.label_color_ndx.serialize_into(bytes);
+        self.label_font.serialize_into(bytes);
     }
 }
 #[derive(Debug, Clone, Default)]
@@ -10670,6 +11950,32 @@ impl GetKbdByNameReplies {
         Ok((result, outer_remaining))
     }
 }
+impl GetKbdByNameReplies {
+    #[allow(dead_code)]
+    fn serialize(&self, reported: u16) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result, reported);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>, reported: u16) {
+        let _ = reported;
+        if let Some(ref types) = self.types {
+            types.serialize_into(bytes);
+        }
+        if let Some(ref compat_map) = self.compat_map {
+            compat_map.serialize_into(bytes);
+        }
+        if let Some(ref indicator_maps) = self.indicator_maps {
+            indicator_maps.serialize_into(bytes);
+        }
+        if let Some(ref key_names) = self.key_names {
+            key_names.serialize_into(bytes);
+        }
+        if let Some(ref geometry) = self.geometry {
+            geometry.serialize_into(bytes);
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -10708,6 +12014,30 @@ impl TryParse for GetKbdByNameReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetKbdByNameReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.device_id.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.min_key_code.serialize_into(bytes);
+        self.max_key_code.serialize_into(bytes);
+        self.loaded.serialize_into(bytes);
+        self.new_keyboard.serialize_into(bytes);
+        self.found.serialize_into(bytes);
+        self.reported.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
+        self.replies.serialize_into(bytes, self.reported);
     }
 }
 
@@ -10859,6 +12189,44 @@ impl TryParse for GetDeviceInfoReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetDeviceInfoReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(34);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.device_id.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.present.serialize_into(bytes);
+        self.supported.serialize_into(bytes);
+        self.unsupported.serialize_into(bytes);
+        let n_device_led_f_bs = u16::try_from(self.leds.len()).expect("`leds` has too many elements");
+        n_device_led_f_bs.serialize_into(bytes);
+        self.first_btn_wanted.serialize_into(bytes);
+        self.n_btns_wanted.serialize_into(bytes);
+        self.first_btn_rtrn.serialize_into(bytes);
+        let n_btns_rtrn = u8::try_from(self.btn_actions.len()).expect("`btn_actions` has too many elements");
+        n_btns_rtrn.serialize_into(bytes);
+        self.total_btns.serialize_into(bytes);
+        self.has_own_state.serialize_into(bytes);
+        self.dflt_kbd_fb.serialize_into(bytes);
+        self.dflt_led_fb.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.dev_type.serialize_into(bytes);
+        let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        name_len.serialize_into(bytes);
+        bytes.extend_from_slice(&self.name);
+        bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
+        self.btn_actions.serialize_into(bytes);
+        self.leds.serialize_into(bytes);
     }
 }
 impl GetDeviceInfoReply {
@@ -11130,6 +12498,65 @@ impl TryParse for SetDebuggingFlagsReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for SetDebuggingFlagsReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let current_flags_bytes = self.current_flags.serialize();
+        let current_ctrls_bytes = self.current_ctrls.serialize();
+        let supported_flags_bytes = self.supported_flags.serialize();
+        let supported_ctrls_bytes = self.supported_ctrls.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            current_flags_bytes[0],
+            current_flags_bytes[1],
+            current_flags_bytes[2],
+            current_flags_bytes[3],
+            current_ctrls_bytes[0],
+            current_ctrls_bytes[1],
+            current_ctrls_bytes[2],
+            current_ctrls_bytes[3],
+            supported_flags_bytes[0],
+            supported_flags_bytes[1],
+            supported_flags_bytes[2],
+            supported_flags_bytes[3],
+            supported_ctrls_bytes[0],
+            supported_ctrls_bytes[1],
+            supported_ctrls_bytes[2],
+            supported_ctrls_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.current_flags.serialize_into(bytes);
+        self.current_ctrls.serialize_into(bytes);
+        self.supported_flags.serialize_into(bytes);
+        self.supported_ctrls.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+    }
+}
 
 /// Opcode for the NewKeyboardNotify event
 pub const NEW_KEYBOARD_NOTIFY_EVENT: u8 = 0;
@@ -11172,6 +12599,75 @@ impl TryParse for NewKeyboardNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for NewKeyboardNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let xkb_type_bytes = self.xkb_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let old_device_id_bytes = self.old_device_id.serialize();
+        let min_key_code_bytes = self.min_key_code.serialize();
+        let max_key_code_bytes = self.max_key_code.serialize();
+        let old_min_key_code_bytes = self.old_min_key_code.serialize();
+        let old_max_key_code_bytes = self.old_max_key_code.serialize();
+        let request_major_bytes = self.request_major.serialize();
+        let request_minor_bytes = self.request_minor.serialize();
+        let changed_bytes = self.changed.serialize();
+        [
+            response_type_bytes[0],
+            xkb_type_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            old_device_id_bytes[0],
+            min_key_code_bytes[0],
+            max_key_code_bytes[0],
+            old_min_key_code_bytes[0],
+            old_max_key_code_bytes[0],
+            request_major_bytes[0],
+            request_minor_bytes[0],
+            changed_bytes[0],
+            changed_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.xkb_type.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.device_id.serialize_into(bytes);
+        self.old_device_id.serialize_into(bytes);
+        self.min_key_code.serialize_into(bytes);
+        self.max_key_code.serialize_into(bytes);
+        self.old_min_key_code.serialize_into(bytes);
+        self.old_max_key_code.serialize_into(bytes);
+        self.request_major.serialize_into(bytes);
+        self.request_minor.serialize_into(bytes);
+        self.changed.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 14]);
     }
 }
 impl From<&NewKeyboardNotifyEvent> for [u8; 32] {
@@ -11294,6 +12790,97 @@ impl TryParse for MapNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for MapNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let xkb_type_bytes = self.xkb_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let ptr_btn_actions_bytes = self.ptr_btn_actions.serialize();
+        let changed_bytes = self.changed.serialize();
+        let min_key_code_bytes = self.min_key_code.serialize();
+        let max_key_code_bytes = self.max_key_code.serialize();
+        let first_type_bytes = self.first_type.serialize();
+        let n_types_bytes = self.n_types.serialize();
+        let first_key_sym_bytes = self.first_key_sym.serialize();
+        let n_key_syms_bytes = self.n_key_syms.serialize();
+        let first_key_act_bytes = self.first_key_act.serialize();
+        let n_key_acts_bytes = self.n_key_acts.serialize();
+        let first_key_behavior_bytes = self.first_key_behavior.serialize();
+        let n_key_behavior_bytes = self.n_key_behavior.serialize();
+        let first_key_explicit_bytes = self.first_key_explicit.serialize();
+        let n_key_explicit_bytes = self.n_key_explicit.serialize();
+        let first_mod_map_key_bytes = self.first_mod_map_key.serialize();
+        let n_mod_map_keys_bytes = self.n_mod_map_keys.serialize();
+        let first_v_mod_map_key_bytes = self.first_v_mod_map_key.serialize();
+        let n_v_mod_map_keys_bytes = self.n_v_mod_map_keys.serialize();
+        let virtual_mods_bytes = self.virtual_mods.serialize();
+        [
+            response_type_bytes[0],
+            xkb_type_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            ptr_btn_actions_bytes[0],
+            changed_bytes[0],
+            changed_bytes[1],
+            min_key_code_bytes[0],
+            max_key_code_bytes[0],
+            first_type_bytes[0],
+            n_types_bytes[0],
+            first_key_sym_bytes[0],
+            n_key_syms_bytes[0],
+            first_key_act_bytes[0],
+            n_key_acts_bytes[0],
+            first_key_behavior_bytes[0],
+            n_key_behavior_bytes[0],
+            first_key_explicit_bytes[0],
+            n_key_explicit_bytes[0],
+            first_mod_map_key_bytes[0],
+            n_mod_map_keys_bytes[0],
+            first_v_mod_map_key_bytes[0],
+            n_v_mod_map_keys_bytes[0],
+            virtual_mods_bytes[0],
+            virtual_mods_bytes[1],
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.xkb_type.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.device_id.serialize_into(bytes);
+        self.ptr_btn_actions.serialize_into(bytes);
+        self.changed.serialize_into(bytes);
+        self.min_key_code.serialize_into(bytes);
+        self.max_key_code.serialize_into(bytes);
+        self.first_type.serialize_into(bytes);
+        self.n_types.serialize_into(bytes);
+        self.first_key_sym.serialize_into(bytes);
+        self.n_key_syms.serialize_into(bytes);
+        self.first_key_act.serialize_into(bytes);
+        self.n_key_acts.serialize_into(bytes);
+        self.first_key_behavior.serialize_into(bytes);
+        self.n_key_behavior.serialize_into(bytes);
+        self.first_key_explicit.serialize_into(bytes);
+        self.n_key_explicit.serialize_into(bytes);
+        self.first_mod_map_key.serialize_into(bytes);
+        self.n_mod_map_keys.serialize_into(bytes);
+        self.first_v_mod_map_key.serialize_into(bytes);
+        self.n_v_mod_map_keys.serialize_into(bytes);
+        self.virtual_mods.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
     }
 }
 impl From<&MapNotifyEvent> for [u8; 32] {
@@ -11430,6 +13017,96 @@ impl TryParse for StateNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for StateNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let xkb_type_bytes = self.xkb_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let mods_bytes = self.mods.serialize();
+        let base_mods_bytes = self.base_mods.serialize();
+        let latched_mods_bytes = self.latched_mods.serialize();
+        let locked_mods_bytes = self.locked_mods.serialize();
+        let group_bytes = u8::from(self.group).serialize();
+        let base_group_bytes = self.base_group.serialize();
+        let latched_group_bytes = self.latched_group.serialize();
+        let locked_group_bytes = u8::from(self.locked_group).serialize();
+        let compat_state_bytes = self.compat_state.serialize();
+        let grab_mods_bytes = self.grab_mods.serialize();
+        let compat_grab_mods_bytes = self.compat_grab_mods.serialize();
+        let lookup_mods_bytes = self.lookup_mods.serialize();
+        let compat_loockup_mods_bytes = self.compat_loockup_mods.serialize();
+        let ptr_btn_state_bytes = self.ptr_btn_state.serialize();
+        let changed_bytes = self.changed.serialize();
+        let keycode_bytes = self.keycode.serialize();
+        let event_type_bytes = self.event_type.serialize();
+        let request_major_bytes = self.request_major.serialize();
+        let request_minor_bytes = self.request_minor.serialize();
+        [
+            response_type_bytes[0],
+            xkb_type_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            mods_bytes[0],
+            base_mods_bytes[0],
+            latched_mods_bytes[0],
+            locked_mods_bytes[0],
+            group_bytes[0],
+            base_group_bytes[0],
+            base_group_bytes[1],
+            latched_group_bytes[0],
+            latched_group_bytes[1],
+            locked_group_bytes[0],
+            compat_state_bytes[0],
+            grab_mods_bytes[0],
+            compat_grab_mods_bytes[0],
+            lookup_mods_bytes[0],
+            compat_loockup_mods_bytes[0],
+            ptr_btn_state_bytes[0],
+            ptr_btn_state_bytes[1],
+            changed_bytes[0],
+            changed_bytes[1],
+            keycode_bytes[0],
+            event_type_bytes[0],
+            request_major_bytes[0],
+            request_minor_bytes[0],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.xkb_type.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.device_id.serialize_into(bytes);
+        self.mods.serialize_into(bytes);
+        self.base_mods.serialize_into(bytes);
+        self.latched_mods.serialize_into(bytes);
+        self.locked_mods.serialize_into(bytes);
+        u8::from(self.group).serialize_into(bytes);
+        self.base_group.serialize_into(bytes);
+        self.latched_group.serialize_into(bytes);
+        u8::from(self.locked_group).serialize_into(bytes);
+        self.compat_state.serialize_into(bytes);
+        self.grab_mods.serialize_into(bytes);
+        self.compat_grab_mods.serialize_into(bytes);
+        self.lookup_mods.serialize_into(bytes);
+        self.compat_loockup_mods.serialize_into(bytes);
+        self.ptr_btn_state.serialize_into(bytes);
+        self.changed.serialize_into(bytes);
+        self.keycode.serialize_into(bytes);
+        self.event_type.serialize_into(bytes);
+        self.request_major.serialize_into(bytes);
+        self.request_minor.serialize_into(bytes);
+    }
+}
 impl From<&StateNotifyEvent> for [u8; 32] {
     fn from(input: &StateNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -11542,6 +13219,76 @@ impl TryParse for ControlsNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for ControlsNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let xkb_type_bytes = self.xkb_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let num_groups_bytes = self.num_groups.serialize();
+        let changed_controls_bytes = self.changed_controls.serialize();
+        let enabled_controls_bytes = self.enabled_controls.serialize();
+        let enabled_control_changes_bytes = self.enabled_control_changes.serialize();
+        let keycode_bytes = self.keycode.serialize();
+        let event_type_bytes = self.event_type.serialize();
+        let request_major_bytes = self.request_major.serialize();
+        let request_minor_bytes = self.request_minor.serialize();
+        [
+            response_type_bytes[0],
+            xkb_type_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            num_groups_bytes[0],
+            0,
+            0,
+            changed_controls_bytes[0],
+            changed_controls_bytes[1],
+            changed_controls_bytes[2],
+            changed_controls_bytes[3],
+            enabled_controls_bytes[0],
+            enabled_controls_bytes[1],
+            enabled_controls_bytes[2],
+            enabled_controls_bytes[3],
+            enabled_control_changes_bytes[0],
+            enabled_control_changes_bytes[1],
+            enabled_control_changes_bytes[2],
+            enabled_control_changes_bytes[3],
+            keycode_bytes[0],
+            event_type_bytes[0],
+            request_major_bytes[0],
+            request_minor_bytes[0],
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.xkb_type.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.device_id.serialize_into(bytes);
+        self.num_groups.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.changed_controls.serialize_into(bytes);
+        self.enabled_controls.serialize_into(bytes);
+        self.enabled_control_changes.serialize_into(bytes);
+        self.keycode.serialize_into(bytes);
+        self.event_type.serialize_into(bytes);
+        self.request_major.serialize_into(bytes);
+        self.request_minor.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+    }
+}
 impl From<&ControlsNotifyEvent> for [u8; 32] {
     fn from(input: &ControlsNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -11631,6 +13378,64 @@ impl TryParse for IndicatorStateNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for IndicatorStateNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let xkb_type_bytes = self.xkb_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let state_bytes = self.state.serialize();
+        let state_changed_bytes = self.state_changed.serialize();
+        [
+            response_type_bytes[0],
+            xkb_type_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+            state_bytes[0],
+            state_bytes[1],
+            state_bytes[2],
+            state_bytes[3],
+            state_changed_bytes[0],
+            state_changed_bytes[1],
+            state_changed_bytes[2],
+            state_changed_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.xkb_type.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.device_id.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 3]);
+        self.state.serialize_into(bytes);
+        self.state_changed.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+    }
+}
 impl From<&IndicatorStateNotifyEvent> for [u8; 32] {
     fn from(input: &IndicatorStateNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -11712,6 +13517,64 @@ impl TryParse for IndicatorMapNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for IndicatorMapNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let xkb_type_bytes = self.xkb_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let state_bytes = self.state.serialize();
+        let map_changed_bytes = self.map_changed.serialize();
+        [
+            response_type_bytes[0],
+            xkb_type_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            0,
+            0,
+            0,
+            state_bytes[0],
+            state_bytes[1],
+            state_bytes[2],
+            state_bytes[3],
+            map_changed_bytes[0],
+            map_changed_bytes[1],
+            map_changed_bytes[2],
+            map_changed_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.xkb_type.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.device_id.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 3]);
+        self.state.serialize_into(bytes);
+        self.map_changed.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
     }
 }
 impl From<&IndicatorMapNotifyEvent> for [u8; 32] {
@@ -11818,6 +13681,85 @@ impl TryParse for NamesNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for NamesNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let xkb_type_bytes = self.xkb_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let changed_bytes = self.changed.serialize();
+        let first_type_bytes = self.first_type.serialize();
+        let n_types_bytes = self.n_types.serialize();
+        let first_level_name_bytes = self.first_level_name.serialize();
+        let n_level_names_bytes = self.n_level_names.serialize();
+        let n_radio_groups_bytes = self.n_radio_groups.serialize();
+        let n_key_aliases_bytes = self.n_key_aliases.serialize();
+        let changed_group_names_bytes = self.changed_group_names.serialize();
+        let changed_virtual_mods_bytes = self.changed_virtual_mods.serialize();
+        let first_key_bytes = self.first_key.serialize();
+        let n_keys_bytes = self.n_keys.serialize();
+        let changed_indicators_bytes = self.changed_indicators.serialize();
+        [
+            response_type_bytes[0],
+            xkb_type_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            0,
+            changed_bytes[0],
+            changed_bytes[1],
+            first_type_bytes[0],
+            n_types_bytes[0],
+            first_level_name_bytes[0],
+            n_level_names_bytes[0],
+            0,
+            n_radio_groups_bytes[0],
+            n_key_aliases_bytes[0],
+            changed_group_names_bytes[0],
+            changed_virtual_mods_bytes[0],
+            changed_virtual_mods_bytes[1],
+            first_key_bytes[0],
+            n_keys_bytes[0],
+            changed_indicators_bytes[0],
+            changed_indicators_bytes[1],
+            changed_indicators_bytes[2],
+            changed_indicators_bytes[3],
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.xkb_type.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.device_id.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.changed.serialize_into(bytes);
+        self.first_type.serialize_into(bytes);
+        self.n_types.serialize_into(bytes);
+        self.first_level_name.serialize_into(bytes);
+        self.n_level_names.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.n_radio_groups.serialize_into(bytes);
+        self.n_key_aliases.serialize_into(bytes);
+        self.changed_group_names.serialize_into(bytes);
+        self.changed_virtual_mods.serialize_into(bytes);
+        self.first_key.serialize_into(bytes);
+        self.n_keys.serialize_into(bytes);
+        self.changed_indicators.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+    }
+}
 impl From<&NamesNotifyEvent> for [u8; 32] {
     fn from(input: &NamesNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -11912,6 +13854,67 @@ impl TryParse for CompatMapNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for CompatMapNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let xkb_type_bytes = self.xkb_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let changed_groups_bytes = self.changed_groups.serialize();
+        let first_si_bytes = self.first_si.serialize();
+        let n_si_bytes = self.n_si.serialize();
+        let n_total_si_bytes = self.n_total_si.serialize();
+        [
+            response_type_bytes[0],
+            xkb_type_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            changed_groups_bytes[0],
+            first_si_bytes[0],
+            first_si_bytes[1],
+            n_si_bytes[0],
+            n_si_bytes[1],
+            n_total_si_bytes[0],
+            n_total_si_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.xkb_type.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.device_id.serialize_into(bytes);
+        self.changed_groups.serialize_into(bytes);
+        self.first_si.serialize_into(bytes);
+        self.n_si.serialize_into(bytes);
+        self.n_total_si.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
     }
 }
 impl From<&CompatMapNotifyEvent> for [u8; 32] {
@@ -12009,6 +14012,75 @@ impl TryParse for BellNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for BellNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let xkb_type_bytes = self.xkb_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let bell_class_bytes = u8::from(self.bell_class).serialize();
+        let bell_id_bytes = self.bell_id.serialize();
+        let percent_bytes = self.percent.serialize();
+        let pitch_bytes = self.pitch.serialize();
+        let duration_bytes = self.duration.serialize();
+        let name_bytes = self.name.serialize();
+        let window_bytes = self.window.serialize();
+        let event_only_bytes = self.event_only.serialize();
+        [
+            response_type_bytes[0],
+            xkb_type_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            bell_class_bytes[0],
+            bell_id_bytes[0],
+            percent_bytes[0],
+            pitch_bytes[0],
+            pitch_bytes[1],
+            duration_bytes[0],
+            duration_bytes[1],
+            name_bytes[0],
+            name_bytes[1],
+            name_bytes[2],
+            name_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            event_only_bytes[0],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.xkb_type.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.device_id.serialize_into(bytes);
+        u8::from(self.bell_class).serialize_into(bytes);
+        self.bell_id.serialize_into(bytes);
+        self.percent.serialize_into(bytes);
+        self.pitch.serialize_into(bytes);
+        self.duration.serialize_into(bytes);
+        self.name.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.event_only.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 7]);
     }
 }
 impl From<&BellNotifyEvent> for [u8; 32] {
@@ -12109,6 +14181,70 @@ impl TryParse for ActionMessageEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for ActionMessageEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let xkb_type_bytes = self.xkb_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let keycode_bytes = self.keycode.serialize();
+        let press_bytes = self.press.serialize();
+        let key_event_follows_bytes = self.key_event_follows.serialize();
+        let mods_bytes = self.mods.serialize();
+        let group_bytes = u8::from(self.group).serialize();
+        [
+            response_type_bytes[0],
+            xkb_type_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            keycode_bytes[0],
+            press_bytes[0],
+            key_event_follows_bytes[0],
+            mods_bytes[0],
+            group_bytes[0],
+            self.message[0],
+            self.message[1],
+            self.message[2],
+            self.message[3],
+            self.message[4],
+            self.message[5],
+            self.message[6],
+            self.message[7],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.xkb_type.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.device_id.serialize_into(bytes);
+        self.keycode.serialize_into(bytes);
+        self.press.serialize_into(bytes);
+        self.key_event_follows.serialize_into(bytes);
+        self.mods.serialize_into(bytes);
+        u8::from(self.group).serialize_into(bytes);
+        bytes.extend_from_slice(&self.message);
+        bytes.extend_from_slice(&[0; 10]);
+    }
+}
 impl From<&ActionMessageEvent> for [u8; 32] {
     fn from(input: &ActionMessageEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -12196,6 +14332,67 @@ impl TryParse for AccessXNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for AccessXNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let xkb_type_bytes = self.xkb_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let keycode_bytes = self.keycode.serialize();
+        let detailt_bytes = self.detailt.serialize();
+        let slow_keys_delay_bytes = self.slow_keys_delay.serialize();
+        let debounce_delay_bytes = self.debounce_delay.serialize();
+        [
+            response_type_bytes[0],
+            xkb_type_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            keycode_bytes[0],
+            detailt_bytes[0],
+            detailt_bytes[1],
+            slow_keys_delay_bytes[0],
+            slow_keys_delay_bytes[1],
+            debounce_delay_bytes[0],
+            debounce_delay_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.xkb_type.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.device_id.serialize_into(bytes);
+        self.keycode.serialize_into(bytes);
+        self.detailt.serialize_into(bytes);
+        self.slow_keys_delay.serialize_into(bytes);
+        self.debounce_delay.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 16]);
     }
 }
 impl From<&AccessXNotifyEvent> for [u8; 32] {
@@ -12296,6 +14493,78 @@ impl TryParse for ExtensionDeviceNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ExtensionDeviceNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let xkb_type_bytes = self.xkb_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let device_id_bytes = self.device_id.serialize();
+        let reason_bytes = self.reason.serialize();
+        let led_class_bytes = u16::from(self.led_class).serialize();
+        let led_id_bytes = self.led_id.serialize();
+        let leds_defined_bytes = self.leds_defined.serialize();
+        let led_state_bytes = self.led_state.serialize();
+        let first_button_bytes = self.first_button.serialize();
+        let n_buttons_bytes = self.n_buttons.serialize();
+        let supported_bytes = self.supported.serialize();
+        let unsupported_bytes = self.unsupported.serialize();
+        [
+            response_type_bytes[0],
+            xkb_type_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            device_id_bytes[0],
+            0,
+            reason_bytes[0],
+            reason_bytes[1],
+            led_class_bytes[0],
+            led_class_bytes[1],
+            led_id_bytes[0],
+            led_id_bytes[1],
+            leds_defined_bytes[0],
+            leds_defined_bytes[1],
+            leds_defined_bytes[2],
+            leds_defined_bytes[3],
+            led_state_bytes[0],
+            led_state_bytes[1],
+            led_state_bytes[2],
+            led_state_bytes[3],
+            first_button_bytes[0],
+            n_buttons_bytes[0],
+            supported_bytes[0],
+            supported_bytes[1],
+            unsupported_bytes[0],
+            unsupported_bytes[1],
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.xkb_type.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.device_id.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.reason.serialize_into(bytes);
+        u16::from(self.led_class).serialize_into(bytes);
+        self.led_id.serialize_into(bytes);
+        self.leds_defined.serialize_into(bytes);
+        self.led_state.serialize_into(bytes);
+        self.first_button.serialize_into(bytes);
+        self.n_buttons.serialize_into(bytes);
+        self.supported.serialize_into(bytes);
+        self.unsupported.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
     }
 }
 impl From<&ExtensionDeviceNotifyEvent> for [u8; 32] {

--- a/x11rb-protocol/src/protocol/xprint.rs
+++ b/x11rb-protocol/src/protocol/xprint.rs
@@ -453,6 +453,40 @@ impl TryParse for PrintQueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for PrintQueryVersionReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_version_bytes = self.major_version.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_version_bytes[0],
+            major_version_bytes[1],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major_version.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the PrintGetPrinterList request
 pub const PRINT_GET_PRINTER_LIST_REQUEST: u8 = 1;
@@ -556,6 +590,26 @@ impl TryParse for PrintGetPrinterListReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for PrintGetPrinterListReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let list_count = u32::try_from(self.printers.len()).expect("`printers` has too many elements");
+        list_count.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.printers.serialize_into(bytes);
     }
 }
 impl PrintGetPrinterListReply {
@@ -826,6 +880,38 @@ impl TryParse for PrintGetContextReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for PrintGetContextReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let context_bytes = self.context.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            context_bytes[0],
+            context_bytes[1],
+            context_bytes[2],
+            context_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.context.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the PrintDestroyContext request
 pub const PRINT_DESTROY_CONTEXT_REQUEST: u8 = 5;
@@ -948,6 +1034,38 @@ impl TryParse for PrintGetScreenOfContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for PrintGetScreenOfContextReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let root_bytes = self.root.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            root_bytes[0],
+            root_bytes[1],
+            root_bytes[2],
+            root_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.root.serialize_into(bytes);
     }
 }
 
@@ -1350,6 +1468,28 @@ impl TryParse for PrintGetDocumentDataReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for PrintGetDocumentDataReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.status_code.serialize_into(bytes);
+        self.finished_flag.serialize_into(bytes);
+        let data_len = u32::try_from(self.data.len()).expect("`data` has too many elements");
+        data_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        bytes.extend_from_slice(&self.data);
+    }
+}
 impl PrintGetDocumentDataReply {
     /// Get the value of the `dataLen` field.
     ///
@@ -1615,6 +1755,44 @@ impl TryParse for PrintInputSelectedReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for PrintInputSelectedReply {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let event_mask_bytes = self.event_mask.serialize();
+        let all_events_mask_bytes = self.all_events_mask.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            event_mask_bytes[0],
+            event_mask_bytes[1],
+            event_mask_bytes[2],
+            event_mask_bytes[3],
+            all_events_mask_bytes[0],
+            all_events_mask_bytes[1],
+            all_events_mask_bytes[2],
+            all_events_mask_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.event_mask.serialize_into(bytes);
+        self.all_events_mask.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the PrintGetAttributes request
 pub const PRINT_GET_ATTRIBUTES_REQUEST: u8 = 17;
@@ -1705,6 +1883,26 @@ impl TryParse for PrintGetAttributesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for PrintGetAttributesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let string_len = u32::try_from(self.attributes.len()).expect("`attributes` has too many elements");
+        string_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.attributes);
     }
 }
 impl PrintGetAttributesReply {
@@ -1833,6 +2031,26 @@ impl TryParse for PrintGetOneAttributesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for PrintGetOneAttributesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let value_len = u32::try_from(self.value.len()).expect("`value` has too many elements");
+        value_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.value);
     }
 }
 impl PrintGetOneAttributesReply {
@@ -2030,6 +2248,56 @@ impl TryParse for PrintGetPageDimensionsReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for PrintGetPageDimensionsReply {
+    type Bytes = [u8; 20];
+    fn serialize(&self) -> [u8; 20] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let offset_x_bytes = self.offset_x.serialize();
+        let offset_y_bytes = self.offset_y.serialize();
+        let reproducible_width_bytes = self.reproducible_width.serialize();
+        let reproducible_height_bytes = self.reproducible_height.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            offset_x_bytes[0],
+            offset_x_bytes[1],
+            offset_y_bytes[0],
+            offset_y_bytes[1],
+            reproducible_width_bytes[0],
+            reproducible_width_bytes[1],
+            reproducible_height_bytes[0],
+            reproducible_height_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(20);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.offset_x.serialize_into(bytes);
+        self.offset_y.serialize_into(bytes);
+        self.reproducible_width.serialize_into(bytes);
+        self.reproducible_height.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the PrintQueryScreens request
 pub const PRINT_QUERY_SCREENS_REQUEST: u8 = 22;
@@ -2101,6 +2369,26 @@ impl TryParse for PrintQueryScreensReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for PrintQueryScreensReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let list_count = u32::try_from(self.roots.len()).expect("`roots` has too many elements");
+        list_count.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.roots.serialize_into(bytes);
     }
 }
 impl PrintQueryScreensReply {
@@ -2207,6 +2495,37 @@ impl TryParse for PrintSetImageResolutionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for PrintSetImageResolutionReply {
+    type Bytes = [u8; 10];
+    fn serialize(&self) -> [u8; 10] {
+        let response_type_bytes = &[1];
+        let status_bytes = self.status.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let previous_resolutions_bytes = self.previous_resolutions.serialize();
+        [
+            response_type_bytes[0],
+            status_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            previous_resolutions_bytes[0],
+            previous_resolutions_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(10);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.status.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.previous_resolutions.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the PrintGetImageResolution request
 pub const PRINT_GET_IMAGE_RESOLUTION_REQUEST: u8 = 24;
@@ -2287,6 +2606,36 @@ impl TryParse for PrintGetImageResolutionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for PrintGetImageResolutionReply {
+    type Bytes = [u8; 10];
+    fn serialize(&self) -> [u8; 10] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let image_resolution_bytes = self.image_resolution.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            image_resolution_bytes[0],
+            image_resolution_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(10);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.image_resolution.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
@@ -2312,6 +2661,35 @@ impl TryParse for NotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for NotifyEvent {
+    type Bytes = [u8; 9];
+    fn serialize(&self) -> [u8; 9] {
+        let response_type_bytes = self.response_type.serialize();
+        let detail_bytes = self.detail.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let context_bytes = self.context.serialize();
+        let cancel_bytes = self.cancel.serialize();
+        [
+            response_type_bytes[0],
+            detail_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            context_bytes[0],
+            context_bytes[1],
+            context_bytes[2],
+            context_bytes[3],
+            cancel_bytes[0],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(9);
+        self.response_type.serialize_into(bytes);
+        self.detail.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.context.serialize_into(bytes);
+        self.cancel.serialize_into(bytes);
     }
 }
 impl From<&NotifyEvent> for [u8; 32] {
@@ -2386,6 +2764,32 @@ impl TryParse for AttributNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for AttributNotifyEvent {
+    type Bytes = [u8; 8];
+    fn serialize(&self) -> [u8; 8] {
+        let response_type_bytes = self.response_type.serialize();
+        let detail_bytes = self.detail.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let context_bytes = self.context.serialize();
+        [
+            response_type_bytes[0],
+            detail_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            context_bytes[0],
+            context_bytes[1],
+            context_bytes[2],
+            context_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(8);
+        self.response_type.serialize_into(bytes);
+        self.detail.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.context.serialize_into(bytes);
     }
 }
 impl From<&AttributNotifyEvent> for [u8; 32] {

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -1355,6 +1355,75 @@ impl TryParse for KeyPressEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for KeyPressEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let detail_bytes = self.detail.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let root_bytes = self.root.serialize();
+        let event_bytes = self.event.serialize();
+        let child_bytes = self.child.serialize();
+        let root_x_bytes = self.root_x.serialize();
+        let root_y_bytes = self.root_y.serialize();
+        let event_x_bytes = self.event_x.serialize();
+        let event_y_bytes = self.event_y.serialize();
+        let state_bytes = self.state.serialize();
+        let same_screen_bytes = self.same_screen.serialize();
+        [
+            response_type_bytes[0],
+            detail_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            root_bytes[0],
+            root_bytes[1],
+            root_bytes[2],
+            root_bytes[3],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            child_bytes[0],
+            child_bytes[1],
+            child_bytes[2],
+            child_bytes[3],
+            root_x_bytes[0],
+            root_x_bytes[1],
+            root_y_bytes[0],
+            root_y_bytes[1],
+            event_x_bytes[0],
+            event_x_bytes[1],
+            event_y_bytes[0],
+            event_y_bytes[1],
+            state_bytes[0],
+            state_bytes[1],
+            same_screen_bytes[0],
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.detail.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.root.serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        self.child.serialize_into(bytes);
+        self.root_x.serialize_into(bytes);
+        self.root_y.serialize_into(bytes);
+        self.event_x.serialize_into(bytes);
+        self.event_y.serialize_into(bytes);
+        self.state.serialize_into(bytes);
+        self.same_screen.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+    }
+}
 impl From<&KeyPressEvent> for [u8; 32] {
     fn from(input: &KeyPressEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -1545,6 +1614,75 @@ impl TryParse for ButtonPressEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for ButtonPressEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let detail_bytes = self.detail.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let root_bytes = self.root.serialize();
+        let event_bytes = self.event.serialize();
+        let child_bytes = self.child.serialize();
+        let root_x_bytes = self.root_x.serialize();
+        let root_y_bytes = self.root_y.serialize();
+        let event_x_bytes = self.event_x.serialize();
+        let event_y_bytes = self.event_y.serialize();
+        let state_bytes = self.state.serialize();
+        let same_screen_bytes = self.same_screen.serialize();
+        [
+            response_type_bytes[0],
+            detail_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            root_bytes[0],
+            root_bytes[1],
+            root_bytes[2],
+            root_bytes[3],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            child_bytes[0],
+            child_bytes[1],
+            child_bytes[2],
+            child_bytes[3],
+            root_x_bytes[0],
+            root_x_bytes[1],
+            root_y_bytes[0],
+            root_y_bytes[1],
+            event_x_bytes[0],
+            event_x_bytes[1],
+            event_y_bytes[0],
+            event_y_bytes[1],
+            state_bytes[0],
+            state_bytes[1],
+            same_screen_bytes[0],
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.detail.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.root.serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        self.child.serialize_into(bytes);
+        self.root_x.serialize_into(bytes);
+        self.root_y.serialize_into(bytes);
+        self.event_x.serialize_into(bytes);
+        self.event_y.serialize_into(bytes);
+        self.state.serialize_into(bytes);
+        self.same_screen.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+    }
+}
 impl From<&ButtonPressEvent> for [u8; 32] {
     fn from(input: &ButtonPressEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -1731,6 +1869,75 @@ impl TryParse for MotionNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for MotionNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let detail_bytes = u8::from(self.detail).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let root_bytes = self.root.serialize();
+        let event_bytes = self.event.serialize();
+        let child_bytes = self.child.serialize();
+        let root_x_bytes = self.root_x.serialize();
+        let root_y_bytes = self.root_y.serialize();
+        let event_x_bytes = self.event_x.serialize();
+        let event_y_bytes = self.event_y.serialize();
+        let state_bytes = self.state.serialize();
+        let same_screen_bytes = self.same_screen.serialize();
+        [
+            response_type_bytes[0],
+            detail_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            root_bytes[0],
+            root_bytes[1],
+            root_bytes[2],
+            root_bytes[3],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            child_bytes[0],
+            child_bytes[1],
+            child_bytes[2],
+            child_bytes[3],
+            root_x_bytes[0],
+            root_x_bytes[1],
+            root_y_bytes[0],
+            root_y_bytes[1],
+            event_x_bytes[0],
+            event_x_bytes[1],
+            event_y_bytes[0],
+            event_y_bytes[1],
+            state_bytes[0],
+            state_bytes[1],
+            same_screen_bytes[0],
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        u8::from(self.detail).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.root.serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        self.child.serialize_into(bytes);
+        self.root_x.serialize_into(bytes);
+        self.root_y.serialize_into(bytes);
+        self.event_x.serialize_into(bytes);
+        self.event_y.serialize_into(bytes);
+        self.state.serialize_into(bytes);
+        self.same_screen.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
     }
 }
 impl From<&MotionNotifyEvent> for [u8; 32] {
@@ -1985,6 +2192,76 @@ impl TryParse for EnterNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for EnterNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let detail_bytes = u8::from(self.detail).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let root_bytes = self.root.serialize();
+        let event_bytes = self.event.serialize();
+        let child_bytes = self.child.serialize();
+        let root_x_bytes = self.root_x.serialize();
+        let root_y_bytes = self.root_y.serialize();
+        let event_x_bytes = self.event_x.serialize();
+        let event_y_bytes = self.event_y.serialize();
+        let state_bytes = self.state.serialize();
+        let mode_bytes = u8::from(self.mode).serialize();
+        let same_screen_focus_bytes = self.same_screen_focus.serialize();
+        [
+            response_type_bytes[0],
+            detail_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            root_bytes[0],
+            root_bytes[1],
+            root_bytes[2],
+            root_bytes[3],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            child_bytes[0],
+            child_bytes[1],
+            child_bytes[2],
+            child_bytes[3],
+            root_x_bytes[0],
+            root_x_bytes[1],
+            root_y_bytes[0],
+            root_y_bytes[1],
+            event_x_bytes[0],
+            event_x_bytes[1],
+            event_y_bytes[0],
+            event_y_bytes[1],
+            state_bytes[0],
+            state_bytes[1],
+            mode_bytes[0],
+            same_screen_focus_bytes[0],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        u8::from(self.detail).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.root.serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        self.child.serialize_into(bytes);
+        self.root_x.serialize_into(bytes);
+        self.root_y.serialize_into(bytes);
+        self.event_x.serialize_into(bytes);
+        self.event_y.serialize_into(bytes);
+        self.state.serialize_into(bytes);
+        u8::from(self.mode).serialize_into(bytes);
+        self.same_screen_focus.serialize_into(bytes);
+    }
+}
 impl From<&EnterNotifyEvent> for [u8; 32] {
     fn from(input: &EnterNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2084,6 +2361,39 @@ impl TryParse for FocusInEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for FocusInEvent {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = self.response_type.serialize();
+        let detail_bytes = u8::from(self.detail).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let event_bytes = self.event.serialize();
+        let mode_bytes = u8::from(self.mode).serialize();
+        [
+            response_type_bytes[0],
+            detail_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            mode_bytes[0],
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        self.response_type.serialize_into(bytes);
+        u8::from(self.detail).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        u8::from(self.mode).serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 3]);
+    }
+}
 impl From<&FocusInEvent> for [u8; 32] {
     fn from(input: &FocusInEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2157,6 +2467,51 @@ impl TryParse for KeymapNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for KeymapNotifyEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        [
+            response_type_bytes[0],
+            self.keys[0],
+            self.keys[1],
+            self.keys[2],
+            self.keys[3],
+            self.keys[4],
+            self.keys[5],
+            self.keys[6],
+            self.keys[7],
+            self.keys[8],
+            self.keys[9],
+            self.keys[10],
+            self.keys[11],
+            self.keys[12],
+            self.keys[13],
+            self.keys[14],
+            self.keys[15],
+            self.keys[16],
+            self.keys[17],
+            self.keys[18],
+            self.keys[19],
+            self.keys[20],
+            self.keys[21],
+            self.keys[22],
+            self.keys[23],
+            self.keys[24],
+            self.keys[25],
+            self.keys[26],
+            self.keys[27],
+            self.keys[28],
+            self.keys[29],
+            self.keys[30],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&self.keys);
     }
 }
 impl From<&KeymapNotifyEvent> for [u8; 32] {
@@ -2253,6 +2608,54 @@ impl TryParse for ExposeEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for ExposeEvent {
+    type Bytes = [u8; 20];
+    fn serialize(&self) -> [u8; 20] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let window_bytes = self.window.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let count_bytes = self.count.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            count_bytes[0],
+            count_bytes[1],
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(20);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.count.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+    }
+}
 impl From<&ExposeEvent> for [u8; 32] {
     fn from(input: &ExposeEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2344,6 +2747,62 @@ impl TryParse for GraphicsExposureEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for GraphicsExposureEvent {
+    type Bytes = [u8; 24];
+    fn serialize(&self) -> [u8; 24] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let minor_opcode_bytes = self.minor_opcode.serialize();
+        let count_bytes = self.count.serialize();
+        let major_opcode_bytes = self.major_opcode.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            minor_opcode_bytes[0],
+            minor_opcode_bytes[1],
+            count_bytes[0],
+            count_bytes[1],
+            major_opcode_bytes[0],
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(24);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.drawable.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.minor_opcode.serialize_into(bytes);
+        self.count.serialize_into(bytes);
+        self.major_opcode.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 3]);
+    }
+}
 impl From<&GraphicsExposureEvent> for [u8; 32] {
     fn from(input: &GraphicsExposureEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2425,6 +2884,40 @@ impl TryParse for NoExposureEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for NoExposureEvent {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let drawable_bytes = self.drawable.serialize();
+        let minor_opcode_bytes = self.minor_opcode.serialize();
+        let major_opcode_bytes = self.major_opcode.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            drawable_bytes[0],
+            drawable_bytes[1],
+            drawable_bytes[2],
+            drawable_bytes[3],
+            minor_opcode_bytes[0],
+            minor_opcode_bytes[1],
+            major_opcode_bytes[0],
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.drawable.serialize_into(bytes);
+        self.minor_opcode.serialize_into(bytes);
+        self.major_opcode.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
     }
 }
 impl From<&NoExposureEvent> for [u8; 32] {
@@ -2565,6 +3058,38 @@ impl TryParse for VisibilityNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for VisibilityNotifyEvent {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let window_bytes = self.window.serialize();
+        let state_bytes = u8::from(self.state).serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            state_bytes[0],
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        u8::from(self.state).serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 3]);
+    }
+}
 impl From<&VisibilityNotifyEvent> for [u8; 32] {
     fn from(input: &VisibilityNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2650,6 +3175,62 @@ impl TryParse for CreateNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for CreateNotifyEvent {
+    type Bytes = [u8; 24];
+    fn serialize(&self) -> [u8; 24] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let parent_bytes = self.parent.serialize();
+        let window_bytes = self.window.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let border_width_bytes = self.border_width.serialize();
+        let override_redirect_bytes = self.override_redirect.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            parent_bytes[0],
+            parent_bytes[1],
+            parent_bytes[2],
+            parent_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            border_width_bytes[0],
+            border_width_bytes[1],
+            override_redirect_bytes[0],
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(24);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.parent.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.border_width.serialize_into(bytes);
+        self.override_redirect.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
     }
 }
 impl From<&CreateNotifyEvent> for [u8; 32] {
@@ -2743,6 +3324,37 @@ impl TryParse for DestroyNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for DestroyNotifyEvent {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let event_bytes = self.event.serialize();
+        let window_bytes = self.window.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+    }
+}
 impl From<&DestroyNotifyEvent> for [u8; 32] {
     fn from(input: &DestroyNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -2831,6 +3443,44 @@ impl TryParse for UnmapNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for UnmapNotifyEvent {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let event_bytes = self.event.serialize();
+        let window_bytes = self.window.serialize();
+        let from_configure_bytes = self.from_configure.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            from_configure_bytes[0],
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.from_configure.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 3]);
     }
 }
 impl From<&UnmapNotifyEvent> for [u8; 32] {
@@ -2923,6 +3573,44 @@ impl TryParse for MapNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for MapNotifyEvent {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let event_bytes = self.event.serialize();
+        let window_bytes = self.window.serialize();
+        let override_redirect_bytes = self.override_redirect.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            override_redirect_bytes[0],
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.override_redirect.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 3]);
+    }
+}
 impl From<&MapNotifyEvent> for [u8; 32] {
     fn from(input: &MapNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -3008,6 +3696,37 @@ impl TryParse for MapRequestEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for MapRequestEvent {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let parent_bytes = self.parent.serialize();
+        let window_bytes = self.window.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            parent_bytes[0],
+            parent_bytes[1],
+            parent_bytes[2],
+            parent_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.parent.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+    }
+}
 impl From<&MapRequestEvent> for [u8; 32] {
     fn from(input: &MapRequestEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -3089,6 +3808,58 @@ impl TryParse for ReparentNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ReparentNotifyEvent {
+    type Bytes = [u8; 24];
+    fn serialize(&self) -> [u8; 24] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let event_bytes = self.event.serialize();
+        let window_bytes = self.window.serialize();
+        let parent_bytes = self.parent.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let override_redirect_bytes = self.override_redirect.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            parent_bytes[0],
+            parent_bytes[1],
+            parent_bytes[2],
+            parent_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            override_redirect_bytes[0],
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(24);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.parent.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+        self.override_redirect.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 3]);
     }
 }
 impl From<&ReparentNotifyEvent> for [u8; 32] {
@@ -3206,6 +3977,68 @@ impl TryParse for ConfigureNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for ConfigureNotifyEvent {
+    type Bytes = [u8; 28];
+    fn serialize(&self) -> [u8; 28] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let event_bytes = self.event.serialize();
+        let window_bytes = self.window.serialize();
+        let above_sibling_bytes = self.above_sibling.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let border_width_bytes = self.border_width.serialize();
+        let override_redirect_bytes = self.override_redirect.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            above_sibling_bytes[0],
+            above_sibling_bytes[1],
+            above_sibling_bytes[2],
+            above_sibling_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            border_width_bytes[0],
+            border_width_bytes[1],
+            override_redirect_bytes[0],
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(28);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.above_sibling.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.border_width.serialize_into(bytes);
+        self.override_redirect.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+    }
+}
 impl From<&ConfigureNotifyEvent> for [u8; 32] {
     fn from(input: &ConfigureNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -3303,6 +4136,68 @@ impl TryParse for ConfigureRequestEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for ConfigureRequestEvent {
+    type Bytes = [u8; 28];
+    fn serialize(&self) -> [u8; 28] {
+        let response_type_bytes = self.response_type.serialize();
+        let stack_mode_bytes = (u32::from(self.stack_mode) as u8).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let parent_bytes = self.parent.serialize();
+        let window_bytes = self.window.serialize();
+        let sibling_bytes = self.sibling.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let border_width_bytes = self.border_width.serialize();
+        let value_mask_bytes = self.value_mask.serialize();
+        [
+            response_type_bytes[0],
+            stack_mode_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            parent_bytes[0],
+            parent_bytes[1],
+            parent_bytes[2],
+            parent_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            sibling_bytes[0],
+            sibling_bytes[1],
+            sibling_bytes[2],
+            sibling_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            border_width_bytes[0],
+            border_width_bytes[1],
+            value_mask_bytes[0],
+            value_mask_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(28);
+        self.response_type.serialize_into(bytes);
+        (u32::from(self.stack_mode) as u8).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.parent.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.sibling.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.border_width.serialize_into(bytes);
+        self.value_mask.serialize_into(bytes);
+    }
+}
 impl From<&ConfigureRequestEvent> for [u8; 32] {
     fn from(input: &ConfigureRequestEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -3389,6 +4284,45 @@ impl TryParse for GravityNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for GravityNotifyEvent {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let event_bytes = self.event.serialize();
+        let window_bytes = self.window.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+    }
+}
 impl From<&GravityNotifyEvent> for [u8; 32] {
     fn from(input: &GravityNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -3465,6 +4399,39 @@ impl TryParse for ResizeRequestEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ResizeRequestEvent {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let window_bytes = self.window.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
     }
 }
 impl From<&ResizeRequestEvent> for [u8; 32] {
@@ -3620,6 +4587,49 @@ impl TryParse for CirculateNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for CirculateNotifyEvent {
+    type Bytes = [u8; 20];
+    fn serialize(&self) -> [u8; 20] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let event_bytes = self.event.serialize();
+        let window_bytes = self.window.serialize();
+        let place_bytes = u8::from(self.place).serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            event_bytes[0],
+            event_bytes[1],
+            event_bytes[2],
+            event_bytes[3],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            0,
+            0,
+            0,
+            0,
+            place_bytes[0],
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(20);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.event.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        u8::from(self.place).serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 3]);
     }
 }
 impl From<&CirculateNotifyEvent> for [u8; 32] {
@@ -3778,6 +4788,50 @@ impl TryParse for PropertyNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for PropertyNotifyEvent {
+    type Bytes = [u8; 20];
+    fn serialize(&self) -> [u8; 20] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let window_bytes = self.window.serialize();
+        let atom_bytes = self.atom.serialize();
+        let time_bytes = self.time.serialize();
+        let state_bytes = u8::from(self.state).serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            atom_bytes[0],
+            atom_bytes[1],
+            atom_bytes[2],
+            atom_bytes[3],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            state_bytes[0],
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(20);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.atom.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        u8::from(self.state).serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 3]);
+    }
+}
 impl From<&PropertyNotifyEvent> for [u8; 32] {
     fn from(input: &PropertyNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -3854,6 +4908,43 @@ impl TryParse for SelectionClearEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for SelectionClearEvent {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let owner_bytes = self.owner.serialize();
+        let selection_bytes = self.selection.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            owner_bytes[0],
+            owner_bytes[1],
+            owner_bytes[2],
+            owner_bytes[3],
+            selection_bytes[0],
+            selection_bytes[1],
+            selection_bytes[2],
+            selection_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.owner.serialize_into(bytes);
+        self.selection.serialize_into(bytes);
     }
 }
 impl From<&SelectionClearEvent> for [u8; 32] {
@@ -4191,6 +5282,61 @@ impl TryParse for SelectionRequestEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for SelectionRequestEvent {
+    type Bytes = [u8; 28];
+    fn serialize(&self) -> [u8; 28] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let owner_bytes = self.owner.serialize();
+        let requestor_bytes = self.requestor.serialize();
+        let selection_bytes = self.selection.serialize();
+        let target_bytes = self.target.serialize();
+        let property_bytes = self.property.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            owner_bytes[0],
+            owner_bytes[1],
+            owner_bytes[2],
+            owner_bytes[3],
+            requestor_bytes[0],
+            requestor_bytes[1],
+            requestor_bytes[2],
+            requestor_bytes[3],
+            selection_bytes[0],
+            selection_bytes[1],
+            selection_bytes[2],
+            selection_bytes[3],
+            target_bytes[0],
+            target_bytes[1],
+            target_bytes[2],
+            target_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(28);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.owner.serialize_into(bytes);
+        self.requestor.serialize_into(bytes);
+        self.selection.serialize_into(bytes);
+        self.target.serialize_into(bytes);
+        self.property.serialize_into(bytes);
+    }
+}
 impl From<&SelectionRequestEvent> for [u8; 32] {
     fn from(input: &SelectionRequestEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -4273,6 +5419,55 @@ impl TryParse for SelectionNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for SelectionNotifyEvent {
+    type Bytes = [u8; 24];
+    fn serialize(&self) -> [u8; 24] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let time_bytes = self.time.serialize();
+        let requestor_bytes = self.requestor.serialize();
+        let selection_bytes = self.selection.serialize();
+        let target_bytes = self.target.serialize();
+        let property_bytes = self.property.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            time_bytes[0],
+            time_bytes[1],
+            time_bytes[2],
+            time_bytes[3],
+            requestor_bytes[0],
+            requestor_bytes[1],
+            requestor_bytes[2],
+            requestor_bytes[3],
+            selection_bytes[0],
+            selection_bytes[1],
+            selection_bytes[2],
+            selection_bytes[3],
+            target_bytes[0],
+            target_bytes[1],
+            target_bytes[2],
+            target_bytes[3],
+            property_bytes[0],
+            property_bytes[1],
+            property_bytes[2],
+            property_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(24);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.time.serialize_into(bytes);
+        self.requestor.serialize_into(bytes);
+        self.selection.serialize_into(bytes);
+        self.target.serialize_into(bytes);
+        self.property.serialize_into(bytes);
     }
 }
 impl From<&SelectionNotifyEvent> for [u8; 32] {
@@ -4489,6 +5684,46 @@ impl TryParse for ColormapNotifyEvent {
         let remaining = initial_value.get(32..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ColormapNotifyEvent {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let window_bytes = self.window.serialize();
+        let colormap_bytes = self.colormap.serialize();
+        let new_bytes = self.new.serialize();
+        let state_bytes = u8::from(self.state).serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            colormap_bytes[0],
+            colormap_bytes[1],
+            colormap_bytes[2],
+            colormap_bytes[3],
+            new_bytes[0],
+            state_bytes[0],
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.colormap.serialize_into(bytes);
+        self.new.serialize_into(bytes);
+        u8::from(self.state).serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
     }
 }
 impl From<&ColormapNotifyEvent> for [u8; 32] {
@@ -4743,6 +5978,60 @@ impl TryParse for ClientMessageEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for ClientMessageEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let format_bytes = self.format.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let window_bytes = self.window.serialize();
+        let type_bytes = self.type_.serialize();
+        let data_bytes = self.data.serialize();
+        [
+            response_type_bytes[0],
+            format_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            window_bytes[0],
+            window_bytes[1],
+            window_bytes[2],
+            window_bytes[3],
+            type_bytes[0],
+            type_bytes[1],
+            type_bytes[2],
+            type_bytes[3],
+            data_bytes[0],
+            data_bytes[1],
+            data_bytes[2],
+            data_bytes[3],
+            data_bytes[4],
+            data_bytes[5],
+            data_bytes[6],
+            data_bytes[7],
+            data_bytes[8],
+            data_bytes[9],
+            data_bytes[10],
+            data_bytes[11],
+            data_bytes[12],
+            data_bytes[13],
+            data_bytes[14],
+            data_bytes[15],
+            data_bytes[16],
+            data_bytes[17],
+            data_bytes[18],
+            data_bytes[19],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.format.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.window.serialize_into(bytes);
+        self.type_.serialize_into(bytes);
+        self.data.serialize_into(bytes);
+    }
+}
 impl From<&ClientMessageEvent> for [u8; 32] {
     fn from(input: &ClientMessageEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -4910,6 +6199,36 @@ impl TryParse for MappingNotifyEvent {
         Ok((result, remaining))
     }
 }
+impl Serialize for MappingNotifyEvent {
+    type Bytes = [u8; 8];
+    fn serialize(&self) -> [u8; 8] {
+        let response_type_bytes = self.response_type.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let request_bytes = u8::from(self.request).serialize();
+        let first_keycode_bytes = self.first_keycode.serialize();
+        let count_bytes = self.count.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            request_bytes[0],
+            first_keycode_bytes[0],
+            count_bytes[0],
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(8);
+        self.response_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        u8::from(self.request).serialize_into(bytes);
+        self.first_keycode.serialize_into(bytes);
+        self.count.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 1]);
+    }
+}
 impl From<&MappingNotifyEvent> for [u8; 32] {
     fn from(input: &MappingNotifyEvent) -> Self {
         let response_type_bytes = input.response_type.serialize();
@@ -4992,6 +6311,59 @@ impl TryParse for GeGenericEvent {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GeGenericEvent {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = self.response_type.serialize();
+        let extension_bytes = self.extension.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let event_type_bytes = self.event_type.serialize();
+        [
+            response_type_bytes[0],
+            extension_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            event_type_bytes[0],
+            event_type_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        self.response_type.serialize_into(bytes);
+        self.extension.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.event_type.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 22]);
     }
 }
 
@@ -5548,7 +6920,7 @@ impl CreateWindowAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
+        let _ = value_mask;
         if let Some(background_pixmap) = self.background_pixmap {
             background_pixmap.serialize_into(bytes);
         }
@@ -6099,7 +7471,7 @@ impl ChangeWindowAttributesAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
+        let _ = value_mask;
         if let Some(background_pixmap) = self.background_pixmap {
             background_pixmap.serialize_into(bytes);
         }
@@ -6594,6 +7966,98 @@ impl TryParse for GetWindowAttributesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetWindowAttributesReply {
+    type Bytes = [u8; 44];
+    fn serialize(&self) -> [u8; 44] {
+        let response_type_bytes = &[1];
+        let backing_store_bytes = (u32::from(self.backing_store) as u8).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let visual_bytes = self.visual.serialize();
+        let class_bytes = u16::from(self.class).serialize();
+        let bit_gravity_bytes = (u32::from(self.bit_gravity) as u8).serialize();
+        let win_gravity_bytes = (u32::from(self.win_gravity) as u8).serialize();
+        let backing_planes_bytes = self.backing_planes.serialize();
+        let backing_pixel_bytes = self.backing_pixel.serialize();
+        let save_under_bytes = self.save_under.serialize();
+        let map_is_installed_bytes = self.map_is_installed.serialize();
+        let map_state_bytes = u8::from(self.map_state).serialize();
+        let override_redirect_bytes = self.override_redirect.serialize();
+        let colormap_bytes = self.colormap.serialize();
+        let all_event_masks_bytes = self.all_event_masks.serialize();
+        let your_event_mask_bytes = self.your_event_mask.serialize();
+        let do_not_propagate_mask_bytes = self.do_not_propagate_mask.serialize();
+        [
+            response_type_bytes[0],
+            backing_store_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            visual_bytes[0],
+            visual_bytes[1],
+            visual_bytes[2],
+            visual_bytes[3],
+            class_bytes[0],
+            class_bytes[1],
+            bit_gravity_bytes[0],
+            win_gravity_bytes[0],
+            backing_planes_bytes[0],
+            backing_planes_bytes[1],
+            backing_planes_bytes[2],
+            backing_planes_bytes[3],
+            backing_pixel_bytes[0],
+            backing_pixel_bytes[1],
+            backing_pixel_bytes[2],
+            backing_pixel_bytes[3],
+            save_under_bytes[0],
+            map_is_installed_bytes[0],
+            map_state_bytes[0],
+            override_redirect_bytes[0],
+            colormap_bytes[0],
+            colormap_bytes[1],
+            colormap_bytes[2],
+            colormap_bytes[3],
+            all_event_masks_bytes[0],
+            all_event_masks_bytes[1],
+            all_event_masks_bytes[2],
+            all_event_masks_bytes[3],
+            your_event_mask_bytes[0],
+            your_event_mask_bytes[1],
+            your_event_mask_bytes[2],
+            your_event_mask_bytes[3],
+            do_not_propagate_mask_bytes[0],
+            do_not_propagate_mask_bytes[1],
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(44);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        (u32::from(self.backing_store) as u8).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.visual.serialize_into(bytes);
+        u16::from(self.class).serialize_into(bytes);
+        (u32::from(self.bit_gravity) as u8).serialize_into(bytes);
+        (u32::from(self.win_gravity) as u8).serialize_into(bytes);
+        self.backing_planes.serialize_into(bytes);
+        self.backing_pixel.serialize_into(bytes);
+        self.save_under.serialize_into(bytes);
+        self.map_is_installed.serialize_into(bytes);
+        u8::from(self.map_state).serialize_into(bytes);
+        self.override_redirect.serialize_into(bytes);
+        self.colormap.serialize_into(bytes);
+        self.all_event_masks.serialize_into(bytes);
+        self.your_event_mask.serialize_into(bytes);
+        self.do_not_propagate_mask.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
     }
 }
 
@@ -7468,7 +8932,7 @@ impl ConfigureWindowAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u16) {
-        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
+        let _ = value_mask;
         if let Some(x) = self.x {
             x.serialize_into(bytes);
         }
@@ -8006,6 +9470,62 @@ impl TryParse for GetGeometryReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetGeometryReply {
+    type Bytes = [u8; 24];
+    fn serialize(&self) -> [u8; 24] {
+        let response_type_bytes = &[1];
+        let depth_bytes = self.depth.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let root_bytes = self.root.serialize();
+        let x_bytes = self.x.serialize();
+        let y_bytes = self.y.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        let border_width_bytes = self.border_width.serialize();
+        [
+            response_type_bytes[0],
+            depth_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            root_bytes[0],
+            root_bytes[1],
+            root_bytes[2],
+            root_bytes[3],
+            x_bytes[0],
+            x_bytes[1],
+            y_bytes[0],
+            y_bytes[1],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+            border_width_bytes[0],
+            border_width_bytes[1],
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(24);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.depth.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.root.serialize_into(bytes);
+        self.x.serialize_into(bytes);
+        self.y.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+        self.border_width.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+    }
+}
 
 /// Opcode for the QueryTree request
 pub const QUERY_TREE_REQUEST: u8 = 15;
@@ -8134,6 +9654,28 @@ impl TryParse for QueryTreeReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryTreeReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.root.serialize_into(bytes);
+        self.parent.serialize_into(bytes);
+        let children_len = u16::try_from(self.children.len()).expect("`children` has too many elements");
+        children_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 14]);
+        self.children.serialize_into(bytes);
     }
 }
 impl QueryTreeReply {
@@ -8294,6 +9836,38 @@ impl TryParse for InternAtomReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for InternAtomReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let atom_bytes = self.atom.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            atom_bytes[0],
+            atom_bytes[1],
+            atom_bytes[2],
+            atom_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.atom.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the GetAtomName request
 pub const GET_ATOM_NAME_REQUEST: u8 = 17;
@@ -8378,6 +9952,26 @@ impl TryParse for GetAtomNameReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetAtomNameReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");
+        name_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 22]);
+        bytes.extend_from_slice(&self.name);
     }
 }
 impl GetAtomNameReply {
@@ -9111,6 +10705,28 @@ impl TryParse for GetPropertyReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetPropertyReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.format.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.type_.serialize_into(bytes);
+        self.bytes_after.serialize_into(bytes);
+        self.value_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 12]);
+        assert_eq!(self.value.len(), usize::try_from(self.value_len.checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`value` has an incorrect length");
+        bytes.extend_from_slice(&self.value);
+    }
+}
 
 /// Opcode for the ListProperties request
 pub const LIST_PROPERTIES_REQUEST: u8 = 21;
@@ -9194,6 +10810,26 @@ impl TryParse for ListPropertiesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ListPropertiesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let atoms_len = u16::try_from(self.atoms.len()).expect("`atoms` has too many elements");
+        atoms_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 22]);
+        self.atoms.serialize_into(bytes);
     }
 }
 impl ListPropertiesReply {
@@ -9413,6 +11049,38 @@ impl TryParse for GetSelectionOwnerReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetSelectionOwnerReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let owner_bytes = self.owner.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            owner_bytes[0],
+            owner_bytes[1],
+            owner_bytes[2],
+            owner_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.owner.serialize_into(bytes);
     }
 }
 
@@ -10114,6 +11782,33 @@ impl TryParse for GrabPointerReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GrabPointerReply {
+    type Bytes = [u8; 8];
+    fn serialize(&self) -> [u8; 8] {
+        let response_type_bytes = &[1];
+        let status_bytes = u8::from(self.status).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            status_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(8);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.status).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the UngrabPointer request
 pub const UNGRAB_POINTER_REQUEST: u8 = 27;
@@ -10753,6 +12448,33 @@ impl TryParse for GrabKeyboardReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GrabKeyboardReply {
+    type Bytes = [u8; 8];
+    fn serialize(&self) -> [u8; 8] {
+        let response_type_bytes = &[1];
+        let status_bytes = u8::from(self.status).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            status_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(8);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.status).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
     }
 }
 
@@ -11538,6 +13260,68 @@ impl TryParse for QueryPointerReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryPointerReply {
+    type Bytes = [u8; 28];
+    fn serialize(&self) -> [u8; 28] {
+        let response_type_bytes = &[1];
+        let same_screen_bytes = self.same_screen.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let root_bytes = self.root.serialize();
+        let child_bytes = self.child.serialize();
+        let root_x_bytes = self.root_x.serialize();
+        let root_y_bytes = self.root_y.serialize();
+        let win_x_bytes = self.win_x.serialize();
+        let win_y_bytes = self.win_y.serialize();
+        let mask_bytes = self.mask.serialize();
+        [
+            response_type_bytes[0],
+            same_screen_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            root_bytes[0],
+            root_bytes[1],
+            root_bytes[2],
+            root_bytes[3],
+            child_bytes[0],
+            child_bytes[1],
+            child_bytes[2],
+            child_bytes[3],
+            root_x_bytes[0],
+            root_x_bytes[1],
+            root_y_bytes[0],
+            root_y_bytes[1],
+            win_x_bytes[0],
+            win_x_bytes[1],
+            win_y_bytes[0],
+            win_y_bytes[1],
+            mask_bytes[0],
+            mask_bytes[1],
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(28);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.same_screen.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.root.serialize_into(bytes);
+        self.child.serialize_into(bytes);
+        self.root_x.serialize_into(bytes);
+        self.root_y.serialize_into(bytes);
+        self.win_x.serialize_into(bytes);
+        self.win_y.serialize_into(bytes);
+        self.mask.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+    }
+}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -11680,6 +13464,26 @@ impl TryParse for GetMotionEventsReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetMotionEventsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let events_len = u32::try_from(self.events.len()).expect("`events` has too many elements");
+        events_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.events.serialize_into(bytes);
+    }
+}
 impl GetMotionEventsReply {
     /// Get the value of the `events_len` field.
     ///
@@ -11801,6 +13605,47 @@ impl TryParse for TranslateCoordinatesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for TranslateCoordinatesReply {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = &[1];
+        let same_screen_bytes = self.same_screen.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let child_bytes = self.child.serialize();
+        let dst_x_bytes = self.dst_x.serialize();
+        let dst_y_bytes = self.dst_y.serialize();
+        [
+            response_type_bytes[0],
+            same_screen_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            child_bytes[0],
+            child_bytes[1],
+            child_bytes[2],
+            child_bytes[3],
+            dst_x_bytes[0],
+            dst_x_bytes[1],
+            dst_y_bytes[0],
+            dst_y_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.same_screen.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.child.serialize_into(bytes);
+        self.dst_x.serialize_into(bytes);
+        self.dst_y.serialize_into(bytes);
     }
 }
 
@@ -12186,6 +14031,39 @@ impl TryParse for GetInputFocusReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetInputFocusReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let revert_to_bytes = u8::from(self.revert_to).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let focus_bytes = self.focus.serialize();
+        [
+            response_type_bytes[0],
+            revert_to_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            focus_bytes[0],
+            focus_bytes[1],
+            focus_bytes[2],
+            focus_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.revert_to).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.focus.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the QueryKeymap request
 pub const QUERY_KEYMAP_REQUEST: u8 = 44;
@@ -12259,6 +14137,65 @@ impl TryParse for QueryKeymapReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for QueryKeymapReply {
+    type Bytes = [u8; 40];
+    fn serialize(&self) -> [u8; 40] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            self.keys[0],
+            self.keys[1],
+            self.keys[2],
+            self.keys[3],
+            self.keys[4],
+            self.keys[5],
+            self.keys[6],
+            self.keys[7],
+            self.keys[8],
+            self.keys[9],
+            self.keys[10],
+            self.keys[11],
+            self.keys[12],
+            self.keys[13],
+            self.keys[14],
+            self.keys[15],
+            self.keys[16],
+            self.keys[17],
+            self.keys[18],
+            self.keys[19],
+            self.keys[20],
+            self.keys[21],
+            self.keys[22],
+            self.keys[23],
+            self.keys[24],
+            self.keys[25],
+            self.keys[26],
+            self.keys[27],
+            self.keys[28],
+            self.keys[29],
+            self.keys[30],
+            self.keys[31],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(40);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&self.keys);
     }
 }
 
@@ -12696,6 +14633,41 @@ impl TryParse for QueryFontReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryFontReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(60);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.min_bounds.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        self.max_bounds.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        self.min_char_or_byte2.serialize_into(bytes);
+        self.max_char_or_byte2.serialize_into(bytes);
+        self.default_char.serialize_into(bytes);
+        let properties_len = u16::try_from(self.properties.len()).expect("`properties` has too many elements");
+        properties_len.serialize_into(bytes);
+        u8::from(self.draw_direction).serialize_into(bytes);
+        self.min_byte1.serialize_into(bytes);
+        self.max_byte1.serialize_into(bytes);
+        self.all_chars_exist.serialize_into(bytes);
+        self.font_ascent.serialize_into(bytes);
+        self.font_descent.serialize_into(bytes);
+        let char_infos_len = u32::try_from(self.char_infos.len()).expect("`char_infos` has too many elements");
+        char_infos_len.serialize_into(bytes);
+        self.properties.serialize_into(bytes);
+        self.char_infos.serialize_into(bytes);
+    }
+}
 impl QueryFontReply {
     /// Get the value of the `properties_len` field.
     ///
@@ -12885,6 +14857,67 @@ impl TryParse for QueryTextExtentsReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryTextExtentsReply {
+    type Bytes = [u8; 28];
+    fn serialize(&self) -> [u8; 28] {
+        let response_type_bytes = &[1];
+        let draw_direction_bytes = u8::from(self.draw_direction).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let font_ascent_bytes = self.font_ascent.serialize();
+        let font_descent_bytes = self.font_descent.serialize();
+        let overall_ascent_bytes = self.overall_ascent.serialize();
+        let overall_descent_bytes = self.overall_descent.serialize();
+        let overall_width_bytes = self.overall_width.serialize();
+        let overall_left_bytes = self.overall_left.serialize();
+        let overall_right_bytes = self.overall_right.serialize();
+        [
+            response_type_bytes[0],
+            draw_direction_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            font_ascent_bytes[0],
+            font_ascent_bytes[1],
+            font_descent_bytes[0],
+            font_descent_bytes[1],
+            overall_ascent_bytes[0],
+            overall_ascent_bytes[1],
+            overall_descent_bytes[0],
+            overall_descent_bytes[1],
+            overall_width_bytes[0],
+            overall_width_bytes[1],
+            overall_width_bytes[2],
+            overall_width_bytes[3],
+            overall_left_bytes[0],
+            overall_left_bytes[1],
+            overall_left_bytes[2],
+            overall_left_bytes[3],
+            overall_right_bytes[0],
+            overall_right_bytes[1],
+            overall_right_bytes[2],
+            overall_right_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(28);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.draw_direction).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.font_ascent.serialize_into(bytes);
+        self.font_descent.serialize_into(bytes);
+        self.overall_ascent.serialize_into(bytes);
+        self.overall_descent.serialize_into(bytes);
+        self.overall_width.serialize_into(bytes);
+        self.overall_left.serialize_into(bytes);
+        self.overall_right.serialize_into(bytes);
+    }
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -13041,6 +15074,26 @@ impl TryParse for ListFontsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ListFontsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let names_len = u16::try_from(self.names.len()).expect("`names` has too many elements");
+        names_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 22]);
+        self.names.serialize_into(bytes);
     }
 }
 impl ListFontsReply {
@@ -13214,6 +15267,41 @@ impl TryParse for ListFontsWithInfoReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for ListFontsWithInfoReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(60);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        let name_len = u8::try_from(self.name.len()).expect("`name` has too many elements");
+        name_len.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.min_bounds.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        self.max_bounds.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 4]);
+        self.min_char_or_byte2.serialize_into(bytes);
+        self.max_char_or_byte2.serialize_into(bytes);
+        self.default_char.serialize_into(bytes);
+        let properties_len = u16::try_from(self.properties.len()).expect("`properties` has too many elements");
+        properties_len.serialize_into(bytes);
+        u8::from(self.draw_direction).serialize_into(bytes);
+        self.min_byte1.serialize_into(bytes);
+        self.max_byte1.serialize_into(bytes);
+        self.all_chars_exist.serialize_into(bytes);
+        self.font_ascent.serialize_into(bytes);
+        self.font_descent.serialize_into(bytes);
+        self.replies_hint.serialize_into(bytes);
+        self.properties.serialize_into(bytes);
+        bytes.extend_from_slice(&self.name);
+    }
+}
 impl ListFontsWithInfoReply {
     /// Get the value of the `name_len` field.
     ///
@@ -13385,6 +15473,26 @@ impl TryParse for GetFontPathReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetFontPathReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let path_len = u16::try_from(self.path.len()).expect("`path` has too many elements");
+        path_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 22]);
+        self.path.serialize_into(bytes);
     }
 }
 impl GetFontPathReply {
@@ -14417,7 +16525,7 @@ impl CreateGCAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
+        let _ = value_mask;
         if let Some(function) = self.function {
             u32::from(function).serialize_into(bytes);
         }
@@ -15054,7 +17162,7 @@ impl ChangeGCAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
+        let _ = value_mask;
         if let Some(function) = self.function {
             u32::from(function).serialize_into(bytes);
         }
@@ -17457,6 +19565,27 @@ impl TryParse for GetImageReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetImageReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.depth.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        assert_eq!(self.data.len() % 4, 0, "`data` has an incorrect length, must be a multiple of 4");
+        let length = u32::try_from(self.data.len() / 4).expect("`data` has too many elements");
+        length.serialize_into(bytes);
+        self.visual.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.data);
+    }
+}
 impl GetImageReply {
     /// Get the value of the `length` field.
     ///
@@ -18363,6 +20492,26 @@ impl TryParse for ListInstalledColormapsReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for ListInstalledColormapsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let cmaps_len = u16::try_from(self.cmaps.len()).expect("`cmaps` has too many elements");
+        cmaps_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 22]);
+        self.cmaps.serialize_into(bytes);
+    }
+}
 impl ListInstalledColormapsReply {
     /// Get the value of the `cmaps_len` field.
     ///
@@ -18507,6 +20656,53 @@ impl TryParse for AllocColorReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for AllocColorReply {
+    type Bytes = [u8; 20];
+    fn serialize(&self) -> [u8; 20] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let red_bytes = self.red.serialize();
+        let green_bytes = self.green.serialize();
+        let blue_bytes = self.blue.serialize();
+        let pixel_bytes = self.pixel.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            red_bytes[0],
+            red_bytes[1],
+            green_bytes[0],
+            green_bytes[1],
+            blue_bytes[0],
+            blue_bytes[1],
+            0,
+            0,
+            pixel_bytes[0],
+            pixel_bytes[1],
+            pixel_bytes[2],
+            pixel_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(20);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.red.serialize_into(bytes);
+        self.green.serialize_into(bytes);
+        self.blue.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.pixel.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the AllocNamedColor request
 pub const ALLOC_NAMED_COLOR_REQUEST: u8 = 85;
@@ -18623,6 +20819,62 @@ impl TryParse for AllocNamedColorReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for AllocNamedColorReply {
+    type Bytes = [u8; 24];
+    fn serialize(&self) -> [u8; 24] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let pixel_bytes = self.pixel.serialize();
+        let exact_red_bytes = self.exact_red.serialize();
+        let exact_green_bytes = self.exact_green.serialize();
+        let exact_blue_bytes = self.exact_blue.serialize();
+        let visual_red_bytes = self.visual_red.serialize();
+        let visual_green_bytes = self.visual_green.serialize();
+        let visual_blue_bytes = self.visual_blue.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            pixel_bytes[0],
+            pixel_bytes[1],
+            pixel_bytes[2],
+            pixel_bytes[3],
+            exact_red_bytes[0],
+            exact_red_bytes[1],
+            exact_green_bytes[0],
+            exact_green_bytes[1],
+            exact_blue_bytes[0],
+            exact_blue_bytes[1],
+            visual_red_bytes[0],
+            visual_red_bytes[1],
+            visual_green_bytes[0],
+            visual_green_bytes[1],
+            visual_blue_bytes[0],
+            visual_blue_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(24);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.pixel.serialize_into(bytes);
+        self.exact_red.serialize_into(bytes);
+        self.exact_green.serialize_into(bytes);
+        self.exact_blue.serialize_into(bytes);
+        self.visual_red.serialize_into(bytes);
+        self.visual_green.serialize_into(bytes);
+        self.visual_blue.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the AllocColorCells request
 pub const ALLOC_COLOR_CELLS_REQUEST: u8 = 86;
@@ -18724,6 +20976,29 @@ impl TryParse for AllocColorCellsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for AllocColorCellsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let pixels_len = u16::try_from(self.pixels.len()).expect("`pixels` has too many elements");
+        pixels_len.serialize_into(bytes);
+        let masks_len = u16::try_from(self.masks.len()).expect("`masks` has too many elements");
+        masks_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.pixels.serialize_into(bytes);
+        self.masks.serialize_into(bytes);
     }
 }
 impl AllocColorCellsReply {
@@ -18871,6 +21146,30 @@ impl TryParse for AllocColorPlanesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for AllocColorPlanesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let pixels_len = u16::try_from(self.pixels.len()).expect("`pixels` has too many elements");
+        pixels_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        self.red_mask.serialize_into(bytes);
+        self.green_mask.serialize_into(bytes);
+        self.blue_mask.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 8]);
+        self.pixels.serialize_into(bytes);
     }
 }
 impl AllocColorPlanesReply {
@@ -19407,6 +21706,26 @@ impl TryParse for QueryColorsReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryColorsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let colors_len = u16::try_from(self.colors.len()).expect("`colors` has too many elements");
+        colors_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 22]);
+        self.colors.serialize_into(bytes);
+    }
+}
 impl QueryColorsReply {
     /// Get the value of the `colors_len` field.
     ///
@@ -19534,6 +21853,56 @@ impl TryParse for LookupColorReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for LookupColorReply {
+    type Bytes = [u8; 20];
+    fn serialize(&self) -> [u8; 20] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let exact_red_bytes = self.exact_red.serialize();
+        let exact_green_bytes = self.exact_green.serialize();
+        let exact_blue_bytes = self.exact_blue.serialize();
+        let visual_red_bytes = self.visual_red.serialize();
+        let visual_green_bytes = self.visual_green.serialize();
+        let visual_blue_bytes = self.visual_blue.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            exact_red_bytes[0],
+            exact_red_bytes[1],
+            exact_green_bytes[0],
+            exact_green_bytes[1],
+            exact_blue_bytes[0],
+            exact_blue_bytes[1],
+            visual_red_bytes[0],
+            visual_red_bytes[1],
+            visual_green_bytes[0],
+            visual_green_bytes[1],
+            visual_blue_bytes[0],
+            visual_blue_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(20);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.exact_red.serialize_into(bytes);
+        self.exact_green.serialize_into(bytes);
+        self.exact_blue.serialize_into(bytes);
+        self.visual_red.serialize_into(bytes);
+        self.visual_green.serialize_into(bytes);
+        self.visual_blue.serialize_into(bytes);
     }
 }
 
@@ -20245,6 +22614,40 @@ impl TryParse for QueryBestSizeReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryBestSizeReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let width_bytes = self.width.serialize();
+        let height_bytes = self.height.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            width_bytes[0],
+            width_bytes[1],
+            height_bytes[0],
+            height_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.width.serialize_into(bytes);
+        self.height.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the QueryExtension request
 pub const QUERY_EXTENSION_REQUEST: u8 = 98;
@@ -20373,6 +22776,44 @@ impl TryParse for QueryExtensionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryExtensionReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let present_bytes = self.present.serialize();
+        let major_opcode_bytes = self.major_opcode.serialize();
+        let first_event_bytes = self.first_event.serialize();
+        let first_error_bytes = self.first_error.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            present_bytes[0],
+            major_opcode_bytes[0],
+            first_event_bytes[0],
+            first_error_bytes[0],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.present.serialize_into(bytes);
+        self.major_opcode.serialize_into(bytes);
+        self.first_event.serialize_into(bytes);
+        self.first_error.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the ListExtensions request
 pub const LIST_EXTENSIONS_REQUEST: u8 = 99;
@@ -20446,6 +22887,25 @@ impl TryParse for ListExtensionsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ListExtensionsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        let names_len = u8::try_from(self.names.len()).expect("`names` has too many elements");
+        names_len.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+        self.names.serialize_into(bytes);
     }
 }
 impl ListExtensionsReply {
@@ -20630,6 +23090,25 @@ impl TryParse for GetKeyboardMappingReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetKeyboardMappingReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.keysyms_per_keycode.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        let length = u32::try_from(self.keysyms.len()).expect("`keysyms` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+        self.keysyms.serialize_into(bytes);
     }
 }
 impl GetKeyboardMappingReply {
@@ -20911,7 +23390,7 @@ impl ChangeKeyboardControlAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        assert_eq!(self.switch_expr(), value_mask, "switch `value_list` has an inconsistent discriminant");
+        let _ = value_mask;
         if let Some(key_click_percent) = self.key_click_percent {
             key_click_percent.serialize_into(bytes);
         }
@@ -21178,6 +23657,89 @@ impl TryParse for GetKeyboardControlReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetKeyboardControlReply {
+    type Bytes = [u8; 52];
+    fn serialize(&self) -> [u8; 52] {
+        let response_type_bytes = &[1];
+        let global_auto_repeat_bytes = (u32::from(self.global_auto_repeat) as u8).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let led_mask_bytes = self.led_mask.serialize();
+        let key_click_percent_bytes = self.key_click_percent.serialize();
+        let bell_percent_bytes = self.bell_percent.serialize();
+        let bell_pitch_bytes = self.bell_pitch.serialize();
+        let bell_duration_bytes = self.bell_duration.serialize();
+        [
+            response_type_bytes[0],
+            global_auto_repeat_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            led_mask_bytes[0],
+            led_mask_bytes[1],
+            led_mask_bytes[2],
+            led_mask_bytes[3],
+            key_click_percent_bytes[0],
+            bell_percent_bytes[0],
+            bell_pitch_bytes[0],
+            bell_pitch_bytes[1],
+            bell_duration_bytes[0],
+            bell_duration_bytes[1],
+            0,
+            0,
+            self.auto_repeats[0],
+            self.auto_repeats[1],
+            self.auto_repeats[2],
+            self.auto_repeats[3],
+            self.auto_repeats[4],
+            self.auto_repeats[5],
+            self.auto_repeats[6],
+            self.auto_repeats[7],
+            self.auto_repeats[8],
+            self.auto_repeats[9],
+            self.auto_repeats[10],
+            self.auto_repeats[11],
+            self.auto_repeats[12],
+            self.auto_repeats[13],
+            self.auto_repeats[14],
+            self.auto_repeats[15],
+            self.auto_repeats[16],
+            self.auto_repeats[17],
+            self.auto_repeats[18],
+            self.auto_repeats[19],
+            self.auto_repeats[20],
+            self.auto_repeats[21],
+            self.auto_repeats[22],
+            self.auto_repeats[23],
+            self.auto_repeats[24],
+            self.auto_repeats[25],
+            self.auto_repeats[26],
+            self.auto_repeats[27],
+            self.auto_repeats[28],
+            self.auto_repeats[29],
+            self.auto_repeats[30],
+            self.auto_repeats[31],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(52);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        (u32::from(self.global_auto_repeat) as u8).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.led_mask.serialize_into(bytes);
+        self.key_click_percent.serialize_into(bytes);
+        self.bell_percent.serialize_into(bytes);
+        self.bell_pitch.serialize_into(bytes);
+        self.bell_duration.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 2]);
+        bytes.extend_from_slice(&self.auto_repeats);
+    }
+}
 
 /// Opcode for the Bell request
 pub const BELL_REQUEST: u8 = 104;
@@ -21382,6 +23944,63 @@ impl TryParse for GetPointerControlReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetPointerControlReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let acceleration_numerator_bytes = self.acceleration_numerator.serialize();
+        let acceleration_denominator_bytes = self.acceleration_denominator.serialize();
+        let threshold_bytes = self.threshold.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            acceleration_numerator_bytes[0],
+            acceleration_numerator_bytes[1],
+            acceleration_denominator_bytes[0],
+            acceleration_denominator_bytes[1],
+            threshold_bytes[0],
+            threshold_bytes[1],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.acceleration_numerator.serialize_into(bytes);
+        self.acceleration_denominator.serialize_into(bytes);
+        self.threshold.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 18]);
     }
 }
 
@@ -21661,6 +24280,65 @@ impl TryParse for GetScreenSaverReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetScreenSaverReply {
+    type Bytes = [u8; 32];
+    fn serialize(&self) -> [u8; 32] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let timeout_bytes = self.timeout.serialize();
+        let interval_bytes = self.interval.serialize();
+        let prefer_blanking_bytes = u8::from(self.prefer_blanking).serialize();
+        let allow_exposures_bytes = u8::from(self.allow_exposures).serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            timeout_bytes[0],
+            timeout_bytes[1],
+            interval_bytes[0],
+            interval_bytes[1],
+            prefer_blanking_bytes[0],
+            allow_exposures_bytes[0],
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.timeout.serialize_into(bytes);
+        self.interval.serialize_into(bytes);
+        u8::from(self.prefer_blanking).serialize_into(bytes);
+        u8::from(self.allow_exposures).serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 18]);
     }
 }
 
@@ -21998,6 +24676,26 @@ impl TryParse for ListHostsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ListHostsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.mode).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let hosts_len = u16::try_from(self.hosts.len()).expect("`hosts` has too many elements");
+        hosts_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 22]);
+        self.hosts.serialize_into(bytes);
     }
 }
 impl ListHostsReply {
@@ -22714,6 +25412,33 @@ impl TryParse for SetPointerMappingReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for SetPointerMappingReply {
+    type Bytes = [u8; 8];
+    fn serialize(&self) -> [u8; 8] {
+        let response_type_bytes = &[1];
+        let status_bytes = u8::from(self.status).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            status_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(8);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.status).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the GetPointerMapping request
 pub const GET_POINTER_MAPPING_REQUEST: u8 = 117;
@@ -22788,6 +25513,25 @@ impl TryParse for GetPointerMappingReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetPointerMappingReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        let map_len = u8::try_from(self.map.len()).expect("`map` has too many elements");
+        map_len.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+        bytes.extend_from_slice(&self.map);
     }
 }
 impl GetPointerMappingReply {
@@ -22966,6 +25710,33 @@ impl TryParse for SetModifierMappingReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for SetModifierMappingReply {
+    type Bytes = [u8; 8];
+    fn serialize(&self) -> [u8; 8] {
+        let response_type_bytes = &[1];
+        let status_bytes = u8::from(self.status).serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            status_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(8);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        u8::from(self.status).serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the GetModifierMapping request
 pub const GET_MODIFIER_MAPPING_REQUEST: u8 = 119;
@@ -23040,6 +25811,26 @@ impl TryParse for GetModifierMappingReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetModifierMappingReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        assert_eq!(self.keycodes.len() % 8, 0, "`keycodes` has an incorrect length, must be a multiple of 8");
+        let keycodes_per_modifier = u8::try_from(self.keycodes.len() / 8).expect("`keycodes` has too many elements");
+        keycodes_per_modifier.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+        bytes.extend_from_slice(&self.keycodes);
     }
 }
 impl GetModifierMappingReply {

--- a/x11rb-protocol/src/protocol/xselinux.rs
+++ b/x11rb-protocol/src/protocol/xselinux.rs
@@ -119,6 +119,40 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 12];
+    fn serialize(&self) -> [u8; 12] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let server_major_bytes = self.server_major.serialize();
+        let server_minor_bytes = self.server_minor.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            server_major_bytes[0],
+            server_major_bytes[1],
+            server_minor_bytes[0],
+            server_minor_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(12);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.server_major.serialize_into(bytes);
+        self.server_minor.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the SetDeviceCreateContext request
 pub const SET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 1;
@@ -255,6 +289,26 @@ impl TryParse for GetDeviceCreateContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetDeviceCreateContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
     }
 }
 impl GetDeviceCreateContextReply {
@@ -428,6 +482,26 @@ impl TryParse for GetDeviceContextReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetDeviceContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
+    }
+}
 impl GetDeviceContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -581,6 +655,26 @@ impl TryParse for GetWindowCreateContextReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetWindowCreateContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
+    }
+}
 impl GetWindowCreateContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -677,6 +771,26 @@ impl TryParse for GetWindowContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetWindowContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
     }
 }
 impl GetWindowContextReply {
@@ -910,6 +1024,26 @@ impl TryParse for GetPropertyCreateContextReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetPropertyCreateContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
+    }
+}
 impl GetPropertyCreateContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -1063,6 +1197,26 @@ impl TryParse for GetPropertyUseContextReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetPropertyUseContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
+    }
+}
 impl GetPropertyUseContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -1167,6 +1321,26 @@ impl TryParse for GetPropertyContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetPropertyContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
     }
 }
 impl GetPropertyContextReply {
@@ -1275,6 +1449,26 @@ impl TryParse for GetPropertyDataContextReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetPropertyDataContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
+    }
+}
 impl GetPropertyDataContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -1370,6 +1564,26 @@ impl TryParse for ListPropertiesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ListPropertiesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let properties_len = u32::try_from(self.properties.len()).expect("`properties` has too many elements");
+        properties_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.properties.serialize_into(bytes);
     }
 }
 impl ListPropertiesReply {
@@ -1525,6 +1739,26 @@ impl TryParse for GetSelectionCreateContextReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetSelectionCreateContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
+    }
+}
 impl GetSelectionCreateContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -1678,6 +1912,26 @@ impl TryParse for GetSelectionUseContextReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetSelectionUseContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
+    }
+}
 impl GetSelectionUseContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -1774,6 +2028,26 @@ impl TryParse for GetSelectionContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetSelectionContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
     }
 }
 impl GetSelectionContextReply {
@@ -1874,6 +2148,26 @@ impl TryParse for GetSelectionDataContextReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetSelectionDataContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
+    }
+}
 impl GetSelectionDataContextReply {
     /// Get the value of the `context_len` field.
     ///
@@ -1960,6 +2254,26 @@ impl TryParse for ListSelectionsReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ListSelectionsReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let selections_len = u32::try_from(self.selections.len()).expect("`selections` has too many elements");
+        selections_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.selections.serialize_into(bytes);
     }
 }
 impl ListSelectionsReply {
@@ -2058,6 +2372,26 @@ impl TryParse for GetClientContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for GetClientContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let context_len = u32::try_from(self.context.len()).expect("`context` has too many elements");
+        context_len.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        bytes.extend_from_slice(&self.context);
     }
 }
 impl GetClientContextReply {

--- a/x11rb-protocol/src/protocol/xtest.rs
+++ b/x11rb-protocol/src/protocol/xtest.rs
@@ -119,6 +119,37 @@ impl TryParse for GetVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for GetVersionReply {
+    type Bytes = [u8; 10];
+    fn serialize(&self) -> [u8; 10] {
+        let response_type_bytes = &[1];
+        let major_version_bytes = self.major_version.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let minor_version_bytes = self.minor_version.serialize();
+        [
+            response_type_bytes[0],
+            major_version_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            minor_version_bytes[0],
+            minor_version_bytes[1],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(10);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.major_version.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.minor_version.serialize_into(bytes);
+    }
+}
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -275,6 +306,33 @@ impl TryParse for CompareCursorReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for CompareCursorReply {
+    type Bytes = [u8; 8];
+    fn serialize(&self) -> [u8; 8] {
+        let response_type_bytes = &[1];
+        let same_bytes = self.same.serialize();
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        [
+            response_type_bytes[0],
+            same_bytes[0],
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(8);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        self.same.serialize_into(bytes);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
     }
 }
 

--- a/x11rb-protocol/src/protocol/xvmc.rs
+++ b/x11rb-protocol/src/protocol/xvmc.rs
@@ -193,6 +193,44 @@ impl TryParse for QueryVersionReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for QueryVersionReply {
+    type Bytes = [u8; 16];
+    fn serialize(&self) -> [u8; 16] {
+        let response_type_bytes = &[1];
+        let sequence_bytes = self.sequence.serialize();
+        let length_bytes = self.length.serialize();
+        let major_bytes = self.major.serialize();
+        let minor_bytes = self.minor.serialize();
+        [
+            response_type_bytes[0],
+            0,
+            sequence_bytes[0],
+            sequence_bytes[1],
+            length_bytes[0],
+            length_bytes[1],
+            length_bytes[2],
+            length_bytes[3],
+            major_bytes[0],
+            major_bytes[1],
+            major_bytes[2],
+            major_bytes[3],
+            minor_bytes[0],
+            minor_bytes[1],
+            minor_bytes[2],
+            minor_bytes[3],
+        ]
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(16);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        self.major.serialize_into(bytes);
+        self.minor.serialize_into(bytes);
+    }
+}
 
 /// Opcode for the ListSurfaceTypes request
 pub const LIST_SURFACE_TYPES_REQUEST: u8 = 1;
@@ -273,6 +311,26 @@ impl TryParse for ListSurfaceTypesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ListSurfaceTypesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let num = u32::try_from(self.surfaces.len()).expect("`surfaces` has too many elements");
+        num.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.surfaces.serialize_into(bytes);
     }
 }
 impl ListSurfaceTypesReply {
@@ -410,6 +468,28 @@ impl TryParse for CreateContextReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for CreateContextReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(36);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        let length = u32::try_from(self.priv_data.len()).expect("`priv_data` has too many elements");
+        length.serialize_into(bytes);
+        self.width_actual.serialize_into(bytes);
+        self.height_actual.serialize_into(bytes);
+        self.flags_return.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.priv_data.serialize_into(bytes);
     }
 }
 impl CreateContextReply {
@@ -566,6 +646,25 @@ impl TryParse for CreateSurfaceReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for CreateSurfaceReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        let length = u32::try_from(self.priv_data.len()).expect("`priv_data` has too many elements");
+        length.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 24]);
+        self.priv_data.serialize_into(bytes);
     }
 }
 impl CreateSurfaceReply {
@@ -755,6 +854,30 @@ impl TryParse for CreateSubpictureReply {
         Ok((result, remaining))
     }
 }
+impl Serialize for CreateSubpictureReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        let length = u32::try_from(self.priv_data.len()).expect("`priv_data` has too many elements");
+        length.serialize_into(bytes);
+        self.width_actual.serialize_into(bytes);
+        self.height_actual.serialize_into(bytes);
+        self.num_palette_entries.serialize_into(bytes);
+        self.entry_bytes.serialize_into(bytes);
+        bytes.extend_from_slice(&self.component_order);
+        bytes.extend_from_slice(&[0; 12]);
+        self.priv_data.serialize_into(bytes);
+    }
+}
 impl CreateSubpictureReply {
     /// Get the value of the `length` field.
     ///
@@ -911,6 +1034,26 @@ impl TryParse for ListSubpictureTypesReply {
         let remaining = initial_value.get(32 + length as usize * 4..)
             .ok_or(ParseError::InsufficientData)?;
         Ok((result, remaining))
+    }
+}
+impl Serialize for ListSubpictureTypesReply {
+    type Bytes = Vec<u8>;
+    fn serialize(&self) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.serialize_into(&mut result);
+        result
+    }
+    fn serialize_into(&self, bytes: &mut Vec<u8>) {
+        bytes.reserve(32);
+        let response_type_bytes = &[1];
+        bytes.push(response_type_bytes[0]);
+        bytes.extend_from_slice(&[0; 1]);
+        self.sequence.serialize_into(bytes);
+        self.length.serialize_into(bytes);
+        let num = u32::try_from(self.types.len()).expect("`types` has too many elements");
+        num.serialize_into(bytes);
+        bytes.extend_from_slice(&[0; 20]);
+        self.types.serialize_into(bytes);
     }
 }
 impl ListSubpictureTypesReply {


### PR DESCRIPTION
Fixes #729 by adding a `Serialize` implementation for replies and events. Mostly just involved setting up some flags and adding some serialization options that were previously ignored.