### PR TITLE
Use newer Rust features in non-lib crates

### DIFF
--- a/cairo-example/Cargo.toml
+++ b/cairo-example/Cargo.toml
@@ -11,5 +11,5 @@ path = "../x11rb"
 features = ["allow-unsafe-code", "render"]
 
 [dependencies.cairo-rs]
-version = "0.9"
+version = "0.15"
 features = ["xcb"]

--- a/cairo-example/src/main.rs
+++ b/cairo-example/src/main.rs
@@ -190,7 +190,11 @@ where
 }
 
 /// Draw the window content
-fn do_draw(cr: &cairo::Context, (width, height): (f64, f64), transparency: bool) {
+fn do_draw(
+    cr: &cairo::Context,
+    (width, height): (f64, f64),
+    transparency: bool,
+) -> Result<(), cairo::Error> {
     use std::f64::consts::PI;
 
     // Draw a background
@@ -200,7 +204,7 @@ fn do_draw(cr: &cairo::Context, (width, height): (f64, f64), transparency: bool)
     } else {
         cr.set_source_rgb(0.9, 1.0, 0.9);
     }
-    cr.paint();
+    cr.paint()?;
     if transparency {
         cr.set_operator(cairo::Operator::Over);
     }
@@ -211,9 +215,9 @@ fn do_draw(cr: &cairo::Context, (width, height): (f64, f64), transparency: bool)
     cr.rel_line_to(radius, 0.0);
     cr.close_path();
     cr.set_source_rgba(1.0, 0.0, 0.0, 0.3);
-    cr.fill_preserve();
+    cr.fill_preserve()?;
     cr.set_source_rgb(1.0, 0.0, 0.0);
-    cr.stroke();
+    cr.stroke()?;
 
     // Draw a cross
     cr.move_to(0.0, 0.0);
@@ -222,13 +226,15 @@ fn do_draw(cr: &cairo::Context, (width, height): (f64, f64), transparency: bool)
     cr.line_to(0.0, height);
 
     cr.set_source_rgb(0.0, 0.0, 0.0);
-    cr.stroke();
+    cr.stroke()?;
 
     // Add some text somewhere
     cr.set_source_rgb(0.1, 0.1, 0.7);
     cr.move_to(10.0, 30.0);
     cr.set_font_size(30.0);
-    cr.show_text("Hi there");
+    cr.show_text("Hi there")?;
+
+    Ok(())
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -293,8 +299,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             event_option = conn.poll_for_event()?;
         }
         if need_redraw {
-            let cr = cairo::Context::new(&surface);
-            do_draw(&cr, (width as _, height as _), transparency);
+            let cr = cairo::Context::new(&surface).expect("failed to create cairo context");
+            do_draw(&cr, (width as _, height as _), transparency).expect("failed to draw");
             surface.flush();
         }
     }

--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -23,7 +23,7 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> Vec<Generated> {
 
     let mut main_proto_out = Output::new();
     let mut main_x11rb_out = Output::new();
-    for out in vec![&mut main_proto_out, &mut main_x11rb_out].into_iter() {
+    for out in [&mut main_proto_out, &mut main_x11rb_out] {
         write_code_header(out);
         outln!(out, "//! Bindings to the X11 protocol.");
         outln!(out, "//!");
@@ -102,7 +102,7 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> Vec<Generated> {
             x11rb: ns_x11rb_out.into_data(),
         });
 
-        for out in vec![&mut main_proto_out, &mut main_x11rb_out].into_iter() {
+        for out in [&mut main_proto_out, &mut main_x11rb_out] {
             if ext_has_feature(&ns.header) {
                 outln!(out, "#[cfg(feature = \"{}\")]", ns.header);
             }

--- a/generator/src/generator/namespace/resource_wrapper.rs
+++ b/generator/src/generator/namespace/resource_wrapper.rs
@@ -154,7 +154,7 @@ fn generate_creator(
     lower_name: &str,
     uses: &mut BTreeSet<String>,
 ) {
-    let (request_ext, request_name) = match split_once(request_info.request_name, ':') {
+    let (request_ext, request_name) = match request_info.request_name.split_once(':') {
         None => (None, request_info.request_name),
         Some((ext_name, request_name)) => (Some(ext_name), request_name),
     };
@@ -398,33 +398,5 @@ fn emit_where(out: &mut Output, wheres: &[String]) {
         for where_ in wheres.iter() {
             outln!(out.indent(), "{},", where_);
         }
-    }
-}
-
-// This is a poor man's reimplementation of str::split_once().
-// TODO: Get rid of this once our MSRV reaches 1.52.0
-fn split_once(string: &str, pattern: char) -> Option<(&str, &str)> {
-    string
-        .find(pattern)
-        .map(|index| (&string[..index], &string[(index + pattern.len_utf8())..]))
-}
-
-#[cfg(test)]
-mod test {
-    use super::split_once;
-
-    #[test]
-    fn split_once_no_match() {
-        assert_eq!(None, split_once("abcdef", 'z'));
-        assert_eq!(None, split_once("äöü€æ@", 'ß'));
-        assert_eq!(None, split_once("abcdef", '𝄞'));
-    }
-
-    #[test]
-    fn split_once_match() {
-        assert_eq!(Some(("abc", "ef")), split_once("abcdef", 'd'));
-        assert_eq!(Some(("", "aa")), split_once("aaa", 'a'));
-        assert_eq!(Some(("a", "c")), split_once("aäc", 'ä'));
-        assert_eq!(Some(("abü", "äö")), split_once("abü𝄞äö", '𝄞'));
     }
 }

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 x11rb-protocol = { version = "0.10.0", path = "../x11rb-protocol" }
 libc = { version = "0.2", optional = true }
 libloading = { version = "0.7.0", optional = true }
-once_cell = { version = "1.8.0", optional = true }
+once_cell = { version = "1.13.0", optional = true }
 gethostname = "0.2.1"
 
 [target.'cfg(unix)'.dependencies.nix]

--- a/xcbgen-rs/Cargo.toml
+++ b/xcbgen-rs/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-once_cell = "1.8.0"
+once_cell = "1.13.0"
 roxmltree = "0.14.0"


### PR DESCRIPTION
Since https://github.com/psychon/x11rb/pull/743 they are not bound by MSRV.