### PR TITLE
Fix broken link for x11rb examples directory

### DIFF
--- a/x11rb/src/lib.rs
+++ b/x11rb/src/lib.rs
@@ -71,7 +71,7 @@
 //! }
 //! ```
 //! More examples can be found in the
-//! [examples](https://github.com/psychon/x11rb/tree/master/examples) directory.
+//! [examples](https://github.com/psychon/x11rb/tree/master/x11rb/examples) directory.
 //!
 //! ## Feature flags
 //!


### PR DESCRIPTION
Broken Link - https://github.com/psychon/x11rb/tree/master/examples
Updated Link - https://github.com/psychon/x11rb/tree/master/x11rb/examples