### PR TITLE
Only check the lib on MSRV

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,7 +85,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - rust: 1.46.0
           - rust: stable
           - rust: beta
           - rust: nightly
@@ -166,6 +165,26 @@ jobs:
         flags: tests
         verbose: true
       continue-on-error: true
+
+  msrv-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.46.0
+        override: true
+          #
+    # build
+    - name: cargo check x11rb-protocol with all features
+      run: cargo build --package x11rb-protocol --verbose --lib --all-features
+    - name: cargo check x11rb with all features
+      run: cargo build --package x11rb --verbose --lib --all-features
+
+    # build no_std
+    - name: cargo check protocol without default features
+      run: cargo build --manifest-path x11rb-protocol/Cargo.toml --no-default-features --features=all-extensions
 
   big-endian-test:
     runs-on: ubuntu-latest

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,7 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - status-success=continuous-integration/appveyor/pr
       - status-success=big-endian-test
-      - status-success=build (1.46.0)
+      - status-success=msrv-check
       - status-success=build (stable)
       - status-success=clippy-rustfmt (stable)
       - status-success=code_gen


### PR DESCRIPTION
Criterion depends on plotters which no longer builds on Rust 1.46 since
version v0.3.2. We only have criterion as a dev-dependency, thus can
avoid this problem by only building the libraries on our MSRV. Actually,
just "cargo check" should be enough.

Fixes: https://github.com/psychon/x11rb/issues/739
Signed-off-by: Uli Schlachter <psychon@znc.in>