### PR TITLE
Pin plotters v0.3.1 as dependency

### DIFF
--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -18,6 +18,9 @@ serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
+# FIXME: Remove this when possible. plotters v0.3.2 no longer builds with Rust
+# 1.46, which is currently our MSRV. Thus, make cargo not pick that version.
+plotters = "= 0.3.1"
 
 [target.'cfg(unix)'.dependencies.nix]
 version = "0.24"

--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -21,6 +21,9 @@ criterion = "0.3"
 # FIXME: Remove this when possible. plotters v0.3.2 no longer builds with Rust
 # 1.46, which is currently our MSRV. Thus, make cargo not pick that version.
 plotters = "= 0.3.1"
+# FIXME: Remove this when possible. image v0.24 no longer builds with Rust
+# 1.46, which is currently our MSRV. Thus, make cargo not pick that version.
+image = "< 0.24.0"
 
 [target.'cfg(unix)'.dependencies.nix]
 version = "0.24"


### PR DESCRIPTION
plotters v0.3.2 was recently released and increases the minimum
supported Rust version to Rust 1.56, which is newer than our MSRV.

We depend on plotters through criterion. Criterion depends "^0.3.1",
which is currently satisfied by v0.3.1 and v0.3.2. Pin v0.3.1 so that
our build is fixed.

Fixes: https://github.com/psychon/x11rb/issues/739
Signed-off-by: Uli Schlachter <psychon@znc.in>