### PR TITLE
Use field "mask" properties to determine the field of a request

### DIFF
--- a/generator/src/generator/namespace/expr_to_str.rs
+++ b/generator/src/generator/namespace/expr_to_str.rs
@@ -194,10 +194,7 @@ fn expr_to_str_impl(
                     format!("x.{}", to_rust_variable_name(&field_ref_expr.field_name))
                 }
             };
-            if cast_to_type == Some(expr_type(expr, "unknown")) {
-                // Field already has the expected type, so no cast needed
-                value
-            } else if let Some(t) = cast_to_type {
+            if let Some(t) = cast_to_type {
                 format!("{}::from({})", t, value)
             } else {
                 value

--- a/generator/src/generator/namespace/expr_to_str.rs
+++ b/generator/src/generator/namespace/expr_to_str.rs
@@ -224,7 +224,7 @@ fn expr_to_str_impl(
                 pop_count_expr,
                 wrap_field_ref,
                 panic_on_overflow,
-                None,
+                Some("u32"),
                 true,
             );
             format!("{}.count_ones()", arg)

--- a/generator/src/generator/namespace/header.rs
+++ b/generator/src/generator/namespace/header.rs
@@ -36,6 +36,13 @@ pub(super) fn write_header(out: &mut Output, ns: &xcbdefs::Namespace, mode: Mode
 
     outln!(out, "");
     outln!(out, "#![allow(clippy::too_many_arguments)]");
+    if mode == Mode::Protocol {
+        outln!(
+            out,
+            "// The code generator is simpler if it can always use conversions"
+        );
+        outln!(out, "#![allow(clippy::useless_conversion)]");
+    }
     outln!(out, "");
     outln!(out, "#[allow(unused_imports)]");
     outln!(out, "use {}::borrow::Cow;", alloc_name);

--- a/generator/src/generator/namespace/helpers.rs
+++ b/generator/src/generator/namespace/helpers.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use xcbgen::defs as xcbdefs;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub(crate) struct EnumInfo {
     // The size needed to hold all defined values for the enum
     pub(super) max_value_size: Option<u8>,
@@ -156,7 +156,8 @@ impl Caches {
     fn gather_enum_infos_in_field_value_type(&mut self, value_type: &xcbdefs::FieldValueType) {
         match value_type.value_set {
             xcbdefs::FieldValueSet::None => {}
-            xcbdefs::FieldValueSet::Enum(ref enum_type) => {
+            xcbdefs::FieldValueSet::Enum(ref enum_type)
+            | xcbdefs::FieldValueSet::Mask(ref enum_type) => {
                 let enum_def = match enum_type.get_resolved().get_original_type() {
                     xcbdefs::TypeRef::Enum(enum_type) => enum_type.upgrade().unwrap(),
                     _ => unreachable!(),
@@ -173,7 +174,6 @@ impl Caches {
                 self.put_enum_wire_size(&enum_def, size);
             }
             xcbdefs::FieldValueSet::AltEnum(_) => {}
-            xcbdefs::FieldValueSet::Mask(_) => {}
             xcbdefs::FieldValueSet::AltMask(_) => {}
         }
     }

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -1247,7 +1247,17 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             if i != 0 || begin_with_comma {
                 s.push_str(", ");
             }
+            let wire_type = match ext_param.type_ {
+                xcbdefs::TypeRef::BuiltIn(_) => Some(self.type_to_rust_type(&ext_param.type_)),
+                _ => None,
+            };
+            if let Some(ref type_) = wire_type {
+                s.push_str(&format!("{}::from(", type_));
+            }
             s.push_str(&wrap_name(&ext_param.name));
+            if wire_type.is_some() {
+                s.push_str(")");
+            }
         }
         s
     }

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -1256,7 +1256,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             }
             s.push_str(&wrap_name(&ext_param.name));
             if wire_type.is_some() {
-                s.push_str(")");
+                s.push(')');
             }
         }
         s

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
 use std::rc::Rc;
 
 use xcbgen::defs as xcbdefs;
@@ -1252,7 +1253,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 _ => None,
             };
             if let Some(ref type_) = wire_type {
-                s.push_str(&format!("{}::from(", type_));
+                write!(s, "{}::from(", type_).unwrap();
             }
             s.push_str(&wrap_name(&ext_param.name));
             if wire_type.is_some() {

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -1016,14 +1016,15 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         &self,
         type_: &xcbdefs::FieldValueType,
     ) -> Option<Rc<xcbdefs::EnumDef>> {
-        if let xcbdefs::FieldValueSet::Enum(ref enum_) = type_.value_set {
-            let enum_def = match enum_.get_resolved() {
-                xcbdefs::TypeRef::Enum(enum_def) => enum_def.upgrade().unwrap(),
-                _ => unreachable!(),
-            };
-            Some(enum_def)
-        } else {
-            None
+        match type_.value_set {
+            xcbdefs::FieldValueSet::Enum(ref enum_) | xcbdefs::FieldValueSet::Mask(ref enum_) => {
+                let enum_def = match enum_.get_resolved() {
+                    xcbdefs::TypeRef::Enum(enum_def) => enum_def.upgrade().unwrap(),
+                    _ => unreachable!(),
+                };
+                Some(enum_def)
+            }
+            _ => None,
         }
     }
 

--- a/generator/src/generator/namespace/parse.rs
+++ b/generator/src/generator/namespace/parse.rs
@@ -207,7 +207,15 @@ pub(super) fn emit_field_parse(
             };
             let mut parse_params = vec![String::from("remaining")];
             for ext_param in switch_field.external_params.borrow().iter() {
-                parse_params.push(to_rust_variable_name(&ext_param.name));
+                let mut variable = to_rust_variable_name(&ext_param.name);
+                if let xcbdefs::TypeRef::BuiltIn(_) = ext_param.type_ {
+                    variable = format!(
+                        "{}::from({})",
+                        generator.type_to_rust_type(&ext_param.type_),
+                        variable
+                    );
+                }
+                parse_params.push(variable);
             }
             outln!(
                 out,

--- a/generator/src/generator/namespace/parse.rs
+++ b/generator/src/generator/namespace/parse.rs
@@ -310,14 +310,17 @@ fn emit_value_parse(
 }
 
 fn emit_value_post_parse(type_: &xcbdefs::FieldValueType, var_name: &str, out: &mut Output) {
-    if let xcbdefs::FieldValueSet::Enum(_) = type_.value_set {
+    if let xcbdefs::FieldValueSet::Enum(_) | xcbdefs::FieldValueSet::Mask(_) = type_.value_set {
         // Handle turning things into enum instances.
         outln!(out, "let {var} = {var}.into();", var = var_name);
     }
 }
 
 fn needs_post_parse(type_: &xcbdefs::FieldValueType) -> bool {
-    matches!(type_.value_set, xcbdefs::FieldValueSet::Enum(_))
+    matches!(
+        type_.value_set,
+        xcbdefs::FieldValueSet::Enum(_) | xcbdefs::FieldValueSet::Mask(_)
+    )
 }
 
 pub(super) fn can_use_simple_list_parsing(

--- a/generator/src/generator/special_cases.rs
+++ b/generator/src/generator/special_cases.rs
@@ -101,7 +101,8 @@ pub(super) fn handle_request_switch(
 /// changes from a `ConfigureRequestEvent`. This function is useful for window managers that want
 /// to handle `ConfigureRequestEvent`s.
 pub fn from_configure_request(event: &ConfigureRequestEvent) -> Self {{
-    let mut result = Self::new();"
+    let mut result = Self::new();
+    let value_mask = u16::from(event.value_mask);"
             );
             out.indented(|out| {
                 for case in switch_field.cases.iter() {
@@ -115,7 +116,7 @@ pub fn from_configure_request(event: &ConfigureRequestEvent) -> Self {{
                     let flag = super::camel_case_to_upper_snake(name);
                     outln!(
                         out,
-                        "if event.value_mask & u16::from(ConfigWindow::{}) != 0 {{",
+                        "if value_mask & u16::from(ConfigWindow::{}) != 0 {{",
                         flag,
                     );
                     if name == "stack_mode" || name == "sibling" {

--- a/x11rb-protocol/src/protocol/bigreq.rs
+++ b/x11rb-protocol/src/protocol/bigreq.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `BigRequests` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/composite.rs
+++ b/x11rb-protocol/src/protocol/composite.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Composite` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/damage.rs
+++ b/x11rb-protocol/src/protocol/damage.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Damage` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/dpms.rs
+++ b/x11rb-protocol/src/protocol/dpms.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `DPMS` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/dri2.rs
+++ b/x11rb-protocol/src/protocol/dri2.rs
@@ -513,7 +513,7 @@ impl TryParse for ConnectReply {
         let remaining = remaining.get(16..).ok_or(ParseError::InsufficientData)?;
         let (driver_name, remaining) = crate::x11_utils::parse_u8_list(remaining, driver_name_length.try_to_usize()?)?;
         let driver_name = driver_name.to_vec();
-        let (alignment_pad, remaining) = crate::x11_utils::parse_u8_list(remaining, (driver_name_length.checked_add(3u32).ok_or(ParseError::InvalidExpression)? & (!3u32)).checked_sub(driver_name_length).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (alignment_pad, remaining) = crate::x11_utils::parse_u8_list(remaining, (u32::from(driver_name_length).checked_add(3u32).ok_or(ParseError::InvalidExpression)? & (!3u32)).checked_sub(u32::from(driver_name_length)).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let alignment_pad = alignment_pad.to_vec();
         let (device_name, remaining) = crate::x11_utils::parse_u8_list(remaining, device_name_length.try_to_usize()?)?;
         let device_name = device_name.to_vec();
@@ -547,7 +547,7 @@ impl Serialize for ConnectReply {
         device_name_length.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 16]);
         bytes.extend_from_slice(&self.driver_name);
-        assert_eq!(self.alignment_pad.len(), usize::try_from((driver_name_length.checked_add(3u32).unwrap() & (!3u32)).checked_sub(driver_name_length).unwrap()).unwrap(), "`alignment_pad` has an incorrect length");
+        assert_eq!(self.alignment_pad.len(), usize::try_from((u32::from(driver_name_length).checked_add(3u32).unwrap() & (!3u32)).checked_sub(u32::from(driver_name_length)).unwrap()).unwrap(), "`alignment_pad` has an incorrect length");
         bytes.extend_from_slice(&self.alignment_pad);
         bytes.extend_from_slice(&self.device_name);
     }

--- a/x11rb-protocol/src/protocol/dri2.rs
+++ b/x11rb-protocol/src/protocol/dri2.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `DRI2` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/dri3.rs
+++ b/x11rb-protocol/src/protocol/dri3.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `DRI3` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/ge.rs
+++ b/x11rb-protocol/src/protocol/ge.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `GenericEvent` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/glx.rs
+++ b/x11rb-protocol/src/protocol/glx.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Glx` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/glx.rs
+++ b/x11rb-protocol/src/protocol/glx.rs
@@ -2075,7 +2075,7 @@ impl TryParse for VendorPrivateWithReplyReply {
         let (retval, remaining) = u32::try_parse(remaining)?;
         let (data1, remaining) = crate::x11_utils::parse_u8_list(remaining, 24)?;
         let data1 = <[u8; 24]>::try_from(data1).unwrap();
-        let (data2, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data2, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data2 = data2.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -2659,7 +2659,7 @@ impl<'input> CreatePixmapRequest<'input> {
         let (pixmap, remaining) = xproto::Pixmap::try_parse(remaining)?;
         let (glx_pixmap, remaining) = Pixmap::try_parse(remaining)?;
         let (num_attribs, remaining) = u32::try_parse(remaining)?;
-        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_attribs.checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, u32::from(num_attribs).checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let _ = remaining;
         Ok(CreatePixmapRequest {
             screen,
@@ -2910,7 +2910,7 @@ impl TryParse for QueryContextReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_attribs, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_attribs.checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, u32::from(num_attribs).checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -3178,7 +3178,7 @@ impl<'input> CreatePbufferRequest<'input> {
         let (fbconfig, remaining) = Fbconfig::try_parse(remaining)?;
         let (pbuffer, remaining) = Pbuffer::try_parse(remaining)?;
         let (num_attribs, remaining) = u32::try_parse(remaining)?;
-        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_attribs.checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, u32::from(num_attribs).checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let _ = remaining;
         Ok(CreatePbufferRequest {
             screen,
@@ -3333,7 +3333,7 @@ impl TryParse for GetDrawableAttributesReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (num_attribs, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_attribs.checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, u32::from(num_attribs).checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -3429,7 +3429,7 @@ impl<'input> ChangeDrawableAttributesRequest<'input> {
         }
         let (drawable, remaining) = Drawable::try_parse(value)?;
         let (num_attribs, remaining) = u32::try_parse(remaining)?;
-        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_attribs.checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, u32::from(num_attribs).checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let _ = remaining;
         Ok(ChangeDrawableAttributesRequest {
             drawable,
@@ -3525,7 +3525,7 @@ impl<'input> CreateWindowRequest<'input> {
         let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (glx_window, remaining) = Window::try_parse(remaining)?;
         let (num_attribs, remaining) = u32::try_parse(remaining)?;
-        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_attribs.checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, u32::from(num_attribs).checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let _ = remaining;
         Ok(CreateWindowRequest {
             screen,
@@ -3684,7 +3684,7 @@ impl<'input> SetClientInfoARBRequest<'input> {
         let (num_versions, remaining) = u32::try_parse(remaining)?;
         let (gl_str_len, remaining) = u32::try_parse(remaining)?;
         let (glx_str_len, remaining) = u32::try_parse(remaining)?;
-        let (gl_versions, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_versions.checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (gl_versions, remaining) = crate::x11_utils::parse_list::<u32>(remaining, u32::from(num_versions).checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let (gl_extension_string, remaining) = crate::x11_utils::parse_u8_list(remaining, gl_str_len.try_to_usize()?)?;
         let (glx_extension_string, remaining) = crate::x11_utils::parse_u8_list(remaining, glx_str_len.try_to_usize()?)?;
         let _ = remaining;
@@ -3796,7 +3796,7 @@ impl<'input> CreateContextAttribsARBRequest<'input> {
         let (is_direct, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::InsufficientData)?;
         let (num_attribs, remaining) = u32::try_parse(remaining)?;
-        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_attribs.checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (attribs, remaining) = crate::x11_utils::parse_list::<u32>(remaining, u32::from(num_attribs).checked_mul(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let _ = remaining;
         Ok(CreateContextAttribsARBRequest {
             context,
@@ -3904,7 +3904,7 @@ impl<'input> SetClientInfo2ARBRequest<'input> {
         let (num_versions, remaining) = u32::try_parse(remaining)?;
         let (gl_str_len, remaining) = u32::try_parse(remaining)?;
         let (glx_str_len, remaining) = u32::try_parse(remaining)?;
-        let (gl_versions, remaining) = crate::x11_utils::parse_list::<u32>(remaining, num_versions.checked_mul(3u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (gl_versions, remaining) = crate::x11_utils::parse_list::<u32>(remaining, u32::from(num_versions).checked_mul(3u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let (gl_extension_string, remaining) = crate::x11_utils::parse_u8_list(remaining, gl_str_len.try_to_usize()?)?;
         let (glx_extension_string, remaining) = crate::x11_utils::parse_u8_list(remaining, glx_str_len.try_to_usize()?)?;
         let _ = remaining;
@@ -4937,7 +4937,7 @@ impl TryParse for ReadPixelsReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -5192,7 +5192,7 @@ impl TryParse for GetClipPlaneReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, length.checked_div(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<Float64>(remaining, u32::from(length).checked_div(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -7173,7 +7173,7 @@ impl TryParse for GetPolygonStippleReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -8155,7 +8155,7 @@ impl TryParse for GetTexImageReply {
         let (height, remaining) = i32::try_parse(remaining)?;
         let (depth, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -9160,7 +9160,7 @@ impl TryParse for AreTexturesResidentReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (ret_val, remaining) = Bool32::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_list::<bool>(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_list::<bool>(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -9628,7 +9628,7 @@ impl TryParse for GetColorTableReply {
         let remaining = remaining.get(8..).ok_or(ParseError::InsufficientData)?;
         let (width, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -10060,7 +10060,7 @@ impl TryParse for GetConvolutionFilterReply {
         let (width, remaining) = i32::try_parse(remaining)?;
         let (height, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -10493,7 +10493,7 @@ impl TryParse for GetSeparableFilterReply {
         let (row_w, remaining) = i32::try_parse(remaining)?;
         let (col_h, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::InsufficientData)?;
-        let (rows_and_cols, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (rows_and_cols, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let rows_and_cols = rows_and_cols.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -10652,7 +10652,7 @@ impl TryParse for GetHistogramReply {
         let remaining = remaining.get(8..).ok_or(ParseError::InsufficientData)?;
         let (width, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -11083,7 +11083,7 @@ impl TryParse for GetMinmaxReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(24..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -11495,7 +11495,7 @@ impl TryParse for GetCompressedTexImageARBReply {
         let remaining = remaining.get(8..).ok_or(ParseError::InsufficientData)?;
         let (size, remaining) = i32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -105,7 +105,7 @@ impl core::fmt::Debug for EventEnum  {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct EventMask(u8);
+pub struct EventMask(u32);
 impl EventMask {
     pub const NO_EVENT: Self = Self(0);
     pub const CONFIGURE_NOTIFY: Self = Self(1 << 0);
@@ -113,61 +113,49 @@ impl EventMask {
     pub const IDLE_NOTIFY: Self = Self(1 << 2);
     pub const REDIRECT_NOTIFY: Self = Self(1 << 3);
 }
-impl From<EventMask> for u8 {
+impl From<EventMask> for u32 {
     #[inline]
     fn from(input: EventMask) -> Self {
         input.0
     }
 }
-impl From<EventMask> for core::option::Option<u8> {
+impl From<EventMask> for core::option::Option<u32> {
     #[inline]
     fn from(input: EventMask) -> Self {
         Some(input.0)
     }
 }
-impl From<EventMask> for u16 {
-    #[inline]
-    fn from(input: EventMask) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<EventMask> for core::option::Option<u16> {
-    #[inline]
-    fn from(input: EventMask) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<EventMask> for u32 {
-    #[inline]
-    fn from(input: EventMask) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<EventMask> for core::option::Option<u32> {
-    #[inline]
-    fn from(input: EventMask) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for EventMask {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for EventMask {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for EventMask {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for EventMask  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::NO_EVENT.0.into(), "NO_EVENT", "NoEvent"),
-            (Self::CONFIGURE_NOTIFY.0.into(), "CONFIGURE_NOTIFY", "ConfigureNotify"),
-            (Self::COMPLETE_NOTIFY.0.into(), "COMPLETE_NOTIFY", "CompleteNotify"),
-            (Self::IDLE_NOTIFY.0.into(), "IDLE_NOTIFY", "IdleNotify"),
-            (Self::REDIRECT_NOTIFY.0.into(), "REDIRECT_NOTIFY", "RedirectNotify"),
+            (Self::NO_EVENT.0, "NO_EVENT", "NoEvent"),
+            (Self::CONFIGURE_NOTIFY.0, "CONFIGURE_NOTIFY", "ConfigureNotify"),
+            (Self::COMPLETE_NOTIFY.0, "COMPLETE_NOTIFY", "CompleteNotify"),
+            (Self::IDLE_NOTIFY.0, "IDLE_NOTIFY", "IdleNotify"),
+            (Self::REDIRECT_NOTIFY.0, "REDIRECT_NOTIFY", "RedirectNotify"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(EventMask, u8);
+bitmask_binop!(EventMask, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -889,7 +889,7 @@ pub const SELECT_INPUT_REQUEST: u8 = 3;
 pub struct SelectInputRequest {
     pub eid: Event,
     pub window: xproto::Window,
-    pub event_mask: u32,
+    pub event_mask: EventMask,
 }
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
@@ -897,7 +897,7 @@ impl SelectInputRequest {
         let length_so_far = 0;
         let eid_bytes = self.eid.serialize();
         let window_bytes = self.window.serialize();
-        let event_mask_bytes = self.event_mask.serialize();
+        let event_mask_bytes = u32::from(self.event_mask).serialize();
         let mut request0 = vec![
             major_opcode,
             SELECT_INPUT_REQUEST,

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -930,6 +930,7 @@ impl SelectInputRequest {
         let (eid, remaining) = Event::try_parse(value)?;
         let (window, remaining) = xproto::Window::try_parse(remaining)?;
         let (event_mask, remaining) = u32::try_parse(remaining)?;
+        let event_mask = event_mask.into();
         let _ = remaining;
         Ok(SelectInputRequest {
             eid,

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Present` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -60,7 +60,7 @@ pub const BAD_PROVIDER_ERROR: u8 = 3;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Rotation(u8);
+pub struct Rotation(u16);
 impl Rotation {
     pub const ROTATE0: Self = Self(1 << 0);
     pub const ROTATE90: Self = Self(1 << 1);
@@ -69,28 +69,16 @@ impl Rotation {
     pub const REFLECT_X: Self = Self(1 << 4);
     pub const REFLECT_Y: Self = Self(1 << 5);
 }
-impl From<Rotation> for u8 {
+impl From<Rotation> for u16 {
     #[inline]
     fn from(input: Rotation) -> Self {
         input.0
     }
 }
-impl From<Rotation> for Option<u8> {
-    #[inline]
-    fn from(input: Rotation) -> Self {
-        Some(input.0)
-    }
-}
-impl From<Rotation> for u16 {
-    #[inline]
-    fn from(input: Rotation) -> Self {
-        u16::from(input.0)
-    }
-}
 impl From<Rotation> for Option<u16> {
     #[inline]
     fn from(input: Rotation) -> Self {
-        Some(u16::from(input.0))
+        Some(input.0)
     }
 }
 impl From<Rotation> for u32 {
@@ -108,6 +96,12 @@ impl From<Rotation> for Option<u32> {
 impl From<u8> for Rotation {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for Rotation {
+    #[inline]
+    fn from(value: u16) -> Self {
         Self(value)
     }
 }
@@ -124,7 +118,7 @@ impl core::fmt::Debug for Rotation  {
         pretty_print_bitmask(fmt, self.0.into(), &variants)
     }
 }
-bitmask_binop!(Rotation, u8);
+bitmask_binop!(Rotation, u16);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -611,7 +605,7 @@ impl Serialize for SetScreenConfigReply {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct NotifyMask(u8);
+pub struct NotifyMask(u16);
 impl NotifyMask {
     pub const SCREEN_CHANGE: Self = Self(1 << 0);
     pub const CRTC_CHANGE: Self = Self(1 << 1);
@@ -622,28 +616,16 @@ impl NotifyMask {
     pub const RESOURCE_CHANGE: Self = Self(1 << 6);
     pub const LEASE: Self = Self(1 << 7);
 }
-impl From<NotifyMask> for u8 {
+impl From<NotifyMask> for u16 {
     #[inline]
     fn from(input: NotifyMask) -> Self {
         input.0
     }
 }
-impl From<NotifyMask> for Option<u8> {
-    #[inline]
-    fn from(input: NotifyMask) -> Self {
-        Some(input.0)
-    }
-}
-impl From<NotifyMask> for u16 {
-    #[inline]
-    fn from(input: NotifyMask) -> Self {
-        u16::from(input.0)
-    }
-}
 impl From<NotifyMask> for Option<u16> {
     #[inline]
     fn from(input: NotifyMask) -> Self {
-        Some(u16::from(input.0))
+        Some(input.0)
     }
 }
 impl From<NotifyMask> for u32 {
@@ -661,6 +643,12 @@ impl From<NotifyMask> for Option<u32> {
 impl From<u8> for NotifyMask {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for NotifyMask {
+    #[inline]
+    fn from(value: u16) -> Self {
         Self(value)
     }
 }
@@ -679,7 +667,7 @@ impl core::fmt::Debug for NotifyMask  {
         pretty_print_bitmask(fmt, self.0.into(), &variants)
     }
 }
-bitmask_binop!(NotifyMask, u8);
+bitmask_binop!(NotifyMask, u16);
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 4;
@@ -1115,7 +1103,7 @@ impl crate::x11_utils::VoidRequest for SetScreenSizeRequest {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ModeFlag(u16);
+pub struct ModeFlag(u32);
 impl ModeFlag {
     pub const HSYNC_POSITIVE: Self = Self(1 << 0);
     pub const HSYNC_NEGATIVE: Self = Self(1 << 1);
@@ -1132,28 +1120,16 @@ impl ModeFlag {
     pub const DOUBLE_CLOCK: Self = Self(1 << 12);
     pub const HALVE_CLOCK: Self = Self(1 << 13);
 }
-impl From<ModeFlag> for u16 {
+impl From<ModeFlag> for u32 {
     #[inline]
     fn from(input: ModeFlag) -> Self {
         input.0
     }
 }
-impl From<ModeFlag> for Option<u16> {
-    #[inline]
-    fn from(input: ModeFlag) -> Self {
-        Some(input.0)
-    }
-}
-impl From<ModeFlag> for u32 {
-    #[inline]
-    fn from(input: ModeFlag) -> Self {
-        u32::from(input.0)
-    }
-}
 impl From<ModeFlag> for Option<u32> {
     #[inline]
     fn from(input: ModeFlag) -> Self {
-        Some(u32::from(input.0))
+        Some(input.0)
     }
 }
 impl From<u8> for ModeFlag {
@@ -1165,31 +1141,37 @@ impl From<u8> for ModeFlag {
 impl From<u16> for ModeFlag {
     #[inline]
     fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for ModeFlag {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for ModeFlag  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::HSYNC_POSITIVE.0.into(), "HSYNC_POSITIVE", "HsyncPositive"),
-            (Self::HSYNC_NEGATIVE.0.into(), "HSYNC_NEGATIVE", "HsyncNegative"),
-            (Self::VSYNC_POSITIVE.0.into(), "VSYNC_POSITIVE", "VsyncPositive"),
-            (Self::VSYNC_NEGATIVE.0.into(), "VSYNC_NEGATIVE", "VsyncNegative"),
-            (Self::INTERLACE.0.into(), "INTERLACE", "Interlace"),
-            (Self::DOUBLE_SCAN.0.into(), "DOUBLE_SCAN", "DoubleScan"),
-            (Self::CSYNC.0.into(), "CSYNC", "Csync"),
-            (Self::CSYNC_POSITIVE.0.into(), "CSYNC_POSITIVE", "CsyncPositive"),
-            (Self::CSYNC_NEGATIVE.0.into(), "CSYNC_NEGATIVE", "CsyncNegative"),
-            (Self::HSKEW_PRESENT.0.into(), "HSKEW_PRESENT", "HskewPresent"),
-            (Self::BCAST.0.into(), "BCAST", "Bcast"),
-            (Self::PIXEL_MULTIPLEX.0.into(), "PIXEL_MULTIPLEX", "PixelMultiplex"),
-            (Self::DOUBLE_CLOCK.0.into(), "DOUBLE_CLOCK", "DoubleClock"),
-            (Self::HALVE_CLOCK.0.into(), "HALVE_CLOCK", "HalveClock"),
+            (Self::HSYNC_POSITIVE.0, "HSYNC_POSITIVE", "HsyncPositive"),
+            (Self::HSYNC_NEGATIVE.0, "HSYNC_NEGATIVE", "HsyncNegative"),
+            (Self::VSYNC_POSITIVE.0, "VSYNC_POSITIVE", "VsyncPositive"),
+            (Self::VSYNC_NEGATIVE.0, "VSYNC_NEGATIVE", "VsyncNegative"),
+            (Self::INTERLACE.0, "INTERLACE", "Interlace"),
+            (Self::DOUBLE_SCAN.0, "DOUBLE_SCAN", "DoubleScan"),
+            (Self::CSYNC.0, "CSYNC", "Csync"),
+            (Self::CSYNC_POSITIVE.0, "CSYNC_POSITIVE", "CsyncPositive"),
+            (Self::CSYNC_NEGATIVE.0, "CSYNC_NEGATIVE", "CsyncNegative"),
+            (Self::HSKEW_PRESENT.0, "HSKEW_PRESENT", "HskewPresent"),
+            (Self::BCAST.0, "BCAST", "Bcast"),
+            (Self::PIXEL_MULTIPLEX.0, "PIXEL_MULTIPLEX", "PixelMultiplex"),
+            (Self::DOUBLE_CLOCK.0, "DOUBLE_CLOCK", "DoubleClock"),
+            (Self::HALVE_CLOCK.0, "HALVE_CLOCK", "HalveClock"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(ModeFlag, u16);
+bitmask_binop!(ModeFlag, u32);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -4755,67 +4737,55 @@ impl GetProvidersReply {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ProviderCapability(u8);
+pub struct ProviderCapability(u32);
 impl ProviderCapability {
     pub const SOURCE_OUTPUT: Self = Self(1 << 0);
     pub const SINK_OUTPUT: Self = Self(1 << 1);
     pub const SOURCE_OFFLOAD: Self = Self(1 << 2);
     pub const SINK_OFFLOAD: Self = Self(1 << 3);
 }
-impl From<ProviderCapability> for u8 {
+impl From<ProviderCapability> for u32 {
     #[inline]
     fn from(input: ProviderCapability) -> Self {
         input.0
     }
 }
-impl From<ProviderCapability> for Option<u8> {
+impl From<ProviderCapability> for Option<u32> {
     #[inline]
     fn from(input: ProviderCapability) -> Self {
         Some(input.0)
     }
 }
-impl From<ProviderCapability> for u16 {
-    #[inline]
-    fn from(input: ProviderCapability) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<ProviderCapability> for Option<u16> {
-    #[inline]
-    fn from(input: ProviderCapability) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<ProviderCapability> for u32 {
-    #[inline]
-    fn from(input: ProviderCapability) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<ProviderCapability> for Option<u32> {
-    #[inline]
-    fn from(input: ProviderCapability) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for ProviderCapability {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for ProviderCapability {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for ProviderCapability {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for ProviderCapability  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::SOURCE_OUTPUT.0.into(), "SOURCE_OUTPUT", "SourceOutput"),
-            (Self::SINK_OUTPUT.0.into(), "SINK_OUTPUT", "SinkOutput"),
-            (Self::SOURCE_OFFLOAD.0.into(), "SOURCE_OFFLOAD", "SourceOffload"),
-            (Self::SINK_OFFLOAD.0.into(), "SINK_OFFLOAD", "SinkOffload"),
+            (Self::SOURCE_OUTPUT.0, "SOURCE_OUTPUT", "SourceOutput"),
+            (Self::SINK_OUTPUT.0, "SINK_OUTPUT", "SinkOutput"),
+            (Self::SOURCE_OFFLOAD.0, "SOURCE_OFFLOAD", "SourceOffload"),
+            (Self::SINK_OFFLOAD.0, "SINK_OFFLOAD", "SinkOffload"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(ProviderCapability, u8);
+bitmask_binop!(ProviderCapability, u32);
 
 /// Opcode for the GetProviderInfo request
 pub const GET_PROVIDER_INFO_REQUEST: u8 = 33;

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -2127,7 +2127,7 @@ impl<'input> ChangeOutputPropertyRequest<'input> {
             num_units_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        assert_eq!(self.data.len(), usize::try_from(self.num_units.checked_mul(u32::from(self.format)).unwrap().checked_div(8u32).unwrap()).unwrap(), "`data` has an incorrect length");
+        assert_eq!(self.data.len(), usize::try_from(u32::from(self.num_units).checked_mul(u32::from(self.format)).unwrap().checked_div(8u32).unwrap()).unwrap(), "`data` has an incorrect length");
         let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -2149,7 +2149,7 @@ impl<'input> ChangeOutputPropertyRequest<'input> {
         let mode = mode.into();
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (num_units, remaining) = u32::try_parse(remaining)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, num_units.checked_mul(u32::from(format)).ok_or(ParseError::InvalidExpression)?.checked_div(8u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(num_units).checked_mul(u32::from(format)).ok_or(ParseError::InvalidExpression)?.checked_div(8u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let _ = remaining;
         Ok(ChangeOutputPropertyRequest {
             output,
@@ -2369,7 +2369,7 @@ impl TryParse for GetOutputPropertyReply {
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, num_items.checked_mul(u32::from(format).checked_div(8u32).ok_or(ParseError::InvalidExpression)?).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(num_items).checked_mul(u32::from(format).checked_div(8u32).ok_or(ParseError::InvalidExpression)?).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -2399,7 +2399,7 @@ impl Serialize for GetOutputPropertyReply {
         self.bytes_after.serialize_into(bytes);
         self.num_items.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 12]);
-        assert_eq!(self.data.len(), usize::try_from(self.num_items.checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`data` has an incorrect length");
+        assert_eq!(self.data.len(), usize::try_from(u32::from(self.num_items).checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`data` has an incorrect length");
         bytes.extend_from_slice(&self.data);
     }
 }
@@ -5524,7 +5524,7 @@ impl<'input> ChangeProviderPropertyRequest<'input> {
             num_items_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        assert_eq!(self.data.len(), usize::try_from(self.num_items.checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`data` has an incorrect length");
+        assert_eq!(self.data.len(), usize::try_from(u32::from(self.num_items).checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`data` has an incorrect length");
         let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -5545,7 +5545,7 @@ impl<'input> ChangeProviderPropertyRequest<'input> {
         let (mode, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, num_items.checked_mul(u32::from(format).checked_div(8u32).ok_or(ParseError::InvalidExpression)?).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(num_items).checked_mul(u32::from(format).checked_div(8u32).ok_or(ParseError::InvalidExpression)?).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let _ = remaining;
         Ok(ChangeProviderPropertyRequest {
             provider,
@@ -5765,7 +5765,7 @@ impl TryParse for GetProviderPropertyReply {
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, num_items.checked_mul(u32::from(format).checked_div(8u32).ok_or(ParseError::InvalidExpression)?).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(num_items).checked_mul(u32::from(format).checked_div(8u32).ok_or(ParseError::InvalidExpression)?).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -5795,7 +5795,7 @@ impl Serialize for GetProviderPropertyReply {
         self.bytes_after.serialize_into(bytes);
         self.num_items.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 12]);
-        assert_eq!(self.data.len(), usize::try_from(self.num_items.checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`data` has an incorrect length");
+        assert_eq!(self.data.len(), usize::try_from(u32::from(self.num_items).checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`data` has an incorrect length");
         bytes.extend_from_slice(&self.data);
     }
 }

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `RandR` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -480,6 +480,7 @@ impl SetScreenConfigRequest {
         let (config_timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
         let (size_id, remaining) = u16::try_parse(remaining)?;
         let (rotation, remaining) = u16::try_parse(remaining)?;
+        let rotation = rotation.into();
         let (rate, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let _ = remaining;
@@ -710,6 +711,7 @@ impl SelectInputRequest {
         }
         let (window, remaining) = xproto::Window::try_parse(value)?;
         let (enable, remaining) = u16::try_parse(remaining)?;
+        let enable = enable.into();
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let _ = remaining;
         Ok(SelectInputRequest {
@@ -822,6 +824,8 @@ impl TryParse for GetScreenInfoReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let rotations = rotations.into();
+        let rotation = rotation.into();
         let result = GetScreenInfoReply { rotations, sequence, length, root, timestamp, config_timestamp, size_id, rotation, rate, n_info, sizes, rates };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -1205,6 +1209,7 @@ impl TryParse for ModeInfo {
         let (vtotal, remaining) = u16::try_parse(remaining)?;
         let (name_len, remaining) = u16::try_parse(remaining)?;
         let (mode_flags, remaining) = u32::try_parse(remaining)?;
+        let mode_flags = mode_flags.into();
         let result = ModeInfo { id, width, height, dot_clock, hsync_start, hsync_end, htotal, hskew, vsync_start, vsync_end, vtotal, name_len, mode_flags };
         Ok((result, remaining))
     }
@@ -2860,6 +2865,8 @@ impl TryParse for GetCrtcInfoReply {
             return Err(ParseError::InvalidValue);
         }
         let status = status.into();
+        let rotation = rotation.into();
+        let rotations = rotations.into();
         let result = GetCrtcInfoReply { status, sequence, length, timestamp, x, y, width, height, mode, rotation, rotations, outputs, possible };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -3003,6 +3010,7 @@ impl<'input> SetCrtcConfigRequest<'input> {
         let (y, remaining) = i16::try_parse(remaining)?;
         let (mode, remaining) = Mode::try_parse(remaining)?;
         let (rotation, remaining) = u16::try_parse(remaining)?;
+        let rotation = rotation.into();
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let mut remaining = remaining;
         // Length is 'everything left in the input'
@@ -4886,6 +4894,7 @@ impl TryParse for GetProviderInfoReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let capabilities = capabilities.into();
         let result = GetProviderInfoReply { status, sequence, length, timestamp, capabilities, crtcs, outputs, associated_providers, associated_capability, name };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -5826,6 +5835,7 @@ impl TryParse for ScreenChangeNotifyEvent {
         let (height, remaining) = u16::try_parse(remaining)?;
         let (mwidth, remaining) = u16::try_parse(remaining)?;
         let (mheight, remaining) = u16::try_parse(remaining)?;
+        let rotation = rotation.into();
         let subpixel_order = subpixel_order.into();
         let result = ScreenChangeNotifyEvent { response_type, rotation, sequence, timestamp, config_timestamp, root, request_window, size_id, subpixel_order, width, height, mwidth, mheight };
         let _ = remaining;
@@ -6053,6 +6063,7 @@ impl TryParse for CrtcChange {
         let (y, remaining) = i16::try_parse(remaining)?;
         let (width, remaining) = u16::try_parse(remaining)?;
         let (height, remaining) = u16::try_parse(remaining)?;
+        let rotation = rotation.into();
         let result = CrtcChange { timestamp, window, crtc, mode, rotation, x, y, width, height };
         Ok((result, remaining))
     }
@@ -6139,6 +6150,7 @@ impl TryParse for OutputChange {
         let (rotation, remaining) = u16::try_parse(remaining)?;
         let (connection, remaining) = u8::try_parse(remaining)?;
         let (subpixel_order, remaining) = u8::try_parse(remaining)?;
+        let rotation = rotation.into();
         let connection = connection.into();
         let subpixel_order = subpixel_order.into();
         let result = OutputChange { timestamp, config_timestamp, window, output, crtc, mode, rotation, connection, subpixel_order };

--- a/x11rb-protocol/src/protocol/record.rs
+++ b/x11rb-protocol/src/protocol/record.rs
@@ -981,7 +981,7 @@ impl TryParse for EnableContextReply {
         let (server_time, remaining) = u32::try_parse(remaining)?;
         let (rec_sequence_num, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(8..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/record.rs
+++ b/x11rb-protocol/src/protocol/record.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Record` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -1814,7 +1814,7 @@ impl CreatePictureAux {
     #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, value_mask);
+        self.serialize_into(&mut result, u32::from(value_mask));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
@@ -2032,7 +2032,7 @@ impl<'input> CreatePictureRequest<'input> {
             value_mask_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let value_list_bytes = self.value_list.serialize(value_mask);
+        let value_list_bytes = self.value_list.serialize(u32::from(value_mask));
         let length_so_far = length_so_far + value_list_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -2220,7 +2220,7 @@ impl ChangePictureAux {
     #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, value_mask);
+        self.serialize_into(&mut result, u32::from(value_mask));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
@@ -2426,7 +2426,7 @@ impl<'input> ChangePictureRequest<'input> {
             value_mask_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let value_list_bytes = self.value_list.serialize(value_mask);
+        let value_list_bytes = self.value_list.serialize(u32::from(value_mask));
         let length_so_far = length_so_far + value_list_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Render` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -1696,7 +1696,7 @@ pub struct CreatePictureAux {
 }
 impl CreatePictureAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = value_mask;
+        let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
         let repeat = if switch_expr & u32::from(CP::REPEAT) != 0 {
             let remaining = outer_remaining;
@@ -2102,7 +2102,7 @@ pub struct ChangePictureAux {
 }
 impl ChangePictureAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = value_mask;
+        let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
         let repeat = if switch_expr & u32::from(CP::REPEAT) != 0 {
             let remaining = outer_remaining;

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -407,7 +407,7 @@ impl core::fmt::Debug for PolyMode  {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct CP(u16);
+pub struct CP(u32);
 impl CP {
     pub const REPEAT: Self = Self(1 << 0);
     pub const ALPHA_MAP: Self = Self(1 << 1);
@@ -423,28 +423,16 @@ impl CP {
     pub const DITHER: Self = Self(1 << 11);
     pub const COMPONENT_ALPHA: Self = Self(1 << 12);
 }
-impl From<CP> for u16 {
+impl From<CP> for u32 {
     #[inline]
     fn from(input: CP) -> Self {
         input.0
     }
 }
-impl From<CP> for Option<u16> {
-    #[inline]
-    fn from(input: CP) -> Self {
-        Some(input.0)
-    }
-}
-impl From<CP> for u32 {
-    #[inline]
-    fn from(input: CP) -> Self {
-        u32::from(input.0)
-    }
-}
 impl From<CP> for Option<u32> {
     #[inline]
     fn from(input: CP) -> Self {
-        Some(u32::from(input.0))
+        Some(input.0)
     }
 }
 impl From<u8> for CP {
@@ -456,30 +444,36 @@ impl From<u8> for CP {
 impl From<u16> for CP {
     #[inline]
     fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for CP {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for CP  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::REPEAT.0.into(), "REPEAT", "Repeat"),
-            (Self::ALPHA_MAP.0.into(), "ALPHA_MAP", "AlphaMap"),
-            (Self::ALPHA_X_ORIGIN.0.into(), "ALPHA_X_ORIGIN", "AlphaXOrigin"),
-            (Self::ALPHA_Y_ORIGIN.0.into(), "ALPHA_Y_ORIGIN", "AlphaYOrigin"),
-            (Self::CLIP_X_ORIGIN.0.into(), "CLIP_X_ORIGIN", "ClipXOrigin"),
-            (Self::CLIP_Y_ORIGIN.0.into(), "CLIP_Y_ORIGIN", "ClipYOrigin"),
-            (Self::CLIP_MASK.0.into(), "CLIP_MASK", "ClipMask"),
-            (Self::GRAPHICS_EXPOSURE.0.into(), "GRAPHICS_EXPOSURE", "GraphicsExposure"),
-            (Self::SUBWINDOW_MODE.0.into(), "SUBWINDOW_MODE", "SubwindowMode"),
-            (Self::POLY_EDGE.0.into(), "POLY_EDGE", "PolyEdge"),
-            (Self::POLY_MODE.0.into(), "POLY_MODE", "PolyMode"),
-            (Self::DITHER.0.into(), "DITHER", "Dither"),
-            (Self::COMPONENT_ALPHA.0.into(), "COMPONENT_ALPHA", "ComponentAlpha"),
+            (Self::REPEAT.0, "REPEAT", "Repeat"),
+            (Self::ALPHA_MAP.0, "ALPHA_MAP", "AlphaMap"),
+            (Self::ALPHA_X_ORIGIN.0, "ALPHA_X_ORIGIN", "AlphaXOrigin"),
+            (Self::ALPHA_Y_ORIGIN.0, "ALPHA_Y_ORIGIN", "AlphaYOrigin"),
+            (Self::CLIP_X_ORIGIN.0, "CLIP_X_ORIGIN", "ClipXOrigin"),
+            (Self::CLIP_Y_ORIGIN.0, "CLIP_Y_ORIGIN", "ClipYOrigin"),
+            (Self::CLIP_MASK.0, "CLIP_MASK", "ClipMask"),
+            (Self::GRAPHICS_EXPOSURE.0, "GRAPHICS_EXPOSURE", "GraphicsExposure"),
+            (Self::SUBWINDOW_MODE.0, "SUBWINDOW_MODE", "SubwindowMode"),
+            (Self::POLY_EDGE.0, "POLY_EDGE", "PolyEdge"),
+            (Self::POLY_MODE.0, "POLY_MODE", "PolyMode"),
+            (Self::DITHER.0, "DITHER", "Dither"),
+            (Self::COMPONENT_ALPHA.0, "COMPONENT_ALPHA", "ComponentAlpha"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(CP, u16);
+bitmask_binop!(CP, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -2050,7 +2050,7 @@ impl<'input> CreatePictureRequest<'input> {
         let (drawable, remaining) = xproto::Drawable::try_parse(remaining)?;
         let (format, remaining) = Pictformat::try_parse(remaining)?;
         let (value_mask, remaining) = u32::try_parse(remaining)?;
-        let (value_list, remaining) = CreatePictureAux::try_parse(remaining, value_mask)?;
+        let (value_list, remaining) = CreatePictureAux::try_parse(remaining, u32::from(value_mask))?;
         let _ = remaining;
         Ok(CreatePictureRequest {
             pid,
@@ -2442,7 +2442,7 @@ impl<'input> ChangePictureRequest<'input> {
         }
         let (picture, remaining) = Picture::try_parse(value)?;
         let (value_mask, remaining) = u32::try_parse(remaining)?;
-        let (value_list, remaining) = ChangePictureAux::try_parse(remaining, value_mask)?;
+        let (value_list, remaining) = ChangePictureAux::try_parse(remaining, u32::from(value_mask))?;
         let _ = remaining;
         Ok(ChangePictureRequest {
             picture,

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -160,7 +160,7 @@ bitmask_binop!(ClientIdMask, u32);
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientIdSpec {
     pub client: u32,
-    pub mask: u32,
+    pub mask: ClientIdMask,
 }
 impl TryParse for ClientIdSpec {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -175,7 +175,7 @@ impl Serialize for ClientIdSpec {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
         let client_bytes = self.client.serialize();
-        let mask_bytes = self.mask.serialize();
+        let mask_bytes = u32::from(self.mask).serialize();
         [
             client_bytes[0],
             client_bytes[1],
@@ -190,7 +190,7 @@ impl Serialize for ClientIdSpec {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
         self.client.serialize_into(bytes);
-        self.mask.serialize_into(bytes);
+        u32::from(self.mask).serialize_into(bytes);
     }
 }
 

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -166,6 +166,7 @@ impl TryParse for ClientIdSpec {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (client, remaining) = u32::try_parse(remaining)?;
         let (mask, remaining) = u32::try_parse(remaining)?;
+        let mask = mask.into();
         let result = ClientIdSpec { client, mask };
         Ok((result, remaining))
     }

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -110,63 +110,51 @@ impl Serialize for Type {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ClientIdMask(u8);
+pub struct ClientIdMask(u32);
 impl ClientIdMask {
     pub const CLIENT_XID: Self = Self(1 << 0);
     pub const LOCAL_CLIENT_PID: Self = Self(1 << 1);
 }
-impl From<ClientIdMask> for u8 {
+impl From<ClientIdMask> for u32 {
     #[inline]
     fn from(input: ClientIdMask) -> Self {
         input.0
     }
 }
-impl From<ClientIdMask> for Option<u8> {
+impl From<ClientIdMask> for Option<u32> {
     #[inline]
     fn from(input: ClientIdMask) -> Self {
         Some(input.0)
     }
 }
-impl From<ClientIdMask> for u16 {
-    #[inline]
-    fn from(input: ClientIdMask) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<ClientIdMask> for Option<u16> {
-    #[inline]
-    fn from(input: ClientIdMask) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<ClientIdMask> for u32 {
-    #[inline]
-    fn from(input: ClientIdMask) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<ClientIdMask> for Option<u32> {
-    #[inline]
-    fn from(input: ClientIdMask) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for ClientIdMask {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for ClientIdMask {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for ClientIdMask {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for ClientIdMask  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::CLIENT_XID.0.into(), "CLIENT_XID", "ClientXID"),
-            (Self::LOCAL_CLIENT_PID.0.into(), "LOCAL_CLIENT_PID", "LocalClientPID"),
+            (Self::CLIENT_XID.0, "CLIENT_XID", "ClientXID"),
+            (Self::LOCAL_CLIENT_PID.0, "LOCAL_CLIENT_PID", "LocalClientPID"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(ClientIdMask, u8);
+bitmask_binop!(ClientIdMask, u32);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -204,7 +204,7 @@ impl TryParse for ClientIdValue {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (spec, remaining) = ClientIdSpec::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (value, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.checked_div(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (value, remaining) = crate::x11_utils::parse_list::<u32>(remaining, u32::from(length).checked_div(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let result = ClientIdValue { spec, value };
         Ok((result, remaining))
     }

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Res` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -586,7 +586,7 @@ pub struct SetAttributesAux {
 }
 impl SetAttributesAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = value_mask;
+        let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
         let background_pixmap = if switch_expr & u32::from(xproto::CW::BACK_PIXMAP) != 0 {
             let remaining = outer_remaining;

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -1008,7 +1008,7 @@ impl<'input> SetAttributesRequest<'input> {
         let (depth, remaining) = u8::try_parse(remaining)?;
         let (visual, remaining) = xproto::Visualid::try_parse(remaining)?;
         let (value_mask, remaining) = u32::try_parse(remaining)?;
-        let (value_list, remaining) = SetAttributesAux::try_parse(remaining, value_mask)?;
+        let (value_list, remaining) = SetAttributesAux::try_parse(remaining, u32::from(value_mask))?;
         let _ = remaining;
         Ok(SetAttributesRequest {
             drawable,

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -508,14 +508,14 @@ pub const SELECT_INPUT_REQUEST: u8 = 2;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputRequest {
     pub drawable: xproto::Drawable,
-    pub event_mask: u32,
+    pub event_mask: Event,
 }
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'static>> {
         let length_so_far = 0;
         let drawable_bytes = self.drawable.serialize();
-        let event_mask_bytes = self.event_mask.serialize();
+        let event_mask_bytes = u32::from(self.event_mask).serialize();
         let mut request0 = vec![
             major_opcode,
             SELECT_INPUT_REQUEST,
@@ -579,8 +579,8 @@ pub struct SetAttributesAux {
     pub backing_pixel: Option<u32>,
     pub override_redirect: Option<xproto::Bool32>,
     pub save_under: Option<xproto::Bool32>,
-    pub event_mask: Option<u32>,
-    pub do_not_propogate_mask: Option<u32>,
+    pub event_mask: Option<xproto::EventMask>,
+    pub do_not_propogate_mask: Option<xproto::EventMask>,
     pub colormap: Option<xproto::Colormap>,
     pub cursor: Option<xproto::Cursor>,
 }
@@ -760,10 +760,10 @@ impl SetAttributesAux {
             save_under.serialize_into(bytes);
         }
         if let Some(event_mask) = self.event_mask {
-            event_mask.serialize_into(bytes);
+            u32::from(event_mask).serialize_into(bytes);
         }
         if let Some(do_not_propogate_mask) = self.do_not_propogate_mask {
-            do_not_propogate_mask.serialize_into(bytes);
+            u32::from(do_not_propogate_mask).serialize_into(bytes);
         }
         if let Some(colormap) = self.colormap {
             colormap.serialize_into(bytes);
@@ -897,13 +897,13 @@ impl SetAttributesAux {
     }
     /// Set the `event_mask` field of this structure.
     #[must_use]
-    pub fn event_mask<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
+    pub fn event_mask<I>(mut self, value: I) -> Self where I: Into<Option<xproto::EventMask>> {
         self.event_mask = value.into();
         self
     }
     /// Set the `do_not_propogate_mask` field of this structure.
     #[must_use]
-    pub fn do_not_propogate_mask<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
+    pub fn do_not_propogate_mask<I>(mut self, value: I) -> Self where I: Into<Option<xproto::EventMask>> {
         self.do_not_propogate_mask = value.into();
         self
     }

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -97,63 +97,51 @@ impl core::fmt::Debug for Kind  {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Event(u8);
+pub struct Event(u32);
 impl Event {
     pub const NOTIFY_MASK: Self = Self(1 << 0);
     pub const CYCLE_MASK: Self = Self(1 << 1);
 }
-impl From<Event> for u8 {
+impl From<Event> for u32 {
     #[inline]
     fn from(input: Event) -> Self {
         input.0
     }
 }
-impl From<Event> for Option<u8> {
+impl From<Event> for Option<u32> {
     #[inline]
     fn from(input: Event) -> Self {
         Some(input.0)
     }
 }
-impl From<Event> for u16 {
-    #[inline]
-    fn from(input: Event) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<Event> for Option<u16> {
-    #[inline]
-    fn from(input: Event) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<Event> for u32 {
-    #[inline]
-    fn from(input: Event) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<Event> for Option<u32> {
-    #[inline]
-    fn from(input: Event) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for Event {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for Event {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for Event {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for Event  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::NOTIFY_MASK.0.into(), "NOTIFY_MASK", "NotifyMask"),
-            (Self::CYCLE_MASK.0.into(), "CYCLE_MASK", "CycleMask"),
+            (Self::NOTIFY_MASK.0, "NOTIFY_MASK", "NotifyMask"),
+            (Self::CYCLE_MASK.0, "CYCLE_MASK", "CycleMask"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(Event, u8);
+bitmask_binop!(Event, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `ScreenSaver` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -721,7 +721,7 @@ impl SetAttributesAux {
     #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, value_mask);
+        self.serialize_into(&mut result, u32::from(value_mask));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
@@ -983,7 +983,7 @@ impl<'input> SetAttributesRequest<'input> {
             value_mask_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let value_list_bytes = self.value_list.serialize(value_mask);
+        let value_list_bytes = self.value_list.serialize(u32::from(value_mask));
         let length_so_far = length_so_far + value_list_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -543,6 +543,7 @@ impl SelectInputRequest {
         }
         let (drawable, remaining) = xproto::Drawable::try_parse(value)?;
         let (event_mask, remaining) = u32::try_parse(remaining)?;
+        let event_mask = event_mask.into();
         let _ = remaining;
         Ok(SelectInputRequest {
             drawable,
@@ -681,6 +682,7 @@ impl SetAttributesAux {
         let event_mask = if switch_expr & u32::from(xproto::CW::EVENT_MASK) != 0 {
             let remaining = outer_remaining;
             let (event_mask, remaining) = u32::try_parse(remaining)?;
+            let event_mask = event_mask.into();
             outer_remaining = remaining;
             Some(event_mask)
         } else {
@@ -689,6 +691,7 @@ impl SetAttributesAux {
         let do_not_propogate_mask = if switch_expr & u32::from(xproto::CW::DONT_PROPAGATE) != 0 {
             let remaining = outer_remaining;
             let (do_not_propogate_mask, remaining) = u32::try_parse(remaining)?;
+            let do_not_propogate_mask = do_not_propogate_mask.into();
             outer_remaining = remaining;
             Some(do_not_propogate_mask)
         } else {

--- a/x11rb-protocol/src/protocol/shape.rs
+++ b/x11rb-protocol/src/protocol/shape.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Shape` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/shm.rs
+++ b/x11rb-protocol/src/protocol/shm.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Shm` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -201,7 +201,7 @@ impl core::fmt::Debug for VALUETYPE  {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct CA(u8);
+pub struct CA(u32);
 impl CA {
     pub const COUNTER: Self = Self(1 << 0);
     pub const VALUE_TYPE: Self = Self(1 << 1);
@@ -210,62 +210,50 @@ impl CA {
     pub const DELTA: Self = Self(1 << 4);
     pub const EVENTS: Self = Self(1 << 5);
 }
-impl From<CA> for u8 {
+impl From<CA> for u32 {
     #[inline]
     fn from(input: CA) -> Self {
         input.0
     }
 }
-impl From<CA> for Option<u8> {
+impl From<CA> for Option<u32> {
     #[inline]
     fn from(input: CA) -> Self {
         Some(input.0)
     }
 }
-impl From<CA> for u16 {
-    #[inline]
-    fn from(input: CA) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<CA> for Option<u16> {
-    #[inline]
-    fn from(input: CA) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<CA> for u32 {
-    #[inline]
-    fn from(input: CA) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<CA> for Option<u32> {
-    #[inline]
-    fn from(input: CA) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for CA {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for CA {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for CA {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for CA  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::COUNTER.0.into(), "COUNTER", "Counter"),
-            (Self::VALUE_TYPE.0.into(), "VALUE_TYPE", "ValueType"),
-            (Self::VALUE.0.into(), "VALUE", "Value"),
-            (Self::TEST_TYPE.0.into(), "TEST_TYPE", "TestType"),
-            (Self::DELTA.0.into(), "DELTA", "Delta"),
-            (Self::EVENTS.0.into(), "EVENTS", "Events"),
+            (Self::COUNTER.0, "COUNTER", "Counter"),
+            (Self::VALUE_TYPE.0, "VALUE_TYPE", "ValueType"),
+            (Self::VALUE.0, "VALUE", "Value"),
+            (Self::TEST_TYPE.0, "TEST_TYPE", "TestType"),
+            (Self::DELTA.0, "DELTA", "Delta"),
+            (Self::EVENTS.0, "EVENTS", "Events"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(CA, u8);
+bitmask_binop!(CA, u32);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -1162,7 +1162,7 @@ pub struct CreateAlarmAux {
 }
 impl CreateAlarmAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = value_mask;
+        let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
         let counter = if switch_expr & u32::from(CA::COUNTER) != 0 {
             let remaining = outer_remaining;
@@ -1401,7 +1401,7 @@ pub struct ChangeAlarmAux {
 }
 impl ChangeAlarmAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = value_mask;
+        let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
         let counter = if switch_expr & u32::from(CA::COUNTER) != 0 {
             let remaining = outer_remaining;

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -1360,7 +1360,7 @@ impl<'input> CreateAlarmRequest<'input> {
         }
         let (id, remaining) = Alarm::try_parse(value)?;
         let (value_mask, remaining) = u32::try_parse(remaining)?;
-        let (value_list, remaining) = CreateAlarmAux::try_parse(remaining, value_mask)?;
+        let (value_list, remaining) = CreateAlarmAux::try_parse(remaining, u32::from(value_mask))?;
         let _ = remaining;
         Ok(CreateAlarmRequest {
             id,
@@ -1599,7 +1599,7 @@ impl<'input> ChangeAlarmRequest<'input> {
         }
         let (id, remaining) = Alarm::try_parse(value)?;
         let (value_mask, remaining) = u32::try_parse(remaining)?;
-        let (value_list, remaining) = ChangeAlarmAux::try_parse(remaining, value_mask)?;
+        let (value_list, remaining) = ChangeAlarmAux::try_parse(remaining, u32::from(value_mask))?;
         let _ = remaining;
         Ok(ChangeAlarmRequest {
             id,

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Sync` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -1222,7 +1222,7 @@ impl CreateAlarmAux {
     #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, value_mask);
+        self.serialize_into(&mut result, u32::from(value_mask));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
@@ -1344,7 +1344,7 @@ impl<'input> CreateAlarmRequest<'input> {
             value_mask_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let value_list_bytes = self.value_list.serialize(value_mask);
+        let value_list_bytes = self.value_list.serialize(u32::from(value_mask));
         let length_so_far = length_so_far + value_list_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -1461,7 +1461,7 @@ impl ChangeAlarmAux {
     #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, value_mask);
+        self.serialize_into(&mut result, u32::from(value_mask));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
@@ -1583,7 +1583,7 @@ impl<'input> ChangeAlarmRequest<'input> {
             value_mask_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let value_list_bytes = self.value_list.serialize(value_mask);
+        let value_list_bytes = self.value_list.serialize(u32::from(value_mask));
         let length_so_far = length_so_far + value_list_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();

--- a/x11rb-protocol/src/protocol/xc_misc.rs
+++ b/x11rb-protocol/src/protocol/xc_misc.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `XCMisc` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xevie.rs
+++ b/x11rb-protocol/src/protocol/xevie.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Xevie` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xf86dri.rs
+++ b/x11rb-protocol/src/protocol/xf86dri.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `XF86Dri` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -213,7 +213,7 @@ pub struct ModeInfo {
     pub vsyncstart: u16,
     pub vsyncend: u16,
     pub vtotal: u16,
-    pub flags: u32,
+    pub flags: ModeFlag,
     pub privsize: u32,
 }
 impl TryParse for ModeInfo {
@@ -250,7 +250,7 @@ impl Serialize for ModeInfo {
         let vsyncstart_bytes = self.vsyncstart.serialize();
         let vsyncend_bytes = self.vsyncend.serialize();
         let vtotal_bytes = self.vtotal.serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u32::from(self.flags).serialize();
         let privsize_bytes = self.privsize.serialize();
         [
             dotclock_bytes[0],
@@ -316,7 +316,7 @@ impl Serialize for ModeInfo {
         self.vsyncend.serialize_into(bytes);
         self.vtotal.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 4]);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 12]);
         self.privsize.serialize_into(bytes);
     }
@@ -499,7 +499,7 @@ pub struct GetModeLineReply {
     pub vsyncstart: u16,
     pub vsyncend: u16,
     pub vtotal: u16,
-    pub flags: u32,
+    pub flags: ModeFlag,
     pub private: Vec<u8>,
 }
 impl TryParse for GetModeLineReply {
@@ -561,7 +561,7 @@ impl Serialize for GetModeLineReply {
         self.vsyncend.serialize_into(bytes);
         self.vtotal.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 12]);
         let privsize = u32::try_from(self.private.len()).expect("`private` has too many elements");
         privsize.serialize_into(bytes);
@@ -599,7 +599,7 @@ pub struct ModModeLineRequest<'input> {
     pub vsyncstart: u16,
     pub vsyncend: u16,
     pub vtotal: u16,
-    pub flags: u32,
+    pub flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
 }
 impl<'input> ModModeLineRequest<'input> {
@@ -616,7 +616,7 @@ impl<'input> ModModeLineRequest<'input> {
         let vsyncstart_bytes = self.vsyncstart.serialize();
         let vsyncend_bytes = self.vsyncend.serialize();
         let vtotal_bytes = self.vtotal.serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u32::from(self.flags).serialize();
         let privsize = u32::try_from(self.private.len()).expect("`private` has too many elements");
         let privsize_bytes = privsize.serialize();
         let mut request0 = vec![
@@ -1176,7 +1176,7 @@ pub struct AddModeLineRequest<'input> {
     pub vsyncstart: u16,
     pub vsyncend: u16,
     pub vtotal: u16,
-    pub flags: u32,
+    pub flags: ModeFlag,
     pub after_dotclock: Dotclock,
     pub after_hdisplay: u16,
     pub after_hsyncstart: u16,
@@ -1187,7 +1187,7 @@ pub struct AddModeLineRequest<'input> {
     pub after_vsyncstart: u16,
     pub after_vsyncend: u16,
     pub after_vtotal: u16,
-    pub after_flags: u32,
+    pub after_flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
 }
 impl<'input> AddModeLineRequest<'input> {
@@ -1205,7 +1205,7 @@ impl<'input> AddModeLineRequest<'input> {
         let vsyncstart_bytes = self.vsyncstart.serialize();
         let vsyncend_bytes = self.vsyncend.serialize();
         let vtotal_bytes = self.vtotal.serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u32::from(self.flags).serialize();
         let privsize = u32::try_from(self.private.len()).expect("`private` has too many elements");
         let privsize_bytes = privsize.serialize();
         let after_dotclock_bytes = self.after_dotclock.serialize();
@@ -1218,7 +1218,7 @@ impl<'input> AddModeLineRequest<'input> {
         let after_vsyncstart_bytes = self.after_vsyncstart.serialize();
         let after_vsyncend_bytes = self.after_vsyncend.serialize();
         let after_vtotal_bytes = self.after_vtotal.serialize();
-        let after_flags_bytes = self.after_flags.serialize();
+        let after_flags_bytes = u32::from(self.after_flags).serialize();
         let mut request0 = vec![
             major_opcode,
             ADD_MODE_LINE_REQUEST,
@@ -1445,7 +1445,7 @@ pub struct DeleteModeLineRequest<'input> {
     pub vsyncstart: u16,
     pub vsyncend: u16,
     pub vtotal: u16,
-    pub flags: u32,
+    pub flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
 }
 impl<'input> DeleteModeLineRequest<'input> {
@@ -1463,7 +1463,7 @@ impl<'input> DeleteModeLineRequest<'input> {
         let vsyncstart_bytes = self.vsyncstart.serialize();
         let vsyncend_bytes = self.vsyncend.serialize();
         let vtotal_bytes = self.vtotal.serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u32::from(self.flags).serialize();
         let privsize = u32::try_from(self.private.len()).expect("`private` has too many elements");
         let privsize_bytes = privsize.serialize();
         let mut request0 = vec![
@@ -1616,7 +1616,7 @@ pub struct ValidateModeLineRequest<'input> {
     pub vsyncstart: u16,
     pub vsyncend: u16,
     pub vtotal: u16,
-    pub flags: u32,
+    pub flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
 }
 impl<'input> ValidateModeLineRequest<'input> {
@@ -1634,7 +1634,7 @@ impl<'input> ValidateModeLineRequest<'input> {
         let vsyncstart_bytes = self.vsyncstart.serialize();
         let vsyncend_bytes = self.vsyncend.serialize();
         let vtotal_bytes = self.vtotal.serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u32::from(self.flags).serialize();
         let privsize = u32::try_from(self.private.len()).expect("`private` has too many elements");
         let privsize_bytes = privsize.serialize();
         let mut request0 = vec![
@@ -1868,7 +1868,7 @@ pub struct SwitchToModeRequest<'input> {
     pub vsyncstart: u16,
     pub vsyncend: u16,
     pub vtotal: u16,
-    pub flags: u32,
+    pub flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
 }
 impl<'input> SwitchToModeRequest<'input> {
@@ -1886,7 +1886,7 @@ impl<'input> SwitchToModeRequest<'input> {
         let vsyncstart_bytes = self.vsyncstart.serialize();
         let vsyncend_bytes = self.vsyncend.serialize();
         let vtotal_bytes = self.vtotal.serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u32::from(self.flags).serialize();
         let privsize = u32::try_from(self.private.len()).expect("`private` has too many elements");
         let privsize_bytes = privsize.serialize();
         let mut request0 = vec![
@@ -2292,7 +2292,7 @@ impl crate::x11_utils::ReplyRequest for GetDotClocksRequest {
 pub struct GetDotClocksReply {
     pub sequence: u16,
     pub length: u32,
-    pub flags: u32,
+    pub flags: ClockFlag,
     pub clocks: u32,
     pub maxclocks: u32,
     pub clock: Vec<u32>,
@@ -2334,7 +2334,7 @@ impl Serialize for GetDotClocksReply {
         bytes.extend_from_slice(&[0; 1]);
         self.sequence.serialize_into(bytes);
         self.length.serialize_into(bytes);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         self.clocks.serialize_into(bytes);
         self.maxclocks.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 12]);
@@ -3055,7 +3055,7 @@ impl crate::x11_utils::ReplyRequest for GetPermissionsRequest {
 pub struct GetPermissionsReply {
     pub sequence: u16,
     pub length: u32,
-    pub permissions: u32,
+    pub permissions: Permission,
 }
 impl TryParse for GetPermissionsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3083,7 +3083,7 @@ impl Serialize for GetPermissionsReply {
         let response_type_bytes = &[1];
         let sequence_bytes = self.sequence.serialize();
         let length_bytes = self.length.serialize();
-        let permissions_bytes = self.permissions.serialize();
+        let permissions_bytes = u32::from(self.permissions).serialize();
         [
             response_type_bytes[0],
             0,
@@ -3126,7 +3126,7 @@ impl Serialize for GetPermissionsReply {
         bytes.extend_from_slice(&[0; 1]);
         self.sequence.serialize_into(bytes);
         self.length.serialize_into(bytes);
-        self.permissions.serialize_into(bytes);
+        u32::from(self.permissions).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 20]);
     }
 }

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -232,6 +232,7 @@ impl TryParse for ModeInfo {
         let (flags, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
         let (privsize, remaining) = u32::try_parse(remaining)?;
+        let flags = flags.into();
         let result = ModeInfo { dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, privsize };
         Ok((result, remaining))
     }
@@ -527,6 +528,7 @@ impl TryParse for GetModeLineReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let flags = flags.into();
         let result = GetModeLineReply { sequence, length, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -693,6 +695,7 @@ impl<'input> ModModeLineRequest<'input> {
         let (vtotal, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (flags, remaining) = u32::try_parse(remaining)?;
+        let flags = flags.into();
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
         let (privsize, remaining) = u32::try_parse(remaining)?;
         let (private, remaining) = crate::x11_utils::parse_u8_list(remaining, privsize.try_to_usize()?)?;
@@ -1337,6 +1340,7 @@ impl<'input> AddModeLineRequest<'input> {
         let (vtotal, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (flags, remaining) = u32::try_parse(remaining)?;
+        let flags = flags.into();
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
         let (privsize, remaining) = u32::try_parse(remaining)?;
         let (after_dotclock, remaining) = Dotclock::try_parse(remaining)?;
@@ -1351,6 +1355,7 @@ impl<'input> AddModeLineRequest<'input> {
         let (after_vtotal, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (after_flags, remaining) = u32::try_parse(remaining)?;
+        let after_flags = after_flags.into();
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
         let (private, remaining) = crate::x11_utils::parse_u8_list(remaining, privsize.try_to_usize()?)?;
         let _ = remaining;
@@ -1542,6 +1547,7 @@ impl<'input> DeleteModeLineRequest<'input> {
         let (vtotal, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (flags, remaining) = u32::try_parse(remaining)?;
+        let flags = flags.into();
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
         let (privsize, remaining) = u32::try_parse(remaining)?;
         let (private, remaining) = crate::x11_utils::parse_u8_list(remaining, privsize.try_to_usize()?)?;
@@ -1712,6 +1718,7 @@ impl<'input> ValidateModeLineRequest<'input> {
         let (vtotal, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (flags, remaining) = u32::try_parse(remaining)?;
+        let flags = flags.into();
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
         let (privsize, remaining) = u32::try_parse(remaining)?;
         let (private, remaining) = crate::x11_utils::parse_u8_list(remaining, privsize.try_to_usize()?)?;
@@ -1963,6 +1970,7 @@ impl<'input> SwitchToModeRequest<'input> {
         let (vtotal, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (flags, remaining) = u32::try_parse(remaining)?;
+        let flags = flags.into();
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
         let (privsize, remaining) = u32::try_parse(remaining)?;
         let (private, remaining) = crate::x11_utils::parse_u8_list(remaining, privsize.try_to_usize()?)?;
@@ -2304,6 +2312,7 @@ impl TryParse for GetDotClocksReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let flags = flags.into();
         let result = GetDotClocksReply { sequence, length, flags, clocks, maxclocks, clock };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -3060,6 +3069,7 @@ impl TryParse for GetPermissionsReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let permissions = permissions.into();
         let result = GetPermissionsReply { sequence, length, permissions };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -2308,7 +2308,7 @@ impl TryParse for GetDotClocksReply {
         let (clocks, remaining) = u32::try_parse(remaining)?;
         let (maxclocks, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (clock, remaining) = crate::x11_utils::parse_list::<u32>(remaining, 1u32.checked_sub(flags & 1u32).ok_or(ParseError::InvalidExpression)?.checked_mul(clocks).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (clock, remaining) = crate::x11_utils::parse_list::<u32>(remaining, 1u32.checked_sub(u32::from(flags) & 1u32).ok_or(ParseError::InvalidExpression)?.checked_mul(u32::from(clocks)).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -2338,7 +2338,7 @@ impl Serialize for GetDotClocksReply {
         self.clocks.serialize_into(bytes);
         self.maxclocks.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 12]);
-        assert_eq!(self.clock.len(), usize::try_from(1u32.checked_sub(self.flags & 1u32).unwrap().checked_mul(self.clocks).unwrap()).unwrap(), "`clock` has an incorrect length");
+        assert_eq!(self.clock.len(), usize::try_from(1u32.checked_sub(u32::from(self.flags) & 1u32).unwrap().checked_mul(u32::from(self.clocks)).unwrap()).unwrap(), "`clock` has an incorrect length");
         self.clock.serialize_into(bytes);
     }
 }

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `XF86VidMode` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -38,7 +38,7 @@ pub type Dotclock = u32;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ModeFlag(u16);
+pub struct ModeFlag(u32);
 impl ModeFlag {
     pub const POSITIVE_H_SYNC: Self = Self(1 << 0);
     pub const NEGATIVE_H_SYNC: Self = Self(1 << 1);
@@ -54,28 +54,16 @@ impl ModeFlag {
     pub const DOUBLE_CLOCK: Self = Self(1 << 11);
     pub const HALF_CLOCK: Self = Self(1 << 12);
 }
-impl From<ModeFlag> for u16 {
+impl From<ModeFlag> for u32 {
     #[inline]
     fn from(input: ModeFlag) -> Self {
         input.0
     }
 }
-impl From<ModeFlag> for Option<u16> {
-    #[inline]
-    fn from(input: ModeFlag) -> Self {
-        Some(input.0)
-    }
-}
-impl From<ModeFlag> for u32 {
-    #[inline]
-    fn from(input: ModeFlag) -> Self {
-        u32::from(input.0)
-    }
-}
 impl From<ModeFlag> for Option<u32> {
     #[inline]
     fn from(input: ModeFlag) -> Self {
-        Some(u32::from(input.0))
+        Some(input.0)
     }
 }
 impl From<u8> for ModeFlag {
@@ -87,148 +75,130 @@ impl From<u8> for ModeFlag {
 impl From<u16> for ModeFlag {
     #[inline]
     fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for ModeFlag {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for ModeFlag  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::POSITIVE_H_SYNC.0.into(), "POSITIVE_H_SYNC", "PositiveHSync"),
-            (Self::NEGATIVE_H_SYNC.0.into(), "NEGATIVE_H_SYNC", "NegativeHSync"),
-            (Self::POSITIVE_V_SYNC.0.into(), "POSITIVE_V_SYNC", "PositiveVSync"),
-            (Self::NEGATIVE_V_SYNC.0.into(), "NEGATIVE_V_SYNC", "NegativeVSync"),
-            (Self::INTERLACE.0.into(), "INTERLACE", "Interlace"),
-            (Self::COMPOSITE_SYNC.0.into(), "COMPOSITE_SYNC", "CompositeSync"),
-            (Self::POSITIVE_C_SYNC.0.into(), "POSITIVE_C_SYNC", "PositiveCSync"),
-            (Self::NEGATIVE_C_SYNC.0.into(), "NEGATIVE_C_SYNC", "NegativeCSync"),
-            (Self::H_SKEW.0.into(), "H_SKEW", "HSkew"),
-            (Self::BROADCAST.0.into(), "BROADCAST", "Broadcast"),
-            (Self::PIXMUX.0.into(), "PIXMUX", "Pixmux"),
-            (Self::DOUBLE_CLOCK.0.into(), "DOUBLE_CLOCK", "DoubleClock"),
-            (Self::HALF_CLOCK.0.into(), "HALF_CLOCK", "HalfClock"),
+            (Self::POSITIVE_H_SYNC.0, "POSITIVE_H_SYNC", "PositiveHSync"),
+            (Self::NEGATIVE_H_SYNC.0, "NEGATIVE_H_SYNC", "NegativeHSync"),
+            (Self::POSITIVE_V_SYNC.0, "POSITIVE_V_SYNC", "PositiveVSync"),
+            (Self::NEGATIVE_V_SYNC.0, "NEGATIVE_V_SYNC", "NegativeVSync"),
+            (Self::INTERLACE.0, "INTERLACE", "Interlace"),
+            (Self::COMPOSITE_SYNC.0, "COMPOSITE_SYNC", "CompositeSync"),
+            (Self::POSITIVE_C_SYNC.0, "POSITIVE_C_SYNC", "PositiveCSync"),
+            (Self::NEGATIVE_C_SYNC.0, "NEGATIVE_C_SYNC", "NegativeCSync"),
+            (Self::H_SKEW.0, "H_SKEW", "HSkew"),
+            (Self::BROADCAST.0, "BROADCAST", "Broadcast"),
+            (Self::PIXMUX.0, "PIXMUX", "Pixmux"),
+            (Self::DOUBLE_CLOCK.0, "DOUBLE_CLOCK", "DoubleClock"),
+            (Self::HALF_CLOCK.0, "HALF_CLOCK", "HalfClock"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(ModeFlag, u16);
+bitmask_binop!(ModeFlag, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ClockFlag(u8);
+pub struct ClockFlag(u32);
 impl ClockFlag {
     pub const PROGRAMABLE: Self = Self(1 << 0);
 }
-impl From<ClockFlag> for u8 {
+impl From<ClockFlag> for u32 {
     #[inline]
     fn from(input: ClockFlag) -> Self {
         input.0
     }
 }
-impl From<ClockFlag> for Option<u8> {
+impl From<ClockFlag> for Option<u32> {
     #[inline]
     fn from(input: ClockFlag) -> Self {
         Some(input.0)
     }
 }
-impl From<ClockFlag> for u16 {
-    #[inline]
-    fn from(input: ClockFlag) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<ClockFlag> for Option<u16> {
-    #[inline]
-    fn from(input: ClockFlag) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<ClockFlag> for u32 {
-    #[inline]
-    fn from(input: ClockFlag) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<ClockFlag> for Option<u32> {
-    #[inline]
-    fn from(input: ClockFlag) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for ClockFlag {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for ClockFlag {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for ClockFlag {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for ClockFlag  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::PROGRAMABLE.0.into(), "PROGRAMABLE", "Programable"),
+            (Self::PROGRAMABLE.0, "PROGRAMABLE", "Programable"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(ClockFlag, u8);
+bitmask_binop!(ClockFlag, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Permission(u8);
+pub struct Permission(u32);
 impl Permission {
     pub const READ: Self = Self(1 << 0);
     pub const WRITE: Self = Self(1 << 1);
 }
-impl From<Permission> for u8 {
+impl From<Permission> for u32 {
     #[inline]
     fn from(input: Permission) -> Self {
         input.0
     }
 }
-impl From<Permission> for Option<u8> {
+impl From<Permission> for Option<u32> {
     #[inline]
     fn from(input: Permission) -> Self {
         Some(input.0)
     }
 }
-impl From<Permission> for u16 {
-    #[inline]
-    fn from(input: Permission) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<Permission> for Option<u16> {
-    #[inline]
-    fn from(input: Permission) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<Permission> for u32 {
-    #[inline]
-    fn from(input: Permission) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<Permission> for Option<u32> {
-    #[inline]
-    fn from(input: Permission) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for Permission {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for Permission {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for Permission {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for Permission  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::READ.0.into(), "READ", "Read"),
-            (Self::WRITE.0.into(), "WRITE", "Write"),
+            (Self::READ.0, "READ", "Read"),
+            (Self::WRITE.0, "WRITE", "Write"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(Permission, u8);
+bitmask_binop!(Permission, u32);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -697,7 +697,7 @@ pub const SELECT_SELECTION_INPUT_REQUEST: u8 = 2;
 pub struct SelectSelectionInputRequest {
     pub window: xproto::Window,
     pub selection: xproto::Atom,
-    pub event_mask: u32,
+    pub event_mask: SelectionEventMask,
 }
 impl SelectSelectionInputRequest {
     /// Serialize this request into bytes for the provided connection
@@ -705,7 +705,7 @@ impl SelectSelectionInputRequest {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
         let selection_bytes = self.selection.serialize();
-        let event_mask_bytes = self.event_mask.serialize();
+        let event_mask_bytes = u32::from(self.event_mask).serialize();
         let mut request0 = vec![
             major_opcode,
             SELECT_SELECTION_INPUT_REQUEST,
@@ -1009,14 +1009,14 @@ pub const SELECT_CURSOR_INPUT_REQUEST: u8 = 3;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectCursorInputRequest {
     pub window: xproto::Window,
-    pub event_mask: u32,
+    pub event_mask: CursorNotifyMask,
 }
 impl SelectCursorInputRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'static>> {
         let length_so_far = 0;
         let window_bytes = self.window.serialize();
-        let event_mask_bytes = self.event_mask.serialize();
+        let event_mask_bytes = u32::from(self.event_mask).serialize();
         let mut request0 = vec![
             major_opcode,
             SELECT_CURSOR_INPUT_REQUEST,
@@ -3231,7 +3231,7 @@ pub struct CreatePointerBarrierRequest<'input> {
     pub y1: u16,
     pub x2: u16,
     pub y2: u16,
-    pub directions: u32,
+    pub directions: BarrierDirections,
     pub devices: Cow<'input, [u16]>,
 }
 impl<'input> CreatePointerBarrierRequest<'input> {
@@ -3244,7 +3244,7 @@ impl<'input> CreatePointerBarrierRequest<'input> {
         let y1_bytes = self.y1.serialize();
         let x2_bytes = self.x2.serialize();
         let y2_bytes = self.y2.serialize();
-        let directions_bytes = self.directions.serialize();
+        let directions_bytes = u32::from(self.directions).serialize();
         let num_devices = u16::try_from(self.devices.len()).expect("`devices` has too many elements");
         let num_devices_bytes = num_devices.serialize();
         let mut request0 = vec![

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -497,65 +497,53 @@ impl core::fmt::Debug for SelectionEvent  {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct SelectionEventMask(u8);
+pub struct SelectionEventMask(u32);
 impl SelectionEventMask {
     pub const SET_SELECTION_OWNER: Self = Self(1 << 0);
     pub const SELECTION_WINDOW_DESTROY: Self = Self(1 << 1);
     pub const SELECTION_CLIENT_CLOSE: Self = Self(1 << 2);
 }
-impl From<SelectionEventMask> for u8 {
+impl From<SelectionEventMask> for u32 {
     #[inline]
     fn from(input: SelectionEventMask) -> Self {
         input.0
     }
 }
-impl From<SelectionEventMask> for Option<u8> {
+impl From<SelectionEventMask> for Option<u32> {
     #[inline]
     fn from(input: SelectionEventMask) -> Self {
         Some(input.0)
     }
 }
-impl From<SelectionEventMask> for u16 {
-    #[inline]
-    fn from(input: SelectionEventMask) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<SelectionEventMask> for Option<u16> {
-    #[inline]
-    fn from(input: SelectionEventMask) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<SelectionEventMask> for u32 {
-    #[inline]
-    fn from(input: SelectionEventMask) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<SelectionEventMask> for Option<u32> {
-    #[inline]
-    fn from(input: SelectionEventMask) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for SelectionEventMask {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for SelectionEventMask {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for SelectionEventMask {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for SelectionEventMask  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::SET_SELECTION_OWNER.0.into(), "SET_SELECTION_OWNER", "SetSelectionOwner"),
-            (Self::SELECTION_WINDOW_DESTROY.0.into(), "SELECTION_WINDOW_DESTROY", "SelectionWindowDestroy"),
-            (Self::SELECTION_CLIENT_CLOSE.0.into(), "SELECTION_CLIENT_CLOSE", "SelectionClientClose"),
+            (Self::SET_SELECTION_OWNER.0, "SET_SELECTION_OWNER", "SetSelectionOwner"),
+            (Self::SELECTION_WINDOW_DESTROY.0, "SELECTION_WINDOW_DESTROY", "SelectionWindowDestroy"),
+            (Self::SELECTION_CLIENT_CLOSE.0, "SELECTION_CLIENT_CLOSE", "SelectionClientClose"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(SelectionEventMask, u8);
+bitmask_binop!(SelectionEventMask, u32);
 
 /// Opcode for the SelectionNotify event
 pub const SELECTION_NOTIFY_EVENT: u8 = 0;
@@ -830,61 +818,49 @@ impl core::fmt::Debug for CursorNotify  {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct CursorNotifyMask(u8);
+pub struct CursorNotifyMask(u32);
 impl CursorNotifyMask {
     pub const DISPLAY_CURSOR: Self = Self(1 << 0);
 }
-impl From<CursorNotifyMask> for u8 {
+impl From<CursorNotifyMask> for u32 {
     #[inline]
     fn from(input: CursorNotifyMask) -> Self {
         input.0
     }
 }
-impl From<CursorNotifyMask> for Option<u8> {
+impl From<CursorNotifyMask> for Option<u32> {
     #[inline]
     fn from(input: CursorNotifyMask) -> Self {
         Some(input.0)
     }
 }
-impl From<CursorNotifyMask> for u16 {
-    #[inline]
-    fn from(input: CursorNotifyMask) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<CursorNotifyMask> for Option<u16> {
-    #[inline]
-    fn from(input: CursorNotifyMask) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<CursorNotifyMask> for u32 {
-    #[inline]
-    fn from(input: CursorNotifyMask) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<CursorNotifyMask> for Option<u32> {
-    #[inline]
-    fn from(input: CursorNotifyMask) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for CursorNotifyMask {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for CursorNotifyMask {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for CursorNotifyMask {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for CursorNotifyMask  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::DISPLAY_CURSOR.0.into(), "DISPLAY_CURSOR", "DisplayCursor"),
+            (Self::DISPLAY_CURSOR.0, "DISPLAY_CURSOR", "DisplayCursor"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(CursorNotifyMask, u8);
+bitmask_binop!(CursorNotifyMask, u32);
 
 /// Opcode for the CursorNotify event
 pub const CURSOR_NOTIFY_EVENT: u8 = 1;
@@ -3192,67 +3168,55 @@ pub type Barrier = u32;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct BarrierDirections(u8);
+pub struct BarrierDirections(u32);
 impl BarrierDirections {
     pub const POSITIVE_X: Self = Self(1 << 0);
     pub const POSITIVE_Y: Self = Self(1 << 1);
     pub const NEGATIVE_X: Self = Self(1 << 2);
     pub const NEGATIVE_Y: Self = Self(1 << 3);
 }
-impl From<BarrierDirections> for u8 {
+impl From<BarrierDirections> for u32 {
     #[inline]
     fn from(input: BarrierDirections) -> Self {
         input.0
     }
 }
-impl From<BarrierDirections> for Option<u8> {
+impl From<BarrierDirections> for Option<u32> {
     #[inline]
     fn from(input: BarrierDirections) -> Self {
         Some(input.0)
     }
 }
-impl From<BarrierDirections> for u16 {
-    #[inline]
-    fn from(input: BarrierDirections) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<BarrierDirections> for Option<u16> {
-    #[inline]
-    fn from(input: BarrierDirections) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<BarrierDirections> for u32 {
-    #[inline]
-    fn from(input: BarrierDirections) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<BarrierDirections> for Option<u32> {
-    #[inline]
-    fn from(input: BarrierDirections) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for BarrierDirections {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for BarrierDirections {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for BarrierDirections {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for BarrierDirections  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::POSITIVE_X.0.into(), "POSITIVE_X", "PositiveX"),
-            (Self::POSITIVE_Y.0.into(), "POSITIVE_Y", "PositiveY"),
-            (Self::NEGATIVE_X.0.into(), "NEGATIVE_X", "NegativeX"),
-            (Self::NEGATIVE_Y.0.into(), "NEGATIVE_Y", "NegativeY"),
+            (Self::POSITIVE_X.0, "POSITIVE_X", "PositiveX"),
+            (Self::POSITIVE_Y.0, "POSITIVE_Y", "PositiveY"),
+            (Self::NEGATIVE_X.0, "NEGATIVE_X", "NegativeX"),
+            (Self::NEGATIVE_Y.0, "NEGATIVE_Y", "NegativeY"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(BarrierDirections, u8);
+bitmask_binop!(BarrierDirections, u32);
 
 /// Opcode for the CreatePointerBarrier request
 pub const CREATE_POINTER_BARRIER_REQUEST: u8 = 31;

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -738,6 +738,7 @@ impl SelectSelectionInputRequest {
         let (window, remaining) = xproto::Window::try_parse(value)?;
         let (selection, remaining) = xproto::Atom::try_parse(remaining)?;
         let (event_mask, remaining) = u32::try_parse(remaining)?;
+        let event_mask = event_mask.into();
         let _ = remaining;
         Ok(SelectSelectionInputRequest {
             window,
@@ -1043,6 +1044,7 @@ impl SelectCursorInputRequest {
         }
         let (window, remaining) = xproto::Window::try_parse(value)?;
         let (event_mask, remaining) = u32::try_parse(remaining)?;
+        let event_mask = event_mask.into();
         let _ = remaining;
         Ok(SelectCursorInputRequest {
             window,
@@ -3297,6 +3299,7 @@ impl<'input> CreatePointerBarrierRequest<'input> {
         let (x2, remaining) = u16::try_parse(remaining)?;
         let (y2, remaining) = u16::try_parse(remaining)?;
         let (directions, remaining) = u32::try_parse(remaining)?;
+        let directions = directions.into();
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (num_devices, remaining) = u16::try_parse(remaining)?;
         let (devices, remaining) = crate::x11_utils::parse_list::<u16>(remaining, num_devices.try_to_usize()?)?;

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -2231,7 +2231,7 @@ impl TryParse for FetchRegionReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (extents, remaining) = xproto::Rectangle::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::InsufficientData)?;
-        let (rectangles, remaining) = crate::x11_utils::parse_list::<xproto::Rectangle>(remaining, length.checked_div(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (rectangles, remaining) = crate::x11_utils::parse_list::<xproto::Rectangle>(remaining, u32::from(length).checked_div(2u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `XFixes` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xinerama.rs
+++ b/x11rb-protocol/src/protocol/xinerama.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Xinerama` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -5304,7 +5304,7 @@ impl Serialize for FeedbackCtl {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ChangeFeedbackControlMask(u8);
+pub struct ChangeFeedbackControlMask(u32);
 impl ChangeFeedbackControlMask {
     pub const KEY_CLICK_PERCENT: Self = Self(1 << 0);
     pub const PERCENT: Self = Self(1 << 1);
@@ -5320,69 +5320,57 @@ impl ChangeFeedbackControlMask {
     pub const ACCEL_DENOM: Self = Self(1 << 1);
     pub const THRESHOLD: Self = Self(1 << 2);
 }
-impl From<ChangeFeedbackControlMask> for u8 {
+impl From<ChangeFeedbackControlMask> for u32 {
     #[inline]
     fn from(input: ChangeFeedbackControlMask) -> Self {
         input.0
     }
 }
-impl From<ChangeFeedbackControlMask> for Option<u8> {
+impl From<ChangeFeedbackControlMask> for Option<u32> {
     #[inline]
     fn from(input: ChangeFeedbackControlMask) -> Self {
         Some(input.0)
     }
 }
-impl From<ChangeFeedbackControlMask> for u16 {
-    #[inline]
-    fn from(input: ChangeFeedbackControlMask) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<ChangeFeedbackControlMask> for Option<u16> {
-    #[inline]
-    fn from(input: ChangeFeedbackControlMask) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<ChangeFeedbackControlMask> for u32 {
-    #[inline]
-    fn from(input: ChangeFeedbackControlMask) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<ChangeFeedbackControlMask> for Option<u32> {
-    #[inline]
-    fn from(input: ChangeFeedbackControlMask) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for ChangeFeedbackControlMask {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for ChangeFeedbackControlMask {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for ChangeFeedbackControlMask {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for ChangeFeedbackControlMask  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::KEY_CLICK_PERCENT.0.into(), "KEY_CLICK_PERCENT", "KeyClickPercent"),
-            (Self::PERCENT.0.into(), "PERCENT", "Percent"),
-            (Self::PITCH.0.into(), "PITCH", "Pitch"),
-            (Self::DURATION.0.into(), "DURATION", "Duration"),
-            (Self::LED.0.into(), "LED", "Led"),
-            (Self::LED_MODE.0.into(), "LED_MODE", "LedMode"),
-            (Self::KEY.0.into(), "KEY", "Key"),
-            (Self::AUTO_REPEAT_MODE.0.into(), "AUTO_REPEAT_MODE", "AutoRepeatMode"),
-            (Self::STRING.0.into(), "STRING", "String"),
-            (Self::INTEGER.0.into(), "INTEGER", "Integer"),
-            (Self::ACCEL_NUM.0.into(), "ACCEL_NUM", "AccelNum"),
-            (Self::ACCEL_DENOM.0.into(), "ACCEL_DENOM", "AccelDenom"),
-            (Self::THRESHOLD.0.into(), "THRESHOLD", "Threshold"),
+            (Self::KEY_CLICK_PERCENT.0, "KEY_CLICK_PERCENT", "KeyClickPercent"),
+            (Self::PERCENT.0, "PERCENT", "Percent"),
+            (Self::PITCH.0, "PITCH", "Pitch"),
+            (Self::DURATION.0, "DURATION", "Duration"),
+            (Self::LED.0, "LED", "Led"),
+            (Self::LED_MODE.0, "LED_MODE", "LedMode"),
+            (Self::KEY.0, "KEY", "Key"),
+            (Self::AUTO_REPEAT_MODE.0, "AUTO_REPEAT_MODE", "AutoRepeatMode"),
+            (Self::STRING.0, "STRING", "String"),
+            (Self::INTEGER.0, "INTEGER", "Integer"),
+            (Self::ACCEL_NUM.0, "ACCEL_NUM", "AccelNum"),
+            (Self::ACCEL_DENOM.0, "ACCEL_DENOM", "AccelDenom"),
+            (Self::THRESHOLD.0, "THRESHOLD", "Threshold"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(ChangeFeedbackControlMask, u8);
+bitmask_binop!(ChangeFeedbackControlMask, u32);
 
 /// Opcode for the ChangeFeedbackControl request
 pub const CHANGE_FEEDBACK_CONTROL_REQUEST: u8 = 23;
@@ -11502,63 +11490,51 @@ impl core::fmt::Debug for DeviceType  {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ScrollFlags(u8);
+pub struct ScrollFlags(u32);
 impl ScrollFlags {
     pub const NO_EMULATION: Self = Self(1 << 0);
     pub const PREFERRED: Self = Self(1 << 1);
 }
-impl From<ScrollFlags> for u8 {
+impl From<ScrollFlags> for u32 {
     #[inline]
     fn from(input: ScrollFlags) -> Self {
         input.0
     }
 }
-impl From<ScrollFlags> for Option<u8> {
+impl From<ScrollFlags> for Option<u32> {
     #[inline]
     fn from(input: ScrollFlags) -> Self {
         Some(input.0)
     }
 }
-impl From<ScrollFlags> for u16 {
-    #[inline]
-    fn from(input: ScrollFlags) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<ScrollFlags> for Option<u16> {
-    #[inline]
-    fn from(input: ScrollFlags) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<ScrollFlags> for u32 {
-    #[inline]
-    fn from(input: ScrollFlags) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<ScrollFlags> for Option<u32> {
-    #[inline]
-    fn from(input: ScrollFlags) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for ScrollFlags {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for ScrollFlags {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for ScrollFlags {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for ScrollFlags  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::NO_EMULATION.0.into(), "NO_EMULATION", "NoEmulation"),
-            (Self::PREFERRED.0.into(), "PREFERRED", "Preferred"),
+            (Self::NO_EMULATION.0, "NO_EMULATION", "NoEmulation"),
+            (Self::PREFERRED.0, "PREFERRED", "Preferred"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(ScrollFlags, u8);
+bitmask_binop!(ScrollFlags, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -17229,7 +17205,7 @@ pub type FocusOutEvent = EnterEvent;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct HierarchyMask(u8);
+pub struct HierarchyMask(u32);
 impl HierarchyMask {
     pub const MASTER_ADDED: Self = Self(1 << 0);
     pub const MASTER_REMOVED: Self = Self(1 << 1);
@@ -17240,64 +17216,52 @@ impl HierarchyMask {
     pub const DEVICE_ENABLED: Self = Self(1 << 6);
     pub const DEVICE_DISABLED: Self = Self(1 << 7);
 }
-impl From<HierarchyMask> for u8 {
+impl From<HierarchyMask> for u32 {
     #[inline]
     fn from(input: HierarchyMask) -> Self {
         input.0
     }
 }
-impl From<HierarchyMask> for Option<u8> {
+impl From<HierarchyMask> for Option<u32> {
     #[inline]
     fn from(input: HierarchyMask) -> Self {
         Some(input.0)
     }
 }
-impl From<HierarchyMask> for u16 {
-    #[inline]
-    fn from(input: HierarchyMask) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<HierarchyMask> for Option<u16> {
-    #[inline]
-    fn from(input: HierarchyMask) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<HierarchyMask> for u32 {
-    #[inline]
-    fn from(input: HierarchyMask) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<HierarchyMask> for Option<u32> {
-    #[inline]
-    fn from(input: HierarchyMask) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for HierarchyMask {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for HierarchyMask {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for HierarchyMask {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for HierarchyMask  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::MASTER_ADDED.0.into(), "MASTER_ADDED", "MasterAdded"),
-            (Self::MASTER_REMOVED.0.into(), "MASTER_REMOVED", "MasterRemoved"),
-            (Self::SLAVE_ADDED.0.into(), "SLAVE_ADDED", "SlaveAdded"),
-            (Self::SLAVE_REMOVED.0.into(), "SLAVE_REMOVED", "SlaveRemoved"),
-            (Self::SLAVE_ATTACHED.0.into(), "SLAVE_ATTACHED", "SlaveAttached"),
-            (Self::SLAVE_DETACHED.0.into(), "SLAVE_DETACHED", "SlaveDetached"),
-            (Self::DEVICE_ENABLED.0.into(), "DEVICE_ENABLED", "DeviceEnabled"),
-            (Self::DEVICE_DISABLED.0.into(), "DEVICE_DISABLED", "DeviceDisabled"),
+            (Self::MASTER_ADDED.0, "MASTER_ADDED", "MasterAdded"),
+            (Self::MASTER_REMOVED.0, "MASTER_REMOVED", "MasterRemoved"),
+            (Self::SLAVE_ADDED.0, "SLAVE_ADDED", "SlaveAdded"),
+            (Self::SLAVE_REMOVED.0, "SLAVE_REMOVED", "SlaveRemoved"),
+            (Self::SLAVE_ATTACHED.0, "SLAVE_ATTACHED", "SlaveAttached"),
+            (Self::SLAVE_DETACHED.0, "SLAVE_DETACHED", "SlaveDetached"),
+            (Self::DEVICE_ENABLED.0, "DEVICE_ENABLED", "DeviceEnabled"),
+            (Self::DEVICE_DISABLED.0, "DEVICE_DISABLED", "DeviceDisabled"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(HierarchyMask, u8);
+bitmask_binop!(HierarchyMask, u32);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -18242,63 +18206,51 @@ pub type RawTouchEndEvent = RawTouchBeginEvent;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct BarrierFlags(u8);
+pub struct BarrierFlags(u32);
 impl BarrierFlags {
     pub const POINTER_RELEASED: Self = Self(1 << 0);
     pub const DEVICE_IS_GRABBED: Self = Self(1 << 1);
 }
-impl From<BarrierFlags> for u8 {
+impl From<BarrierFlags> for u32 {
     #[inline]
     fn from(input: BarrierFlags) -> Self {
         input.0
     }
 }
-impl From<BarrierFlags> for Option<u8> {
+impl From<BarrierFlags> for Option<u32> {
     #[inline]
     fn from(input: BarrierFlags) -> Self {
         Some(input.0)
     }
 }
-impl From<BarrierFlags> for u16 {
-    #[inline]
-    fn from(input: BarrierFlags) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<BarrierFlags> for Option<u16> {
-    #[inline]
-    fn from(input: BarrierFlags) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<BarrierFlags> for u32 {
-    #[inline]
-    fn from(input: BarrierFlags) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<BarrierFlags> for Option<u32> {
-    #[inline]
-    fn from(input: BarrierFlags) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for BarrierFlags {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for BarrierFlags {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for BarrierFlags {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for BarrierFlags  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::POINTER_RELEASED.0.into(), "POINTER_RELEASED", "PointerReleased"),
-            (Self::DEVICE_IS_GRABBED.0.into(), "DEVICE_IS_GRABBED", "DeviceIsGrabbed"),
+            (Self::POINTER_RELEASED.0, "POINTER_RELEASED", "PointerReleased"),
+            (Self::DEVICE_IS_GRABBED.0, "DEVICE_IS_GRABBED", "DeviceIsGrabbed"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(BarrierFlags, u8);
+bitmask_binop!(BarrierFlags, u32);
 
 /// Opcode for the BarrierHit event
 pub const BARRIER_HIT_EVENT: u16 = 25;

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -854,7 +854,7 @@ impl InputInfoInfo {
     #[allow(dead_code)]
     fn serialize(&self, class_id: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, class_id);
+        self.serialize_into(&mut result, u8::from(class_id));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
@@ -905,7 +905,7 @@ impl Serialize for InputInfo {
         let class_id: u8 = self.info.switch_expr();
         class_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
-        self.info.serialize_into(bytes, class_id);
+        self.info.serialize_into(bytes, u8::from(class_id));
     }
 }
 
@@ -1920,7 +1920,7 @@ impl DeviceTimeCoord {
     #[allow(dead_code)]
     fn serialize(&self, num_axes: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, num_axes);
+        self.serialize_into(&mut result, u8::from(num_axes));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, num_axes: u8) {
@@ -2061,7 +2061,7 @@ impl Serialize for GetDeviceMotionEventsReply {
         u8::from(self.device_mode).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 18]);
         for element in self.events.iter() {
-            element.serialize_into(bytes, self.num_axes);
+            element.serialize_into(bytes, u8::from(self.num_axes));
         }
     }
 }
@@ -4330,7 +4330,7 @@ impl FeedbackStateData {
     #[allow(dead_code)]
     fn serialize(&self, class_id: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, class_id);
+        self.serialize_into(&mut result, u8::from(class_id));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
@@ -4390,7 +4390,7 @@ impl Serialize for FeedbackState {
         class_id.serialize_into(bytes);
         self.feedback_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
-        self.data.serialize_into(bytes, class_id);
+        self.data.serialize_into(bytes, u8::from(class_id));
     }
 }
 
@@ -5242,7 +5242,7 @@ impl FeedbackCtlData {
     #[allow(dead_code)]
     fn serialize(&self, class_id: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, class_id);
+        self.serialize_into(&mut result, u8::from(class_id));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
@@ -5302,7 +5302,7 @@ impl Serialize for FeedbackCtl {
         class_id.serialize_into(bytes);
         self.feedback_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
-        self.data.serialize_into(bytes, class_id);
+        self.data.serialize_into(bytes, u8::from(class_id));
     }
 }
 
@@ -6726,7 +6726,7 @@ impl InputStateData {
     #[allow(dead_code)]
     fn serialize(&self, class_id: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, class_id);
+        self.serialize_into(&mut result, u8::from(class_id));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
@@ -6777,7 +6777,7 @@ impl Serialize for InputState {
         let class_id: u8 = self.data.switch_expr();
         class_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
-        self.data.serialize_into(bytes, class_id);
+        self.data.serialize_into(bytes, u8::from(class_id));
     }
 }
 
@@ -7846,7 +7846,7 @@ impl DeviceStateData {
     #[allow(dead_code)]
     fn serialize(&self, control_id: u16) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, control_id);
+        self.serialize_into(&mut result, u16::from(control_id));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, control_id: u16) {
@@ -7905,7 +7905,7 @@ impl Serialize for DeviceState {
         let control_id: u16 = self.data.switch_expr();
         control_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
-        self.data.serialize_into(bytes, control_id);
+        self.data.serialize_into(bytes, u16::from(control_id));
     }
 }
 
@@ -8667,7 +8667,7 @@ impl DeviceCtlData {
     #[allow(dead_code)]
     fn serialize(&self, control_id: u16) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, control_id);
+        self.serialize_into(&mut result, u16::from(control_id));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, control_id: u16) {
@@ -8726,7 +8726,7 @@ impl Serialize for DeviceCtl {
         let control_id: u16 = self.data.switch_expr();
         control_id.serialize_into(bytes);
         self.len.serialize_into(bytes);
-        self.data.serialize_into(bytes, control_id);
+        self.data.serialize_into(bytes, u16::from(control_id));
     }
 }
 
@@ -9142,7 +9142,7 @@ impl ChangeDevicePropertyAux {
     #[allow(dead_code)]
     fn serialize(&self, format: u8, num_items: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, format, num_items);
+        self.serialize_into(&mut result, u8::from(format), u32::from(num_items));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
@@ -9224,7 +9224,7 @@ impl<'input> ChangeDevicePropertyRequest<'input> {
             num_items_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let items_bytes = self.items.serialize(format, self.num_items);
+        let items_bytes = self.items.serialize(u8::from(format), u32::from(self.num_items));
         let length_so_far = length_so_far + items_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -9518,7 +9518,7 @@ impl GetDevicePropertyItems {
     #[allow(dead_code)]
     fn serialize(&self, format: u8, num_items: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, format, num_items);
+        self.serialize_into(&mut result, u8::from(format), u32::from(num_items));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
@@ -9611,7 +9611,7 @@ impl Serialize for GetDevicePropertyReply {
         format.serialize_into(bytes);
         self.device_id.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 10]);
-        self.items.serialize_into(bytes, format, self.num_items);
+        self.items.serialize_into(bytes, u8::from(format), u32::from(self.num_items));
     }
 }
 
@@ -10693,7 +10693,7 @@ impl HierarchyChangeData {
     #[allow(dead_code)]
     fn serialize(&self, type_: u16) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, type_);
+        self.serialize_into(&mut result, u16::from(type_));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, type_: u16) {
@@ -10746,7 +10746,7 @@ impl Serialize for HierarchyChange {
         let type_: u16 = self.data.switch_expr();
         type_.serialize_into(bytes);
         self.len.serialize_into(bytes);
-        self.data.serialize_into(bytes, type_);
+        self.data.serialize_into(bytes, u16::from(type_));
     }
 }
 
@@ -12372,7 +12372,7 @@ impl DeviceClassData {
     #[allow(dead_code)]
     fn serialize(&self, type_: u16) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, type_);
+        self.serialize_into(&mut result, u16::from(type_));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, type_: u16) {
@@ -12430,7 +12430,7 @@ impl Serialize for DeviceClass {
         type_.serialize_into(bytes);
         self.len.serialize_into(bytes);
         self.sourceid.serialize_into(bytes);
-        self.data.serialize_into(bytes, type_);
+        self.data.serialize_into(bytes, u16::from(type_));
     }
 }
 
@@ -14054,7 +14054,7 @@ impl XIChangePropertyAux {
     #[allow(dead_code)]
     fn serialize(&self, format: u8, num_items: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, format, num_items);
+        self.serialize_into(&mut result, u8::from(format), u32::from(num_items));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
@@ -14136,7 +14136,7 @@ impl<'input> XIChangePropertyRequest<'input> {
             num_items_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let items_bytes = self.items.serialize(format, self.num_items);
+        let items_bytes = self.items.serialize(u8::from(format), u32::from(self.num_items));
         let length_so_far = length_so_far + items_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -14429,7 +14429,7 @@ impl XIGetPropertyItems {
     #[allow(dead_code)]
     fn serialize(&self, format: u8, num_items: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, format, num_items);
+        self.serialize_into(&mut result, u8::from(format), u32::from(num_items));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
@@ -14518,7 +14518,7 @@ impl Serialize for XIGetPropertyReply {
         let format: u8 = self.items.switch_expr();
         format.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 11]);
-        self.items.serialize_into(bytes, format, self.num_items);
+        self.items.serialize_into(bytes, u8::from(format), u32::from(self.num_items));
     }
 }
 

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -2684,7 +2684,7 @@ pub const GRAB_DEVICE_KEY_REQUEST: u8 = 15;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabDeviceKeyRequest<'input> {
     pub grab_window: xproto::Window,
-    pub modifiers: u16,
+    pub modifiers: xproto::ModMask,
     pub modifier_device: u8,
     pub grabbed_device: u8,
     pub key: u8,
@@ -2700,7 +2700,7 @@ impl<'input> GrabDeviceKeyRequest<'input> {
         let grab_window_bytes = self.grab_window.serialize();
         let num_classes = u16::try_from(self.classes.len()).expect("`classes` has too many elements");
         let num_classes_bytes = num_classes.serialize();
-        let modifiers_bytes = self.modifiers.serialize();
+        let modifiers_bytes = u16::from(self.modifiers).serialize();
         let modifier_device_bytes = self.modifier_device.serialize();
         let grabbed_device_bytes = self.grabbed_device.serialize();
         let key_bytes = self.key.serialize();
@@ -2805,7 +2805,7 @@ pub const UNGRAB_DEVICE_KEY_REQUEST: u8 = 16;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabDeviceKeyRequest {
     pub grab_window: xproto::Window,
-    pub modifiers: u16,
+    pub modifiers: xproto::ModMask,
     pub modifier_device: u8,
     pub key: u8,
     pub grabbed_device: u8,
@@ -2815,7 +2815,7 @@ impl UngrabDeviceKeyRequest {
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'static>> {
         let length_so_far = 0;
         let grab_window_bytes = self.grab_window.serialize();
-        let modifiers_bytes = self.modifiers.serialize();
+        let modifiers_bytes = u16::from(self.modifiers).serialize();
         let modifier_device_bytes = self.modifier_device.serialize();
         let key_bytes = self.key.serialize();
         let grabbed_device_bytes = self.grabbed_device.serialize();
@@ -2885,7 +2885,7 @@ pub struct GrabDeviceButtonRequest<'input> {
     pub grab_window: xproto::Window,
     pub grabbed_device: u8,
     pub modifier_device: u8,
-    pub modifiers: u16,
+    pub modifiers: xproto::ModMask,
     pub this_device_mode: xproto::GrabMode,
     pub other_device_mode: xproto::GrabMode,
     pub button: u8,
@@ -2901,7 +2901,7 @@ impl<'input> GrabDeviceButtonRequest<'input> {
         let modifier_device_bytes = self.modifier_device.serialize();
         let num_classes = u16::try_from(self.classes.len()).expect("`classes` has too many elements");
         let num_classes_bytes = num_classes.serialize();
-        let modifiers_bytes = self.modifiers.serialize();
+        let modifiers_bytes = u16::from(self.modifiers).serialize();
         let this_device_mode_bytes = u8::from(self.this_device_mode).serialize();
         let other_device_mode_bytes = u8::from(self.other_device_mode).serialize();
         let button_bytes = self.button.serialize();
@@ -3004,7 +3004,7 @@ pub const UNGRAB_DEVICE_BUTTON_REQUEST: u8 = 18;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabDeviceButtonRequest {
     pub grab_window: xproto::Window,
-    pub modifiers: u16,
+    pub modifiers: xproto::ModMask,
     pub modifier_device: u8,
     pub button: u8,
     pub grabbed_device: u8,
@@ -3014,7 +3014,7 @@ impl UngrabDeviceButtonRequest {
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'static>> {
         let length_so_far = 0;
         let grab_window_bytes = self.grab_window.serialize();
-        let modifiers_bytes = self.modifiers.serialize();
+        let modifiers_bytes = u16::from(self.modifiers).serialize();
         let modifier_device_bytes = self.modifier_device.serialize();
         let button_bytes = self.button.serialize();
         let grabbed_device_bytes = self.grabbed_device.serialize();
@@ -5381,7 +5381,7 @@ pub const CHANGE_FEEDBACK_CONTROL_REQUEST: u8 = 23;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeFeedbackControlRequest {
-    pub mask: u32,
+    pub mask: ChangeFeedbackControlMask,
     pub device_id: u8,
     pub feedback_id: u8,
     pub feedback: FeedbackCtl,
@@ -5390,7 +5390,7 @@ impl ChangeFeedbackControlRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'static>> {
         let length_so_far = 0;
-        let mask_bytes = self.mask.serialize();
+        let mask_bytes = u32::from(self.mask).serialize();
         let device_id_bytes = self.device_id.serialize();
         let feedback_id_bytes = self.feedback_id.serialize();
         let mut request0 = vec![
@@ -6434,7 +6434,7 @@ bitmask_binop!(ValuatorStateModeMask, u8);
 pub struct ValuatorState {
     pub class_id: InputClass,
     pub len: u8,
-    pub mode: u8,
+    pub mode: ValuatorStateModeMask,
     pub valuators: Vec<i32>,
 }
 impl TryParse for ValuatorState {
@@ -6463,7 +6463,7 @@ impl Serialize for ValuatorState {
         self.len.serialize_into(bytes);
         let num_valuators = u8::try_from(self.valuators.len()).expect("`valuators` has too many elements");
         num_valuators.serialize_into(bytes);
-        self.mode.serialize_into(bytes);
+        u8::from(self.mode).serialize_into(bytes);
         self.valuators.serialize_into(bytes);
     }
 }
@@ -6614,7 +6614,7 @@ impl Serialize for InputStateDataButton {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputStateDataValuator {
-    pub mode: u8,
+    pub mode: ValuatorStateModeMask,
     pub valuators: Vec<i32>,
 }
 impl TryParse for InputStateDataValuator {
@@ -6638,7 +6638,7 @@ impl Serialize for InputStateDataValuator {
         bytes.reserve(2);
         let num_valuators = u8::try_from(self.valuators.len()).expect("`valuators` has too many elements");
         num_valuators.serialize_into(bytes);
-        self.mode.serialize_into(bytes);
+        u8::from(self.mode).serialize_into(bytes);
         self.valuators.serialize_into(bytes);
     }
 }
@@ -11118,7 +11118,7 @@ bitmask_binop!(XIEventMask, u32);
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EventMask {
     pub deviceid: DeviceId,
-    pub mask: Vec<u32>,
+    pub mask: Vec<XIEventMask>,
 }
 impl TryParse for EventMask {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11149,8 +11149,8 @@ impl Serialize for EventMask {
         self.deviceid.serialize_into(bytes);
         let mask_len = u16::try_from(self.mask.len()).expect("`mask` has too many elements");
         mask_len.serialize_into(bytes);
-        for element in self.mask.iter() {
-            element.serialize_into(bytes);
+        for element in self.mask.iter().copied() {
+            u32::from(element).serialize_into(bytes);
         }
     }
 }
@@ -11783,7 +11783,7 @@ pub struct ScrollClass {
     pub sourceid: DeviceId,
     pub number: u16,
     pub scroll_type: ScrollType,
-    pub flags: u32,
+    pub flags: ScrollFlags,
     pub increment: Fp3232,
 }
 impl TryParse for ScrollClass {
@@ -11811,7 +11811,7 @@ impl Serialize for ScrollClass {
         let sourceid_bytes = self.sourceid.serialize();
         let number_bytes = self.number.serialize();
         let scroll_type_bytes = u16::from(self.scroll_type).serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u32::from(self.flags).serialize();
         let increment_bytes = self.increment.serialize();
         [
             type_bytes[0],
@@ -11848,7 +11848,7 @@ impl Serialize for ScrollClass {
         self.number.serialize_into(bytes);
         u16::from(self.scroll_type).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         self.increment.serialize_into(bytes);
     }
 }
@@ -12193,7 +12193,7 @@ impl Serialize for DeviceClassDataValuator {
 pub struct DeviceClassDataScroll {
     pub number: u16,
     pub scroll_type: ScrollType,
-    pub flags: u32,
+    pub flags: ScrollFlags,
     pub increment: Fp3232,
 }
 impl TryParse for DeviceClassDataScroll {
@@ -12214,7 +12214,7 @@ impl Serialize for DeviceClassDataScroll {
     fn serialize(&self) -> [u8; 18] {
         let number_bytes = self.number.serialize();
         let scroll_type_bytes = u16::from(self.scroll_type).serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u32::from(self.flags).serialize();
         let increment_bytes = self.increment.serialize();
         [
             number_bytes[0],
@@ -12242,7 +12242,7 @@ impl Serialize for DeviceClassDataScroll {
         self.number.serialize_into(bytes);
         u16::from(self.scroll_type).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         self.increment.serialize_into(bytes);
     }
 }
@@ -14985,7 +14985,7 @@ pub struct DeviceKeyPressEvent {
     pub root_y: i16,
     pub event_x: i16,
     pub event_y: i16,
-    pub state: u16,
+    pub state: xproto::KeyButMask,
     pub same_screen: bool,
     pub device_id: u8,
 }
@@ -15028,7 +15028,7 @@ impl Serialize for DeviceKeyPressEvent {
         let root_y_bytes = self.root_y.serialize();
         let event_x_bytes = self.event_x.serialize();
         let event_y_bytes = self.event_y.serialize();
-        let state_bytes = self.state.serialize();
+        let state_bytes = u16::from(self.state).serialize();
         let same_screen_bytes = self.same_screen.serialize();
         let device_id_bytes = self.device_id.serialize();
         [
@@ -15079,7 +15079,7 @@ impl Serialize for DeviceKeyPressEvent {
         self.root_y.serialize_into(bytes);
         self.event_x.serialize_into(bytes);
         self.event_y.serialize_into(bytes);
-        self.state.serialize_into(bytes);
+        u16::from(self.state).serialize_into(bytes);
         self.same_screen.serialize_into(bytes);
         self.device_id.serialize_into(bytes);
     }
@@ -15097,7 +15097,7 @@ impl From<&DeviceKeyPressEvent> for [u8; 32] {
         let root_y_bytes = input.root_y.serialize();
         let event_x_bytes = input.event_x.serialize();
         let event_y_bytes = input.event_y.serialize();
-        let state_bytes = input.state.serialize();
+        let state_bytes = u16::from(input.state).serialize();
         let same_screen_bytes = input.same_screen.serialize();
         let device_id_bytes = input.device_id.serialize();
         [
@@ -15389,7 +15389,7 @@ pub struct DeviceStateNotifyEvent {
     pub num_keys: u8,
     pub num_buttons: u8,
     pub num_valuators: u8,
-    pub classes_reported: u8,
+    pub classes_reported: ClassesReportedMask,
     pub buttons: [u8; 4],
     pub keys: [u8; 4],
     pub valuators: [u32; 3],
@@ -15435,7 +15435,7 @@ impl Serialize for DeviceStateNotifyEvent {
         let num_keys_bytes = self.num_keys.serialize();
         let num_buttons_bytes = self.num_buttons.serialize();
         let num_valuators_bytes = self.num_valuators.serialize();
-        let classes_reported_bytes = self.classes_reported.serialize();
+        let classes_reported_bytes = u8::from(self.classes_reported).serialize();
         let valuators_0_bytes = self.valuators[0].serialize();
         let valuators_1_bytes = self.valuators[1].serialize();
         let valuators_2_bytes = self.valuators[2].serialize();
@@ -15483,7 +15483,7 @@ impl Serialize for DeviceStateNotifyEvent {
         self.num_keys.serialize_into(bytes);
         self.num_buttons.serialize_into(bytes);
         self.num_valuators.serialize_into(bytes);
-        self.classes_reported.serialize_into(bytes);
+        u8::from(self.classes_reported).serialize_into(bytes);
         bytes.extend_from_slice(&self.buttons);
         bytes.extend_from_slice(&self.keys);
         self.valuators.serialize_into(bytes);
@@ -15498,7 +15498,7 @@ impl From<&DeviceStateNotifyEvent> for [u8; 32] {
         let num_keys_bytes = input.num_keys.serialize();
         let num_buttons_bytes = input.num_buttons.serialize();
         let num_valuators_bytes = input.num_valuators.serialize();
-        let classes_reported_bytes = input.classes_reported.serialize();
+        let classes_reported_bytes = u8::from(input.classes_reported).serialize();
         let valuators_0_bytes = input.valuators[0].serialize();
         let valuators_1_bytes = input.valuators[1].serialize();
         let valuators_2_bytes = input.valuators[2].serialize();
@@ -16661,7 +16661,7 @@ pub struct KeyPressEvent {
     pub event_x: Fp1616,
     pub event_y: Fp1616,
     pub sourceid: DeviceId,
-    pub flags: u32,
+    pub flags: KeyEventFlags,
     pub mods: ModifierInfo,
     pub group: GroupInfo,
     pub button_mask: Vec<u32>,
@@ -16734,7 +16734,7 @@ impl Serialize for KeyPressEvent {
         valuators_len.serialize_into(bytes);
         self.sourceid.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         self.mods.serialize_into(bytes);
         self.group.serialize_into(bytes);
         self.button_mask.serialize_into(bytes);
@@ -16843,7 +16843,7 @@ pub struct ButtonPressEvent {
     pub event_x: Fp1616,
     pub event_y: Fp1616,
     pub sourceid: DeviceId,
-    pub flags: u32,
+    pub flags: PointerEventFlags,
     pub mods: ModifierInfo,
     pub group: GroupInfo,
     pub button_mask: Vec<u32>,
@@ -16916,7 +16916,7 @@ impl Serialize for ButtonPressEvent {
         valuators_len.serialize_into(bytes);
         self.sourceid.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         self.mods.serialize_into(bytes);
         self.group.serialize_into(bytes);
         self.button_mask.serialize_into(bytes);
@@ -17293,7 +17293,7 @@ pub struct HierarchyInfo {
     pub attachment: DeviceId,
     pub type_: DeviceType,
     pub enabled: bool,
-    pub flags: u32,
+    pub flags: HierarchyMask,
 }
 impl TryParse for HierarchyInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -17316,7 +17316,7 @@ impl Serialize for HierarchyInfo {
         let attachment_bytes = self.attachment.serialize();
         let type_bytes = (u16::from(self.type_) as u8).serialize();
         let enabled_bytes = self.enabled.serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u32::from(self.flags).serialize();
         [
             deviceid_bytes[0],
             deviceid_bytes[1],
@@ -17339,7 +17339,7 @@ impl Serialize for HierarchyInfo {
         (u16::from(self.type_) as u8).serialize_into(bytes);
         self.enabled.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
     }
 }
 
@@ -17355,7 +17355,7 @@ pub struct HierarchyEvent {
     pub event_type: u16,
     pub deviceid: DeviceId,
     pub time: xproto::Timestamp,
-    pub flags: u32,
+    pub flags: HierarchyMask,
     pub infos: Vec<HierarchyInfo>,
 }
 impl TryParse for HierarchyEvent {
@@ -17396,7 +17396,7 @@ impl Serialize for HierarchyEvent {
         self.event_type.serialize_into(bytes);
         self.deviceid.serialize_into(bytes);
         self.time.serialize_into(bytes);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         let num_infos = u16::try_from(self.infos.len()).expect("`infos` has too many elements");
         num_infos.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 10]);
@@ -17592,7 +17592,7 @@ pub struct RawKeyPressEvent {
     pub time: xproto::Timestamp,
     pub detail: u32,
     pub sourceid: DeviceId,
-    pub flags: u32,
+    pub flags: KeyEventFlags,
     pub valuator_mask: Vec<u32>,
     pub axisvalues: Vec<Fp3232>,
     pub axisvalues_raw: Vec<Fp3232>,
@@ -17643,7 +17643,7 @@ impl Serialize for RawKeyPressEvent {
         self.sourceid.serialize_into(bytes);
         let valuators_len = u16::try_from(self.valuator_mask.len()).expect("`valuator_mask` has too many elements");
         valuators_len.serialize_into(bytes);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 4]);
         self.valuator_mask.serialize_into(bytes);
         assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
@@ -17686,7 +17686,7 @@ pub struct RawButtonPressEvent {
     pub time: xproto::Timestamp,
     pub detail: u32,
     pub sourceid: DeviceId,
-    pub flags: u32,
+    pub flags: PointerEventFlags,
     pub valuator_mask: Vec<u32>,
     pub axisvalues: Vec<Fp3232>,
     pub axisvalues_raw: Vec<Fp3232>,
@@ -17737,7 +17737,7 @@ impl Serialize for RawButtonPressEvent {
         self.sourceid.serialize_into(bytes);
         let valuators_len = u16::try_from(self.valuator_mask.len()).expect("`valuator_mask` has too many elements");
         valuators_len.serialize_into(bytes);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 4]);
         self.valuator_mask.serialize_into(bytes);
         assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
@@ -17839,7 +17839,7 @@ pub struct TouchBeginEvent {
     pub event_x: Fp1616,
     pub event_y: Fp1616,
     pub sourceid: DeviceId,
-    pub flags: u32,
+    pub flags: TouchEventFlags,
     pub mods: ModifierInfo,
     pub group: GroupInfo,
     pub button_mask: Vec<u32>,
@@ -17912,7 +17912,7 @@ impl Serialize for TouchBeginEvent {
         valuators_len.serialize_into(bytes);
         self.sourceid.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         self.mods.serialize_into(bytes);
         self.group.serialize_into(bytes);
         self.button_mask.serialize_into(bytes);
@@ -18149,7 +18149,7 @@ pub struct RawTouchBeginEvent {
     pub time: xproto::Timestamp,
     pub detail: u32,
     pub sourceid: DeviceId,
-    pub flags: u32,
+    pub flags: TouchEventFlags,
     pub valuator_mask: Vec<u32>,
     pub axisvalues: Vec<Fp3232>,
     pub axisvalues_raw: Vec<Fp3232>,
@@ -18200,7 +18200,7 @@ impl Serialize for RawTouchBeginEvent {
         self.sourceid.serialize_into(bytes);
         let valuators_len = u16::try_from(self.valuator_mask.len()).expect("`valuator_mask` has too many elements");
         valuators_len.serialize_into(bytes);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 4]);
         self.valuator_mask.serialize_into(bytes);
         assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
@@ -18298,7 +18298,7 @@ pub struct BarrierHitEvent {
     pub event: xproto::Window,
     pub barrier: xfixes::Barrier,
     pub dtime: u32,
-    pub flags: u32,
+    pub flags: BarrierFlags,
     pub sourceid: DeviceId,
     pub root_x: Fp1616,
     pub root_y: Fp1616,
@@ -18350,7 +18350,7 @@ impl Serialize for BarrierHitEvent {
         let event_bytes = self.event.serialize();
         let barrier_bytes = self.barrier.serialize();
         let dtime_bytes = self.dtime.serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u32::from(self.flags).serialize();
         let sourceid_bytes = self.sourceid.serialize();
         let root_x_bytes = self.root_x.serialize();
         let root_y_bytes = self.root_y.serialize();
@@ -18441,7 +18441,7 @@ impl Serialize for BarrierHitEvent {
         self.event.serialize_into(bytes);
         self.barrier.serialize_into(bytes);
         self.dtime.serialize_into(bytes);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         self.sourceid.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
         self.root_x.serialize_into(bytes);

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -16695,7 +16695,7 @@ impl TryParse for KeyPressEvent {
         let (group, remaining) = GroupInfo::try_parse(remaining)?;
         let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len.try_to_usize()?)?;
         let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_to_usize()?)?;
-        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
         let flags = flags.into();
         let result = KeyPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
         let _ = remaining;
@@ -16739,7 +16739,7 @@ impl Serialize for KeyPressEvent {
         self.group.serialize_into(bytes);
         self.button_mask.serialize_into(bytes);
         self.valuator_mask.serialize_into(bytes);
-        assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
+        assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
         self.axisvalues.serialize_into(bytes);
     }
 }
@@ -16877,7 +16877,7 @@ impl TryParse for ButtonPressEvent {
         let (group, remaining) = GroupInfo::try_parse(remaining)?;
         let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len.try_to_usize()?)?;
         let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_to_usize()?)?;
-        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
         let flags = flags.into();
         let result = ButtonPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
         let _ = remaining;
@@ -16921,7 +16921,7 @@ impl Serialize for ButtonPressEvent {
         self.group.serialize_into(bytes);
         self.button_mask.serialize_into(bytes);
         self.valuator_mask.serialize_into(bytes);
-        assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
+        assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
         self.axisvalues.serialize_into(bytes);
     }
 }
@@ -17613,8 +17613,8 @@ impl TryParse for RawKeyPressEvent {
         let (flags, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::InsufficientData)?;
         let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_to_usize()?)?;
-        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
-        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
         let flags = flags.into();
         let result = RawKeyPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
         let _ = remaining;
@@ -17646,9 +17646,9 @@ impl Serialize for RawKeyPressEvent {
         u32::from(self.flags).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 4]);
         self.valuator_mask.serialize_into(bytes);
-        assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
+        assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
         self.axisvalues.serialize_into(bytes);
-        assert_eq!(self.axisvalues_raw.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).unwrap())).unwrap(), "`axisvalues_raw` has an incorrect length");
+        assert_eq!(self.axisvalues_raw.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).unwrap())).unwrap(), "`axisvalues_raw` has an incorrect length");
         self.axisvalues_raw.serialize_into(bytes);
     }
 }
@@ -17707,8 +17707,8 @@ impl TryParse for RawButtonPressEvent {
         let (flags, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::InsufficientData)?;
         let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_to_usize()?)?;
-        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
-        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
         let flags = flags.into();
         let result = RawButtonPressEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
         let _ = remaining;
@@ -17740,9 +17740,9 @@ impl Serialize for RawButtonPressEvent {
         u32::from(self.flags).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 4]);
         self.valuator_mask.serialize_into(bytes);
-        assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
+        assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
         self.axisvalues.serialize_into(bytes);
-        assert_eq!(self.axisvalues_raw.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).unwrap())).unwrap(), "`axisvalues_raw` has an incorrect length");
+        assert_eq!(self.axisvalues_raw.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).unwrap())).unwrap(), "`axisvalues_raw` has an incorrect length");
         self.axisvalues_raw.serialize_into(bytes);
     }
 }
@@ -17873,7 +17873,7 @@ impl TryParse for TouchBeginEvent {
         let (group, remaining) = GroupInfo::try_parse(remaining)?;
         let (button_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, buttons_len.try_to_usize()?)?;
         let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_to_usize()?)?;
-        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
         let flags = flags.into();
         let result = TouchBeginEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, root, event, child, root_x, root_y, event_x, event_y, sourceid, flags, mods, group, button_mask, valuator_mask, axisvalues };
         let _ = remaining;
@@ -17917,7 +17917,7 @@ impl Serialize for TouchBeginEvent {
         self.group.serialize_into(bytes);
         self.button_mask.serialize_into(bytes);
         self.valuator_mask.serialize_into(bytes);
-        assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
+        assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
         self.axisvalues.serialize_into(bytes);
     }
 }
@@ -18170,8 +18170,8 @@ impl TryParse for RawTouchBeginEvent {
         let (flags, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::InsufficientData)?;
         let (valuator_mask, remaining) = crate::x11_utils::parse_list::<u32>(remaining, valuators_len.try_to_usize()?)?;
-        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
-        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
+        let (axisvalues, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
+        let (axisvalues_raw, remaining) = crate::x11_utils::parse_list::<Fp3232>(remaining, valuator_mask.iter().try_fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).ok_or(ParseError::InvalidExpression))?.try_to_usize()?)?;
         let flags = flags.into();
         let result = RawTouchBeginEvent { response_type, extension, sequence, length, event_type, deviceid, time, detail, sourceid, flags, valuator_mask, axisvalues, axisvalues_raw };
         let _ = remaining;
@@ -18203,9 +18203,9 @@ impl Serialize for RawTouchBeginEvent {
         u32::from(self.flags).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 4]);
         self.valuator_mask.serialize_into(bytes);
-        assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
+        assert_eq!(self.axisvalues.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).unwrap())).unwrap(), "`axisvalues` has an incorrect length");
         self.axisvalues.serialize_into(bytes);
-        assert_eq!(self.axisvalues_raw.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add((*x).count_ones()).unwrap())).unwrap(), "`axisvalues_raw` has an incorrect length");
+        assert_eq!(self.axisvalues_raw.len(), usize::try_from(self.valuator_mask.iter().fold(0u32, |acc, x| acc.checked_add(u32::from(*x).count_ones()).unwrap())).unwrap(), "`axisvalues_raw` has an incorrect length");
         self.axisvalues_raw.serialize_into(bytes);
     }
 }

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -803,7 +803,7 @@ pub enum InputInfoInfo {
 }
 impl InputInfoInfo {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = class_id;
+        let switch_expr = u8::from(class_id);
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(InputClass::KEY) {
@@ -4243,7 +4243,7 @@ pub enum FeedbackStateData {
 }
 impl FeedbackStateData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = class_id;
+        let switch_expr = u8::from(class_id);
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(FeedbackClass::KEYBOARD) {
@@ -5155,7 +5155,7 @@ pub enum FeedbackCtlData {
 }
 impl FeedbackCtlData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = class_id;
+        let switch_expr = u8::from(class_id);
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(FeedbackClass::KEYBOARD) {
@@ -6675,7 +6675,7 @@ pub enum InputStateData {
 }
 impl InputStateData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = class_id;
+        let switch_expr = u8::from(class_id);
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(InputClass::KEY) {
@@ -7769,7 +7769,7 @@ pub enum DeviceStateData {
 }
 impl DeviceStateData {
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = control_id;
+        let switch_expr = u16::from(control_id);
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u16::from(DeviceControl::RESOLUTION) {
@@ -8590,7 +8590,7 @@ pub enum DeviceCtlData {
 }
 impl DeviceCtlData {
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = control_id;
+        let switch_expr = u16::from(control_id);
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u16::from(DeviceControl::RESOLUTION) {
@@ -9077,7 +9077,7 @@ pub enum ChangeDevicePropertyAux {
 }
 impl ChangeDevicePropertyAux {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = format;
+        let switch_expr = u8::from(format);
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(PropertyFormat::M8_BITS) {
@@ -9453,7 +9453,7 @@ pub enum GetDevicePropertyItems {
 }
 impl GetDevicePropertyItems {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = format;
+        let switch_expr = u8::from(format);
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(PropertyFormat::M8_BITS) {
@@ -10630,7 +10630,7 @@ pub enum HierarchyChangeData {
 }
 impl HierarchyChangeData {
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = type_;
+        let switch_expr = u16::from(type_);
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u16::from(HierarchyChangeType::ADD_MASTER) {
@@ -12297,7 +12297,7 @@ pub enum DeviceClassData {
 }
 impl DeviceClassData {
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = type_;
+        let switch_expr = u16::from(type_);
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u16::from(DeviceClassType::KEY) {
@@ -13989,7 +13989,7 @@ pub enum XIChangePropertyAux {
 }
 impl XIChangePropertyAux {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = format;
+        let switch_expr = u8::from(format);
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(PropertyFormat::M8_BITS) {
@@ -14364,7 +14364,7 @@ pub enum XIGetPropertyItems {
 }
 impl XIGetPropertyItems {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = format;
+        let switch_expr = u8::from(format);
         let mut outer_remaining = value;
         let mut parse_result = None;
         if switch_expr == u8::from(PropertyFormat::M8_BITS) {

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Input` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -888,7 +888,7 @@ impl TryParse for InputInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
         let (len, remaining) = u8::try_parse(remaining)?;
-        let (info, remaining) = InputInfoInfo::try_parse(remaining, class_id)?;
+        let (info, remaining) = InputInfoInfo::try_parse(remaining, u8::from(class_id))?;
         let result = InputInfo { len, info };
         Ok((result, remaining))
     }
@@ -4372,7 +4372,7 @@ impl TryParse for FeedbackState {
         let (class_id, remaining) = u8::try_parse(remaining)?;
         let (feedback_id, remaining) = u8::try_parse(remaining)?;
         let (len, remaining) = u16::try_parse(remaining)?;
-        let (data, remaining) = FeedbackStateData::try_parse(remaining, class_id)?;
+        let (data, remaining) = FeedbackStateData::try_parse(remaining, u8::from(class_id))?;
         let result = FeedbackState { feedback_id, len, data };
         Ok((result, remaining))
     }
@@ -5284,7 +5284,7 @@ impl TryParse for FeedbackCtl {
         let (class_id, remaining) = u8::try_parse(remaining)?;
         let (feedback_id, remaining) = u8::try_parse(remaining)?;
         let (len, remaining) = u16::try_parse(remaining)?;
-        let (data, remaining) = FeedbackCtlData::try_parse(remaining, class_id)?;
+        let (data, remaining) = FeedbackCtlData::try_parse(remaining, u8::from(class_id))?;
         let result = FeedbackCtl { feedback_id, len, data };
         Ok((result, remaining))
     }
@@ -6760,7 +6760,7 @@ impl TryParse for InputState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
         let (len, remaining) = u8::try_parse(remaining)?;
-        let (data, remaining) = InputStateData::try_parse(remaining, class_id)?;
+        let (data, remaining) = InputStateData::try_parse(remaining, u8::from(class_id))?;
         let result = InputState { len, data };
         Ok((result, remaining))
     }
@@ -7888,7 +7888,7 @@ impl TryParse for DeviceState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
         let (len, remaining) = u16::try_parse(remaining)?;
-        let (data, remaining) = DeviceStateData::try_parse(remaining, control_id)?;
+        let (data, remaining) = DeviceStateData::try_parse(remaining, u16::from(control_id))?;
         let result = DeviceState { len, data };
         Ok((result, remaining))
     }
@@ -8709,7 +8709,7 @@ impl TryParse for DeviceCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
         let (len, remaining) = u16::try_parse(remaining)?;
-        let (data, remaining) = DeviceCtlData::try_parse(remaining, control_id)?;
+        let (data, remaining) = DeviceCtlData::try_parse(remaining, u16::from(control_id))?;
         let result = DeviceCtl { len, data };
         Ok((result, remaining))
     }
@@ -9246,7 +9246,7 @@ impl<'input> ChangeDevicePropertyRequest<'input> {
         let mode = mode.into();
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
-        let (items, remaining) = ChangeDevicePropertyAux::try_parse(remaining, format, num_items)?;
+        let (items, remaining) = ChangeDevicePropertyAux::try_parse(remaining, u8::from(format), u32::from(num_items))?;
         let _ = remaining;
         Ok(ChangeDevicePropertyRequest {
             property,
@@ -9579,7 +9579,7 @@ impl TryParse for GetDevicePropertyReply {
         let (format, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(10..).ok_or(ParseError::InsufficientData)?;
-        let (items, remaining) = GetDevicePropertyItems::try_parse(remaining, format, num_items)?;
+        let (items, remaining) = GetDevicePropertyItems::try_parse(remaining, u8::from(format), u32::from(num_items))?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -10729,7 +10729,7 @@ impl TryParse for HierarchyChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u16::try_parse(remaining)?;
         let (len, remaining) = u16::try_parse(remaining)?;
-        let (data, remaining) = HierarchyChangeData::try_parse(remaining, type_)?;
+        let (data, remaining) = HierarchyChangeData::try_parse(remaining, u16::from(type_))?;
         let result = HierarchyChange { len, data };
         Ok((result, remaining))
     }
@@ -12412,7 +12412,7 @@ impl TryParse for DeviceClass {
         let (type_, remaining) = u16::try_parse(remaining)?;
         let (len, remaining) = u16::try_parse(remaining)?;
         let (sourceid, remaining) = DeviceId::try_parse(remaining)?;
-        let (data, remaining) = DeviceClassData::try_parse(remaining, type_)?;
+        let (data, remaining) = DeviceClassData::try_parse(remaining, u16::from(type_))?;
         let result = DeviceClass { len, sourceid, data };
         Ok((result, remaining))
     }
@@ -14157,7 +14157,7 @@ impl<'input> XIChangePropertyRequest<'input> {
         let (property, remaining) = xproto::Atom::try_parse(remaining)?;
         let (type_, remaining) = xproto::Atom::try_parse(remaining)?;
         let (num_items, remaining) = u32::try_parse(remaining)?;
-        let (items, remaining) = XIChangePropertyAux::try_parse(remaining, format, num_items)?;
+        let (items, remaining) = XIChangePropertyAux::try_parse(remaining, u8::from(format), u32::from(num_items))?;
         let _ = remaining;
         Ok(XIChangePropertyRequest {
             deviceid,
@@ -14487,7 +14487,7 @@ impl TryParse for XIGetPropertyReply {
         let (num_items, remaining) = u32::try_parse(remaining)?;
         let (format, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(11..).ok_or(ParseError::InsufficientData)?;
-        let (items, remaining) = XIGetPropertyItems::try_parse(remaining, format, num_items)?;
+        let (items, remaining) = XIGetPropertyItems::try_parse(remaining, u8::from(format), u32::from(num_items))?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -6436,7 +6436,7 @@ impl SelectEventsAux {
     #[allow(dead_code)]
     fn serialize(&self, affect_which: u16, clear: u16, select_all: u16) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, affect_which, clear, select_all);
+        self.serialize_into(&mut result, u16::from(affect_which), u16::from(clear), u16::from(select_all));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, affect_which: u16, clear: u16, select_all: u16) {
@@ -6632,7 +6632,7 @@ impl<'input> SelectEventsRequest<'input> {
             map_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let details_bytes = self.details.serialize(affect_which, self.clear, self.select_all);
+        let details_bytes = self.details.serialize(u16::from(affect_which), u16::from(self.clear), u16::from(self.select_all));
         let length_so_far = length_so_far + details_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -7864,7 +7864,7 @@ impl GetMapMapBitcase3 {
     #[allow(dead_code)]
     fn serialize(&self, n_key_actions: u8, total_actions: u16) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, n_key_actions, total_actions);
+        self.serialize_into(&mut result, u8::from(n_key_actions), u16::from(total_actions));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, n_key_actions: u8, total_actions: u16) {
@@ -7985,7 +7985,7 @@ impl GetMapMap {
     #[allow(dead_code)]
     fn serialize(&self, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys);
+        self.serialize_into(&mut result, u16::from(present), u8::from(n_types), u8::from(n_key_syms), u8::from(n_key_actions), u16::from(total_actions), u8::from(total_key_behaviors), u16::from(virtual_mods), u8::from(total_key_explicit), u8::from(total_mod_map_keys), u8::from(total_v_mod_map_keys));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) {
@@ -8008,7 +8008,7 @@ impl GetMapMap {
             syms_rtrn.serialize_into(bytes);
         }
         if let Some(ref bitcase3) = self.bitcase3 {
-            bitcase3.serialize_into(bytes, n_key_actions, total_actions);
+            bitcase3.serialize_into(bytes, u8::from(n_key_actions), u16::from(total_actions));
         }
         if let Some(ref behaviors_rtrn) = self.behaviors_rtrn {
             assert_eq!(behaviors_rtrn.len(), usize::try_from(total_key_behaviors).unwrap(), "`behaviors_rtrn` has an incorrect length");
@@ -8188,7 +8188,7 @@ impl Serialize for GetMapReply {
         self.total_v_mod_map_keys.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
         u16::from(self.virtual_mods).serialize_into(bytes);
-        self.map.serialize_into(bytes, present, self.n_types, self.n_key_syms, self.n_key_actions, self.total_actions, self.total_key_behaviors, self.virtual_mods, self.total_key_explicit, self.total_mod_map_keys, self.total_v_mod_map_keys);
+        self.map.serialize_into(bytes, u16::from(present), u8::from(self.n_types), u8::from(self.n_key_syms), u8::from(self.n_key_actions), u16::from(self.total_actions), u8::from(self.total_key_behaviors), u16::from(self.virtual_mods), u8::from(self.total_key_explicit), u8::from(self.total_mod_map_keys), u8::from(self.total_v_mod_map_keys));
     }
 }
 
@@ -8216,7 +8216,7 @@ impl SetMapAuxBitcase3 {
     #[allow(dead_code)]
     fn serialize(&self, n_key_actions: u8, total_actions: u16) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, n_key_actions, total_actions);
+        self.serialize_into(&mut result, u8::from(n_key_actions), u16::from(total_actions));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, n_key_actions: u8, total_actions: u16) {
@@ -8321,7 +8321,7 @@ impl SetMapAux {
     #[allow(dead_code)]
     fn serialize(&self, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys);
+        self.serialize_into(&mut result, u16::from(present), u8::from(n_types), u8::from(n_key_syms), u8::from(n_key_actions), u16::from(total_actions), u8::from(total_key_behaviors), u16::from(virtual_mods), u8::from(total_key_explicit), u8::from(total_mod_map_keys), u8::from(total_v_mod_map_keys));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) {
@@ -8344,7 +8344,7 @@ impl SetMapAux {
             syms.serialize_into(bytes);
         }
         if let Some(ref bitcase3) = self.bitcase3 {
-            bitcase3.serialize_into(bytes, n_key_actions, total_actions);
+            bitcase3.serialize_into(bytes, u8::from(n_key_actions), u16::from(total_actions));
         }
         if let Some(ref behaviors) = self.behaviors {
             assert_eq!(behaviors.len(), usize::try_from(total_key_behaviors).unwrap(), "`behaviors` has an incorrect length");
@@ -8556,7 +8556,7 @@ impl<'input> SetMapRequest<'input> {
             virtual_mods_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let values_bytes = self.values.serialize(present, self.n_types, self.n_key_syms, self.n_key_actions, self.total_actions, self.total_key_behaviors, self.virtual_mods, self.total_key_explicit, self.total_mod_map_keys, self.total_v_mod_map_keys);
+        let values_bytes = self.values.serialize(u16::from(present), u8::from(self.n_types), u8::from(self.n_key_syms), u8::from(self.n_key_actions), u16::from(self.total_actions), u8::from(self.total_key_behaviors), u16::from(self.virtual_mods), u8::from(self.total_key_explicit), u8::from(self.total_mod_map_keys), u8::from(self.total_v_mod_map_keys));
         let length_so_far = length_so_far + values_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -9720,7 +9720,7 @@ impl GetNamesValueListBitcase8 {
     #[allow(dead_code)]
     fn serialize(&self, n_types: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, n_types);
+        self.serialize_into(&mut result, u8::from(n_types));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, n_types: u8) {
@@ -9872,7 +9872,7 @@ impl GetNamesValueList {
     #[allow(dead_code)]
     fn serialize(&self, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups);
+        self.serialize_into(&mut result, u32::from(which), u8::from(n_types), u32::from(indicators), u16::from(virtual_mods), u8::from(group_names), u8::from(n_keys), u8::from(n_key_aliases), u8::from(n_radio_groups));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) {
@@ -9907,7 +9907,7 @@ impl GetNamesValueList {
             type_names.serialize_into(bytes);
         }
         if let Some(ref bitcase8) = self.bitcase8 {
-            bitcase8.serialize_into(bytes, n_types);
+            bitcase8.serialize_into(bytes, u8::from(n_types));
         }
         if let Some(ref indicator_names) = self.indicator_names {
             assert_eq!(indicator_names.len(), usize::try_from(indicators.count_ones()).unwrap(), "`indicator_names` has an incorrect length");
@@ -10064,7 +10064,7 @@ impl Serialize for GetNamesReply {
         self.n_key_aliases.serialize_into(bytes);
         self.n_kt_levels.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 4]);
-        self.value_list.serialize_into(bytes, which, self.n_types, self.indicators, self.virtual_mods, self.group_names, self.n_keys, self.n_key_aliases, self.n_radio_groups);
+        self.value_list.serialize_into(bytes, u32::from(which), u8::from(self.n_types), u32::from(self.indicators), u16::from(self.virtual_mods), u8::from(self.group_names), u8::from(self.n_keys), u8::from(self.n_key_aliases), u8::from(self.n_radio_groups));
     }
 }
 
@@ -10092,7 +10092,7 @@ impl SetNamesAuxBitcase8 {
     #[allow(dead_code)]
     fn serialize(&self, n_types: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, n_types);
+        self.serialize_into(&mut result, u8::from(n_types));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, n_types: u8) {
@@ -10245,7 +10245,7 @@ impl SetNamesAux {
     #[allow(dead_code)]
     fn serialize(&self, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups);
+        self.serialize_into(&mut result, u32::from(which), u8::from(n_types), u32::from(indicators), u16::from(virtual_mods), u8::from(group_names), u8::from(n_keys), u8::from(n_key_aliases), u8::from(n_radio_groups));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) {
@@ -10280,7 +10280,7 @@ impl SetNamesAux {
             type_names.serialize_into(bytes);
         }
         if let Some(ref bitcase8) = self.bitcase8 {
-            bitcase8.serialize_into(bytes, n_types);
+            bitcase8.serialize_into(bytes, u8::from(n_types));
         }
         if let Some(ref indicator_names) = self.indicator_names {
             assert_eq!(indicator_names.len(), usize::try_from(indicators.count_ones()).unwrap(), "`indicator_names` has an incorrect length");
@@ -10517,7 +10517,7 @@ impl<'input> SetNamesRequest<'input> {
             total_kt_level_names_bytes[1],
         ];
         let length_so_far = length_so_far + request0.len();
-        let values_bytes = self.values.serialize(which, self.n_types, self.indicators, self.virtual_mods, self.group_names, self.n_keys, self.n_key_aliases, self.n_radio_groups);
+        let values_bytes = self.values.serialize(u32::from(which), u8::from(self.n_types), u32::from(self.indicators), u16::from(self.virtual_mods), u8::from(self.group_names), u8::from(self.n_keys), u8::from(self.n_key_aliases), u8::from(self.n_radio_groups));
         let length_so_far = length_so_far + values_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -11115,7 +11115,7 @@ impl GetKbdByNameRepliesTypesMapBitcase3 {
     #[allow(dead_code)]
     fn serialize(&self, n_key_actions: u8, total_actions: u16) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, n_key_actions, total_actions);
+        self.serialize_into(&mut result, u8::from(n_key_actions), u16::from(total_actions));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, n_key_actions: u8, total_actions: u16) {
@@ -11236,7 +11236,7 @@ impl GetKbdByNameRepliesTypesMap {
     #[allow(dead_code)]
     fn serialize(&self, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys);
+        self.serialize_into(&mut result, u16::from(present), u8::from(n_types), u8::from(n_key_syms), u8::from(n_key_actions), u16::from(total_actions), u8::from(total_key_behaviors), u16::from(virtual_mods), u8::from(total_key_explicit), u8::from(total_mod_map_keys), u8::from(total_v_mod_map_keys));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) {
@@ -11259,7 +11259,7 @@ impl GetKbdByNameRepliesTypesMap {
             syms_rtrn.serialize_into(bytes);
         }
         if let Some(ref bitcase3) = self.bitcase3 {
-            bitcase3.serialize_into(bytes, n_key_actions, total_actions);
+            bitcase3.serialize_into(bytes, u8::from(n_key_actions), u16::from(total_actions));
         }
         if let Some(ref behaviors_rtrn) = self.behaviors_rtrn {
             assert_eq!(behaviors_rtrn.len(), usize::try_from(total_key_behaviors).unwrap(), "`behaviors_rtrn` has an incorrect length");
@@ -11432,7 +11432,7 @@ impl Serialize for GetKbdByNameRepliesTypes {
         self.total_v_mod_map_keys.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
         u16::from(self.virtual_mods).serialize_into(bytes);
-        self.map.serialize_into(bytes, present, self.n_types, self.n_key_syms, self.n_key_actions, self.total_actions, self.total_key_behaviors, self.virtual_mods, self.total_key_explicit, self.total_mod_map_keys, self.total_v_mod_map_keys);
+        self.map.serialize_into(bytes, u16::from(present), u8::from(self.n_types), u8::from(self.n_key_syms), u8::from(self.n_key_actions), u16::from(self.total_actions), u8::from(self.total_key_behaviors), u16::from(self.virtual_mods), u8::from(self.total_key_explicit), u8::from(self.total_mod_map_keys), u8::from(self.total_v_mod_map_keys));
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -11593,7 +11593,7 @@ impl GetKbdByNameRepliesKeyNamesValueListBitcase8 {
     #[allow(dead_code)]
     fn serialize(&self, n_types: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, n_types);
+        self.serialize_into(&mut result, u8::from(n_types));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, n_types: u8) {
@@ -11745,7 +11745,7 @@ impl GetKbdByNameRepliesKeyNamesValueList {
     #[allow(dead_code)]
     fn serialize(&self, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups);
+        self.serialize_into(&mut result, u32::from(which), u8::from(n_types), u32::from(indicators), u16::from(virtual_mods), u8::from(group_names), u8::from(n_keys), u8::from(n_key_aliases), u8::from(n_radio_groups));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) {
@@ -11780,7 +11780,7 @@ impl GetKbdByNameRepliesKeyNamesValueList {
             type_names.serialize_into(bytes);
         }
         if let Some(ref bitcase8) = self.bitcase8 {
-            bitcase8.serialize_into(bytes, n_types);
+            bitcase8.serialize_into(bytes, u8::from(n_types));
         }
         if let Some(ref indicator_names) = self.indicator_names {
             assert_eq!(indicator_names.len(), usize::try_from(indicators.count_ones()).unwrap(), "`indicator_names` has an incorrect length");
@@ -11930,7 +11930,7 @@ impl Serialize for GetKbdByNameRepliesKeyNames {
         self.n_key_aliases.serialize_into(bytes);
         self.n_kt_levels.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 4]);
-        self.value_list.serialize_into(bytes, which, self.n_types, self.indicators, self.virtual_mods, self.group_names, self.n_keys, self.n_key_aliases, self.n_radio_groups);
+        self.value_list.serialize_into(bytes, u32::from(which), u8::from(self.n_types), u32::from(self.indicators), u16::from(self.virtual_mods), u8::from(self.group_names), u8::from(self.n_keys), u8::from(self.n_key_aliases), u8::from(self.n_radio_groups));
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -12063,7 +12063,7 @@ impl GetKbdByNameReplies {
     #[allow(dead_code)]
     fn serialize(&self, reported: u16) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, reported);
+        self.serialize_into(&mut result, u16::from(reported));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, reported: u16) {
@@ -12148,7 +12148,7 @@ impl Serialize for GetKbdByNameReply {
         u16::from(self.found).serialize_into(bytes);
         u16::from(self.reported).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 16]);
-        self.replies.serialize_into(bytes, self.reported);
+        self.replies.serialize_into(bytes, u16::from(self.reported));
     }
 }
 

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -1928,6 +1928,10 @@ impl TryParse for IndicatorMap {
         let which_groups = which_groups.into();
         let groups = groups.into();
         let which_mods = which_mods.into();
+        let mods = mods.into();
+        let real_mods = real_mods.into();
+        let vmods = vmods.into();
+        let ctrls = ctrls.into();
         let result = IndicatorMap { flags, which_groups, groups, which_mods, mods, real_mods, vmods, ctrls };
         Ok((result, remaining))
     }
@@ -2295,6 +2299,9 @@ impl TryParse for ModDef {
         let (mask, remaining) = u8::try_parse(remaining)?;
         let (real_mods, remaining) = u8::try_parse(remaining)?;
         let (vmods, remaining) = u16::try_parse(remaining)?;
+        let mask = mask.into();
+        let real_mods = real_mods.into();
+        let vmods = vmods.into();
         let result = ModDef { mask, real_mods, vmods };
         Ok((result, remaining))
     }
@@ -2451,6 +2458,9 @@ impl TryParse for KTMapEntry {
         let (mods_mods, remaining) = u8::try_parse(remaining)?;
         let (mods_vmods, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
+        let mods_mask = mods_mask.into();
+        let mods_mods = mods_mods.into();
+        let mods_vmods = mods_vmods.into();
         let result = KTMapEntry { active, mods_mask, level, mods_mods, mods_vmods };
         Ok((result, remaining))
     }
@@ -2507,6 +2517,9 @@ impl TryParse for KeyType {
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (map, remaining) = crate::x11_utils::parse_list::<KTMapEntry>(remaining, n_map_entries.try_to_usize()?)?;
         let (preserve, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, u32::from(has_preserve).checked_mul(u32::from(n_map_entries)).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let mods_mask = mods_mask.into();
+        let mods_mods = mods_mods.into();
+        let mods_vmods = mods_vmods.into();
         let result = KeyType { mods_mask, mods_mods, mods_vmods, num_levels, has_preserve, map, preserve };
         Ok((result, remaining))
     }
@@ -2997,6 +3010,7 @@ impl TryParse for SetExplicit {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (explicit, remaining) = u8::try_parse(remaining)?;
+        let explicit = explicit.into();
         let result = SetExplicit { keycode, explicit };
         Ok((result, remaining))
     }
@@ -3028,6 +3042,7 @@ impl TryParse for KeyModMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (mods, remaining) = u8::try_parse(remaining)?;
+        let mods = mods.into();
         let result = KeyModMap { keycode, mods };
         Ok((result, remaining))
     }
@@ -3060,6 +3075,7 @@ impl TryParse for KeyVModMap {
         let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (vmods, remaining) = u16::try_parse(remaining)?;
+        let vmods = vmods.into();
         let result = KeyVModMap { keycode, vmods };
         Ok((result, remaining))
     }
@@ -3096,6 +3112,8 @@ impl TryParse for KTSetMapEntry {
         let (level, remaining) = u8::try_parse(remaining)?;
         let (real_mods, remaining) = u8::try_parse(remaining)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let real_mods = real_mods.into();
+        let virtual_mods = virtual_mods.into();
         let result = KTSetMapEntry { level, real_mods, virtual_mods };
         Ok((result, remaining))
     }
@@ -3143,6 +3161,9 @@ impl TryParse for SetKeyType {
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (entries, remaining) = crate::x11_utils::parse_list::<KTSetMapEntry>(remaining, n_map_entries.try_to_usize()?)?;
         let (preserve_entries, remaining) = crate::x11_utils::parse_list::<KTSetMapEntry>(remaining, u32::from(preserve).checked_mul(u32::from(n_map_entries)).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let mask = mask.into();
+        let real_mods = real_mods.into();
+        let virtual_mods = virtual_mods.into();
         let result = SetKeyType { mask, real_mods, virtual_mods, num_levels, preserve, entries, preserve_entries };
         Ok((result, remaining))
     }
@@ -3969,6 +3990,11 @@ impl TryParse for SASetMods {
         let (vmods_low, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let type_ = type_.into();
+        let flags = flags.into();
+        let mask = mask.into();
+        let real_mods = real_mods.into();
+        let vmods_high = vmods_high.into();
+        let vmods_low = vmods_low.into();
         let result = SASetMods { type_, flags, mask, real_mods, vmods_high, vmods_low };
         Ok((result, remaining))
     }
@@ -4023,6 +4049,7 @@ impl TryParse for SASetGroup {
         let (group, remaining) = i8::try_parse(remaining)?;
         let remaining = remaining.get(5..).ok_or(ParseError::InsufficientData)?;
         let type_ = type_.into();
+        let flags = flags.into();
         let result = SASetGroup { type_, flags, group };
         Ok((result, remaining))
     }
@@ -4139,6 +4166,7 @@ impl TryParse for SAMovePtr {
         let (y_low, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let type_ = type_.into();
+        let flags = flags.into();
         let result = SAMovePtr { type_, flags, x_high, x_low, y_high, y_low };
         Ok((result, remaining))
     }
@@ -4345,6 +4373,8 @@ impl TryParse for SASetPtrDflt {
         let (value, remaining) = i8::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::InsufficientData)?;
         let type_ = type_.into();
+        let flags = flags.into();
+        let affect = affect.into();
         let result = SASetPtrDflt { type_, flags, affect, value };
         Ok((result, remaining))
     }
@@ -4530,6 +4560,12 @@ impl TryParse for SAIsoLock {
         let (vmods_high, remaining) = u8::try_parse(remaining)?;
         let (vmods_low, remaining) = u8::try_parse(remaining)?;
         let type_ = type_.into();
+        let flags = flags.into();
+        let mask = mask.into();
+        let real_mods = real_mods.into();
+        let affect = affect.into();
+        let vmods_high = vmods_high.into();
+        let vmods_low = vmods_low.into();
         let result = SAIsoLock { type_, flags, mask, real_mods, group, affect, vmods_high, vmods_low };
         Ok((result, remaining))
     }
@@ -4862,6 +4898,8 @@ impl TryParse for SASetControls {
         let (bool_ctrls_low, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let type_ = type_.into();
+        let bool_ctrls_high = bool_ctrls_high.into();
+        let bool_ctrls_low = bool_ctrls_low.into();
         let result = SASetControls { type_, bool_ctrls_high, bool_ctrls_low };
         Ok((result, remaining))
     }
@@ -4971,6 +5009,7 @@ impl TryParse for SAActionMessage {
         let (message, remaining) = crate::x11_utils::parse_u8_list(remaining, 6)?;
         let message = <[u8; 6]>::try_from(message).unwrap();
         let type_ = type_.into();
+        let flags = flags.into();
         let result = SAActionMessage { type_, flags, message };
         Ok((result, remaining))
     }
@@ -5022,6 +5061,12 @@ impl TryParse for SARedirectKey {
         let (vmods_high, remaining) = u8::try_parse(remaining)?;
         let (vmods_low, remaining) = u8::try_parse(remaining)?;
         let type_ = type_.into();
+        let mask = mask.into();
+        let real_modifiers = real_modifiers.into();
+        let vmods_mask_high = vmods_mask_high.into();
+        let vmods_mask_low = vmods_mask_low.into();
+        let vmods_high = vmods_high.into();
+        let vmods_low = vmods_low.into();
         let result = SARedirectKey { type_, newkey, mask, real_modifiers, vmods_mask_high, vmods_mask_low, vmods_high, vmods_low };
         Ok((result, remaining))
     }
@@ -5190,6 +5235,7 @@ impl TryParse for SALockDeviceBtn {
         let (device, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::InsufficientData)?;
         let type_ = type_.into();
+        let flags = flags.into();
         let result = SALockDeviceBtn { type_, flags, button, device };
         Ok((result, remaining))
     }
@@ -5410,6 +5456,8 @@ impl TryParse for SymInterpret {
         let (virtual_mod, remaining) = u8::try_parse(remaining)?;
         let (flags, remaining) = u8::try_parse(remaining)?;
         let (action, remaining) = SIAction::try_parse(remaining)?;
+        let mods = mods.into();
+        let virtual_mod = virtual_mod.into();
         let result = SymInterpret { sym, mods, match_, virtual_mod, flags, action };
         Ok((result, remaining))
     }
@@ -5921,6 +5969,8 @@ impl TryParse for SelectEventsAuxBitcase1 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_new_keyboard, remaining) = u16::try_parse(remaining)?;
         let (new_keyboard_details, remaining) = u16::try_parse(remaining)?;
+        let affect_new_keyboard = affect_new_keyboard.into();
+        let new_keyboard_details = new_keyboard_details.into();
         let result = SelectEventsAuxBitcase1 { affect_new_keyboard, new_keyboard_details };
         Ok((result, remaining))
     }
@@ -5953,6 +6003,8 @@ impl TryParse for SelectEventsAuxBitcase2 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_state, remaining) = u16::try_parse(remaining)?;
         let (state_details, remaining) = u16::try_parse(remaining)?;
+        let affect_state = affect_state.into();
+        let state_details = state_details.into();
         let result = SelectEventsAuxBitcase2 { affect_state, state_details };
         Ok((result, remaining))
     }
@@ -5985,6 +6037,8 @@ impl TryParse for SelectEventsAuxBitcase3 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_ctrls, remaining) = u32::try_parse(remaining)?;
         let (ctrl_details, remaining) = u32::try_parse(remaining)?;
+        let affect_ctrls = affect_ctrls.into();
+        let ctrl_details = ctrl_details.into();
         let result = SelectEventsAuxBitcase3 { affect_ctrls, ctrl_details };
         Ok((result, remaining))
     }
@@ -6093,6 +6147,8 @@ impl TryParse for SelectEventsAuxBitcase6 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_names, remaining) = u16::try_parse(remaining)?;
         let (names_details, remaining) = u16::try_parse(remaining)?;
+        let affect_names = affect_names.into();
+        let names_details = names_details.into();
         let result = SelectEventsAuxBitcase6 { affect_names, names_details };
         Ok((result, remaining))
     }
@@ -6125,6 +6181,8 @@ impl TryParse for SelectEventsAuxBitcase7 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_compat, remaining) = u8::try_parse(remaining)?;
         let (compat_details, remaining) = u8::try_parse(remaining)?;
+        let affect_compat = affect_compat.into();
+        let compat_details = compat_details.into();
         let result = SelectEventsAuxBitcase7 { affect_compat, compat_details };
         Ok((result, remaining))
     }
@@ -6215,6 +6273,8 @@ impl TryParse for SelectEventsAuxBitcase10 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_access_x, remaining) = u16::try_parse(remaining)?;
         let (access_x_details, remaining) = u16::try_parse(remaining)?;
+        let affect_access_x = affect_access_x.into();
+        let access_x_details = access_x_details.into();
         let result = SelectEventsAuxBitcase10 { affect_access_x, access_x_details };
         Ok((result, remaining))
     }
@@ -6247,6 +6307,8 @@ impl TryParse for SelectEventsAuxBitcase11 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_ext_dev, remaining) = u16::try_parse(remaining)?;
         let (extdev_details, remaining) = u16::try_parse(remaining)?;
+        let affect_ext_dev = affect_ext_dev.into();
+        let extdev_details = extdev_details.into();
         let result = SelectEventsAuxBitcase11 { affect_ext_dev, extdev_details };
         Ok((result, remaining))
     }
@@ -6587,9 +6649,13 @@ impl<'input> SelectEventsRequest<'input> {
         let (device_spec, remaining) = DeviceSpec::try_parse(value)?;
         let (affect_which, remaining) = u16::try_parse(remaining)?;
         let (clear, remaining) = u16::try_parse(remaining)?;
+        let clear = clear.into();
         let (select_all, remaining) = u16::try_parse(remaining)?;
+        let select_all = select_all.into();
         let (affect_map, remaining) = u16::try_parse(remaining)?;
+        let affect_map = affect_map.into();
         let (map, remaining) = u16::try_parse(remaining)?;
+        let map = map.into();
         let (details, remaining) = SelectEventsAux::try_parse(remaining, affect_which, clear, select_all)?;
         let _ = remaining;
         Ok(SelectEventsRequest {
@@ -6839,8 +6905,18 @@ impl TryParse for GetStateReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let mods = mods.into();
+        let base_mods = base_mods.into();
+        let latched_mods = latched_mods.into();
+        let locked_mods = locked_mods.into();
         let group = group.into();
         let locked_group = locked_group.into();
+        let compat_state = compat_state.into();
+        let grab_mods = grab_mods.into();
+        let compat_grab_mods = compat_grab_mods.into();
+        let lookup_mods = lookup_mods.into();
+        let compat_lookup_mods = compat_lookup_mods.into();
+        let ptr_btn_state = ptr_btn_state.into();
         let result = GetStateReply { device_id, sequence, length, mods, base_mods, latched_mods, locked_mods, group, locked_group, base_group, latched_group, compat_state, grab_mods, compat_grab_mods, lookup_mods, compat_lookup_mods, ptr_btn_state };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -6987,11 +7063,14 @@ impl LatchLockStateRequest {
         }
         let (device_spec, remaining) = DeviceSpec::try_parse(value)?;
         let (affect_mod_locks, remaining) = u8::try_parse(remaining)?;
+        let affect_mod_locks = affect_mod_locks.into();
         let (mod_locks, remaining) = u8::try_parse(remaining)?;
+        let mod_locks = mod_locks.into();
         let (lock_group, remaining) = bool::try_parse(remaining)?;
         let (group_lock, remaining) = u8::try_parse(remaining)?;
         let group_lock = group_lock.into();
         let (affect_mod_latches, remaining) = u8::try_parse(remaining)?;
+        let affect_mod_latches = affect_mod_latches.into();
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (latch_group, remaining) = bool::try_parse(remaining)?;
@@ -7149,6 +7228,18 @@ impl TryParse for GetControlsReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let internal_mods_mask = internal_mods_mask.into();
+        let ignore_lock_mods_mask = ignore_lock_mods_mask.into();
+        let internal_mods_real_mods = internal_mods_real_mods.into();
+        let ignore_lock_mods_real_mods = ignore_lock_mods_real_mods.into();
+        let internal_mods_vmods = internal_mods_vmods.into();
+        let ignore_lock_mods_vmods = ignore_lock_mods_vmods.into();
+        let access_x_option = access_x_option.into();
+        let access_x_timeout_options_mask = access_x_timeout_options_mask.into();
+        let access_x_timeout_options_values = access_x_timeout_options_values.into();
+        let access_x_timeout_mask = access_x_timeout_mask.into();
+        let access_x_timeout_values = access_x_timeout_values.into();
+        let enabled_controls = enabled_controls.into();
         let result = GetControlsReply { device_id, sequence, length, mouse_keys_dflt_btn, num_groups, groups_wrap, internal_mods_mask, ignore_lock_mods_mask, internal_mods_real_mods, ignore_lock_mods_real_mods, internal_mods_vmods, ignore_lock_mods_vmods, repeat_delay, repeat_interval, slow_keys_delay, debounce_delay, mouse_keys_delay, mouse_keys_interval, mouse_keys_time_to_max, mouse_keys_max_speed, mouse_keys_curve, access_x_option, access_x_timeout, access_x_timeout_options_mask, access_x_timeout_options_values, access_x_timeout_mask, access_x_timeout_values, enabled_controls, per_key_repeat };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -7474,20 +7565,32 @@ impl<'input> SetControlsRequest<'input> {
         }
         let (device_spec, remaining) = DeviceSpec::try_parse(value)?;
         let (affect_internal_real_mods, remaining) = u8::try_parse(remaining)?;
+        let affect_internal_real_mods = affect_internal_real_mods.into();
         let (internal_real_mods, remaining) = u8::try_parse(remaining)?;
+        let internal_real_mods = internal_real_mods.into();
         let (affect_ignore_lock_real_mods, remaining) = u8::try_parse(remaining)?;
+        let affect_ignore_lock_real_mods = affect_ignore_lock_real_mods.into();
         let (ignore_lock_real_mods, remaining) = u8::try_parse(remaining)?;
+        let ignore_lock_real_mods = ignore_lock_real_mods.into();
         let (affect_internal_virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let affect_internal_virtual_mods = affect_internal_virtual_mods.into();
         let (internal_virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let internal_virtual_mods = internal_virtual_mods.into();
         let (affect_ignore_lock_virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let affect_ignore_lock_virtual_mods = affect_ignore_lock_virtual_mods.into();
         let (ignore_lock_virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let ignore_lock_virtual_mods = ignore_lock_virtual_mods.into();
         let (mouse_keys_dflt_btn, remaining) = u8::try_parse(remaining)?;
         let (groups_wrap, remaining) = u8::try_parse(remaining)?;
         let (access_x_options, remaining) = u16::try_parse(remaining)?;
+        let access_x_options = access_x_options.into();
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (affect_enabled_controls, remaining) = u32::try_parse(remaining)?;
+        let affect_enabled_controls = affect_enabled_controls.into();
         let (enabled_controls, remaining) = u32::try_parse(remaining)?;
+        let enabled_controls = enabled_controls.into();
         let (change_controls, remaining) = u32::try_parse(remaining)?;
+        let change_controls = change_controls.into();
         let (repeat_delay, remaining) = u16::try_parse(remaining)?;
         let (repeat_interval, remaining) = u16::try_parse(remaining)?;
         let (slow_keys_delay, remaining) = u16::try_parse(remaining)?;
@@ -7499,9 +7602,13 @@ impl<'input> SetControlsRequest<'input> {
         let (mouse_keys_curve, remaining) = i16::try_parse(remaining)?;
         let (access_x_timeout, remaining) = u16::try_parse(remaining)?;
         let (access_x_timeout_mask, remaining) = u32::try_parse(remaining)?;
+        let access_x_timeout_mask = access_x_timeout_mask.into();
         let (access_x_timeout_values, remaining) = u32::try_parse(remaining)?;
+        let access_x_timeout_values = access_x_timeout_values.into();
         let (access_x_timeout_options_mask, remaining) = u16::try_parse(remaining)?;
+        let access_x_timeout_options_mask = access_x_timeout_options_mask.into();
         let (access_x_timeout_options_values, remaining) = u16::try_parse(remaining)?;
+        let access_x_timeout_options_values = access_x_timeout_options_values.into();
         let (per_key_repeat, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
         let per_key_repeat = <&[u8; 32]>::try_from(per_key_repeat).unwrap();
         let _ = remaining;
@@ -7676,7 +7783,9 @@ impl GetMapRequest {
         }
         let (device_spec, remaining) = DeviceSpec::try_parse(value)?;
         let (full, remaining) = u16::try_parse(remaining)?;
+        let full = full.into();
         let (partial, remaining) = u16::try_parse(remaining)?;
+        let partial = partial.into();
         let (first_type, remaining) = u8::try_parse(remaining)?;
         let (n_types, remaining) = u8::try_parse(remaining)?;
         let (first_key_sym, remaining) = xproto::Keycode::try_parse(remaining)?;
@@ -7686,6 +7795,7 @@ impl GetMapRequest {
         let (first_key_behavior, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_key_behaviors, remaining) = u8::try_parse(remaining)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let virtual_mods = virtual_mods.into();
         let (first_key_explicit, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_key_explicit, remaining) = u8::try_parse(remaining)?;
         let (first_mod_map_key, remaining) = xproto::Keycode::try_parse(remaining)?;
@@ -8019,6 +8129,7 @@ impl TryParse for GetMapReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let virtual_mods = virtual_mods.into();
         let result = GetMapReply { device_id, sequence, length, min_key_code, max_key_code, first_type, n_types, total_types, first_key_sym, total_syms, n_key_syms, first_key_action, total_actions, n_key_actions, first_key_behavior, n_key_behaviors, total_key_behaviors, first_key_explicit, n_key_explicit, total_key_explicit, first_mod_map_key, n_mod_map_keys, total_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys, total_v_mod_map_keys, virtual_mods, map };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -8453,6 +8564,7 @@ impl<'input> SetMapRequest<'input> {
         let (device_spec, remaining) = DeviceSpec::try_parse(value)?;
         let (present, remaining) = u16::try_parse(remaining)?;
         let (flags, remaining) = u16::try_parse(remaining)?;
+        let flags = flags.into();
         let (min_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (max_key_code, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (first_type, remaining) = u8::try_parse(remaining)?;
@@ -8476,6 +8588,7 @@ impl<'input> SetMapRequest<'input> {
         let (n_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let (total_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let virtual_mods = virtual_mods.into();
         let (values, remaining) = SetMapAux::try_parse(remaining, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys)?;
         let _ = remaining;
         Ok(SetMapRequest {
@@ -8599,6 +8712,7 @@ impl GetCompatMapRequest {
         }
         let (device_spec, remaining) = DeviceSpec::try_parse(value)?;
         let (groups, remaining) = u8::try_parse(remaining)?;
+        let groups = groups.into();
         let (get_all_si, remaining) = bool::try_parse(remaining)?;
         let (first_si, remaining) = u16::try_parse(remaining)?;
         let (n_si, remaining) = u16::try_parse(remaining)?;
@@ -8656,6 +8770,7 @@ impl TryParse for GetCompatMapReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let groups_rtrn = groups_rtrn.into();
         let result = GetCompatMapReply { device_id, sequence, length, groups_rtrn, first_si_rtrn, n_total_si, si_rtrn, group_rtrn };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -8770,6 +8885,7 @@ impl<'input> SetCompatMapRequest<'input> {
         let (recompute_actions, remaining) = bool::try_parse(remaining)?;
         let (truncate_si, remaining) = bool::try_parse(remaining)?;
         let (groups, remaining) = u8::try_parse(remaining)?;
+        let groups = groups.into();
         let (first_si, remaining) = u16::try_parse(remaining)?;
         let (n_si, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
@@ -9268,6 +9384,14 @@ impl TryParse for GetNamedIndicatorReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let map_flags = map_flags.into();
+        let map_which_groups = map_which_groups.into();
+        let map_groups = map_groups.into();
+        let map_which_mods = map_which_mods.into();
+        let map_mods = map_mods.into();
+        let map_real_mods = map_real_mods.into();
+        let map_vmod = map_vmod.into();
+        let map_ctrls = map_ctrls.into();
         let result = GetNamedIndicatorReply { device_id, sequence, length, indicator, found, on, real_indicator, ndx, map_flags, map_which_groups, map_groups, map_which_mods, map_mods, map_real_mods, map_vmod, map_ctrls, supported };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -9453,12 +9577,19 @@ impl SetNamedIndicatorRequest {
         let (create_map, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (map_flags, remaining) = u8::try_parse(remaining)?;
+        let map_flags = map_flags.into();
         let (map_which_groups, remaining) = u8::try_parse(remaining)?;
+        let map_which_groups = map_which_groups.into();
         let (map_groups, remaining) = u8::try_parse(remaining)?;
+        let map_groups = map_groups.into();
         let (map_which_mods, remaining) = u8::try_parse(remaining)?;
+        let map_which_mods = map_which_mods.into();
         let (map_real_mods, remaining) = u8::try_parse(remaining)?;
+        let map_real_mods = map_real_mods.into();
         let (map_vmods, remaining) = u16::try_parse(remaining)?;
+        let map_vmods = map_vmods.into();
         let (map_ctrls, remaining) = u32::try_parse(remaining)?;
+        let map_ctrls = map_ctrls.into();
         let _ = remaining;
         Ok(SetNamedIndicatorRequest {
             device_spec,
@@ -9534,6 +9665,7 @@ impl GetNamesRequest {
         let (device_spec, remaining) = DeviceSpec::try_parse(value)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (which, remaining) = u32::try_parse(remaining)?;
+        let which = which.into();
         let _ = remaining;
         Ok(GetNamesRequest {
             device_spec,
@@ -9886,6 +10018,8 @@ impl TryParse for GetNamesReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let group_names = group_names.into();
+        let virtual_mods = virtual_mods.into();
         let result = GetNamesReply { device_id, sequence, length, min_key_code, max_key_code, n_types, group_names, virtual_mods, first_key, n_keys, indicators, n_radio_groups, n_key_aliases, n_kt_levels, value_list };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -10390,6 +10524,7 @@ impl<'input> SetNamesRequest<'input> {
         }
         let (device_spec, remaining) = DeviceSpec::try_parse(value)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
+        let virtual_mods = virtual_mods.into();
         let (which, remaining) = u32::try_parse(remaining)?;
         let (first_type, remaining) = u8::try_parse(remaining)?;
         let (n_types, remaining) = u8::try_parse(remaining)?;
@@ -10397,6 +10532,7 @@ impl<'input> SetNamesRequest<'input> {
         let (n_kt_levels, remaining) = u8::try_parse(remaining)?;
         let (indicators, remaining) = u32::try_parse(remaining)?;
         let (group_names, remaining) = u8::try_parse(remaining)?;
+        let group_names = group_names.into();
         let (n_radio_groups, remaining) = u8::try_parse(remaining)?;
         let (first_key, remaining) = xproto::Keycode::try_parse(remaining)?;
         let (n_keys, remaining) = u8::try_parse(remaining)?;
@@ -10521,10 +10657,15 @@ impl PerClientFlagsRequest {
         let (device_spec, remaining) = DeviceSpec::try_parse(value)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let (change, remaining) = u32::try_parse(remaining)?;
+        let change = change.into();
         let (value, remaining) = u32::try_parse(remaining)?;
+        let value = value.into();
         let (ctrls_to_change, remaining) = u32::try_parse(remaining)?;
+        let ctrls_to_change = ctrls_to_change.into();
         let (auto_ctrls, remaining) = u32::try_parse(remaining)?;
+        let auto_ctrls = auto_ctrls.into();
         let (auto_ctrls_values, remaining) = u32::try_parse(remaining)?;
+        let auto_ctrls_values = auto_ctrls_values.into();
         let _ = remaining;
         Ok(PerClientFlagsRequest {
             device_spec,
@@ -10576,6 +10717,10 @@ impl TryParse for PerClientFlagsReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let supported = supported.into();
+        let value = value.into();
+        let auto_ctrls = auto_ctrls.into();
+        let auto_ctrls_values = auto_ctrls_values.into();
         let result = PerClientFlagsReply { device_id, sequence, length, supported, value, auto_ctrls, auto_ctrls_values };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -10909,7 +11054,9 @@ impl GetKbdByNameRequest {
         }
         let (device_spec, remaining) = DeviceSpec::try_parse(value)?;
         let (need, remaining) = u16::try_parse(remaining)?;
+        let need = need.into();
         let (want, remaining) = u16::try_parse(remaining)?;
+        let want = want.into();
         let (load, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let _ = remaining;
@@ -11221,6 +11368,7 @@ impl TryParse for GetKbdByNameRepliesTypes {
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
         let (map, remaining) = GetKbdByNameRepliesTypesMap::try_parse(remaining, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys)?;
+        let virtual_mods = virtual_mods.into();
         let result = GetKbdByNameRepliesTypes { getmap_type, type_device_id, getmap_sequence, getmap_length, type_min_key_code, type_max_key_code, first_type, n_types, total_types, first_key_sym, total_syms, n_key_syms, first_key_action, total_actions, n_key_actions, first_key_behavior, n_key_behaviors, total_key_behaviors, first_key_explicit, n_key_explicit, total_key_explicit, first_mod_map_key, n_mod_map_keys, total_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys, total_v_mod_map_keys, virtual_mods, map };
         Ok((result, remaining))
     }
@@ -11296,6 +11444,7 @@ impl TryParse for GetKbdByNameRepliesCompatMap {
         let remaining = remaining.get(16..).ok_or(ParseError::InsufficientData)?;
         let (si_rtrn, remaining) = crate::x11_utils::parse_list::<SymInterpret>(remaining, n_si_rtrn.try_to_usize()?)?;
         let (group_rtrn, remaining) = crate::x11_utils::parse_list::<ModDef>(remaining, groups_rtrn.count_ones().try_to_usize()?)?;
+        let groups_rtrn = groups_rtrn.into();
         let result = GetKbdByNameRepliesCompatMap { compatmap_type, compat_device_id, compatmap_sequence, compatmap_length, groups_rtrn, first_si_rtrn, n_total_si, si_rtrn, group_rtrn };
         Ok((result, remaining))
     }
@@ -11730,6 +11879,8 @@ impl TryParse for GetKbdByNameRepliesKeyNames {
         let (n_kt_levels, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::InsufficientData)?;
         let (value_list, remaining) = GetKbdByNameRepliesKeyNamesValueList::try_parse(remaining, which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups)?;
+        let group_names = group_names.into();
+        let virtual_mods = virtual_mods.into();
         let result = GetKbdByNameRepliesKeyNames { keyname_type, key_device_id, keyname_sequence, keyname_length, key_min_key_code, key_max_key_code, n_types, group_names, virtual_mods, first_key, n_keys, indicators, n_radio_groups, n_key_aliases, n_kt_levels, value_list };
         Ok((result, remaining))
     }
@@ -11949,6 +12100,8 @@ impl TryParse for GetKbdByNameReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let found = found.into();
+        let reported = reported.into();
         let result = GetKbdByNameReply { device_id, sequence, length, min_key_code, max_key_code, loaded, new_keyboard, found, reported, replies };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -12036,6 +12189,7 @@ impl GetDeviceInfoRequest {
         }
         let (device_spec, remaining) = DeviceSpec::try_parse(value)?;
         let (wanted, remaining) = u16::try_parse(remaining)?;
+        let wanted = wanted.into();
         let (all_buttons, remaining) = bool::try_parse(remaining)?;
         let (first_button, remaining) = u8::try_parse(remaining)?;
         let (n_buttons, remaining) = u8::try_parse(remaining)?;
@@ -12124,6 +12278,9 @@ impl TryParse for GetDeviceInfoReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let present = present.into();
+        let supported = supported.into();
+        let unsupported = unsupported.into();
         let result = GetDeviceInfoReply { device_id, sequence, length, present, supported, unsupported, first_btn_wanted, n_btns_wanted, first_btn_rtrn, total_btns, has_own_state, dflt_kbd_fb, dflt_led_fb, dev_type, name, btn_actions, leds };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -12268,6 +12425,7 @@ impl<'input> SetDeviceInfoRequest<'input> {
         let (first_btn, remaining) = u8::try_parse(remaining)?;
         let (n_btns, remaining) = u8::try_parse(remaining)?;
         let (change, remaining) = u16::try_parse(remaining)?;
+        let change = change.into();
         let (n_device_led_f_bs, remaining) = u16::try_parse(remaining)?;
         let (btn_actions, remaining) = crate::x11_utils::parse_list::<Action>(remaining, n_btns.try_to_usize()?)?;
         let (leds, remaining) = crate::x11_utils::parse_list::<DeviceLedInfo>(remaining, n_device_led_f_bs.try_to_usize()?)?;
@@ -12534,6 +12692,7 @@ impl TryParse for NewKeyboardNotifyEvent {
         let (request_minor, remaining) = u8::try_parse(remaining)?;
         let (changed, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(14..).ok_or(ParseError::InsufficientData)?;
+        let changed = changed.into();
         let result = NewKeyboardNotifyEvent { response_type, xkb_type, sequence, time, device_id, old_device_id, min_key_code, max_key_code, old_min_key_code, old_max_key_code, request_major, request_minor, changed };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -12725,6 +12884,8 @@ impl TryParse for MapNotifyEvent {
         let (n_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
+        let changed = changed.into();
+        let virtual_mods = virtual_mods.into();
         let result = MapNotifyEvent { response_type, xkb_type, sequence, time, device_id, ptr_btn_actions, changed, min_key_code, max_key_code, first_type, n_types, first_key_sym, n_key_syms, first_key_act, n_key_acts, first_key_behavior, n_key_behavior, first_key_explicit, n_key_explicit, first_mod_map_key, n_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys, virtual_mods };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -12948,8 +13109,19 @@ impl TryParse for StateNotifyEvent {
         let (event_type, remaining) = u8::try_parse(remaining)?;
         let (request_major, remaining) = u8::try_parse(remaining)?;
         let (request_minor, remaining) = u8::try_parse(remaining)?;
+        let mods = mods.into();
+        let base_mods = base_mods.into();
+        let latched_mods = latched_mods.into();
+        let locked_mods = locked_mods.into();
         let group = group.into();
         let locked_group = locked_group.into();
+        let compat_state = compat_state.into();
+        let grab_mods = grab_mods.into();
+        let compat_grab_mods = compat_grab_mods.into();
+        let lookup_mods = lookup_mods.into();
+        let compat_loockup_mods = compat_loockup_mods.into();
+        let ptr_btn_state = ptr_btn_state.into();
+        let changed = changed.into();
         let result = StateNotifyEvent { response_type, xkb_type, sequence, time, device_id, mods, base_mods, latched_mods, locked_mods, group, base_group, latched_group, locked_group, compat_state, grab_mods, compat_grab_mods, lookup_mods, compat_loockup_mods, ptr_btn_state, changed, keycode, event_type, request_major, request_minor };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -13152,6 +13324,9 @@ impl TryParse for ControlsNotifyEvent {
         let (request_major, remaining) = u8::try_parse(remaining)?;
         let (request_minor, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::InsufficientData)?;
+        let changed_controls = changed_controls.into();
+        let enabled_controls = enabled_controls.into();
+        let enabled_control_changes = enabled_control_changes.into();
         let result = ControlsNotifyEvent { response_type, xkb_type, sequence, time, device_id, num_groups, changed_controls, enabled_controls, enabled_control_changes, keycode, event_type, request_major, request_minor };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -13614,6 +13789,9 @@ impl TryParse for NamesNotifyEvent {
         let (n_keys, remaining) = u8::try_parse(remaining)?;
         let (changed_indicators, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::InsufficientData)?;
+        let changed = changed.into();
+        let changed_group_names = changed_group_names.into();
+        let changed_virtual_mods = changed_virtual_mods.into();
         let result = NamesNotifyEvent { response_type, xkb_type, sequence, time, device_id, changed, first_type, n_types, first_level_name, n_level_names, n_radio_groups, n_key_aliases, changed_group_names, changed_virtual_mods, first_key, n_keys, changed_indicators };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -13789,6 +13967,7 @@ impl TryParse for CompatMapNotifyEvent {
         let (n_si, remaining) = u16::try_parse(remaining)?;
         let (n_total_si, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::InsufficientData)?;
+        let changed_groups = changed_groups.into();
         let result = CompatMapNotifyEvent { response_type, xkb_type, sequence, time, device_id, changed_groups, first_si, n_si, n_total_si };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -14113,6 +14292,7 @@ impl TryParse for ActionMessageEvent {
         let (message, remaining) = crate::x11_utils::parse_u8_list(remaining, 8)?;
         let message = <[u8; 8]>::try_from(message).unwrap();
         let remaining = remaining.get(10..).ok_or(ParseError::InsufficientData)?;
+        let mods = mods.into();
         let group = group.into();
         let result = ActionMessageEvent { response_type, xkb_type, sequence, time, device_id, keycode, press, key_event_follows, mods, group, message };
         let _ = remaining;
@@ -14267,6 +14447,7 @@ impl TryParse for AccessXNotifyEvent {
         let (slow_keys_delay, remaining) = u16::try_parse(remaining)?;
         let (debounce_delay, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::InsufficientData)?;
+        let detailt = detailt.into();
         let result = AccessXNotifyEvent { response_type, xkb_type, sequence, time, device_id, keycode, detailt, slow_keys_delay, debounce_delay };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -14427,7 +14608,10 @@ impl TryParse for ExtensionDeviceNotifyEvent {
         let (supported, remaining) = u16::try_parse(remaining)?;
         let (unsupported, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
+        let reason = reason.into();
         let led_class = led_class.into();
+        let supported = supported.into();
+        let unsupported = unsupported.into();
         let result = ExtensionDeviceNotifyEvent { response_type, xkb_type, sequence, time, device_id, reason, led_class, led_id, leds_defined, led_state, first_button, n_buttons, supported, unsupported };
         let _ = remaining;
         let remaining = initial_value.get(32..)

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -1909,10 +1909,10 @@ pub struct IndicatorMap {
     pub which_groups: IMGroupsWhich,
     pub groups: SetOfGroup,
     pub which_mods: IMModsWhich,
-    pub mods: u8,
-    pub real_mods: u8,
-    pub vmods: u16,
-    pub ctrls: u32,
+    pub mods: xproto::ModMask,
+    pub real_mods: xproto::ModMask,
+    pub vmods: VMod,
+    pub ctrls: BoolCtrl,
 }
 impl TryParse for IndicatorMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1943,10 +1943,10 @@ impl Serialize for IndicatorMap {
         let which_groups_bytes = u8::from(self.which_groups).serialize();
         let groups_bytes = u8::from(self.groups).serialize();
         let which_mods_bytes = u8::from(self.which_mods).serialize();
-        let mods_bytes = self.mods.serialize();
-        let real_mods_bytes = self.real_mods.serialize();
-        let vmods_bytes = self.vmods.serialize();
-        let ctrls_bytes = self.ctrls.serialize();
+        let mods_bytes = (u16::from(self.mods) as u8).serialize();
+        let real_mods_bytes = (u16::from(self.real_mods) as u8).serialize();
+        let vmods_bytes = u16::from(self.vmods).serialize();
+        let ctrls_bytes = u32::from(self.ctrls).serialize();
         [
             flags_bytes[0],
             which_groups_bytes[0],
@@ -1968,10 +1968,10 @@ impl Serialize for IndicatorMap {
         u8::from(self.which_groups).serialize_into(bytes);
         u8::from(self.groups).serialize_into(bytes);
         u8::from(self.which_mods).serialize_into(bytes);
-        self.mods.serialize_into(bytes);
-        self.real_mods.serialize_into(bytes);
-        self.vmods.serialize_into(bytes);
-        self.ctrls.serialize_into(bytes);
+        (u16::from(self.mods) as u8).serialize_into(bytes);
+        (u16::from(self.real_mods) as u8).serialize_into(bytes);
+        u16::from(self.vmods).serialize_into(bytes);
+        u32::from(self.ctrls).serialize_into(bytes);
     }
 }
 
@@ -2290,9 +2290,9 @@ bitmask_binop!(PerClientFlag, u32);
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModDef {
-    pub mask: u8,
-    pub real_mods: u8,
-    pub vmods: u16,
+    pub mask: xproto::ModMask,
+    pub real_mods: xproto::ModMask,
+    pub vmods: VMod,
 }
 impl TryParse for ModDef {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2309,9 +2309,9 @@ impl TryParse for ModDef {
 impl Serialize for ModDef {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
-        let mask_bytes = self.mask.serialize();
-        let real_mods_bytes = self.real_mods.serialize();
-        let vmods_bytes = self.vmods.serialize();
+        let mask_bytes = (u16::from(self.mask) as u8).serialize();
+        let real_mods_bytes = (u16::from(self.real_mods) as u8).serialize();
+        let vmods_bytes = u16::from(self.vmods).serialize();
         [
             mask_bytes[0],
             real_mods_bytes[0],
@@ -2321,9 +2321,9 @@ impl Serialize for ModDef {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        self.mask.serialize_into(bytes);
-        self.real_mods.serialize_into(bytes);
-        self.vmods.serialize_into(bytes);
+        (u16::from(self.mask) as u8).serialize_into(bytes);
+        (u16::from(self.real_mods) as u8).serialize_into(bytes);
+        u16::from(self.vmods).serialize_into(bytes);
     }
 }
 
@@ -2445,10 +2445,10 @@ impl CountedString16 {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KTMapEntry {
     pub active: bool,
-    pub mods_mask: u8,
+    pub mods_mask: xproto::ModMask,
     pub level: u8,
-    pub mods_mods: u8,
-    pub mods_vmods: u16,
+    pub mods_mods: xproto::ModMask,
+    pub mods_vmods: VMod,
 }
 impl TryParse for KTMapEntry {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2469,10 +2469,10 @@ impl Serialize for KTMapEntry {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
         let active_bytes = self.active.serialize();
-        let mods_mask_bytes = self.mods_mask.serialize();
+        let mods_mask_bytes = (u16::from(self.mods_mask) as u8).serialize();
         let level_bytes = self.level.serialize();
-        let mods_mods_bytes = self.mods_mods.serialize();
-        let mods_vmods_bytes = self.mods_vmods.serialize();
+        let mods_mods_bytes = (u16::from(self.mods_mods) as u8).serialize();
+        let mods_vmods_bytes = u16::from(self.mods_vmods).serialize();
         [
             active_bytes[0],
             mods_mask_bytes[0],
@@ -2487,10 +2487,10 @@ impl Serialize for KTMapEntry {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
         self.active.serialize_into(bytes);
-        self.mods_mask.serialize_into(bytes);
+        (u16::from(self.mods_mask) as u8).serialize_into(bytes);
         self.level.serialize_into(bytes);
-        self.mods_mods.serialize_into(bytes);
-        self.mods_vmods.serialize_into(bytes);
+        (u16::from(self.mods_mods) as u8).serialize_into(bytes);
+        u16::from(self.mods_vmods).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
     }
 }
@@ -2498,9 +2498,9 @@ impl Serialize for KTMapEntry {
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyType {
-    pub mods_mask: u8,
-    pub mods_mods: u8,
-    pub mods_vmods: u16,
+    pub mods_mask: xproto::ModMask,
+    pub mods_mods: xproto::ModMask,
+    pub mods_vmods: VMod,
     pub num_levels: u8,
     pub has_preserve: bool,
     pub map: Vec<KTMapEntry>,
@@ -2533,9 +2533,9 @@ impl Serialize for KeyType {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
-        self.mods_mask.serialize_into(bytes);
-        self.mods_mods.serialize_into(bytes);
-        self.mods_vmods.serialize_into(bytes);
+        (u16::from(self.mods_mask) as u8).serialize_into(bytes);
+        (u16::from(self.mods_mods) as u8).serialize_into(bytes);
+        u16::from(self.mods_vmods).serialize_into(bytes);
         self.num_levels.serialize_into(bytes);
         let n_map_entries = u8::try_from(self.map.len()).expect("`map` has too many elements");
         n_map_entries.serialize_into(bytes);
@@ -3004,7 +3004,7 @@ impl Serialize for SetBehavior {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetExplicit {
     pub keycode: xproto::Keycode,
-    pub explicit: u8,
+    pub explicit: Explicit,
 }
 impl TryParse for SetExplicit {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3019,7 +3019,7 @@ impl Serialize for SetExplicit {
     type Bytes = [u8; 2];
     fn serialize(&self) -> [u8; 2] {
         let keycode_bytes = self.keycode.serialize();
-        let explicit_bytes = self.explicit.serialize();
+        let explicit_bytes = u8::from(self.explicit).serialize();
         [
             keycode_bytes[0],
             explicit_bytes[0],
@@ -3028,7 +3028,7 @@ impl Serialize for SetExplicit {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(2);
         self.keycode.serialize_into(bytes);
-        self.explicit.serialize_into(bytes);
+        u8::from(self.explicit).serialize_into(bytes);
     }
 }
 
@@ -3036,7 +3036,7 @@ impl Serialize for SetExplicit {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyModMap {
     pub keycode: xproto::Keycode,
-    pub mods: u8,
+    pub mods: xproto::ModMask,
 }
 impl TryParse for KeyModMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3051,7 +3051,7 @@ impl Serialize for KeyModMap {
     type Bytes = [u8; 2];
     fn serialize(&self) -> [u8; 2] {
         let keycode_bytes = self.keycode.serialize();
-        let mods_bytes = self.mods.serialize();
+        let mods_bytes = (u16::from(self.mods) as u8).serialize();
         [
             keycode_bytes[0],
             mods_bytes[0],
@@ -3060,7 +3060,7 @@ impl Serialize for KeyModMap {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(2);
         self.keycode.serialize_into(bytes);
-        self.mods.serialize_into(bytes);
+        (u16::from(self.mods) as u8).serialize_into(bytes);
     }
 }
 
@@ -3068,7 +3068,7 @@ impl Serialize for KeyModMap {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyVModMap {
     pub keycode: xproto::Keycode,
-    pub vmods: u16,
+    pub vmods: VMod,
 }
 impl TryParse for KeyVModMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3084,7 +3084,7 @@ impl Serialize for KeyVModMap {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
         let keycode_bytes = self.keycode.serialize();
-        let vmods_bytes = self.vmods.serialize();
+        let vmods_bytes = u16::from(self.vmods).serialize();
         [
             keycode_bytes[0],
             0,
@@ -3096,7 +3096,7 @@ impl Serialize for KeyVModMap {
         bytes.reserve(4);
         self.keycode.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
-        self.vmods.serialize_into(bytes);
+        u16::from(self.vmods).serialize_into(bytes);
     }
 }
 
@@ -3104,8 +3104,8 @@ impl Serialize for KeyVModMap {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KTSetMapEntry {
     pub level: u8,
-    pub real_mods: u8,
-    pub virtual_mods: u16,
+    pub real_mods: xproto::ModMask,
+    pub virtual_mods: VMod,
 }
 impl TryParse for KTSetMapEntry {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3122,8 +3122,8 @@ impl Serialize for KTSetMapEntry {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
         let level_bytes = self.level.serialize();
-        let real_mods_bytes = self.real_mods.serialize();
-        let virtual_mods_bytes = self.virtual_mods.serialize();
+        let real_mods_bytes = (u16::from(self.real_mods) as u8).serialize();
+        let virtual_mods_bytes = u16::from(self.virtual_mods).serialize();
         [
             level_bytes[0],
             real_mods_bytes[0],
@@ -3134,17 +3134,17 @@ impl Serialize for KTSetMapEntry {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
         self.level.serialize_into(bytes);
-        self.real_mods.serialize_into(bytes);
-        self.virtual_mods.serialize_into(bytes);
+        (u16::from(self.real_mods) as u8).serialize_into(bytes);
+        u16::from(self.virtual_mods).serialize_into(bytes);
     }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetKeyType {
-    pub mask: u8,
-    pub real_mods: u8,
-    pub virtual_mods: u16,
+    pub mask: xproto::ModMask,
+    pub real_mods: xproto::ModMask,
+    pub virtual_mods: VMod,
     pub num_levels: u8,
     pub preserve: bool,
     pub entries: Vec<KTSetMapEntry>,
@@ -3177,9 +3177,9 @@ impl Serialize for SetKeyType {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
-        self.mask.serialize_into(bytes);
-        self.real_mods.serialize_into(bytes);
-        self.virtual_mods.serialize_into(bytes);
+        (u16::from(self.mask) as u8).serialize_into(bytes);
+        (u16::from(self.real_mods) as u8).serialize_into(bytes);
+        u16::from(self.virtual_mods).serialize_into(bytes);
         self.num_levels.serialize_into(bytes);
         let n_map_entries = u8::try_from(self.entries.len()).expect("`entries` has too many elements");
         n_map_entries.serialize_into(bytes);
@@ -3974,11 +3974,11 @@ impl Serialize for SANoAction {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetMods {
     pub type_: SAType,
-    pub flags: u8,
-    pub mask: u8,
-    pub real_mods: u8,
-    pub vmods_high: u8,
-    pub vmods_low: u8,
+    pub flags: SA,
+    pub mask: xproto::ModMask,
+    pub real_mods: xproto::ModMask,
+    pub vmods_high: VModsHigh,
+    pub vmods_low: VModsLow,
 }
 impl TryParse for SASetMods {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4003,11 +4003,11 @@ impl Serialize for SASetMods {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
-        let flags_bytes = self.flags.serialize();
-        let mask_bytes = self.mask.serialize();
-        let real_mods_bytes = self.real_mods.serialize();
-        let vmods_high_bytes = self.vmods_high.serialize();
-        let vmods_low_bytes = self.vmods_low.serialize();
+        let flags_bytes = u8::from(self.flags).serialize();
+        let mask_bytes = (u16::from(self.mask) as u8).serialize();
+        let real_mods_bytes = (u16::from(self.real_mods) as u8).serialize();
+        let vmods_high_bytes = u8::from(self.vmods_high).serialize();
+        let vmods_low_bytes = u8::from(self.vmods_low).serialize();
         [
             type_bytes[0],
             flags_bytes[0],
@@ -4022,11 +4022,11 @@ impl Serialize for SASetMods {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
         u8::from(self.type_).serialize_into(bytes);
-        self.flags.serialize_into(bytes);
-        self.mask.serialize_into(bytes);
-        self.real_mods.serialize_into(bytes);
-        self.vmods_high.serialize_into(bytes);
-        self.vmods_low.serialize_into(bytes);
+        u8::from(self.flags).serialize_into(bytes);
+        (u16::from(self.mask) as u8).serialize_into(bytes);
+        (u16::from(self.real_mods) as u8).serialize_into(bytes);
+        u8::from(self.vmods_high).serialize_into(bytes);
+        u8::from(self.vmods_low).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
     }
 }
@@ -4039,7 +4039,7 @@ pub type SALockMods = SASetMods;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetGroup {
     pub type_: SAType,
-    pub flags: u8,
+    pub flags: SA,
     pub group: i8,
 }
 impl TryParse for SASetGroup {
@@ -4058,7 +4058,7 @@ impl Serialize for SASetGroup {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u8::from(self.flags).serialize();
         let group_bytes = self.group.serialize();
         [
             type_bytes[0],
@@ -4074,7 +4074,7 @@ impl Serialize for SASetGroup {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
         u8::from(self.type_).serialize_into(bytes);
-        self.flags.serialize_into(bytes);
+        u8::from(self.flags).serialize_into(bytes);
         self.group.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 5]);
     }
@@ -4150,7 +4150,7 @@ bitmask_binop!(SAMovePtrFlag, u8);
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAMovePtr {
     pub type_: SAType,
-    pub flags: u8,
+    pub flags: SAMovePtrFlag,
     pub x_high: i8,
     pub x_low: u8,
     pub y_high: i8,
@@ -4175,7 +4175,7 @@ impl Serialize for SAMovePtr {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u8::from(self.flags).serialize();
         let x_high_bytes = self.x_high.serialize();
         let x_low_bytes = self.x_low.serialize();
         let y_high_bytes = self.y_high.serialize();
@@ -4194,7 +4194,7 @@ impl Serialize for SAMovePtr {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
         u8::from(self.type_).serialize_into(bytes);
-        self.flags.serialize_into(bytes);
+        u8::from(self.flags).serialize_into(bytes);
         self.x_high.serialize_into(bytes);
         self.x_low.serialize_into(bytes);
         self.y_high.serialize_into(bytes);
@@ -4361,8 +4361,8 @@ bitmask_binop!(SASetPtrDfltFlag, u8);
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetPtrDflt {
     pub type_: SAType,
-    pub flags: u8,
-    pub affect: u8,
+    pub flags: SASetPtrDfltFlag,
+    pub affect: SASetPtrDfltFlag,
     pub value: i8,
 }
 impl TryParse for SASetPtrDflt {
@@ -4383,8 +4383,8 @@ impl Serialize for SASetPtrDflt {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
-        let flags_bytes = self.flags.serialize();
-        let affect_bytes = self.affect.serialize();
+        let flags_bytes = u8::from(self.flags).serialize();
+        let affect_bytes = u8::from(self.affect).serialize();
         let value_bytes = self.value.serialize();
         [
             type_bytes[0],
@@ -4400,8 +4400,8 @@ impl Serialize for SASetPtrDflt {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
         u8::from(self.type_).serialize_into(bytes);
-        self.flags.serialize_into(bytes);
-        self.affect.serialize_into(bytes);
+        u8::from(self.flags).serialize_into(bytes);
+        u8::from(self.affect).serialize_into(bytes);
         self.value.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 4]);
     }
@@ -4541,13 +4541,13 @@ bitmask_binop!(SAIsoLockNoAffect, u8);
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAIsoLock {
     pub type_: SAType,
-    pub flags: u8,
-    pub mask: u8,
-    pub real_mods: u8,
+    pub flags: SAIsoLockFlag,
+    pub mask: xproto::ModMask,
+    pub real_mods: xproto::ModMask,
     pub group: i8,
-    pub affect: u8,
-    pub vmods_high: u8,
-    pub vmods_low: u8,
+    pub affect: SAIsoLockNoAffect,
+    pub vmods_high: VModsHigh,
+    pub vmods_low: VModsLow,
 }
 impl TryParse for SAIsoLock {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4574,13 +4574,13 @@ impl Serialize for SAIsoLock {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
-        let flags_bytes = self.flags.serialize();
-        let mask_bytes = self.mask.serialize();
-        let real_mods_bytes = self.real_mods.serialize();
+        let flags_bytes = u8::from(self.flags).serialize();
+        let mask_bytes = (u16::from(self.mask) as u8).serialize();
+        let real_mods_bytes = (u16::from(self.real_mods) as u8).serialize();
         let group_bytes = self.group.serialize();
-        let affect_bytes = self.affect.serialize();
-        let vmods_high_bytes = self.vmods_high.serialize();
-        let vmods_low_bytes = self.vmods_low.serialize();
+        let affect_bytes = u8::from(self.affect).serialize();
+        let vmods_high_bytes = u8::from(self.vmods_high).serialize();
+        let vmods_low_bytes = u8::from(self.vmods_low).serialize();
         [
             type_bytes[0],
             flags_bytes[0],
@@ -4595,13 +4595,13 @@ impl Serialize for SAIsoLock {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
         u8::from(self.type_).serialize_into(bytes);
-        self.flags.serialize_into(bytes);
-        self.mask.serialize_into(bytes);
-        self.real_mods.serialize_into(bytes);
+        u8::from(self.flags).serialize_into(bytes);
+        (u16::from(self.mask) as u8).serialize_into(bytes);
+        (u16::from(self.real_mods) as u8).serialize_into(bytes);
         self.group.serialize_into(bytes);
-        self.affect.serialize_into(bytes);
-        self.vmods_high.serialize_into(bytes);
-        self.vmods_low.serialize_into(bytes);
+        u8::from(self.affect).serialize_into(bytes);
+        u8::from(self.vmods_high).serialize_into(bytes);
+        u8::from(self.vmods_low).serialize_into(bytes);
     }
 }
 
@@ -4887,8 +4887,8 @@ bitmask_binop!(BoolCtrlsLow, u8);
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetControls {
     pub type_: SAType,
-    pub bool_ctrls_high: u8,
-    pub bool_ctrls_low: u8,
+    pub bool_ctrls_high: BoolCtrlsHigh,
+    pub bool_ctrls_low: BoolCtrlsLow,
 }
 impl TryParse for SASetControls {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4908,8 +4908,8 @@ impl Serialize for SASetControls {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
-        let bool_ctrls_high_bytes = self.bool_ctrls_high.serialize();
-        let bool_ctrls_low_bytes = self.bool_ctrls_low.serialize();
+        let bool_ctrls_high_bytes = u8::from(self.bool_ctrls_high).serialize();
+        let bool_ctrls_low_bytes = u8::from(self.bool_ctrls_low).serialize();
         [
             type_bytes[0],
             0,
@@ -4925,8 +4925,8 @@ impl Serialize for SASetControls {
         bytes.reserve(8);
         u8::from(self.type_).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 3]);
-        self.bool_ctrls_high.serialize_into(bytes);
-        self.bool_ctrls_low.serialize_into(bytes);
+        u8::from(self.bool_ctrls_high).serialize_into(bytes);
+        u8::from(self.bool_ctrls_low).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
     }
 }
@@ -4999,7 +4999,7 @@ bitmask_binop!(ActionMessageFlag, u8);
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAActionMessage {
     pub type_: SAType,
-    pub flags: u8,
+    pub flags: ActionMessageFlag,
     pub message: [u8; 6],
 }
 impl TryParse for SAActionMessage {
@@ -5018,7 +5018,7 @@ impl Serialize for SAActionMessage {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u8::from(self.flags).serialize();
         [
             type_bytes[0],
             flags_bytes[0],
@@ -5033,7 +5033,7 @@ impl Serialize for SAActionMessage {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
         u8::from(self.type_).serialize_into(bytes);
-        self.flags.serialize_into(bytes);
+        u8::from(self.flags).serialize_into(bytes);
         bytes.extend_from_slice(&self.message);
     }
 }
@@ -5043,12 +5043,12 @@ impl Serialize for SAActionMessage {
 pub struct SARedirectKey {
     pub type_: SAType,
     pub newkey: xproto::Keycode,
-    pub mask: u8,
-    pub real_modifiers: u8,
-    pub vmods_mask_high: u8,
-    pub vmods_mask_low: u8,
-    pub vmods_high: u8,
-    pub vmods_low: u8,
+    pub mask: xproto::ModMask,
+    pub real_modifiers: xproto::ModMask,
+    pub vmods_mask_high: VModsHigh,
+    pub vmods_mask_low: VModsLow,
+    pub vmods_high: VModsHigh,
+    pub vmods_low: VModsLow,
 }
 impl TryParse for SARedirectKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5076,12 +5076,12 @@ impl Serialize for SARedirectKey {
     fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
         let newkey_bytes = self.newkey.serialize();
-        let mask_bytes = self.mask.serialize();
-        let real_modifiers_bytes = self.real_modifiers.serialize();
-        let vmods_mask_high_bytes = self.vmods_mask_high.serialize();
-        let vmods_mask_low_bytes = self.vmods_mask_low.serialize();
-        let vmods_high_bytes = self.vmods_high.serialize();
-        let vmods_low_bytes = self.vmods_low.serialize();
+        let mask_bytes = (u16::from(self.mask) as u8).serialize();
+        let real_modifiers_bytes = (u16::from(self.real_modifiers) as u8).serialize();
+        let vmods_mask_high_bytes = u8::from(self.vmods_mask_high).serialize();
+        let vmods_mask_low_bytes = u8::from(self.vmods_mask_low).serialize();
+        let vmods_high_bytes = u8::from(self.vmods_high).serialize();
+        let vmods_low_bytes = u8::from(self.vmods_low).serialize();
         [
             type_bytes[0],
             newkey_bytes[0],
@@ -5097,12 +5097,12 @@ impl Serialize for SARedirectKey {
         bytes.reserve(8);
         u8::from(self.type_).serialize_into(bytes);
         self.newkey.serialize_into(bytes);
-        self.mask.serialize_into(bytes);
-        self.real_modifiers.serialize_into(bytes);
-        self.vmods_mask_high.serialize_into(bytes);
-        self.vmods_mask_low.serialize_into(bytes);
-        self.vmods_high.serialize_into(bytes);
-        self.vmods_low.serialize_into(bytes);
+        (u16::from(self.mask) as u8).serialize_into(bytes);
+        (u16::from(self.real_modifiers) as u8).serialize_into(bytes);
+        u8::from(self.vmods_mask_high).serialize_into(bytes);
+        u8::from(self.vmods_mask_low).serialize_into(bytes);
+        u8::from(self.vmods_high).serialize_into(bytes);
+        u8::from(self.vmods_low).serialize_into(bytes);
     }
 }
 
@@ -5222,7 +5222,7 @@ bitmask_binop!(LockDeviceFlags, u8);
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SALockDeviceBtn {
     pub type_: SAType,
-    pub flags: u8,
+    pub flags: LockDeviceFlags,
     pub button: u8,
     pub device: u8,
 }
@@ -5244,7 +5244,7 @@ impl Serialize for SALockDeviceBtn {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
         let type_bytes = u8::from(self.type_).serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u8::from(self.flags).serialize();
         let button_bytes = self.button.serialize();
         let device_bytes = self.device.serialize();
         [
@@ -5261,7 +5261,7 @@ impl Serialize for SALockDeviceBtn {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
         u8::from(self.type_).serialize_into(bytes);
-        self.flags.serialize_into(bytes);
+        u8::from(self.flags).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
         self.button.serialize_into(bytes);
         self.device.serialize_into(bytes);
@@ -5442,9 +5442,9 @@ impl Serialize for SIAction {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SymInterpret {
     pub sym: xproto::Keysym,
-    pub mods: u8,
+    pub mods: xproto::ModMask,
     pub match_: u8,
-    pub virtual_mod: u8,
+    pub virtual_mod: VModsLow,
     pub flags: u8,
     pub action: SIAction,
 }
@@ -5466,9 +5466,9 @@ impl Serialize for SymInterpret {
     type Bytes = [u8; 16];
     fn serialize(&self) -> [u8; 16] {
         let sym_bytes = self.sym.serialize();
-        let mods_bytes = self.mods.serialize();
+        let mods_bytes = (u16::from(self.mods) as u8).serialize();
         let match_bytes = self.match_.serialize();
-        let virtual_mod_bytes = self.virtual_mod.serialize();
+        let virtual_mod_bytes = u8::from(self.virtual_mod).serialize();
         let flags_bytes = self.flags.serialize();
         let action_bytes = self.action.serialize();
         [
@@ -5493,9 +5493,9 @@ impl Serialize for SymInterpret {
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(16);
         self.sym.serialize_into(bytes);
-        self.mods.serialize_into(bytes);
+        (u16::from(self.mods) as u8).serialize_into(bytes);
         self.match_.serialize_into(bytes);
-        self.virtual_mod.serialize_into(bytes);
+        u8::from(self.virtual_mod).serialize_into(bytes);
         self.flags.serialize_into(bytes);
         self.action.serialize_into(bytes);
     }
@@ -5962,8 +5962,8 @@ impl Serialize for UseExtensionReply {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase1 {
-    pub affect_new_keyboard: u16,
-    pub new_keyboard_details: u16,
+    pub affect_new_keyboard: NKNDetail,
+    pub new_keyboard_details: NKNDetail,
 }
 impl TryParse for SelectEventsAuxBitcase1 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5978,8 +5978,8 @@ impl TryParse for SelectEventsAuxBitcase1 {
 impl Serialize for SelectEventsAuxBitcase1 {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
-        let affect_new_keyboard_bytes = self.affect_new_keyboard.serialize();
-        let new_keyboard_details_bytes = self.new_keyboard_details.serialize();
+        let affect_new_keyboard_bytes = u16::from(self.affect_new_keyboard).serialize();
+        let new_keyboard_details_bytes = u16::from(self.new_keyboard_details).serialize();
         [
             affect_new_keyboard_bytes[0],
             affect_new_keyboard_bytes[1],
@@ -5989,15 +5989,15 @@ impl Serialize for SelectEventsAuxBitcase1 {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        self.affect_new_keyboard.serialize_into(bytes);
-        self.new_keyboard_details.serialize_into(bytes);
+        u16::from(self.affect_new_keyboard).serialize_into(bytes);
+        u16::from(self.new_keyboard_details).serialize_into(bytes);
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase2 {
-    pub affect_state: u16,
-    pub state_details: u16,
+    pub affect_state: StatePart,
+    pub state_details: StatePart,
 }
 impl TryParse for SelectEventsAuxBitcase2 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6012,8 +6012,8 @@ impl TryParse for SelectEventsAuxBitcase2 {
 impl Serialize for SelectEventsAuxBitcase2 {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
-        let affect_state_bytes = self.affect_state.serialize();
-        let state_details_bytes = self.state_details.serialize();
+        let affect_state_bytes = u16::from(self.affect_state).serialize();
+        let state_details_bytes = u16::from(self.state_details).serialize();
         [
             affect_state_bytes[0],
             affect_state_bytes[1],
@@ -6023,15 +6023,15 @@ impl Serialize for SelectEventsAuxBitcase2 {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        self.affect_state.serialize_into(bytes);
-        self.state_details.serialize_into(bytes);
+        u16::from(self.affect_state).serialize_into(bytes);
+        u16::from(self.state_details).serialize_into(bytes);
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase3 {
-    pub affect_ctrls: u32,
-    pub ctrl_details: u32,
+    pub affect_ctrls: Control,
+    pub ctrl_details: Control,
 }
 impl TryParse for SelectEventsAuxBitcase3 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6046,8 +6046,8 @@ impl TryParse for SelectEventsAuxBitcase3 {
 impl Serialize for SelectEventsAuxBitcase3 {
     type Bytes = [u8; 8];
     fn serialize(&self) -> [u8; 8] {
-        let affect_ctrls_bytes = self.affect_ctrls.serialize();
-        let ctrl_details_bytes = self.ctrl_details.serialize();
+        let affect_ctrls_bytes = u32::from(self.affect_ctrls).serialize();
+        let ctrl_details_bytes = u32::from(self.ctrl_details).serialize();
         [
             affect_ctrls_bytes[0],
             affect_ctrls_bytes[1],
@@ -6061,8 +6061,8 @@ impl Serialize for SelectEventsAuxBitcase3 {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(8);
-        self.affect_ctrls.serialize_into(bytes);
-        self.ctrl_details.serialize_into(bytes);
+        u32::from(self.affect_ctrls).serialize_into(bytes);
+        u32::from(self.ctrl_details).serialize_into(bytes);
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -6140,8 +6140,8 @@ impl Serialize for SelectEventsAuxBitcase5 {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase6 {
-    pub affect_names: u16,
-    pub names_details: u16,
+    pub affect_names: NameDetail,
+    pub names_details: NameDetail,
 }
 impl TryParse for SelectEventsAuxBitcase6 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6156,8 +6156,8 @@ impl TryParse for SelectEventsAuxBitcase6 {
 impl Serialize for SelectEventsAuxBitcase6 {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
-        let affect_names_bytes = self.affect_names.serialize();
-        let names_details_bytes = self.names_details.serialize();
+        let affect_names_bytes = (u32::from(self.affect_names) as u16).serialize();
+        let names_details_bytes = (u32::from(self.names_details) as u16).serialize();
         [
             affect_names_bytes[0],
             affect_names_bytes[1],
@@ -6167,15 +6167,15 @@ impl Serialize for SelectEventsAuxBitcase6 {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        self.affect_names.serialize_into(bytes);
-        self.names_details.serialize_into(bytes);
+        (u32::from(self.affect_names) as u16).serialize_into(bytes);
+        (u32::from(self.names_details) as u16).serialize_into(bytes);
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase7 {
-    pub affect_compat: u8,
-    pub compat_details: u8,
+    pub affect_compat: CMDetail,
+    pub compat_details: CMDetail,
 }
 impl TryParse for SelectEventsAuxBitcase7 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6190,8 +6190,8 @@ impl TryParse for SelectEventsAuxBitcase7 {
 impl Serialize for SelectEventsAuxBitcase7 {
     type Bytes = [u8; 2];
     fn serialize(&self) -> [u8; 2] {
-        let affect_compat_bytes = self.affect_compat.serialize();
-        let compat_details_bytes = self.compat_details.serialize();
+        let affect_compat_bytes = u8::from(self.affect_compat).serialize();
+        let compat_details_bytes = u8::from(self.compat_details).serialize();
         [
             affect_compat_bytes[0],
             compat_details_bytes[0],
@@ -6199,8 +6199,8 @@ impl Serialize for SelectEventsAuxBitcase7 {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(2);
-        self.affect_compat.serialize_into(bytes);
-        self.compat_details.serialize_into(bytes);
+        u8::from(self.affect_compat).serialize_into(bytes);
+        u8::from(self.compat_details).serialize_into(bytes);
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -6266,8 +6266,8 @@ impl Serialize for SelectEventsAuxBitcase9 {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase10 {
-    pub affect_access_x: u16,
-    pub access_x_details: u16,
+    pub affect_access_x: AXNDetail,
+    pub access_x_details: AXNDetail,
 }
 impl TryParse for SelectEventsAuxBitcase10 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6282,8 +6282,8 @@ impl TryParse for SelectEventsAuxBitcase10 {
 impl Serialize for SelectEventsAuxBitcase10 {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
-        let affect_access_x_bytes = self.affect_access_x.serialize();
-        let access_x_details_bytes = self.access_x_details.serialize();
+        let affect_access_x_bytes = u16::from(self.affect_access_x).serialize();
+        let access_x_details_bytes = u16::from(self.access_x_details).serialize();
         [
             affect_access_x_bytes[0],
             affect_access_x_bytes[1],
@@ -6293,15 +6293,15 @@ impl Serialize for SelectEventsAuxBitcase10 {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        self.affect_access_x.serialize_into(bytes);
-        self.access_x_details.serialize_into(bytes);
+        u16::from(self.affect_access_x).serialize_into(bytes);
+        u16::from(self.access_x_details).serialize_into(bytes);
     }
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBitcase11 {
-    pub affect_ext_dev: u16,
-    pub extdev_details: u16,
+    pub affect_ext_dev: XIFeature,
+    pub extdev_details: XIFeature,
 }
 impl TryParse for SelectEventsAuxBitcase11 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6316,8 +6316,8 @@ impl TryParse for SelectEventsAuxBitcase11 {
 impl Serialize for SelectEventsAuxBitcase11 {
     type Bytes = [u8; 4];
     fn serialize(&self) -> [u8; 4] {
-        let affect_ext_dev_bytes = self.affect_ext_dev.serialize();
-        let extdev_details_bytes = self.extdev_details.serialize();
+        let affect_ext_dev_bytes = u16::from(self.affect_ext_dev).serialize();
+        let extdev_details_bytes = u16::from(self.extdev_details).serialize();
         [
             affect_ext_dev_bytes[0],
             affect_ext_dev_bytes[1],
@@ -6327,8 +6327,8 @@ impl Serialize for SelectEventsAuxBitcase11 {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(4);
-        self.affect_ext_dev.serialize_into(bytes);
-        self.extdev_details.serialize_into(bytes);
+        u16::from(self.affect_ext_dev).serialize_into(bytes);
+        u16::from(self.extdev_details).serialize_into(bytes);
     }
 }
 /// Auxiliary and optional information for the `select_events` function
@@ -6596,10 +6596,10 @@ pub const SELECT_EVENTS_REQUEST: u8 = 1;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsRequest<'input> {
     pub device_spec: DeviceSpec,
-    pub clear: u16,
-    pub select_all: u16,
-    pub affect_map: u16,
-    pub map: u16,
+    pub clear: EventType,
+    pub select_all: EventType,
+    pub affect_map: MapPart,
+    pub map: MapPart,
     pub details: Cow<'input, SelectEventsAux>,
 }
 impl<'input> SelectEventsRequest<'input> {
@@ -6609,10 +6609,10 @@ impl<'input> SelectEventsRequest<'input> {
         let device_spec_bytes = self.device_spec.serialize();
         let affect_which: u16 = self.details.switch_expr() | (self.clear | self.select_all);
         let affect_which_bytes = affect_which.serialize();
-        let clear_bytes = self.clear.serialize();
-        let select_all_bytes = self.select_all.serialize();
-        let affect_map_bytes = self.affect_map.serialize();
-        let map_bytes = self.map.serialize();
+        let clear_bytes = u16::from(self.clear).serialize();
+        let select_all_bytes = u16::from(self.select_all).serialize();
+        let affect_map_bytes = u16::from(self.affect_map).serialize();
+        let map_bytes = u16::from(self.map).serialize();
         let mut request0 = vec![
             major_opcode,
             SELECT_EVENTS_REQUEST,
@@ -6864,20 +6864,20 @@ pub struct GetStateReply {
     pub device_id: u8,
     pub sequence: u16,
     pub length: u32,
-    pub mods: u8,
-    pub base_mods: u8,
-    pub latched_mods: u8,
-    pub locked_mods: u8,
+    pub mods: xproto::ModMask,
+    pub base_mods: xproto::ModMask,
+    pub latched_mods: xproto::ModMask,
+    pub locked_mods: xproto::ModMask,
     pub group: Group,
     pub locked_group: Group,
     pub base_group: i16,
     pub latched_group: i16,
-    pub compat_state: u8,
-    pub grab_mods: u8,
-    pub compat_grab_mods: u8,
-    pub lookup_mods: u8,
-    pub compat_lookup_mods: u8,
-    pub ptr_btn_state: u16,
+    pub compat_state: xproto::ModMask,
+    pub grab_mods: xproto::ModMask,
+    pub compat_grab_mods: xproto::ModMask,
+    pub lookup_mods: xproto::ModMask,
+    pub compat_lookup_mods: xproto::ModMask,
+    pub ptr_btn_state: xproto::KeyButMask,
 }
 impl TryParse for GetStateReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6931,20 +6931,20 @@ impl Serialize for GetStateReply {
         let device_id_bytes = self.device_id.serialize();
         let sequence_bytes = self.sequence.serialize();
         let length_bytes = self.length.serialize();
-        let mods_bytes = self.mods.serialize();
-        let base_mods_bytes = self.base_mods.serialize();
-        let latched_mods_bytes = self.latched_mods.serialize();
-        let locked_mods_bytes = self.locked_mods.serialize();
+        let mods_bytes = (u16::from(self.mods) as u8).serialize();
+        let base_mods_bytes = (u16::from(self.base_mods) as u8).serialize();
+        let latched_mods_bytes = (u16::from(self.latched_mods) as u8).serialize();
+        let locked_mods_bytes = (u16::from(self.locked_mods) as u8).serialize();
         let group_bytes = u8::from(self.group).serialize();
         let locked_group_bytes = u8::from(self.locked_group).serialize();
         let base_group_bytes = self.base_group.serialize();
         let latched_group_bytes = self.latched_group.serialize();
-        let compat_state_bytes = self.compat_state.serialize();
-        let grab_mods_bytes = self.grab_mods.serialize();
-        let compat_grab_mods_bytes = self.compat_grab_mods.serialize();
-        let lookup_mods_bytes = self.lookup_mods.serialize();
-        let compat_lookup_mods_bytes = self.compat_lookup_mods.serialize();
-        let ptr_btn_state_bytes = self.ptr_btn_state.serialize();
+        let compat_state_bytes = (u16::from(self.compat_state) as u8).serialize();
+        let grab_mods_bytes = (u16::from(self.grab_mods) as u8).serialize();
+        let compat_grab_mods_bytes = (u16::from(self.compat_grab_mods) as u8).serialize();
+        let lookup_mods_bytes = (u16::from(self.lookup_mods) as u8).serialize();
+        let compat_lookup_mods_bytes = (u16::from(self.compat_lookup_mods) as u8).serialize();
+        let ptr_btn_state_bytes = u16::from(self.ptr_btn_state).serialize();
         [
             response_type_bytes[0],
             device_id_bytes[0],
@@ -6987,21 +6987,21 @@ impl Serialize for GetStateReply {
         self.device_id.serialize_into(bytes);
         self.sequence.serialize_into(bytes);
         self.length.serialize_into(bytes);
-        self.mods.serialize_into(bytes);
-        self.base_mods.serialize_into(bytes);
-        self.latched_mods.serialize_into(bytes);
-        self.locked_mods.serialize_into(bytes);
+        (u16::from(self.mods) as u8).serialize_into(bytes);
+        (u16::from(self.base_mods) as u8).serialize_into(bytes);
+        (u16::from(self.latched_mods) as u8).serialize_into(bytes);
+        (u16::from(self.locked_mods) as u8).serialize_into(bytes);
         u8::from(self.group).serialize_into(bytes);
         u8::from(self.locked_group).serialize_into(bytes);
         self.base_group.serialize_into(bytes);
         self.latched_group.serialize_into(bytes);
-        self.compat_state.serialize_into(bytes);
-        self.grab_mods.serialize_into(bytes);
-        self.compat_grab_mods.serialize_into(bytes);
-        self.lookup_mods.serialize_into(bytes);
-        self.compat_lookup_mods.serialize_into(bytes);
+        (u16::from(self.compat_state) as u8).serialize_into(bytes);
+        (u16::from(self.grab_mods) as u8).serialize_into(bytes);
+        (u16::from(self.compat_grab_mods) as u8).serialize_into(bytes);
+        (u16::from(self.lookup_mods) as u8).serialize_into(bytes);
+        (u16::from(self.compat_lookup_mods) as u8).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
-        self.ptr_btn_state.serialize_into(bytes);
+        u16::from(self.ptr_btn_state).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 6]);
     }
 }
@@ -7012,11 +7012,11 @@ pub const LATCH_LOCK_STATE_REQUEST: u8 = 5;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LatchLockStateRequest {
     pub device_spec: DeviceSpec,
-    pub affect_mod_locks: u8,
-    pub mod_locks: u8,
+    pub affect_mod_locks: xproto::ModMask,
+    pub mod_locks: xproto::ModMask,
     pub lock_group: bool,
     pub group_lock: Group,
-    pub affect_mod_latches: u8,
+    pub affect_mod_latches: xproto::ModMask,
     pub latch_group: bool,
     pub group_latch: u16,
 }
@@ -7025,11 +7025,11 @@ impl LatchLockStateRequest {
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'static>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let affect_mod_locks_bytes = self.affect_mod_locks.serialize();
-        let mod_locks_bytes = self.mod_locks.serialize();
+        let affect_mod_locks_bytes = (u16::from(self.affect_mod_locks) as u8).serialize();
+        let mod_locks_bytes = (u16::from(self.mod_locks) as u8).serialize();
         let lock_group_bytes = self.lock_group.serialize();
         let group_lock_bytes = u8::from(self.group_lock).serialize();
-        let affect_mod_latches_bytes = self.affect_mod_latches.serialize();
+        let affect_mod_latches_bytes = (u16::from(self.affect_mod_latches) as u8).serialize();
         let latch_group_bytes = self.latch_group.serialize();
         let group_latch_bytes = self.group_latch.serialize();
         let mut request0 = vec![
@@ -7165,12 +7165,12 @@ pub struct GetControlsReply {
     pub mouse_keys_dflt_btn: u8,
     pub num_groups: u8,
     pub groups_wrap: u8,
-    pub internal_mods_mask: u8,
-    pub ignore_lock_mods_mask: u8,
-    pub internal_mods_real_mods: u8,
-    pub ignore_lock_mods_real_mods: u8,
-    pub internal_mods_vmods: u16,
-    pub ignore_lock_mods_vmods: u16,
+    pub internal_mods_mask: xproto::ModMask,
+    pub ignore_lock_mods_mask: xproto::ModMask,
+    pub internal_mods_real_mods: xproto::ModMask,
+    pub ignore_lock_mods_real_mods: xproto::ModMask,
+    pub internal_mods_vmods: VMod,
+    pub ignore_lock_mods_vmods: VMod,
     pub repeat_delay: u16,
     pub repeat_interval: u16,
     pub slow_keys_delay: u16,
@@ -7180,13 +7180,13 @@ pub struct GetControlsReply {
     pub mouse_keys_time_to_max: u16,
     pub mouse_keys_max_speed: u16,
     pub mouse_keys_curve: i16,
-    pub access_x_option: u16,
+    pub access_x_option: AXOption,
     pub access_x_timeout: u16,
-    pub access_x_timeout_options_mask: u16,
-    pub access_x_timeout_options_values: u16,
-    pub access_x_timeout_mask: u32,
-    pub access_x_timeout_values: u32,
-    pub enabled_controls: u32,
+    pub access_x_timeout_options_mask: AXOption,
+    pub access_x_timeout_options_values: AXOption,
+    pub access_x_timeout_mask: BoolCtrl,
+    pub access_x_timeout_values: BoolCtrl,
+    pub enabled_controls: BoolCtrl,
     pub per_key_repeat: [u8; 32],
 }
 impl TryParse for GetControlsReply {
@@ -7257,12 +7257,12 @@ impl Serialize for GetControlsReply {
         let mouse_keys_dflt_btn_bytes = self.mouse_keys_dflt_btn.serialize();
         let num_groups_bytes = self.num_groups.serialize();
         let groups_wrap_bytes = self.groups_wrap.serialize();
-        let internal_mods_mask_bytes = self.internal_mods_mask.serialize();
-        let ignore_lock_mods_mask_bytes = self.ignore_lock_mods_mask.serialize();
-        let internal_mods_real_mods_bytes = self.internal_mods_real_mods.serialize();
-        let ignore_lock_mods_real_mods_bytes = self.ignore_lock_mods_real_mods.serialize();
-        let internal_mods_vmods_bytes = self.internal_mods_vmods.serialize();
-        let ignore_lock_mods_vmods_bytes = self.ignore_lock_mods_vmods.serialize();
+        let internal_mods_mask_bytes = (u16::from(self.internal_mods_mask) as u8).serialize();
+        let ignore_lock_mods_mask_bytes = (u16::from(self.ignore_lock_mods_mask) as u8).serialize();
+        let internal_mods_real_mods_bytes = (u16::from(self.internal_mods_real_mods) as u8).serialize();
+        let ignore_lock_mods_real_mods_bytes = (u16::from(self.ignore_lock_mods_real_mods) as u8).serialize();
+        let internal_mods_vmods_bytes = u16::from(self.internal_mods_vmods).serialize();
+        let ignore_lock_mods_vmods_bytes = u16::from(self.ignore_lock_mods_vmods).serialize();
         let repeat_delay_bytes = self.repeat_delay.serialize();
         let repeat_interval_bytes = self.repeat_interval.serialize();
         let slow_keys_delay_bytes = self.slow_keys_delay.serialize();
@@ -7272,13 +7272,13 @@ impl Serialize for GetControlsReply {
         let mouse_keys_time_to_max_bytes = self.mouse_keys_time_to_max.serialize();
         let mouse_keys_max_speed_bytes = self.mouse_keys_max_speed.serialize();
         let mouse_keys_curve_bytes = self.mouse_keys_curve.serialize();
-        let access_x_option_bytes = self.access_x_option.serialize();
+        let access_x_option_bytes = u16::from(self.access_x_option).serialize();
         let access_x_timeout_bytes = self.access_x_timeout.serialize();
-        let access_x_timeout_options_mask_bytes = self.access_x_timeout_options_mask.serialize();
-        let access_x_timeout_options_values_bytes = self.access_x_timeout_options_values.serialize();
-        let access_x_timeout_mask_bytes = self.access_x_timeout_mask.serialize();
-        let access_x_timeout_values_bytes = self.access_x_timeout_values.serialize();
-        let enabled_controls_bytes = self.enabled_controls.serialize();
+        let access_x_timeout_options_mask_bytes = u16::from(self.access_x_timeout_options_mask).serialize();
+        let access_x_timeout_options_values_bytes = u16::from(self.access_x_timeout_options_values).serialize();
+        let access_x_timeout_mask_bytes = u32::from(self.access_x_timeout_mask).serialize();
+        let access_x_timeout_values_bytes = u32::from(self.access_x_timeout_values).serialize();
+        let enabled_controls_bytes = u32::from(self.enabled_controls).serialize();
         [
             response_type_bytes[0],
             device_id_bytes[0],
@@ -7384,13 +7384,13 @@ impl Serialize for GetControlsReply {
         self.mouse_keys_dflt_btn.serialize_into(bytes);
         self.num_groups.serialize_into(bytes);
         self.groups_wrap.serialize_into(bytes);
-        self.internal_mods_mask.serialize_into(bytes);
-        self.ignore_lock_mods_mask.serialize_into(bytes);
-        self.internal_mods_real_mods.serialize_into(bytes);
-        self.ignore_lock_mods_real_mods.serialize_into(bytes);
+        (u16::from(self.internal_mods_mask) as u8).serialize_into(bytes);
+        (u16::from(self.ignore_lock_mods_mask) as u8).serialize_into(bytes);
+        (u16::from(self.internal_mods_real_mods) as u8).serialize_into(bytes);
+        (u16::from(self.ignore_lock_mods_real_mods) as u8).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
-        self.internal_mods_vmods.serialize_into(bytes);
-        self.ignore_lock_mods_vmods.serialize_into(bytes);
+        u16::from(self.internal_mods_vmods).serialize_into(bytes);
+        u16::from(self.ignore_lock_mods_vmods).serialize_into(bytes);
         self.repeat_delay.serialize_into(bytes);
         self.repeat_interval.serialize_into(bytes);
         self.slow_keys_delay.serialize_into(bytes);
@@ -7400,14 +7400,14 @@ impl Serialize for GetControlsReply {
         self.mouse_keys_time_to_max.serialize_into(bytes);
         self.mouse_keys_max_speed.serialize_into(bytes);
         self.mouse_keys_curve.serialize_into(bytes);
-        self.access_x_option.serialize_into(bytes);
+        u16::from(self.access_x_option).serialize_into(bytes);
         self.access_x_timeout.serialize_into(bytes);
-        self.access_x_timeout_options_mask.serialize_into(bytes);
-        self.access_x_timeout_options_values.serialize_into(bytes);
+        u16::from(self.access_x_timeout_options_mask).serialize_into(bytes);
+        u16::from(self.access_x_timeout_options_values).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
-        self.access_x_timeout_mask.serialize_into(bytes);
-        self.access_x_timeout_values.serialize_into(bytes);
-        self.enabled_controls.serialize_into(bytes);
+        u32::from(self.access_x_timeout_mask).serialize_into(bytes);
+        u32::from(self.access_x_timeout_values).serialize_into(bytes);
+        u32::from(self.enabled_controls).serialize_into(bytes);
         bytes.extend_from_slice(&self.per_key_repeat);
     }
 }
@@ -7418,20 +7418,20 @@ pub const SET_CONTROLS_REQUEST: u8 = 7;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetControlsRequest<'input> {
     pub device_spec: DeviceSpec,
-    pub affect_internal_real_mods: u8,
-    pub internal_real_mods: u8,
-    pub affect_ignore_lock_real_mods: u8,
-    pub ignore_lock_real_mods: u8,
-    pub affect_internal_virtual_mods: u16,
-    pub internal_virtual_mods: u16,
-    pub affect_ignore_lock_virtual_mods: u16,
-    pub ignore_lock_virtual_mods: u16,
+    pub affect_internal_real_mods: xproto::ModMask,
+    pub internal_real_mods: xproto::ModMask,
+    pub affect_ignore_lock_real_mods: xproto::ModMask,
+    pub ignore_lock_real_mods: xproto::ModMask,
+    pub affect_internal_virtual_mods: VMod,
+    pub internal_virtual_mods: VMod,
+    pub affect_ignore_lock_virtual_mods: VMod,
+    pub ignore_lock_virtual_mods: VMod,
     pub mouse_keys_dflt_btn: u8,
     pub groups_wrap: u8,
-    pub access_x_options: u16,
-    pub affect_enabled_controls: u32,
-    pub enabled_controls: u32,
-    pub change_controls: u32,
+    pub access_x_options: AXOption,
+    pub affect_enabled_controls: BoolCtrl,
+    pub enabled_controls: BoolCtrl,
+    pub change_controls: Control,
     pub repeat_delay: u16,
     pub repeat_interval: u16,
     pub slow_keys_delay: u16,
@@ -7442,10 +7442,10 @@ pub struct SetControlsRequest<'input> {
     pub mouse_keys_max_speed: u16,
     pub mouse_keys_curve: i16,
     pub access_x_timeout: u16,
-    pub access_x_timeout_mask: u32,
-    pub access_x_timeout_values: u32,
-    pub access_x_timeout_options_mask: u16,
-    pub access_x_timeout_options_values: u16,
+    pub access_x_timeout_mask: BoolCtrl,
+    pub access_x_timeout_values: BoolCtrl,
+    pub access_x_timeout_options_mask: AXOption,
+    pub access_x_timeout_options_values: AXOption,
     pub per_key_repeat: Cow<'input, [u8; 32]>,
 }
 impl<'input> SetControlsRequest<'input> {
@@ -7453,20 +7453,20 @@ impl<'input> SetControlsRequest<'input> {
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let affect_internal_real_mods_bytes = self.affect_internal_real_mods.serialize();
-        let internal_real_mods_bytes = self.internal_real_mods.serialize();
-        let affect_ignore_lock_real_mods_bytes = self.affect_ignore_lock_real_mods.serialize();
-        let ignore_lock_real_mods_bytes = self.ignore_lock_real_mods.serialize();
-        let affect_internal_virtual_mods_bytes = self.affect_internal_virtual_mods.serialize();
-        let internal_virtual_mods_bytes = self.internal_virtual_mods.serialize();
-        let affect_ignore_lock_virtual_mods_bytes = self.affect_ignore_lock_virtual_mods.serialize();
-        let ignore_lock_virtual_mods_bytes = self.ignore_lock_virtual_mods.serialize();
+        let affect_internal_real_mods_bytes = (u16::from(self.affect_internal_real_mods) as u8).serialize();
+        let internal_real_mods_bytes = (u16::from(self.internal_real_mods) as u8).serialize();
+        let affect_ignore_lock_real_mods_bytes = (u16::from(self.affect_ignore_lock_real_mods) as u8).serialize();
+        let ignore_lock_real_mods_bytes = (u16::from(self.ignore_lock_real_mods) as u8).serialize();
+        let affect_internal_virtual_mods_bytes = u16::from(self.affect_internal_virtual_mods).serialize();
+        let internal_virtual_mods_bytes = u16::from(self.internal_virtual_mods).serialize();
+        let affect_ignore_lock_virtual_mods_bytes = u16::from(self.affect_ignore_lock_virtual_mods).serialize();
+        let ignore_lock_virtual_mods_bytes = u16::from(self.ignore_lock_virtual_mods).serialize();
         let mouse_keys_dflt_btn_bytes = self.mouse_keys_dflt_btn.serialize();
         let groups_wrap_bytes = self.groups_wrap.serialize();
-        let access_x_options_bytes = self.access_x_options.serialize();
-        let affect_enabled_controls_bytes = self.affect_enabled_controls.serialize();
-        let enabled_controls_bytes = self.enabled_controls.serialize();
-        let change_controls_bytes = self.change_controls.serialize();
+        let access_x_options_bytes = u16::from(self.access_x_options).serialize();
+        let affect_enabled_controls_bytes = u32::from(self.affect_enabled_controls).serialize();
+        let enabled_controls_bytes = u32::from(self.enabled_controls).serialize();
+        let change_controls_bytes = u32::from(self.change_controls).serialize();
         let repeat_delay_bytes = self.repeat_delay.serialize();
         let repeat_interval_bytes = self.repeat_interval.serialize();
         let slow_keys_delay_bytes = self.slow_keys_delay.serialize();
@@ -7477,10 +7477,10 @@ impl<'input> SetControlsRequest<'input> {
         let mouse_keys_max_speed_bytes = self.mouse_keys_max_speed.serialize();
         let mouse_keys_curve_bytes = self.mouse_keys_curve.serialize();
         let access_x_timeout_bytes = self.access_x_timeout.serialize();
-        let access_x_timeout_mask_bytes = self.access_x_timeout_mask.serialize();
-        let access_x_timeout_values_bytes = self.access_x_timeout_values.serialize();
-        let access_x_timeout_options_mask_bytes = self.access_x_timeout_options_mask.serialize();
-        let access_x_timeout_options_values_bytes = self.access_x_timeout_options_values.serialize();
+        let access_x_timeout_mask_bytes = u32::from(self.access_x_timeout_mask).serialize();
+        let access_x_timeout_values_bytes = u32::from(self.access_x_timeout_values).serialize();
+        let access_x_timeout_options_mask_bytes = u16::from(self.access_x_timeout_options_mask).serialize();
+        let access_x_timeout_options_values_bytes = u16::from(self.access_x_timeout_options_values).serialize();
         let mut request0 = vec![
             major_opcode,
             SET_CONTROLS_REQUEST,
@@ -7700,8 +7700,8 @@ pub const GET_MAP_REQUEST: u8 = 8;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapRequest {
     pub device_spec: DeviceSpec,
-    pub full: u16,
-    pub partial: u16,
+    pub full: MapPart,
+    pub partial: MapPart,
     pub first_type: u8,
     pub n_types: u8,
     pub first_key_sym: xproto::Keycode,
@@ -7710,7 +7710,7 @@ pub struct GetMapRequest {
     pub n_key_actions: u8,
     pub first_key_behavior: xproto::Keycode,
     pub n_key_behaviors: u8,
-    pub virtual_mods: u16,
+    pub virtual_mods: VMod,
     pub first_key_explicit: xproto::Keycode,
     pub n_key_explicit: u8,
     pub first_mod_map_key: xproto::Keycode,
@@ -7723,8 +7723,8 @@ impl GetMapRequest {
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'static>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let full_bytes = self.full.serialize();
-        let partial_bytes = self.partial.serialize();
+        let full_bytes = u16::from(self.full).serialize();
+        let partial_bytes = u16::from(self.partial).serialize();
         let first_type_bytes = self.first_type.serialize();
         let n_types_bytes = self.n_types.serialize();
         let first_key_sym_bytes = self.first_key_sym.serialize();
@@ -7733,7 +7733,7 @@ impl GetMapRequest {
         let n_key_actions_bytes = self.n_key_actions.serialize();
         let first_key_behavior_bytes = self.first_key_behavior.serialize();
         let n_key_behaviors_bytes = self.n_key_behaviors.serialize();
-        let virtual_mods_bytes = self.virtual_mods.serialize();
+        let virtual_mods_bytes = u16::from(self.virtual_mods).serialize();
         let first_key_explicit_bytes = self.first_key_explicit.serialize();
         let n_key_explicit_bytes = self.n_key_explicit.serialize();
         let first_mod_map_key_bytes = self.first_mod_map_key.serialize();
@@ -7882,7 +7882,7 @@ pub struct GetMapMap {
     pub syms_rtrn: Option<Vec<KeySymMap>>,
     pub bitcase3: Option<GetMapMapBitcase3>,
     pub behaviors_rtrn: Option<Vec<SetBehavior>>,
-    pub vmods_rtrn: Option<Vec<u8>>,
+    pub vmods_rtrn: Option<Vec<xproto::ModMask>>,
     pub explicit_rtrn: Option<Vec<SetExplicit>>,
     pub modmap_rtrn: Option<Vec<KeyModMap>>,
     pub vmodmap_rtrn: Option<Vec<KeyVModMap>>,
@@ -7925,8 +7925,15 @@ impl GetMapMap {
         let vmods_rtrn = if switch_expr & u16::from(MapPart::VIRTUAL_MODS) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
-            let (vmods_rtrn, remaining) = crate::x11_utils::parse_u8_list(remaining, virtual_mods.count_ones().try_to_usize()?)?;
-            let vmods_rtrn = vmods_rtrn.to_vec();
+            let mut remaining = remaining;
+            let list_length = virtual_mods.count_ones().try_to_usize()?;
+            let mut vmods_rtrn = Vec::with_capacity(list_length);
+            for _ in 0..list_length {
+                let (v, new_remaining) = u8::try_parse(remaining)?;
+                let v = v.into();
+                remaining = new_remaining;
+                vmods_rtrn.push(v);
+            }
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
@@ -8009,7 +8016,9 @@ impl GetMapMap {
         }
         if let Some(ref vmods_rtrn) = self.vmods_rtrn {
             assert_eq!(vmods_rtrn.len(), usize::try_from(virtual_mods.count_ones()).unwrap(), "`vmods_rtrn` has an incorrect length");
-            bytes.extend_from_slice(&vmods_rtrn);
+            for element in vmods_rtrn.iter().copied() {
+                (u16::from(element) as u8).serialize_into(bytes);
+            }
             bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
         }
         if let Some(ref explicit_rtrn) = self.explicit_rtrn {
@@ -8088,7 +8097,7 @@ pub struct GetMapReply {
     pub first_v_mod_map_key: xproto::Keycode,
     pub n_v_mod_map_keys: u8,
     pub total_v_mod_map_keys: u8,
-    pub virtual_mods: u16,
+    pub virtual_mods: VMod,
     pub map: GetMapMap,
 }
 impl TryParse for GetMapReply {
@@ -8178,7 +8187,7 @@ impl Serialize for GetMapReply {
         self.n_v_mod_map_keys.serialize_into(bytes);
         self.total_v_mod_map_keys.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
-        self.virtual_mods.serialize_into(bytes);
+        u16::from(self.virtual_mods).serialize_into(bytes);
         self.map.serialize_into(bytes, present, self.n_types, self.n_key_syms, self.n_key_actions, self.total_actions, self.total_key_behaviors, self.virtual_mods, self.total_key_explicit, self.total_mod_map_keys, self.total_v_mod_map_keys);
     }
 }
@@ -8451,7 +8460,7 @@ pub const SET_MAP_REQUEST: u8 = 9;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetMapRequest<'input> {
     pub device_spec: DeviceSpec,
-    pub flags: u16,
+    pub flags: SetMapFlags,
     pub min_key_code: xproto::Keycode,
     pub max_key_code: xproto::Keycode,
     pub first_type: u8,
@@ -8474,7 +8483,7 @@ pub struct SetMapRequest<'input> {
     pub first_v_mod_map_key: xproto::Keycode,
     pub n_v_mod_map_keys: u8,
     pub total_v_mod_map_keys: u8,
-    pub virtual_mods: u16,
+    pub virtual_mods: VMod,
     pub values: Cow<'input, SetMapAux>,
 }
 impl<'input> SetMapRequest<'input> {
@@ -8484,7 +8493,7 @@ impl<'input> SetMapRequest<'input> {
         let device_spec_bytes = self.device_spec.serialize();
         let present: u16 = self.values.switch_expr();
         let present_bytes = present.serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u16::from(self.flags).serialize();
         let min_key_code_bytes = self.min_key_code.serialize();
         let max_key_code_bytes = self.max_key_code.serialize();
         let first_type_bytes = self.first_type.serialize();
@@ -8507,7 +8516,7 @@ impl<'input> SetMapRequest<'input> {
         let first_v_mod_map_key_bytes = self.first_v_mod_map_key.serialize();
         let n_v_mod_map_keys_bytes = self.n_v_mod_map_keys.serialize();
         let total_v_mod_map_keys_bytes = self.total_v_mod_map_keys.serialize();
-        let virtual_mods_bytes = self.virtual_mods.serialize();
+        let virtual_mods_bytes = u16::from(self.virtual_mods).serialize();
         let mut request0 = vec![
             major_opcode,
             SET_MAP_REQUEST,
@@ -8671,7 +8680,7 @@ pub const GET_COMPAT_MAP_REQUEST: u8 = 10;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCompatMapRequest {
     pub device_spec: DeviceSpec,
-    pub groups: u8,
+    pub groups: SetOfGroup,
     pub get_all_si: bool,
     pub first_si: u16,
     pub n_si: u16,
@@ -8681,7 +8690,7 @@ impl GetCompatMapRequest {
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'static>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let groups_bytes = self.groups.serialize();
+        let groups_bytes = u8::from(self.groups).serialize();
         let get_all_si_bytes = self.get_all_si.serialize();
         let first_si_bytes = self.first_si.serialize();
         let n_si_bytes = self.n_si.serialize();
@@ -8746,7 +8755,7 @@ pub struct GetCompatMapReply {
     pub device_id: u8,
     pub sequence: u16,
     pub length: u32,
-    pub groups_rtrn: u8,
+    pub groups_rtrn: SetOfGroup,
     pub first_si_rtrn: u16,
     pub n_total_si: u16,
     pub si_rtrn: Vec<SymInterpret>,
@@ -8792,7 +8801,7 @@ impl Serialize for GetCompatMapReply {
         self.device_id.serialize_into(bytes);
         self.sequence.serialize_into(bytes);
         self.length.serialize_into(bytes);
-        self.groups_rtrn.serialize_into(bytes);
+        u8::from(self.groups_rtrn).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
         self.first_si_rtrn.serialize_into(bytes);
         let n_si_rtrn = u16::try_from(self.si_rtrn.len()).expect("`si_rtrn` has too many elements");
@@ -8828,7 +8837,7 @@ pub struct SetCompatMapRequest<'input> {
     pub device_spec: DeviceSpec,
     pub recompute_actions: bool,
     pub truncate_si: bool,
-    pub groups: u8,
+    pub groups: SetOfGroup,
     pub first_si: u16,
     pub si: Cow<'input, [SymInterpret]>,
     pub group_maps: Cow<'input, [ModDef]>,
@@ -8840,7 +8849,7 @@ impl<'input> SetCompatMapRequest<'input> {
         let device_spec_bytes = self.device_spec.serialize();
         let recompute_actions_bytes = self.recompute_actions.serialize();
         let truncate_si_bytes = self.truncate_si.serialize();
-        let groups_bytes = self.groups.serialize();
+        let groups_bytes = u8::from(self.groups).serialize();
         let first_si_bytes = self.first_si.serialize();
         let n_si = u16::try_from(self.si.len()).expect("`si` has too many elements");
         let n_si_bytes = n_si.serialize();
@@ -9349,14 +9358,14 @@ pub struct GetNamedIndicatorReply {
     pub on: bool,
     pub real_indicator: bool,
     pub ndx: u8,
-    pub map_flags: u8,
-    pub map_which_groups: u8,
-    pub map_groups: u8,
-    pub map_which_mods: u8,
-    pub map_mods: u8,
-    pub map_real_mods: u8,
-    pub map_vmod: u16,
-    pub map_ctrls: u32,
+    pub map_flags: IMFlag,
+    pub map_which_groups: IMGroupsWhich,
+    pub map_groups: SetOfGroups,
+    pub map_which_mods: IMModsWhich,
+    pub map_mods: xproto::ModMask,
+    pub map_real_mods: xproto::ModMask,
+    pub map_vmod: VMod,
+    pub map_ctrls: BoolCtrl,
     pub supported: bool,
 }
 impl TryParse for GetNamedIndicatorReply {
@@ -9411,14 +9420,14 @@ impl Serialize for GetNamedIndicatorReply {
         let on_bytes = self.on.serialize();
         let real_indicator_bytes = self.real_indicator.serialize();
         let ndx_bytes = self.ndx.serialize();
-        let map_flags_bytes = self.map_flags.serialize();
-        let map_which_groups_bytes = self.map_which_groups.serialize();
-        let map_groups_bytes = self.map_groups.serialize();
-        let map_which_mods_bytes = self.map_which_mods.serialize();
-        let map_mods_bytes = self.map_mods.serialize();
-        let map_real_mods_bytes = self.map_real_mods.serialize();
-        let map_vmod_bytes = self.map_vmod.serialize();
-        let map_ctrls_bytes = self.map_ctrls.serialize();
+        let map_flags_bytes = u8::from(self.map_flags).serialize();
+        let map_which_groups_bytes = u8::from(self.map_which_groups).serialize();
+        let map_groups_bytes = u8::from(self.map_groups).serialize();
+        let map_which_mods_bytes = u8::from(self.map_which_mods).serialize();
+        let map_mods_bytes = (u16::from(self.map_mods) as u8).serialize();
+        let map_real_mods_bytes = (u16::from(self.map_real_mods) as u8).serialize();
+        let map_vmod_bytes = u16::from(self.map_vmod).serialize();
+        let map_ctrls_bytes = u32::from(self.map_ctrls).serialize();
         let supported_bytes = self.supported.serialize();
         [
             response_type_bytes[0],
@@ -9467,14 +9476,14 @@ impl Serialize for GetNamedIndicatorReply {
         self.on.serialize_into(bytes);
         self.real_indicator.serialize_into(bytes);
         self.ndx.serialize_into(bytes);
-        self.map_flags.serialize_into(bytes);
-        self.map_which_groups.serialize_into(bytes);
-        self.map_groups.serialize_into(bytes);
-        self.map_which_mods.serialize_into(bytes);
-        self.map_mods.serialize_into(bytes);
-        self.map_real_mods.serialize_into(bytes);
-        self.map_vmod.serialize_into(bytes);
-        self.map_ctrls.serialize_into(bytes);
+        u8::from(self.map_flags).serialize_into(bytes);
+        u8::from(self.map_which_groups).serialize_into(bytes);
+        u8::from(self.map_groups).serialize_into(bytes);
+        u8::from(self.map_which_mods).serialize_into(bytes);
+        (u16::from(self.map_mods) as u8).serialize_into(bytes);
+        (u16::from(self.map_real_mods) as u8).serialize_into(bytes);
+        u16::from(self.map_vmod).serialize_into(bytes);
+        u32::from(self.map_ctrls).serialize_into(bytes);
         self.supported.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 3]);
     }
@@ -9493,13 +9502,13 @@ pub struct SetNamedIndicatorRequest {
     pub on: bool,
     pub set_map: bool,
     pub create_map: bool,
-    pub map_flags: u8,
-    pub map_which_groups: u8,
-    pub map_groups: u8,
-    pub map_which_mods: u8,
-    pub map_real_mods: u8,
-    pub map_vmods: u16,
-    pub map_ctrls: u32,
+    pub map_flags: IMFlag,
+    pub map_which_groups: IMGroupsWhich,
+    pub map_groups: SetOfGroups,
+    pub map_which_mods: IMModsWhich,
+    pub map_real_mods: xproto::ModMask,
+    pub map_vmods: VMod,
+    pub map_ctrls: BoolCtrl,
 }
 impl SetNamedIndicatorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9513,13 +9522,13 @@ impl SetNamedIndicatorRequest {
         let on_bytes = self.on.serialize();
         let set_map_bytes = self.set_map.serialize();
         let create_map_bytes = self.create_map.serialize();
-        let map_flags_bytes = self.map_flags.serialize();
-        let map_which_groups_bytes = self.map_which_groups.serialize();
-        let map_groups_bytes = self.map_groups.serialize();
-        let map_which_mods_bytes = self.map_which_mods.serialize();
-        let map_real_mods_bytes = self.map_real_mods.serialize();
-        let map_vmods_bytes = self.map_vmods.serialize();
-        let map_ctrls_bytes = self.map_ctrls.serialize();
+        let map_flags_bytes = u8::from(self.map_flags).serialize();
+        let map_which_groups_bytes = u8::from(self.map_which_groups).serialize();
+        let map_groups_bytes = u8::from(self.map_groups).serialize();
+        let map_which_mods_bytes = u8::from(self.map_which_mods).serialize();
+        let map_real_mods_bytes = (u16::from(self.map_real_mods) as u8).serialize();
+        let map_vmods_bytes = u16::from(self.map_vmods).serialize();
+        let map_ctrls_bytes = u32::from(self.map_ctrls).serialize();
         let mut request0 = vec![
             major_opcode,
             SET_NAMED_INDICATOR_REQUEST,
@@ -9629,14 +9638,14 @@ pub const GET_NAMES_REQUEST: u8 = 17;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamesRequest {
     pub device_spec: DeviceSpec,
-    pub which: u32,
+    pub which: NameDetail,
 }
 impl GetNamesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'static>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let which_bytes = self.which.serialize();
+        let which_bytes = u32::from(self.which).serialize();
         let mut request0 = vec![
             major_opcode,
             GET_NAMES_REQUEST,
@@ -9984,8 +9993,8 @@ pub struct GetNamesReply {
     pub min_key_code: xproto::Keycode,
     pub max_key_code: xproto::Keycode,
     pub n_types: u8,
-    pub group_names: u8,
-    pub virtual_mods: u16,
+    pub group_names: SetOfGroup,
+    pub virtual_mods: VMod,
     pub first_key: xproto::Keycode,
     pub n_keys: u8,
     pub indicators: u32,
@@ -10046,8 +10055,8 @@ impl Serialize for GetNamesReply {
         self.min_key_code.serialize_into(bytes);
         self.max_key_code.serialize_into(bytes);
         self.n_types.serialize_into(bytes);
-        self.group_names.serialize_into(bytes);
-        self.virtual_mods.serialize_into(bytes);
+        u8::from(self.group_names).serialize_into(bytes);
+        u16::from(self.virtual_mods).serialize_into(bytes);
         self.first_key.serialize_into(bytes);
         self.n_keys.serialize_into(bytes);
         self.indicators.serialize_into(bytes);
@@ -10444,13 +10453,13 @@ pub const SET_NAMES_REQUEST: u8 = 18;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetNamesRequest<'input> {
     pub device_spec: DeviceSpec,
-    pub virtual_mods: u16,
+    pub virtual_mods: VMod,
     pub first_type: u8,
     pub n_types: u8,
     pub first_kt_levelt: u8,
     pub n_kt_levels: u8,
     pub indicators: u32,
-    pub group_names: u8,
+    pub group_names: SetOfGroup,
     pub n_radio_groups: u8,
     pub first_key: xproto::Keycode,
     pub n_keys: u8,
@@ -10463,7 +10472,7 @@ impl<'input> SetNamesRequest<'input> {
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let virtual_mods_bytes = self.virtual_mods.serialize();
+        let virtual_mods_bytes = u16::from(self.virtual_mods).serialize();
         let which: u32 = self.values.switch_expr();
         let which_bytes = which.serialize();
         let first_type_bytes = self.first_type.serialize();
@@ -10471,7 +10480,7 @@ impl<'input> SetNamesRequest<'input> {
         let first_kt_levelt_bytes = self.first_kt_levelt.serialize();
         let n_kt_levels_bytes = self.n_kt_levels.serialize();
         let indicators_bytes = self.indicators.serialize();
-        let group_names_bytes = self.group_names.serialize();
+        let group_names_bytes = u8::from(self.group_names).serialize();
         let n_radio_groups_bytes = self.n_radio_groups.serialize();
         let first_key_bytes = self.first_key.serialize();
         let n_keys_bytes = self.n_keys.serialize();
@@ -10597,22 +10606,22 @@ pub const PER_CLIENT_FLAGS_REQUEST: u8 = 21;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PerClientFlagsRequest {
     pub device_spec: DeviceSpec,
-    pub change: u32,
-    pub value: u32,
-    pub ctrls_to_change: u32,
-    pub auto_ctrls: u32,
-    pub auto_ctrls_values: u32,
+    pub change: PerClientFlag,
+    pub value: PerClientFlag,
+    pub ctrls_to_change: BoolCtrl,
+    pub auto_ctrls: BoolCtrl,
+    pub auto_ctrls_values: BoolCtrl,
 }
 impl PerClientFlagsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'static>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let change_bytes = self.change.serialize();
-        let value_bytes = self.value.serialize();
-        let ctrls_to_change_bytes = self.ctrls_to_change.serialize();
-        let auto_ctrls_bytes = self.auto_ctrls.serialize();
-        let auto_ctrls_values_bytes = self.auto_ctrls_values.serialize();
+        let change_bytes = u32::from(self.change).serialize();
+        let value_bytes = u32::from(self.value).serialize();
+        let ctrls_to_change_bytes = u32::from(self.ctrls_to_change).serialize();
+        let auto_ctrls_bytes = u32::from(self.auto_ctrls).serialize();
+        let auto_ctrls_values_bytes = u32::from(self.auto_ctrls_values).serialize();
         let mut request0 = vec![
             major_opcode,
             PER_CLIENT_FLAGS_REQUEST,
@@ -10697,10 +10706,10 @@ pub struct PerClientFlagsReply {
     pub device_id: u8,
     pub sequence: u16,
     pub length: u32,
-    pub supported: u32,
-    pub value: u32,
-    pub auto_ctrls: u32,
-    pub auto_ctrls_values: u32,
+    pub supported: PerClientFlag,
+    pub value: PerClientFlag,
+    pub auto_ctrls: BoolCtrl,
+    pub auto_ctrls_values: BoolCtrl,
 }
 impl TryParse for PerClientFlagsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10735,10 +10744,10 @@ impl Serialize for PerClientFlagsReply {
         let device_id_bytes = self.device_id.serialize();
         let sequence_bytes = self.sequence.serialize();
         let length_bytes = self.length.serialize();
-        let supported_bytes = self.supported.serialize();
-        let value_bytes = self.value.serialize();
-        let auto_ctrls_bytes = self.auto_ctrls.serialize();
-        let auto_ctrls_values_bytes = self.auto_ctrls_values.serialize();
+        let supported_bytes = u32::from(self.supported).serialize();
+        let value_bytes = u32::from(self.value).serialize();
+        let auto_ctrls_bytes = u32::from(self.auto_ctrls).serialize();
+        let auto_ctrls_values_bytes = u32::from(self.auto_ctrls_values).serialize();
         [
             response_type_bytes[0],
             device_id_bytes[0],
@@ -10781,10 +10790,10 @@ impl Serialize for PerClientFlagsReply {
         self.device_id.serialize_into(bytes);
         self.sequence.serialize_into(bytes);
         self.length.serialize_into(bytes);
-        self.supported.serialize_into(bytes);
-        self.value.serialize_into(bytes);
-        self.auto_ctrls.serialize_into(bytes);
-        self.auto_ctrls_values.serialize_into(bytes);
+        u32::from(self.supported).serialize_into(bytes);
+        u32::from(self.value).serialize_into(bytes);
+        u32::from(self.auto_ctrls).serialize_into(bytes);
+        u32::from(self.auto_ctrls_values).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 8]);
     }
 }
@@ -11015,8 +11024,8 @@ pub const GET_KBD_BY_NAME_REQUEST: u8 = 23;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRequest {
     pub device_spec: DeviceSpec,
-    pub need: u16,
-    pub want: u16,
+    pub need: GBNDetail,
+    pub want: GBNDetail,
     pub load: bool,
 }
 impl GetKbdByNameRequest {
@@ -11024,8 +11033,8 @@ impl GetKbdByNameRequest {
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'static>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let need_bytes = self.need.serialize();
-        let want_bytes = self.want.serialize();
+        let need_bytes = u16::from(self.need).serialize();
+        let want_bytes = u16::from(self.want).serialize();
         let load_bytes = self.load.serialize();
         let mut request0 = vec![
             major_opcode,
@@ -11124,7 +11133,7 @@ pub struct GetKbdByNameRepliesTypesMap {
     pub syms_rtrn: Option<Vec<KeySymMap>>,
     pub bitcase3: Option<GetKbdByNameRepliesTypesMapBitcase3>,
     pub behaviors_rtrn: Option<Vec<SetBehavior>>,
-    pub vmods_rtrn: Option<Vec<u8>>,
+    pub vmods_rtrn: Option<Vec<xproto::ModMask>>,
     pub explicit_rtrn: Option<Vec<SetExplicit>>,
     pub modmap_rtrn: Option<Vec<KeyModMap>>,
     pub vmodmap_rtrn: Option<Vec<KeyVModMap>>,
@@ -11167,8 +11176,15 @@ impl GetKbdByNameRepliesTypesMap {
         let vmods_rtrn = if switch_expr & u16::from(MapPart::VIRTUAL_MODS) != 0 {
             let remaining = outer_remaining;
             let value = remaining;
-            let (vmods_rtrn, remaining) = crate::x11_utils::parse_u8_list(remaining, virtual_mods.count_ones().try_to_usize()?)?;
-            let vmods_rtrn = vmods_rtrn.to_vec();
+            let mut remaining = remaining;
+            let list_length = virtual_mods.count_ones().try_to_usize()?;
+            let mut vmods_rtrn = Vec::with_capacity(list_length);
+            for _ in 0..list_length {
+                let (v, new_remaining) = u8::try_parse(remaining)?;
+                let v = v.into();
+                remaining = new_remaining;
+                vmods_rtrn.push(v);
+            }
             // Align offset to multiple of 4
             let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
             let misalignment = (4 - (offset % 4)) % 4;
@@ -11251,7 +11267,9 @@ impl GetKbdByNameRepliesTypesMap {
         }
         if let Some(ref vmods_rtrn) = self.vmods_rtrn {
             assert_eq!(vmods_rtrn.len(), usize::try_from(virtual_mods.count_ones()).unwrap(), "`vmods_rtrn` has an incorrect length");
-            bytes.extend_from_slice(&vmods_rtrn);
+            for element in vmods_rtrn.iter().copied() {
+                (u16::from(element) as u8).serialize_into(bytes);
+            }
             bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
         }
         if let Some(ref explicit_rtrn) = self.explicit_rtrn {
@@ -11331,7 +11349,7 @@ pub struct GetKbdByNameRepliesTypes {
     pub first_v_mod_map_key: xproto::Keycode,
     pub n_v_mod_map_keys: u8,
     pub total_v_mod_map_keys: u8,
-    pub virtual_mods: u16,
+    pub virtual_mods: VMod,
     pub map: GetKbdByNameRepliesTypesMap,
 }
 impl TryParse for GetKbdByNameRepliesTypes {
@@ -11413,7 +11431,7 @@ impl Serialize for GetKbdByNameRepliesTypes {
         self.n_v_mod_map_keys.serialize_into(bytes);
         self.total_v_mod_map_keys.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
-        self.virtual_mods.serialize_into(bytes);
+        u16::from(self.virtual_mods).serialize_into(bytes);
         self.map.serialize_into(bytes, present, self.n_types, self.n_key_syms, self.n_key_actions, self.total_actions, self.total_key_behaviors, self.virtual_mods, self.total_key_explicit, self.total_mod_map_keys, self.total_v_mod_map_keys);
     }
 }
@@ -11424,7 +11442,7 @@ pub struct GetKbdByNameRepliesCompatMap {
     pub compat_device_id: u8,
     pub compatmap_sequence: u16,
     pub compatmap_length: u32,
-    pub groups_rtrn: u8,
+    pub groups_rtrn: SetOfGroup,
     pub first_si_rtrn: u16,
     pub n_total_si: u16,
     pub si_rtrn: Vec<SymInterpret>,
@@ -11462,7 +11480,7 @@ impl Serialize for GetKbdByNameRepliesCompatMap {
         self.compat_device_id.serialize_into(bytes);
         self.compatmap_sequence.serialize_into(bytes);
         self.compatmap_length.serialize_into(bytes);
-        self.groups_rtrn.serialize_into(bytes);
+        u8::from(self.groups_rtrn).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
         self.first_si_rtrn.serialize_into(bytes);
         let n_si_rtrn = u16::try_from(self.si_rtrn.len()).expect("`si_rtrn` has too many elements");
@@ -11849,8 +11867,8 @@ pub struct GetKbdByNameRepliesKeyNames {
     pub key_min_key_code: xproto::Keycode,
     pub key_max_key_code: xproto::Keycode,
     pub n_types: u8,
-    pub group_names: u8,
-    pub virtual_mods: u16,
+    pub group_names: SetOfGroup,
+    pub virtual_mods: VMod,
     pub first_key: xproto::Keycode,
     pub n_keys: u8,
     pub indicators: u32,
@@ -11903,8 +11921,8 @@ impl Serialize for GetKbdByNameRepliesKeyNames {
         self.key_min_key_code.serialize_into(bytes);
         self.key_max_key_code.serialize_into(bytes);
         self.n_types.serialize_into(bytes);
-        self.group_names.serialize_into(bytes);
-        self.virtual_mods.serialize_into(bytes);
+        u8::from(self.group_names).serialize_into(bytes);
+        u16::from(self.virtual_mods).serialize_into(bytes);
         self.first_key.serialize_into(bytes);
         self.n_keys.serialize_into(bytes);
         self.indicators.serialize_into(bytes);
@@ -12078,8 +12096,8 @@ pub struct GetKbdByNameReply {
     pub max_key_code: xproto::Keycode,
     pub loaded: bool,
     pub new_keyboard: bool,
-    pub found: u16,
-    pub reported: u16,
+    pub found: GBNDetail,
+    pub reported: GBNDetail,
     pub replies: GetKbdByNameReplies,
 }
 impl TryParse for GetKbdByNameReply {
@@ -12127,8 +12145,8 @@ impl Serialize for GetKbdByNameReply {
         self.max_key_code.serialize_into(bytes);
         self.loaded.serialize_into(bytes);
         self.new_keyboard.serialize_into(bytes);
-        self.found.serialize_into(bytes);
-        self.reported.serialize_into(bytes);
+        u16::from(self.found).serialize_into(bytes);
+        u16::from(self.reported).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 16]);
         self.replies.serialize_into(bytes, self.reported);
     }
@@ -12140,7 +12158,7 @@ pub const GET_DEVICE_INFO_REQUEST: u8 = 24;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceInfoRequest {
     pub device_spec: DeviceSpec,
-    pub wanted: u16,
+    pub wanted: XIFeature,
     pub all_buttons: bool,
     pub first_button: u8,
     pub n_buttons: u8,
@@ -12152,7 +12170,7 @@ impl GetDeviceInfoRequest {
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'static>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let wanted_bytes = self.wanted.serialize();
+        let wanted_bytes = u16::from(self.wanted).serialize();
         let all_buttons_bytes = self.all_buttons.serialize();
         let first_button_bytes = self.first_button.serialize();
         let n_buttons_bytes = self.n_buttons.serialize();
@@ -12229,9 +12247,9 @@ pub struct GetDeviceInfoReply {
     pub device_id: u8,
     pub sequence: u16,
     pub length: u32,
-    pub present: u16,
-    pub supported: u16,
-    pub unsupported: u16,
+    pub present: XIFeature,
+    pub supported: XIFeature,
+    pub unsupported: XIFeature,
     pub first_btn_wanted: u8,
     pub n_btns_wanted: u8,
     pub first_btn_rtrn: u8,
@@ -12302,9 +12320,9 @@ impl Serialize for GetDeviceInfoReply {
         self.device_id.serialize_into(bytes);
         self.sequence.serialize_into(bytes);
         self.length.serialize_into(bytes);
-        self.present.serialize_into(bytes);
-        self.supported.serialize_into(bytes);
-        self.unsupported.serialize_into(bytes);
+        u16::from(self.present).serialize_into(bytes);
+        u16::from(self.supported).serialize_into(bytes);
+        u16::from(self.unsupported).serialize_into(bytes);
         let n_device_led_f_bs = u16::try_from(self.leds.len()).expect("`leds` has too many elements");
         n_device_led_f_bs.serialize_into(bytes);
         self.first_btn_wanted.serialize_into(bytes);
@@ -12375,7 +12393,7 @@ pub const SET_DEVICE_INFO_REQUEST: u8 = 25;
 pub struct SetDeviceInfoRequest<'input> {
     pub device_spec: DeviceSpec,
     pub first_btn: u8,
-    pub change: u16,
+    pub change: XIFeature,
     pub btn_actions: Cow<'input, [Action]>,
     pub leds: Cow<'input, [DeviceLedInfo]>,
 }
@@ -12387,7 +12405,7 @@ impl<'input> SetDeviceInfoRequest<'input> {
         let first_btn_bytes = self.first_btn.serialize();
         let n_btns = u8::try_from(self.btn_actions.len()).expect("`btn_actions` has too many elements");
         let n_btns_bytes = n_btns.serialize();
-        let change_bytes = self.change.serialize();
+        let change_bytes = u16::from(self.change).serialize();
         let n_device_led_f_bs = u16::try_from(self.leds.len()).expect("`leds` has too many elements");
         let n_device_led_f_bs_bytes = n_device_led_f_bs.serialize();
         let mut request0 = vec![
@@ -12673,7 +12691,7 @@ pub struct NewKeyboardNotifyEvent {
     pub old_max_key_code: xproto::Keycode,
     pub request_major: u8,
     pub request_minor: u8,
-    pub changed: u16,
+    pub changed: NKNDetail,
 }
 impl TryParse for NewKeyboardNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12715,7 +12733,7 @@ impl Serialize for NewKeyboardNotifyEvent {
         let old_max_key_code_bytes = self.old_max_key_code.serialize();
         let request_major_bytes = self.request_major.serialize();
         let request_minor_bytes = self.request_minor.serialize();
-        let changed_bytes = self.changed.serialize();
+        let changed_bytes = u16::from(self.changed).serialize();
         [
             response_type_bytes[0],
             xkb_type_bytes[0],
@@ -12765,7 +12783,7 @@ impl Serialize for NewKeyboardNotifyEvent {
         self.old_max_key_code.serialize_into(bytes);
         self.request_major.serialize_into(bytes);
         self.request_minor.serialize_into(bytes);
-        self.changed.serialize_into(bytes);
+        u16::from(self.changed).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 14]);
     }
 }
@@ -12783,7 +12801,7 @@ impl From<&NewKeyboardNotifyEvent> for [u8; 32] {
         let old_max_key_code_bytes = input.old_max_key_code.serialize();
         let request_major_bytes = input.request_major.serialize();
         let request_minor_bytes = input.request_minor.serialize();
-        let changed_bytes = input.changed.serialize();
+        let changed_bytes = u16::from(input.changed).serialize();
         [
             response_type_bytes[0],
             xkb_type_bytes[0],
@@ -12837,7 +12855,7 @@ pub struct MapNotifyEvent {
     pub time: xproto::Timestamp,
     pub device_id: u8,
     pub ptr_btn_actions: u8,
-    pub changed: u16,
+    pub changed: MapPart,
     pub min_key_code: xproto::Keycode,
     pub max_key_code: xproto::Keycode,
     pub first_type: u8,
@@ -12854,7 +12872,7 @@ pub struct MapNotifyEvent {
     pub n_mod_map_keys: u8,
     pub first_v_mod_map_key: xproto::Keycode,
     pub n_v_mod_map_keys: u8,
-    pub virtual_mods: u16,
+    pub virtual_mods: VMod,
 }
 impl TryParse for MapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12902,7 +12920,7 @@ impl Serialize for MapNotifyEvent {
         let time_bytes = self.time.serialize();
         let device_id_bytes = self.device_id.serialize();
         let ptr_btn_actions_bytes = self.ptr_btn_actions.serialize();
-        let changed_bytes = self.changed.serialize();
+        let changed_bytes = u16::from(self.changed).serialize();
         let min_key_code_bytes = self.min_key_code.serialize();
         let max_key_code_bytes = self.max_key_code.serialize();
         let first_type_bytes = self.first_type.serialize();
@@ -12919,7 +12937,7 @@ impl Serialize for MapNotifyEvent {
         let n_mod_map_keys_bytes = self.n_mod_map_keys.serialize();
         let first_v_mod_map_key_bytes = self.first_v_mod_map_key.serialize();
         let n_v_mod_map_keys_bytes = self.n_v_mod_map_keys.serialize();
-        let virtual_mods_bytes = self.virtual_mods.serialize();
+        let virtual_mods_bytes = u16::from(self.virtual_mods).serialize();
         [
             response_type_bytes[0],
             xkb_type_bytes[0],
@@ -12963,7 +12981,7 @@ impl Serialize for MapNotifyEvent {
         self.time.serialize_into(bytes);
         self.device_id.serialize_into(bytes);
         self.ptr_btn_actions.serialize_into(bytes);
-        self.changed.serialize_into(bytes);
+        u16::from(self.changed).serialize_into(bytes);
         self.min_key_code.serialize_into(bytes);
         self.max_key_code.serialize_into(bytes);
         self.first_type.serialize_into(bytes);
@@ -12980,7 +12998,7 @@ impl Serialize for MapNotifyEvent {
         self.n_mod_map_keys.serialize_into(bytes);
         self.first_v_mod_map_key.serialize_into(bytes);
         self.n_v_mod_map_keys.serialize_into(bytes);
-        self.virtual_mods.serialize_into(bytes);
+        u16::from(self.virtual_mods).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
     }
 }
@@ -12992,7 +13010,7 @@ impl From<&MapNotifyEvent> for [u8; 32] {
         let time_bytes = input.time.serialize();
         let device_id_bytes = input.device_id.serialize();
         let ptr_btn_actions_bytes = input.ptr_btn_actions.serialize();
-        let changed_bytes = input.changed.serialize();
+        let changed_bytes = u16::from(input.changed).serialize();
         let min_key_code_bytes = input.min_key_code.serialize();
         let max_key_code_bytes = input.max_key_code.serialize();
         let first_type_bytes = input.first_type.serialize();
@@ -13009,7 +13027,7 @@ impl From<&MapNotifyEvent> for [u8; 32] {
         let n_mod_map_keys_bytes = input.n_mod_map_keys.serialize();
         let first_v_mod_map_key_bytes = input.first_v_mod_map_key.serialize();
         let n_v_mod_map_keys_bytes = input.n_v_mod_map_keys.serialize();
-        let virtual_mods_bytes = input.virtual_mods.serialize();
+        let virtual_mods_bytes = u16::from(input.virtual_mods).serialize();
         [
             response_type_bytes[0],
             xkb_type_bytes[0],
@@ -13062,21 +13080,21 @@ pub struct StateNotifyEvent {
     pub sequence: u16,
     pub time: xproto::Timestamp,
     pub device_id: u8,
-    pub mods: u8,
-    pub base_mods: u8,
-    pub latched_mods: u8,
-    pub locked_mods: u8,
+    pub mods: xproto::ModMask,
+    pub base_mods: xproto::ModMask,
+    pub latched_mods: xproto::ModMask,
+    pub locked_mods: xproto::ModMask,
     pub group: Group,
     pub base_group: i16,
     pub latched_group: i16,
     pub locked_group: Group,
-    pub compat_state: u8,
-    pub grab_mods: u8,
-    pub compat_grab_mods: u8,
-    pub lookup_mods: u8,
-    pub compat_loockup_mods: u8,
-    pub ptr_btn_state: u16,
-    pub changed: u16,
+    pub compat_state: xproto::ModMask,
+    pub grab_mods: xproto::ModMask,
+    pub compat_grab_mods: xproto::ModMask,
+    pub lookup_mods: xproto::ModMask,
+    pub compat_loockup_mods: xproto::ModMask,
+    pub ptr_btn_state: xproto::KeyButMask,
+    pub changed: StatePart,
     pub keycode: xproto::Keycode,
     pub event_type: u8,
     pub request_major: u8,
@@ -13137,21 +13155,21 @@ impl Serialize for StateNotifyEvent {
         let sequence_bytes = self.sequence.serialize();
         let time_bytes = self.time.serialize();
         let device_id_bytes = self.device_id.serialize();
-        let mods_bytes = self.mods.serialize();
-        let base_mods_bytes = self.base_mods.serialize();
-        let latched_mods_bytes = self.latched_mods.serialize();
-        let locked_mods_bytes = self.locked_mods.serialize();
+        let mods_bytes = (u16::from(self.mods) as u8).serialize();
+        let base_mods_bytes = (u16::from(self.base_mods) as u8).serialize();
+        let latched_mods_bytes = (u16::from(self.latched_mods) as u8).serialize();
+        let locked_mods_bytes = (u16::from(self.locked_mods) as u8).serialize();
         let group_bytes = u8::from(self.group).serialize();
         let base_group_bytes = self.base_group.serialize();
         let latched_group_bytes = self.latched_group.serialize();
         let locked_group_bytes = u8::from(self.locked_group).serialize();
-        let compat_state_bytes = self.compat_state.serialize();
-        let grab_mods_bytes = self.grab_mods.serialize();
-        let compat_grab_mods_bytes = self.compat_grab_mods.serialize();
-        let lookup_mods_bytes = self.lookup_mods.serialize();
-        let compat_loockup_mods_bytes = self.compat_loockup_mods.serialize();
-        let ptr_btn_state_bytes = self.ptr_btn_state.serialize();
-        let changed_bytes = self.changed.serialize();
+        let compat_state_bytes = (u16::from(self.compat_state) as u8).serialize();
+        let grab_mods_bytes = (u16::from(self.grab_mods) as u8).serialize();
+        let compat_grab_mods_bytes = (u16::from(self.compat_grab_mods) as u8).serialize();
+        let lookup_mods_bytes = (u16::from(self.lookup_mods) as u8).serialize();
+        let compat_loockup_mods_bytes = (u16::from(self.compat_loockup_mods) as u8).serialize();
+        let ptr_btn_state_bytes = u16::from(self.ptr_btn_state).serialize();
+        let changed_bytes = u16::from(self.changed).serialize();
         let keycode_bytes = self.keycode.serialize();
         let event_type_bytes = self.event_type.serialize();
         let request_major_bytes = self.request_major.serialize();
@@ -13198,21 +13216,21 @@ impl Serialize for StateNotifyEvent {
         self.sequence.serialize_into(bytes);
         self.time.serialize_into(bytes);
         self.device_id.serialize_into(bytes);
-        self.mods.serialize_into(bytes);
-        self.base_mods.serialize_into(bytes);
-        self.latched_mods.serialize_into(bytes);
-        self.locked_mods.serialize_into(bytes);
+        (u16::from(self.mods) as u8).serialize_into(bytes);
+        (u16::from(self.base_mods) as u8).serialize_into(bytes);
+        (u16::from(self.latched_mods) as u8).serialize_into(bytes);
+        (u16::from(self.locked_mods) as u8).serialize_into(bytes);
         u8::from(self.group).serialize_into(bytes);
         self.base_group.serialize_into(bytes);
         self.latched_group.serialize_into(bytes);
         u8::from(self.locked_group).serialize_into(bytes);
-        self.compat_state.serialize_into(bytes);
-        self.grab_mods.serialize_into(bytes);
-        self.compat_grab_mods.serialize_into(bytes);
-        self.lookup_mods.serialize_into(bytes);
-        self.compat_loockup_mods.serialize_into(bytes);
-        self.ptr_btn_state.serialize_into(bytes);
-        self.changed.serialize_into(bytes);
+        (u16::from(self.compat_state) as u8).serialize_into(bytes);
+        (u16::from(self.grab_mods) as u8).serialize_into(bytes);
+        (u16::from(self.compat_grab_mods) as u8).serialize_into(bytes);
+        (u16::from(self.lookup_mods) as u8).serialize_into(bytes);
+        (u16::from(self.compat_loockup_mods) as u8).serialize_into(bytes);
+        u16::from(self.ptr_btn_state).serialize_into(bytes);
+        u16::from(self.changed).serialize_into(bytes);
         self.keycode.serialize_into(bytes);
         self.event_type.serialize_into(bytes);
         self.request_major.serialize_into(bytes);
@@ -13226,21 +13244,21 @@ impl From<&StateNotifyEvent> for [u8; 32] {
         let sequence_bytes = input.sequence.serialize();
         let time_bytes = input.time.serialize();
         let device_id_bytes = input.device_id.serialize();
-        let mods_bytes = input.mods.serialize();
-        let base_mods_bytes = input.base_mods.serialize();
-        let latched_mods_bytes = input.latched_mods.serialize();
-        let locked_mods_bytes = input.locked_mods.serialize();
+        let mods_bytes = (u16::from(input.mods) as u8).serialize();
+        let base_mods_bytes = (u16::from(input.base_mods) as u8).serialize();
+        let latched_mods_bytes = (u16::from(input.latched_mods) as u8).serialize();
+        let locked_mods_bytes = (u16::from(input.locked_mods) as u8).serialize();
         let group_bytes = u8::from(input.group).serialize();
         let base_group_bytes = input.base_group.serialize();
         let latched_group_bytes = input.latched_group.serialize();
         let locked_group_bytes = u8::from(input.locked_group).serialize();
-        let compat_state_bytes = input.compat_state.serialize();
-        let grab_mods_bytes = input.grab_mods.serialize();
-        let compat_grab_mods_bytes = input.compat_grab_mods.serialize();
-        let lookup_mods_bytes = input.lookup_mods.serialize();
-        let compat_loockup_mods_bytes = input.compat_loockup_mods.serialize();
-        let ptr_btn_state_bytes = input.ptr_btn_state.serialize();
-        let changed_bytes = input.changed.serialize();
+        let compat_state_bytes = (u16::from(input.compat_state) as u8).serialize();
+        let grab_mods_bytes = (u16::from(input.grab_mods) as u8).serialize();
+        let compat_grab_mods_bytes = (u16::from(input.compat_grab_mods) as u8).serialize();
+        let lookup_mods_bytes = (u16::from(input.lookup_mods) as u8).serialize();
+        let compat_loockup_mods_bytes = (u16::from(input.compat_loockup_mods) as u8).serialize();
+        let ptr_btn_state_bytes = u16::from(input.ptr_btn_state).serialize();
+        let changed_bytes = u16::from(input.changed).serialize();
         let keycode_bytes = input.keycode.serialize();
         let event_type_bytes = input.event_type.serialize();
         let request_major_bytes = input.request_major.serialize();
@@ -13298,9 +13316,9 @@ pub struct ControlsNotifyEvent {
     pub time: xproto::Timestamp,
     pub device_id: u8,
     pub num_groups: u8,
-    pub changed_controls: u32,
-    pub enabled_controls: u32,
-    pub enabled_control_changes: u32,
+    pub changed_controls: Control,
+    pub enabled_controls: BoolCtrl,
+    pub enabled_control_changes: BoolCtrl,
     pub keycode: xproto::Keycode,
     pub event_type: u8,
     pub request_major: u8,
@@ -13343,9 +13361,9 @@ impl Serialize for ControlsNotifyEvent {
         let time_bytes = self.time.serialize();
         let device_id_bytes = self.device_id.serialize();
         let num_groups_bytes = self.num_groups.serialize();
-        let changed_controls_bytes = self.changed_controls.serialize();
-        let enabled_controls_bytes = self.enabled_controls.serialize();
-        let enabled_control_changes_bytes = self.enabled_control_changes.serialize();
+        let changed_controls_bytes = u32::from(self.changed_controls).serialize();
+        let enabled_controls_bytes = u32::from(self.enabled_controls).serialize();
+        let enabled_control_changes_bytes = u32::from(self.enabled_control_changes).serialize();
         let keycode_bytes = self.keycode.serialize();
         let event_type_bytes = self.event_type.serialize();
         let request_major_bytes = self.request_major.serialize();
@@ -13394,9 +13412,9 @@ impl Serialize for ControlsNotifyEvent {
         self.device_id.serialize_into(bytes);
         self.num_groups.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
-        self.changed_controls.serialize_into(bytes);
-        self.enabled_controls.serialize_into(bytes);
-        self.enabled_control_changes.serialize_into(bytes);
+        u32::from(self.changed_controls).serialize_into(bytes);
+        u32::from(self.enabled_controls).serialize_into(bytes);
+        u32::from(self.enabled_control_changes).serialize_into(bytes);
         self.keycode.serialize_into(bytes);
         self.event_type.serialize_into(bytes);
         self.request_major.serialize_into(bytes);
@@ -13412,9 +13430,9 @@ impl From<&ControlsNotifyEvent> for [u8; 32] {
         let time_bytes = input.time.serialize();
         let device_id_bytes = input.device_id.serialize();
         let num_groups_bytes = input.num_groups.serialize();
-        let changed_controls_bytes = input.changed_controls.serialize();
-        let enabled_controls_bytes = input.enabled_controls.serialize();
-        let enabled_control_changes_bytes = input.enabled_control_changes.serialize();
+        let changed_controls_bytes = u32::from(input.changed_controls).serialize();
+        let enabled_controls_bytes = u32::from(input.enabled_controls).serialize();
+        let enabled_control_changes_bytes = u32::from(input.enabled_control_changes).serialize();
         let keycode_bytes = input.keycode.serialize();
         let event_type_bytes = input.event_type.serialize();
         let request_major_bytes = input.request_major.serialize();
@@ -13753,15 +13771,15 @@ pub struct NamesNotifyEvent {
     pub sequence: u16,
     pub time: xproto::Timestamp,
     pub device_id: u8,
-    pub changed: u16,
+    pub changed: NameDetail,
     pub first_type: u8,
     pub n_types: u8,
     pub first_level_name: u8,
     pub n_level_names: u8,
     pub n_radio_groups: u8,
     pub n_key_aliases: u8,
-    pub changed_group_names: u8,
-    pub changed_virtual_mods: u16,
+    pub changed_group_names: SetOfGroup,
+    pub changed_virtual_mods: VMod,
     pub first_key: xproto::Keycode,
     pub n_keys: u8,
     pub changed_indicators: u32,
@@ -13807,15 +13825,15 @@ impl Serialize for NamesNotifyEvent {
         let sequence_bytes = self.sequence.serialize();
         let time_bytes = self.time.serialize();
         let device_id_bytes = self.device_id.serialize();
-        let changed_bytes = self.changed.serialize();
+        let changed_bytes = (u32::from(self.changed) as u16).serialize();
         let first_type_bytes = self.first_type.serialize();
         let n_types_bytes = self.n_types.serialize();
         let first_level_name_bytes = self.first_level_name.serialize();
         let n_level_names_bytes = self.n_level_names.serialize();
         let n_radio_groups_bytes = self.n_radio_groups.serialize();
         let n_key_aliases_bytes = self.n_key_aliases.serialize();
-        let changed_group_names_bytes = self.changed_group_names.serialize();
-        let changed_virtual_mods_bytes = self.changed_virtual_mods.serialize();
+        let changed_group_names_bytes = u8::from(self.changed_group_names).serialize();
+        let changed_virtual_mods_bytes = u16::from(self.changed_virtual_mods).serialize();
         let first_key_bytes = self.first_key.serialize();
         let n_keys_bytes = self.n_keys.serialize();
         let changed_indicators_bytes = self.changed_indicators.serialize();
@@ -13862,7 +13880,7 @@ impl Serialize for NamesNotifyEvent {
         self.time.serialize_into(bytes);
         self.device_id.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
-        self.changed.serialize_into(bytes);
+        (u32::from(self.changed) as u16).serialize_into(bytes);
         self.first_type.serialize_into(bytes);
         self.n_types.serialize_into(bytes);
         self.first_level_name.serialize_into(bytes);
@@ -13870,8 +13888,8 @@ impl Serialize for NamesNotifyEvent {
         bytes.extend_from_slice(&[0; 1]);
         self.n_radio_groups.serialize_into(bytes);
         self.n_key_aliases.serialize_into(bytes);
-        self.changed_group_names.serialize_into(bytes);
-        self.changed_virtual_mods.serialize_into(bytes);
+        u8::from(self.changed_group_names).serialize_into(bytes);
+        u16::from(self.changed_virtual_mods).serialize_into(bytes);
         self.first_key.serialize_into(bytes);
         self.n_keys.serialize_into(bytes);
         self.changed_indicators.serialize_into(bytes);
@@ -13885,15 +13903,15 @@ impl From<&NamesNotifyEvent> for [u8; 32] {
         let sequence_bytes = input.sequence.serialize();
         let time_bytes = input.time.serialize();
         let device_id_bytes = input.device_id.serialize();
-        let changed_bytes = input.changed.serialize();
+        let changed_bytes = (u32::from(input.changed) as u16).serialize();
         let first_type_bytes = input.first_type.serialize();
         let n_types_bytes = input.n_types.serialize();
         let first_level_name_bytes = input.first_level_name.serialize();
         let n_level_names_bytes = input.n_level_names.serialize();
         let n_radio_groups_bytes = input.n_radio_groups.serialize();
         let n_key_aliases_bytes = input.n_key_aliases.serialize();
-        let changed_group_names_bytes = input.changed_group_names.serialize();
-        let changed_virtual_mods_bytes = input.changed_virtual_mods.serialize();
+        let changed_group_names_bytes = u8::from(input.changed_group_names).serialize();
+        let changed_virtual_mods_bytes = u16::from(input.changed_virtual_mods).serialize();
         let first_key_bytes = input.first_key.serialize();
         let n_keys_bytes = input.n_keys.serialize();
         let changed_indicators_bytes = input.changed_indicators.serialize();
@@ -13949,7 +13967,7 @@ pub struct CompatMapNotifyEvent {
     pub sequence: u16,
     pub time: xproto::Timestamp,
     pub device_id: u8,
-    pub changed_groups: u8,
+    pub changed_groups: SetOfGroup,
     pub first_si: u16,
     pub n_si: u16,
     pub n_total_si: u16,
@@ -13983,7 +14001,7 @@ impl Serialize for CompatMapNotifyEvent {
         let sequence_bytes = self.sequence.serialize();
         let time_bytes = self.time.serialize();
         let device_id_bytes = self.device_id.serialize();
-        let changed_groups_bytes = self.changed_groups.serialize();
+        let changed_groups_bytes = u8::from(self.changed_groups).serialize();
         let first_si_bytes = self.first_si.serialize();
         let n_si_bytes = self.n_si.serialize();
         let n_total_si_bytes = self.n_total_si.serialize();
@@ -14029,7 +14047,7 @@ impl Serialize for CompatMapNotifyEvent {
         self.sequence.serialize_into(bytes);
         self.time.serialize_into(bytes);
         self.device_id.serialize_into(bytes);
-        self.changed_groups.serialize_into(bytes);
+        u8::from(self.changed_groups).serialize_into(bytes);
         self.first_si.serialize_into(bytes);
         self.n_si.serialize_into(bytes);
         self.n_total_si.serialize_into(bytes);
@@ -14043,7 +14061,7 @@ impl From<&CompatMapNotifyEvent> for [u8; 32] {
         let sequence_bytes = input.sequence.serialize();
         let time_bytes = input.time.serialize();
         let device_id_bytes = input.device_id.serialize();
-        let changed_groups_bytes = input.changed_groups.serialize();
+        let changed_groups_bytes = u8::from(input.changed_groups).serialize();
         let first_si_bytes = input.first_si.serialize();
         let n_si_bytes = input.n_si.serialize();
         let n_total_si_bytes = input.n_total_si.serialize();
@@ -14272,7 +14290,7 @@ pub struct ActionMessageEvent {
     pub keycode: xproto::Keycode,
     pub press: bool,
     pub key_event_follows: bool,
-    pub mods: u8,
+    pub mods: xproto::ModMask,
     pub group: Group,
     pub message: [String8; 8],
 }
@@ -14312,7 +14330,7 @@ impl Serialize for ActionMessageEvent {
         let keycode_bytes = self.keycode.serialize();
         let press_bytes = self.press.serialize();
         let key_event_follows_bytes = self.key_event_follows.serialize();
-        let mods_bytes = self.mods.serialize();
+        let mods_bytes = (u16::from(self.mods) as u8).serialize();
         let group_bytes = u8::from(self.group).serialize();
         [
             response_type_bytes[0],
@@ -14359,7 +14377,7 @@ impl Serialize for ActionMessageEvent {
         self.keycode.serialize_into(bytes);
         self.press.serialize_into(bytes);
         self.key_event_follows.serialize_into(bytes);
-        self.mods.serialize_into(bytes);
+        (u16::from(self.mods) as u8).serialize_into(bytes);
         u8::from(self.group).serialize_into(bytes);
         bytes.extend_from_slice(&self.message);
         bytes.extend_from_slice(&[0; 10]);
@@ -14375,7 +14393,7 @@ impl From<&ActionMessageEvent> for [u8; 32] {
         let keycode_bytes = input.keycode.serialize();
         let press_bytes = input.press.serialize();
         let key_event_follows_bytes = input.key_event_follows.serialize();
-        let mods_bytes = input.mods.serialize();
+        let mods_bytes = (u16::from(input.mods) as u8).serialize();
         let group_bytes = u8::from(input.group).serialize();
         [
             response_type_bytes[0],
@@ -14430,7 +14448,7 @@ pub struct AccessXNotifyEvent {
     pub time: xproto::Timestamp,
     pub device_id: u8,
     pub keycode: xproto::Keycode,
-    pub detailt: u16,
+    pub detailt: AXNDetail,
     pub slow_keys_delay: u16,
     pub debounce_delay: u16,
 }
@@ -14464,7 +14482,7 @@ impl Serialize for AccessXNotifyEvent {
         let time_bytes = self.time.serialize();
         let device_id_bytes = self.device_id.serialize();
         let keycode_bytes = self.keycode.serialize();
-        let detailt_bytes = self.detailt.serialize();
+        let detailt_bytes = u16::from(self.detailt).serialize();
         let slow_keys_delay_bytes = self.slow_keys_delay.serialize();
         let debounce_delay_bytes = self.debounce_delay.serialize();
         [
@@ -14510,7 +14528,7 @@ impl Serialize for AccessXNotifyEvent {
         self.time.serialize_into(bytes);
         self.device_id.serialize_into(bytes);
         self.keycode.serialize_into(bytes);
-        self.detailt.serialize_into(bytes);
+        u16::from(self.detailt).serialize_into(bytes);
         self.slow_keys_delay.serialize_into(bytes);
         self.debounce_delay.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 16]);
@@ -14524,7 +14542,7 @@ impl From<&AccessXNotifyEvent> for [u8; 32] {
         let time_bytes = input.time.serialize();
         let device_id_bytes = input.device_id.serialize();
         let keycode_bytes = input.keycode.serialize();
-        let detailt_bytes = input.detailt.serialize();
+        let detailt_bytes = u16::from(input.detailt).serialize();
         let slow_keys_delay_bytes = input.slow_keys_delay.serialize();
         let debounce_delay_bytes = input.debounce_delay.serialize();
         [
@@ -14579,15 +14597,15 @@ pub struct ExtensionDeviceNotifyEvent {
     pub sequence: u16,
     pub time: xproto::Timestamp,
     pub device_id: u8,
-    pub reason: u16,
+    pub reason: XIFeature,
     pub led_class: LedClassResult,
     pub led_id: u16,
     pub leds_defined: u32,
     pub led_state: u32,
     pub first_button: u8,
     pub n_buttons: u8,
-    pub supported: u16,
-    pub unsupported: u16,
+    pub supported: XIFeature,
+    pub unsupported: XIFeature,
 }
 impl TryParse for ExtensionDeviceNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14627,15 +14645,15 @@ impl Serialize for ExtensionDeviceNotifyEvent {
         let sequence_bytes = self.sequence.serialize();
         let time_bytes = self.time.serialize();
         let device_id_bytes = self.device_id.serialize();
-        let reason_bytes = self.reason.serialize();
+        let reason_bytes = u16::from(self.reason).serialize();
         let led_class_bytes = u16::from(self.led_class).serialize();
         let led_id_bytes = self.led_id.serialize();
         let leds_defined_bytes = self.leds_defined.serialize();
         let led_state_bytes = self.led_state.serialize();
         let first_button_bytes = self.first_button.serialize();
         let n_buttons_bytes = self.n_buttons.serialize();
-        let supported_bytes = self.supported.serialize();
-        let unsupported_bytes = self.unsupported.serialize();
+        let supported_bytes = u16::from(self.supported).serialize();
+        let unsupported_bytes = u16::from(self.unsupported).serialize();
         [
             response_type_bytes[0],
             xkb_type_bytes[0],
@@ -14679,15 +14697,15 @@ impl Serialize for ExtensionDeviceNotifyEvent {
         self.time.serialize_into(bytes);
         self.device_id.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
-        self.reason.serialize_into(bytes);
+        u16::from(self.reason).serialize_into(bytes);
         u16::from(self.led_class).serialize_into(bytes);
         self.led_id.serialize_into(bytes);
         self.leds_defined.serialize_into(bytes);
         self.led_state.serialize_into(bytes);
         self.first_button.serialize_into(bytes);
         self.n_buttons.serialize_into(bytes);
-        self.supported.serialize_into(bytes);
-        self.unsupported.serialize_into(bytes);
+        u16::from(self.supported).serialize_into(bytes);
+        u16::from(self.unsupported).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
     }
 }
@@ -14698,15 +14716,15 @@ impl From<&ExtensionDeviceNotifyEvent> for [u8; 32] {
         let sequence_bytes = input.sequence.serialize();
         let time_bytes = input.time.serialize();
         let device_id_bytes = input.device_id.serialize();
-        let reason_bytes = input.reason.serialize();
+        let reason_bytes = u16::from(input.reason).serialize();
         let led_class_bytes = u16::from(input.led_class).serialize();
         let led_id_bytes = input.led_id.serialize();
         let leds_defined_bytes = input.leds_defined.serialize();
         let led_state_bytes = input.led_state.serialize();
         let first_button_bytes = input.first_button.serialize();
         let n_buttons_bytes = input.n_buttons.serialize();
-        let supported_bytes = input.supported.serialize();
-        let unsupported_bytes = input.unsupported.serialize();
+        let supported_bytes = u16::from(input.supported).serialize();
+        let unsupported_bytes = u16::from(input.unsupported).serialize();
         [
             response_type_bytes[0],
             xkb_type_bytes[0],

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -171,34 +171,22 @@ bitmask_binop!(EventType, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct NKNDetail(u8);
+pub struct NKNDetail(u16);
 impl NKNDetail {
     pub const KEYCODES: Self = Self(1 << 0);
     pub const GEOMETRY: Self = Self(1 << 1);
     pub const DEVICE_ID: Self = Self(1 << 2);
 }
-impl From<NKNDetail> for u8 {
+impl From<NKNDetail> for u16 {
     #[inline]
     fn from(input: NKNDetail) -> Self {
         input.0
     }
 }
-impl From<NKNDetail> for Option<u8> {
-    #[inline]
-    fn from(input: NKNDetail) -> Self {
-        Some(input.0)
-    }
-}
-impl From<NKNDetail> for u16 {
-    #[inline]
-    fn from(input: NKNDetail) -> Self {
-        u16::from(input.0)
-    }
-}
 impl From<NKNDetail> for Option<u16> {
     #[inline]
     fn from(input: NKNDetail) -> Self {
-        Some(u16::from(input.0))
+        Some(input.0)
     }
 }
 impl From<NKNDetail> for u32 {
@@ -216,6 +204,12 @@ impl From<NKNDetail> for Option<u32> {
 impl From<u8> for NKNDetail {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for NKNDetail {
+    #[inline]
+    fn from(value: u16) -> Self {
         Self(value)
     }
 }
@@ -229,11 +223,11 @@ impl core::fmt::Debug for NKNDetail  {
         pretty_print_bitmask(fmt, self.0.into(), &variants)
     }
 }
-bitmask_binop!(NKNDetail, u8);
+bitmask_binop!(NKNDetail, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct AXNDetail(u8);
+pub struct AXNDetail(u16);
 impl AXNDetail {
     pub const SK_PRESS: Self = Self(1 << 0);
     pub const SK_ACCEPT: Self = Self(1 << 1);
@@ -243,28 +237,16 @@ impl AXNDetail {
     pub const BK_REJECT: Self = Self(1 << 5);
     pub const AXK_WARNING: Self = Self(1 << 6);
 }
-impl From<AXNDetail> for u8 {
+impl From<AXNDetail> for u16 {
     #[inline]
     fn from(input: AXNDetail) -> Self {
         input.0
     }
 }
-impl From<AXNDetail> for Option<u8> {
-    #[inline]
-    fn from(input: AXNDetail) -> Self {
-        Some(input.0)
-    }
-}
-impl From<AXNDetail> for u16 {
-    #[inline]
-    fn from(input: AXNDetail) -> Self {
-        u16::from(input.0)
-    }
-}
 impl From<AXNDetail> for Option<u16> {
     #[inline]
     fn from(input: AXNDetail) -> Self {
-        Some(u16::from(input.0))
+        Some(input.0)
     }
 }
 impl From<AXNDetail> for u32 {
@@ -282,6 +264,12 @@ impl From<AXNDetail> for Option<u32> {
 impl From<u8> for AXNDetail {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for AXNDetail {
+    #[inline]
+    fn from(value: u16) -> Self {
         Self(value)
     }
 }
@@ -299,11 +287,11 @@ impl core::fmt::Debug for AXNDetail  {
         pretty_print_bitmask(fmt, self.0.into(), &variants)
     }
 }
-bitmask_binop!(AXNDetail, u8);
+bitmask_binop!(AXNDetail, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct MapPart(u8);
+pub struct MapPart(u16);
 impl MapPart {
     pub const KEY_TYPES: Self = Self(1 << 0);
     pub const KEY_SYMS: Self = Self(1 << 1);
@@ -314,28 +302,16 @@ impl MapPart {
     pub const VIRTUAL_MODS: Self = Self(1 << 6);
     pub const VIRTUAL_MOD_MAP: Self = Self(1 << 7);
 }
-impl From<MapPart> for u8 {
+impl From<MapPart> for u16 {
     #[inline]
     fn from(input: MapPart) -> Self {
         input.0
     }
 }
-impl From<MapPart> for Option<u8> {
-    #[inline]
-    fn from(input: MapPart) -> Self {
-        Some(input.0)
-    }
-}
-impl From<MapPart> for u16 {
-    #[inline]
-    fn from(input: MapPart) -> Self {
-        u16::from(input.0)
-    }
-}
 impl From<MapPart> for Option<u16> {
     #[inline]
     fn from(input: MapPart) -> Self {
-        Some(u16::from(input.0))
+        Some(input.0)
     }
 }
 impl From<MapPart> for u32 {
@@ -353,6 +329,12 @@ impl From<MapPart> for Option<u32> {
 impl From<u8> for MapPart {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for MapPart {
+    #[inline]
+    fn from(value: u16) -> Self {
         Self(value)
     }
 }
@@ -371,37 +353,25 @@ impl core::fmt::Debug for MapPart  {
         pretty_print_bitmask(fmt, self.0.into(), &variants)
     }
 }
-bitmask_binop!(MapPart, u8);
+bitmask_binop!(MapPart, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct SetMapFlags(u8);
+pub struct SetMapFlags(u16);
 impl SetMapFlags {
     pub const RESIZE_TYPES: Self = Self(1 << 0);
     pub const RECOMPUTE_ACTIONS: Self = Self(1 << 1);
 }
-impl From<SetMapFlags> for u8 {
+impl From<SetMapFlags> for u16 {
     #[inline]
     fn from(input: SetMapFlags) -> Self {
         input.0
     }
 }
-impl From<SetMapFlags> for Option<u8> {
-    #[inline]
-    fn from(input: SetMapFlags) -> Self {
-        Some(input.0)
-    }
-}
-impl From<SetMapFlags> for u16 {
-    #[inline]
-    fn from(input: SetMapFlags) -> Self {
-        u16::from(input.0)
-    }
-}
 impl From<SetMapFlags> for Option<u16> {
     #[inline]
     fn from(input: SetMapFlags) -> Self {
-        Some(u16::from(input.0))
+        Some(input.0)
     }
 }
 impl From<SetMapFlags> for u32 {
@@ -419,6 +389,12 @@ impl From<SetMapFlags> for Option<u32> {
 impl From<u8> for SetMapFlags {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for SetMapFlags {
+    #[inline]
+    fn from(value: u16) -> Self {
         Self(value)
     }
 }
@@ -431,7 +407,7 @@ impl core::fmt::Debug for SetMapFlags  {
         pretty_print_bitmask(fmt, self.0.into(), &variants)
     }
 }
-bitmask_binop!(SetMapFlags, u8);
+bitmask_binop!(SetMapFlags, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -513,7 +489,7 @@ bitmask_binop!(StatePart, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct BoolCtrl(u16);
+pub struct BoolCtrl(u32);
 impl BoolCtrl {
     pub const REPEAT_KEYS: Self = Self(1 << 0);
     pub const SLOW_KEYS: Self = Self(1 << 1);
@@ -529,28 +505,16 @@ impl BoolCtrl {
     pub const OVERLAY2_MASK: Self = Self(1 << 11);
     pub const IGNORE_GROUP_LOCK_MASK: Self = Self(1 << 12);
 }
-impl From<BoolCtrl> for u16 {
+impl From<BoolCtrl> for u32 {
     #[inline]
     fn from(input: BoolCtrl) -> Self {
         input.0
     }
 }
-impl From<BoolCtrl> for Option<u16> {
-    #[inline]
-    fn from(input: BoolCtrl) -> Self {
-        Some(input.0)
-    }
-}
-impl From<BoolCtrl> for u32 {
-    #[inline]
-    fn from(input: BoolCtrl) -> Self {
-        u32::from(input.0)
-    }
-}
 impl From<BoolCtrl> for Option<u32> {
     #[inline]
     fn from(input: BoolCtrl) -> Self {
-        Some(u32::from(input.0))
+        Some(input.0)
     }
 }
 impl From<u8> for BoolCtrl {
@@ -562,30 +526,36 @@ impl From<u8> for BoolCtrl {
 impl From<u16> for BoolCtrl {
     #[inline]
     fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for BoolCtrl {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for BoolCtrl  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::REPEAT_KEYS.0.into(), "REPEAT_KEYS", "RepeatKeys"),
-            (Self::SLOW_KEYS.0.into(), "SLOW_KEYS", "SlowKeys"),
-            (Self::BOUNCE_KEYS.0.into(), "BOUNCE_KEYS", "BounceKeys"),
-            (Self::STICKY_KEYS.0.into(), "STICKY_KEYS", "StickyKeys"),
-            (Self::MOUSE_KEYS.0.into(), "MOUSE_KEYS", "MouseKeys"),
-            (Self::MOUSE_KEYS_ACCEL.0.into(), "MOUSE_KEYS_ACCEL", "MouseKeysAccel"),
-            (Self::ACCESS_X_KEYS.0.into(), "ACCESS_X_KEYS", "AccessXKeys"),
-            (Self::ACCESS_X_TIMEOUT_MASK.0.into(), "ACCESS_X_TIMEOUT_MASK", "AccessXTimeoutMask"),
-            (Self::ACCESS_X_FEEDBACK_MASK.0.into(), "ACCESS_X_FEEDBACK_MASK", "AccessXFeedbackMask"),
-            (Self::AUDIBLE_BELL_MASK.0.into(), "AUDIBLE_BELL_MASK", "AudibleBellMask"),
-            (Self::OVERLAY1_MASK.0.into(), "OVERLAY1_MASK", "Overlay1Mask"),
-            (Self::OVERLAY2_MASK.0.into(), "OVERLAY2_MASK", "Overlay2Mask"),
-            (Self::IGNORE_GROUP_LOCK_MASK.0.into(), "IGNORE_GROUP_LOCK_MASK", "IgnoreGroupLockMask"),
+            (Self::REPEAT_KEYS.0, "REPEAT_KEYS", "RepeatKeys"),
+            (Self::SLOW_KEYS.0, "SLOW_KEYS", "SlowKeys"),
+            (Self::BOUNCE_KEYS.0, "BOUNCE_KEYS", "BounceKeys"),
+            (Self::STICKY_KEYS.0, "STICKY_KEYS", "StickyKeys"),
+            (Self::MOUSE_KEYS.0, "MOUSE_KEYS", "MouseKeys"),
+            (Self::MOUSE_KEYS_ACCEL.0, "MOUSE_KEYS_ACCEL", "MouseKeysAccel"),
+            (Self::ACCESS_X_KEYS.0, "ACCESS_X_KEYS", "AccessXKeys"),
+            (Self::ACCESS_X_TIMEOUT_MASK.0, "ACCESS_X_TIMEOUT_MASK", "AccessXTimeoutMask"),
+            (Self::ACCESS_X_FEEDBACK_MASK.0, "ACCESS_X_FEEDBACK_MASK", "AccessXFeedbackMask"),
+            (Self::AUDIBLE_BELL_MASK.0, "AUDIBLE_BELL_MASK", "AudibleBellMask"),
+            (Self::OVERLAY1_MASK.0, "OVERLAY1_MASK", "Overlay1Mask"),
+            (Self::OVERLAY2_MASK.0, "OVERLAY2_MASK", "Overlay2Mask"),
+            (Self::IGNORE_GROUP_LOCK_MASK.0, "IGNORE_GROUP_LOCK_MASK", "IgnoreGroupLockMask"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(BoolCtrl, u16);
+bitmask_binop!(BoolCtrl, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -2063,7 +2033,7 @@ bitmask_binop!(CMDetail, u8);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct NameDetail(u16);
+pub struct NameDetail(u32);
 impl NameDetail {
     pub const KEYCODES: Self = Self(1 << 0);
     pub const GEOMETRY: Self = Self(1 << 1);
@@ -2080,28 +2050,16 @@ impl NameDetail {
     pub const GROUP_NAMES: Self = Self(1 << 12);
     pub const RG_NAMES: Self = Self(1 << 13);
 }
-impl From<NameDetail> for u16 {
+impl From<NameDetail> for u32 {
     #[inline]
     fn from(input: NameDetail) -> Self {
         input.0
     }
 }
-impl From<NameDetail> for Option<u16> {
-    #[inline]
-    fn from(input: NameDetail) -> Self {
-        Some(input.0)
-    }
-}
-impl From<NameDetail> for u32 {
-    #[inline]
-    fn from(input: NameDetail) -> Self {
-        u32::from(input.0)
-    }
-}
 impl From<NameDetail> for Option<u32> {
     #[inline]
     fn from(input: NameDetail) -> Self {
-        Some(u32::from(input.0))
+        Some(input.0)
     }
 }
 impl From<u8> for NameDetail {
@@ -2113,35 +2071,41 @@ impl From<u8> for NameDetail {
 impl From<u16> for NameDetail {
     #[inline]
     fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for NameDetail {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for NameDetail  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::KEYCODES.0.into(), "KEYCODES", "Keycodes"),
-            (Self::GEOMETRY.0.into(), "GEOMETRY", "Geometry"),
-            (Self::SYMBOLS.0.into(), "SYMBOLS", "Symbols"),
-            (Self::PHYS_SYMBOLS.0.into(), "PHYS_SYMBOLS", "PhysSymbols"),
-            (Self::TYPES.0.into(), "TYPES", "Types"),
-            (Self::COMPAT.0.into(), "COMPAT", "Compat"),
-            (Self::KEY_TYPE_NAMES.0.into(), "KEY_TYPE_NAMES", "KeyTypeNames"),
-            (Self::KT_LEVEL_NAMES.0.into(), "KT_LEVEL_NAMES", "KTLevelNames"),
-            (Self::INDICATOR_NAMES.0.into(), "INDICATOR_NAMES", "IndicatorNames"),
-            (Self::KEY_NAMES.0.into(), "KEY_NAMES", "KeyNames"),
-            (Self::KEY_ALIASES.0.into(), "KEY_ALIASES", "KeyAliases"),
-            (Self::VIRTUAL_MOD_NAMES.0.into(), "VIRTUAL_MOD_NAMES", "VirtualModNames"),
-            (Self::GROUP_NAMES.0.into(), "GROUP_NAMES", "GroupNames"),
-            (Self::RG_NAMES.0.into(), "RG_NAMES", "RGNames"),
+            (Self::KEYCODES.0, "KEYCODES", "Keycodes"),
+            (Self::GEOMETRY.0, "GEOMETRY", "Geometry"),
+            (Self::SYMBOLS.0, "SYMBOLS", "Symbols"),
+            (Self::PHYS_SYMBOLS.0, "PHYS_SYMBOLS", "PhysSymbols"),
+            (Self::TYPES.0, "TYPES", "Types"),
+            (Self::COMPAT.0, "COMPAT", "Compat"),
+            (Self::KEY_TYPE_NAMES.0, "KEY_TYPE_NAMES", "KeyTypeNames"),
+            (Self::KT_LEVEL_NAMES.0, "KT_LEVEL_NAMES", "KTLevelNames"),
+            (Self::INDICATOR_NAMES.0, "INDICATOR_NAMES", "IndicatorNames"),
+            (Self::KEY_NAMES.0, "KEY_NAMES", "KeyNames"),
+            (Self::KEY_ALIASES.0, "KEY_ALIASES", "KeyAliases"),
+            (Self::VIRTUAL_MOD_NAMES.0, "VIRTUAL_MOD_NAMES", "VirtualModNames"),
+            (Self::GROUP_NAMES.0, "GROUP_NAMES", "GroupNames"),
+            (Self::RG_NAMES.0, "RG_NAMES", "RGNames"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(NameDetail, u16);
+bitmask_binop!(NameDetail, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct GBNDetail(u8);
+pub struct GBNDetail(u16);
 impl GBNDetail {
     pub const TYPES: Self = Self(1 << 0);
     pub const COMPAT_MAP: Self = Self(1 << 1);
@@ -2152,28 +2116,16 @@ impl GBNDetail {
     pub const GEOMETRY: Self = Self(1 << 6);
     pub const OTHER_NAMES: Self = Self(1 << 7);
 }
-impl From<GBNDetail> for u8 {
+impl From<GBNDetail> for u16 {
     #[inline]
     fn from(input: GBNDetail) -> Self {
         input.0
     }
 }
-impl From<GBNDetail> for Option<u8> {
-    #[inline]
-    fn from(input: GBNDetail) -> Self {
-        Some(input.0)
-    }
-}
-impl From<GBNDetail> for u16 {
-    #[inline]
-    fn from(input: GBNDetail) -> Self {
-        u16::from(input.0)
-    }
-}
 impl From<GBNDetail> for Option<u16> {
     #[inline]
     fn from(input: GBNDetail) -> Self {
-        Some(u16::from(input.0))
+        Some(input.0)
     }
 }
 impl From<GBNDetail> for u32 {
@@ -2191,6 +2143,12 @@ impl From<GBNDetail> for Option<u32> {
 impl From<u8> for GBNDetail {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for GBNDetail {
+    #[inline]
+    fn from(value: u16) -> Self {
         Self(value)
     }
 }
@@ -2209,11 +2167,11 @@ impl core::fmt::Debug for GBNDetail  {
         pretty_print_bitmask(fmt, self.0.into(), &variants)
     }
 }
-bitmask_binop!(GBNDetail, u8);
+bitmask_binop!(GBNDetail, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct XIFeature(u8);
+pub struct XIFeature(u16);
 impl XIFeature {
     pub const KEYBOARDS: Self = Self(1 << 0);
     pub const BUTTON_ACTIONS: Self = Self(1 << 1);
@@ -2221,28 +2179,16 @@ impl XIFeature {
     pub const INDICATOR_MAPS: Self = Self(1 << 3);
     pub const INDICATOR_STATE: Self = Self(1 << 4);
 }
-impl From<XIFeature> for u8 {
+impl From<XIFeature> for u16 {
     #[inline]
     fn from(input: XIFeature) -> Self {
         input.0
     }
 }
-impl From<XIFeature> for Option<u8> {
-    #[inline]
-    fn from(input: XIFeature) -> Self {
-        Some(input.0)
-    }
-}
-impl From<XIFeature> for u16 {
-    #[inline]
-    fn from(input: XIFeature) -> Self {
-        u16::from(input.0)
-    }
-}
 impl From<XIFeature> for Option<u16> {
     #[inline]
     fn from(input: XIFeature) -> Self {
-        Some(u16::from(input.0))
+        Some(input.0)
     }
 }
 impl From<XIFeature> for u32 {
@@ -2260,6 +2206,12 @@ impl From<XIFeature> for Option<u32> {
 impl From<u8> for XIFeature {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for XIFeature {
+    #[inline]
+    fn from(value: u16) -> Self {
         Self(value)
     }
 }
@@ -2275,11 +2227,11 @@ impl core::fmt::Debug for XIFeature  {
         pretty_print_bitmask(fmt, self.0.into(), &variants)
     }
 }
-bitmask_binop!(XIFeature, u8);
+bitmask_binop!(XIFeature, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct PerClientFlag(u8);
+pub struct PerClientFlag(u32);
 impl PerClientFlag {
     pub const DETECTABLE_AUTO_REPEAT: Self = Self(1 << 0);
     pub const GRABS_USE_XKB_STATE: Self = Self(1 << 1);
@@ -2287,61 +2239,49 @@ impl PerClientFlag {
     pub const LOOKUP_STATE_WHEN_GRABBED: Self = Self(1 << 3);
     pub const SEND_EVENT_USES_XKB_STATE: Self = Self(1 << 4);
 }
-impl From<PerClientFlag> for u8 {
+impl From<PerClientFlag> for u32 {
     #[inline]
     fn from(input: PerClientFlag) -> Self {
         input.0
     }
 }
-impl From<PerClientFlag> for Option<u8> {
+impl From<PerClientFlag> for Option<u32> {
     #[inline]
     fn from(input: PerClientFlag) -> Self {
         Some(input.0)
     }
 }
-impl From<PerClientFlag> for u16 {
-    #[inline]
-    fn from(input: PerClientFlag) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<PerClientFlag> for Option<u16> {
-    #[inline]
-    fn from(input: PerClientFlag) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<PerClientFlag> for u32 {
-    #[inline]
-    fn from(input: PerClientFlag) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<PerClientFlag> for Option<u32> {
-    #[inline]
-    fn from(input: PerClientFlag) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for PerClientFlag {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for PerClientFlag {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for PerClientFlag {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for PerClientFlag  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::DETECTABLE_AUTO_REPEAT.0.into(), "DETECTABLE_AUTO_REPEAT", "DetectableAutoRepeat"),
-            (Self::GRABS_USE_XKB_STATE.0.into(), "GRABS_USE_XKB_STATE", "GrabsUseXKBState"),
-            (Self::AUTO_RESET_CONTROLS.0.into(), "AUTO_RESET_CONTROLS", "AutoResetControls"),
-            (Self::LOOKUP_STATE_WHEN_GRABBED.0.into(), "LOOKUP_STATE_WHEN_GRABBED", "LookupStateWhenGrabbed"),
-            (Self::SEND_EVENT_USES_XKB_STATE.0.into(), "SEND_EVENT_USES_XKB_STATE", "SendEventUsesXKBState"),
+            (Self::DETECTABLE_AUTO_REPEAT.0, "DETECTABLE_AUTO_REPEAT", "DetectableAutoRepeat"),
+            (Self::GRABS_USE_XKB_STATE.0, "GRABS_USE_XKB_STATE", "GrabsUseXKBState"),
+            (Self::AUTO_RESET_CONTROLS.0, "AUTO_RESET_CONTROLS", "AutoResetControls"),
+            (Self::LOOKUP_STATE_WHEN_GRABBED.0, "LOOKUP_STATE_WHEN_GRABBED", "LookupStateWhenGrabbed"),
+            (Self::SEND_EVENT_USES_XKB_STATE.0, "SEND_EVENT_USES_XKB_STATE", "SendEventUsesXKBState"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(PerClientFlag, u8);
+bitmask_binop!(PerClientFlag, u32);
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -6349,7 +6349,7 @@ pub struct SelectEventsAux {
 }
 impl SelectEventsAux {
     fn try_parse(value: &[u8], affect_which: u16, clear: u16, select_all: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = affect_which & ((!clear) & (!select_all));
+        let switch_expr = u16::from(affect_which) & ((!u16::from(clear)) & (!u16::from(select_all)));
         let mut outer_remaining = value;
         let bitcase1 = if switch_expr & u16::from(EventType::NEW_KEYBOARD_NOTIFY) != 0 {
             let (bitcase1, new_remaining) = SelectEventsAuxBitcase1::try_parse(outer_remaining)?;
@@ -6607,7 +6607,7 @@ impl<'input> SelectEventsRequest<'input> {
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
         let device_spec_bytes = self.device_spec.serialize();
-        let affect_which: u16 = self.details.switch_expr() | (self.clear | self.select_all);
+        let affect_which: u16 = self.details.switch_expr() | (u16::from(self.clear) | u16::from(self.select_all));
         let affect_which_bytes = affect_which.serialize();
         let clear_bytes = u16::from(self.clear).serialize();
         let select_all_bytes = u16::from(self.select_all).serialize();
@@ -7889,7 +7889,7 @@ pub struct GetMapMap {
 }
 impl GetMapMap {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = present;
+        let switch_expr = u16::from(present);
         let mut outer_remaining = value;
         let types_rtrn = if switch_expr & u16::from(MapPart::KEY_TYPES) != 0 {
             let remaining = outer_remaining;
@@ -8242,7 +8242,7 @@ pub struct SetMapAux {
 }
 impl SetMapAux {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = present;
+        let switch_expr = u16::from(present);
         let mut outer_remaining = value;
         let types = if switch_expr & u16::from(MapPart::KEY_TYPES) != 0 {
             let remaining = outer_remaining;
@@ -9751,7 +9751,7 @@ pub struct GetNamesValueList {
 }
 impl GetNamesValueList {
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = which;
+        let switch_expr = u32::from(which);
         let mut outer_remaining = value;
         let keycodes_name = if switch_expr & u32::from(NameDetail::KEYCODES) != 0 {
             let remaining = outer_remaining;
@@ -10124,7 +10124,7 @@ pub struct SetNamesAux {
 }
 impl SetNamesAux {
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = which;
+        let switch_expr = u32::from(which);
         let mut outer_remaining = value;
         let keycodes_name = if switch_expr & u32::from(NameDetail::KEYCODES) != 0 {
             let remaining = outer_remaining;
@@ -11140,7 +11140,7 @@ pub struct GetKbdByNameRepliesTypesMap {
 }
 impl GetKbdByNameRepliesTypesMap {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = present;
+        let switch_expr = u16::from(present);
         let mut outer_remaining = value;
         let types_rtrn = if switch_expr & u16::from(MapPart::KEY_TYPES) != 0 {
             let remaining = outer_remaining;
@@ -11624,7 +11624,7 @@ pub struct GetKbdByNameRepliesKeyNamesValueList {
 }
 impl GetKbdByNameRepliesKeyNamesValueList {
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = which;
+        let switch_expr = u32::from(which);
         let mut outer_remaining = value;
         let keycodes_name = if switch_expr & u32::from(NameDetail::KEYCODES) != 0 {
             let remaining = outer_remaining;
@@ -12018,7 +12018,7 @@ pub struct GetKbdByNameReplies {
 }
 impl GetKbdByNameReplies {
     fn try_parse(value: &[u8], reported: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = reported;
+        let switch_expr = u16::from(reported);
         let mut outer_remaining = value;
         let types = if switch_expr & u16::from(GBNDetail::TYPES) != 0 || switch_expr & u16::from(GBNDetail::CLIENT_SYMBOLS) != 0 || switch_expr & u16::from(GBNDetail::SERVER_SYMBOLS) != 0 {
             let (types, new_remaining) = GetKbdByNameRepliesTypes::try_parse(outer_remaining)?;

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -6656,7 +6656,7 @@ impl<'input> SelectEventsRequest<'input> {
         let affect_map = affect_map.into();
         let (map, remaining) = u16::try_parse(remaining)?;
         let map = map.into();
-        let (details, remaining) = SelectEventsAux::try_parse(remaining, affect_which, clear, select_all)?;
+        let (details, remaining) = SelectEventsAux::try_parse(remaining, u16::from(affect_which), u16::from(clear), u16::from(select_all))?;
         let _ = remaining;
         Ok(SelectEventsRequest {
             device_spec,
@@ -8134,7 +8134,7 @@ impl TryParse for GetMapReply {
         let (total_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
-        let (map, remaining) = GetMapMap::try_parse(remaining, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys)?;
+        let (map, remaining) = GetMapMap::try_parse(remaining, u16::from(present), u8::from(n_types), u8::from(n_key_syms), u8::from(n_key_actions), u16::from(total_actions), u8::from(total_key_behaviors), u16::from(virtual_mods), u8::from(total_key_explicit), u8::from(total_mod_map_keys), u8::from(total_v_mod_map_keys))?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -8598,7 +8598,7 @@ impl<'input> SetMapRequest<'input> {
         let (total_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
         let virtual_mods = virtual_mods.into();
-        let (values, remaining) = SetMapAux::try_parse(remaining, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys)?;
+        let (values, remaining) = SetMapAux::try_parse(remaining, u16::from(present), u8::from(n_types), u8::from(n_key_syms), u8::from(n_key_actions), u16::from(total_actions), u8::from(total_key_behaviors), u16::from(virtual_mods), u8::from(total_key_explicit), u8::from(total_mod_map_keys), u8::from(total_v_mod_map_keys))?;
         let _ = remaining;
         Ok(SetMapRequest {
             device_spec,
@@ -10023,7 +10023,7 @@ impl TryParse for GetNamesReply {
         let (n_key_aliases, remaining) = u8::try_parse(remaining)?;
         let (n_kt_levels, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::InsufficientData)?;
-        let (value_list, remaining) = GetNamesValueList::try_parse(remaining, which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups)?;
+        let (value_list, remaining) = GetNamesValueList::try_parse(remaining, u32::from(which), u8::from(n_types), u32::from(indicators), u16::from(virtual_mods), u8::from(group_names), u8::from(n_keys), u8::from(n_key_aliases), u8::from(n_radio_groups))?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -10548,7 +10548,7 @@ impl<'input> SetNamesRequest<'input> {
         let (n_key_aliases, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (total_kt_level_names, remaining) = u16::try_parse(remaining)?;
-        let (values, remaining) = SetNamesAux::try_parse(remaining, which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups)?;
+        let (values, remaining) = SetNamesAux::try_parse(remaining, u32::from(which), u8::from(n_types), u32::from(indicators), u16::from(virtual_mods), u8::from(group_names), u8::from(n_keys), u8::from(n_key_aliases), u8::from(n_radio_groups))?;
         let _ = remaining;
         Ok(SetNamesRequest {
             device_spec,
@@ -11385,7 +11385,7 @@ impl TryParse for GetKbdByNameRepliesTypes {
         let (total_v_mod_map_keys, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (virtual_mods, remaining) = u16::try_parse(remaining)?;
-        let (map, remaining) = GetKbdByNameRepliesTypesMap::try_parse(remaining, present, n_types, n_key_syms, n_key_actions, total_actions, total_key_behaviors, virtual_mods, total_key_explicit, total_mod_map_keys, total_v_mod_map_keys)?;
+        let (map, remaining) = GetKbdByNameRepliesTypesMap::try_parse(remaining, u16::from(present), u8::from(n_types), u8::from(n_key_syms), u8::from(n_key_actions), u16::from(total_actions), u8::from(total_key_behaviors), u16::from(virtual_mods), u8::from(total_key_explicit), u8::from(total_mod_map_keys), u8::from(total_v_mod_map_keys))?;
         let virtual_mods = virtual_mods.into();
         let result = GetKbdByNameRepliesTypes { getmap_type, type_device_id, getmap_sequence, getmap_length, type_min_key_code, type_max_key_code, first_type, n_types, total_types, first_key_sym, total_syms, n_key_syms, first_key_action, total_actions, n_key_actions, first_key_behavior, n_key_behaviors, total_key_behaviors, first_key_explicit, n_key_explicit, total_key_explicit, first_mod_map_key, n_mod_map_keys, total_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys, total_v_mod_map_keys, virtual_mods, map };
         Ok((result, remaining))
@@ -11896,7 +11896,7 @@ impl TryParse for GetKbdByNameRepliesKeyNames {
         let (n_key_aliases, remaining) = u8::try_parse(remaining)?;
         let (n_kt_levels, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(4..).ok_or(ParseError::InsufficientData)?;
-        let (value_list, remaining) = GetKbdByNameRepliesKeyNamesValueList::try_parse(remaining, which, n_types, indicators, virtual_mods, group_names, n_keys, n_key_aliases, n_radio_groups)?;
+        let (value_list, remaining) = GetKbdByNameRepliesKeyNamesValueList::try_parse(remaining, u32::from(which), u8::from(n_types), u32::from(indicators), u16::from(virtual_mods), u8::from(group_names), u8::from(n_keys), u8::from(n_key_aliases), u8::from(n_radio_groups))?;
         let group_names = group_names.into();
         let virtual_mods = virtual_mods.into();
         let result = GetKbdByNameRepliesKeyNames { keyname_type, key_device_id, keyname_sequence, keyname_length, key_min_key_code, key_max_key_code, n_types, group_names, virtual_mods, first_key, n_keys, indicators, n_radio_groups, n_key_aliases, n_kt_levels, value_list };
@@ -12114,7 +12114,7 @@ impl TryParse for GetKbdByNameReply {
         let (found, remaining) = u16::try_parse(remaining)?;
         let (reported, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(16..).ok_or(ParseError::InsufficientData)?;
-        let (replies, remaining) = GetKbdByNameReplies::try_parse(remaining, reported)?;
+        let (replies, remaining) = GetKbdByNameReplies::try_parse(remaining, u16::from(reported))?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `xkb` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xprint.rs
+++ b/x11rb-protocol/src/protocol/xprint.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `XPrint` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -9,6 +9,8 @@
 //! specific errors, events, or requests.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -7268,7 +7268,7 @@ impl<'input> CreateWindowRequest<'input> {
         let class = class.into();
         let (visual, remaining) = Visualid::try_parse(remaining)?;
         let (value_mask, remaining) = u32::try_parse(remaining)?;
-        let (value_list, remaining) = CreateWindowAux::try_parse(remaining, value_mask)?;
+        let (value_list, remaining) = CreateWindowAux::try_parse(remaining, u32::from(value_mask))?;
         let _ = remaining;
         Ok(CreateWindowRequest {
             depth,
@@ -7740,7 +7740,7 @@ impl<'input> ChangeWindowAttributesRequest<'input> {
         let _ = remaining;
         let (window, remaining) = Window::try_parse(value)?;
         let (value_mask, remaining) = u32::try_parse(remaining)?;
-        let (value_list, remaining) = ChangeWindowAttributesAux::try_parse(remaining, value_mask)?;
+        let (value_list, remaining) = ChangeWindowAttributesAux::try_parse(remaining, u32::from(value_mask))?;
         let _ = remaining;
         Ok(ChangeWindowAttributesRequest {
             window,
@@ -9165,7 +9165,7 @@ impl<'input> ConfigureWindowRequest<'input> {
         let (window, remaining) = Window::try_parse(value)?;
         let (value_mask, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (value_list, remaining) = ConfigureWindowAux::try_parse(remaining, value_mask)?;
+        let (value_list, remaining) = ConfigureWindowAux::try_parse(remaining, u16::from(value_mask))?;
         let _ = remaining;
         Ok(ConfigureWindowRequest {
             window,
@@ -16907,7 +16907,7 @@ impl<'input> CreateGCRequest<'input> {
         let (cid, remaining) = Gcontext::try_parse(value)?;
         let (drawable, remaining) = Drawable::try_parse(remaining)?;
         let (value_mask, remaining) = u32::try_parse(remaining)?;
-        let (value_list, remaining) = CreateGCAux::try_parse(remaining, value_mask)?;
+        let (value_list, remaining) = CreateGCAux::try_parse(remaining, u32::from(value_mask))?;
         let _ = remaining;
         Ok(CreateGCRequest {
             cid,
@@ -17558,7 +17558,7 @@ impl<'input> ChangeGCRequest<'input> {
         let _ = remaining;
         let (gc, remaining) = Gcontext::try_parse(value)?;
         let (value_mask, remaining) = u32::try_parse(remaining)?;
-        let (value_list, remaining) = ChangeGCAux::try_parse(remaining, value_mask)?;
+        let (value_list, remaining) = ChangeGCAux::try_parse(remaining, u32::from(value_mask))?;
         let _ = remaining;
         Ok(ChangeGCRequest {
             gc,
@@ -23546,7 +23546,7 @@ impl<'input> ChangeKeyboardControlRequest<'input> {
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let _ = remaining;
         let (value_mask, remaining) = u32::try_parse(value)?;
-        let (value_list, remaining) = ChangeKeyboardControlAux::try_parse(remaining, value_mask)?;
+        let (value_list, remaining) = ChangeKeyboardControlAux::try_parse(remaining, u32::from(value_mask))?;
         let _ = remaining;
         Ok(ChangeKeyboardControlRequest {
             value_list: Cow::Owned(value_list),

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -6783,7 +6783,7 @@ pub struct CreateWindowAux {
 }
 impl CreateWindowAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = value_mask;
+        let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
         let background_pixmap = if switch_expr & u32::from(CW::BACK_PIXMAP) != 0 {
             let remaining = outer_remaining;
@@ -7336,7 +7336,7 @@ pub struct ChangeWindowAttributesAux {
 }
 impl ChangeWindowAttributesAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = value_mask;
+        let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
         let background_pixmap = if switch_expr & u32::from(CW::BACK_PIXMAP) != 0 {
             let remaining = outer_remaining;
@@ -8862,7 +8862,7 @@ pub struct ConfigureWindowAux {
 }
 impl ConfigureWindowAux {
     fn try_parse(value: &[u8], value_mask: u16) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = value_mask;
+        let switch_expr = u16::from(value_mask);
         let mut outer_remaining = value;
         let x = if switch_expr & u16::from(ConfigWindow::X) != 0 {
             let remaining = outer_remaining;
@@ -10163,7 +10163,7 @@ impl<'input> ChangePropertyRequest<'input> {
             data_len_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        assert_eq!(self.data.len(), usize::try_from(self.data_len.checked_mul(u32::from(self.format)).unwrap().checked_div(8u32).unwrap()).unwrap(), "`data` has an incorrect length");
+        assert_eq!(self.data.len(), usize::try_from(u32::from(self.data_len).checked_mul(u32::from(self.format)).unwrap().checked_div(8u32).unwrap()).unwrap(), "`data` has an incorrect length");
         let length_so_far = length_so_far + self.data.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -10187,7 +10187,7 @@ impl<'input> ChangePropertyRequest<'input> {
         let (format, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(3..).ok_or(ParseError::InsufficientData)?;
         let (data_len, remaining) = u32::try_parse(remaining)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, data_len.checked_mul(u32::from(format)).ok_or(ParseError::InvalidExpression)?.checked_div(8u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(data_len).checked_mul(u32::from(format)).ok_or(ParseError::InvalidExpression)?.checked_div(8u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let _ = remaining;
         Ok(ChangePropertyRequest {
             mode,
@@ -10695,7 +10695,7 @@ impl TryParse for GetPropertyReply {
         let (bytes_after, remaining) = u32::try_parse(remaining)?;
         let (value_len, remaining) = u32::try_parse(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
-        let (value, remaining) = crate::x11_utils::parse_u8_list(remaining, value_len.checked_mul(u32::from(format).checked_div(8u32).ok_or(ParseError::InvalidExpression)?).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (value, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(value_len).checked_mul(u32::from(format).checked_div(8u32).ok_or(ParseError::InvalidExpression)?).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let value = value.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -10725,7 +10725,7 @@ impl Serialize for GetPropertyReply {
         self.bytes_after.serialize_into(bytes);
         self.value_len.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 12]);
-        assert_eq!(self.value.len(), usize::try_from(self.value_len.checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`value` has an incorrect length");
+        assert_eq!(self.value.len(), usize::try_from(u32::from(self.value_len).checked_mul(u32::from(self.format).checked_div(8u32).unwrap()).unwrap()).unwrap(), "`value` has an incorrect length");
         bytes.extend_from_slice(&self.value);
     }
 }
@@ -14755,7 +14755,7 @@ impl<'input> QueryTextExtentsRequest<'input> {
     pub fn serialize(self) -> BufWithFds<PiecewiseBuf<'input>> {
         let string_len = u32::try_from(self.string.len()).unwrap();
         let length_so_far = 0;
-        let odd_length = (string_len & 1u32) != 0;
+        let odd_length = (u32::from(string_len) & 1u32) != 0;
         let odd_length_bytes = odd_length.serialize();
         let font_bytes = self.font.serialize();
         let mut request0 = vec![
@@ -16330,7 +16330,7 @@ pub struct CreateGCAux {
 }
 impl CreateGCAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = value_mask;
+        let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
         let function = if switch_expr & u32::from(GC::FUNCTION) != 0 {
             let remaining = outer_remaining;
@@ -16967,7 +16967,7 @@ pub struct ChangeGCAux {
 }
 impl ChangeGCAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = value_mask;
+        let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
         let function = if switch_expr & u32::from(GC::FUNCTION) != 0 {
             let remaining = outer_remaining;
@@ -19565,7 +19565,7 @@ impl TryParse for GetImageReply {
         let (length, remaining) = u32::try_parse(remaining)?;
         let (visual, remaining) = Visualid::try_parse(remaining)?;
         let remaining = remaining.get(20..).ok_or(ParseError::InsufficientData)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, length.checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
+        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data = data.to_vec();
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
@@ -23312,7 +23312,7 @@ pub struct ChangeKeyboardControlAux {
 }
 impl ChangeKeyboardControlAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
-        let switch_expr = value_mask;
+        let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
         let key_click_percent = if switch_expr & u32::from(KB::KEY_CLICK_PERCENT) != 0 {
             let remaining = outer_remaining;

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -9027,25 +9027,26 @@ impl ConfigureWindowAux {
     /// to handle `ConfigureRequestEvent`s.
     pub fn from_configure_request(event: &ConfigureRequestEvent) -> Self {
         let mut result = Self::new();
-        if event.value_mask & u16::from(ConfigWindow::X) != 0 {
+        let value_mask = u16::from(event.value_mask);
+        if value_mask & u16::from(ConfigWindow::X) != 0 {
             result = result.x(i32::from(event.x));
         }
-        if event.value_mask & u16::from(ConfigWindow::Y) != 0 {
+        if value_mask & u16::from(ConfigWindow::Y) != 0 {
             result = result.y(i32::from(event.y));
         }
-        if event.value_mask & u16::from(ConfigWindow::WIDTH) != 0 {
+        if value_mask & u16::from(ConfigWindow::WIDTH) != 0 {
             result = result.width(u32::from(event.width));
         }
-        if event.value_mask & u16::from(ConfigWindow::HEIGHT) != 0 {
+        if value_mask & u16::from(ConfigWindow::HEIGHT) != 0 {
             result = result.height(u32::from(event.height));
         }
-        if event.value_mask & u16::from(ConfigWindow::BORDER_WIDTH) != 0 {
+        if value_mask & u16::from(ConfigWindow::BORDER_WIDTH) != 0 {
             result = result.border_width(u32::from(event.border_width));
         }
-        if event.value_mask & u16::from(ConfigWindow::SIBLING) != 0 {
+        if value_mask & u16::from(ConfigWindow::SIBLING) != 0 {
             result = result.sibling(event.sibling);
         }
-        if event.value_mask & u16::from(ConfigWindow::STACK_MODE) != 0 {
+        if value_mask & u16::from(ConfigWindow::STACK_MODE) != 0 {
             result = result.stack_mode(event.stack_mode);
         }
         result

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -6918,7 +6918,7 @@ impl CreateWindowAux {
     #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, value_mask);
+        self.serialize_into(&mut result, u32::from(value_mask));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
@@ -7240,7 +7240,7 @@ impl<'input> CreateWindowRequest<'input> {
             value_mask_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let value_list_bytes = self.value_list.serialize(value_mask);
+        let value_list_bytes = self.value_list.serialize(u32::from(value_mask));
         let length_so_far = length_so_far + value_list_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -7471,7 +7471,7 @@ impl ChangeWindowAttributesAux {
     #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, value_mask);
+        self.serialize_into(&mut result, u32::from(value_mask));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
@@ -7721,7 +7721,7 @@ impl<'input> ChangeWindowAttributesRequest<'input> {
             value_mask_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let value_list_bytes = self.value_list.serialize(value_mask);
+        let value_list_bytes = self.value_list.serialize(u32::from(value_mask));
         let length_so_far = length_so_far + value_list_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -8929,7 +8929,7 @@ impl ConfigureWindowAux {
     #[allow(dead_code)]
     fn serialize(&self, value_mask: u16) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, value_mask);
+        self.serialize_into(&mut result, u16::from(value_mask));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u16) {
@@ -9145,7 +9145,7 @@ impl<'input> ConfigureWindowRequest<'input> {
             0,
         ];
         let length_so_far = length_so_far + request0.len();
-        let value_list_bytes = self.value_list.serialize(value_mask);
+        let value_list_bytes = self.value_list.serialize(u16::from(value_mask));
         let length_so_far = length_so_far + value_list_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -16532,7 +16532,7 @@ impl CreateGCAux {
     #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, value_mask);
+        self.serialize_into(&mut result, u32::from(value_mask));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
@@ -16887,7 +16887,7 @@ impl<'input> CreateGCRequest<'input> {
             value_mask_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let value_list_bytes = self.value_list.serialize(value_mask);
+        let value_list_bytes = self.value_list.serialize(u32::from(value_mask));
         let length_so_far = length_so_far + value_list_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -17169,7 +17169,7 @@ impl ChangeGCAux {
     #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, value_mask);
+        self.serialize_into(&mut result, u32::from(value_mask));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
@@ -17539,7 +17539,7 @@ impl<'input> ChangeGCRequest<'input> {
             value_mask_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let value_list_bytes = self.value_list.serialize(value_mask);
+        let value_list_bytes = self.value_list.serialize(u32::from(value_mask));
         let length_so_far = length_so_far + value_list_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();
@@ -23388,7 +23388,7 @@ impl ChangeKeyboardControlAux {
     #[allow(dead_code)]
     fn serialize(&self, value_mask: u32) -> Vec<u8> {
         let mut result = Vec::new();
-        self.serialize_into(&mut result, value_mask);
+        self.serialize_into(&mut result, u32::from(value_mask));
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
@@ -23528,7 +23528,7 @@ impl<'input> ChangeKeyboardControlRequest<'input> {
             value_mask_bytes[3],
         ];
         let length_so_far = length_so_far + request0.len();
-        let value_list_bytes = self.value_list.serialize(value_mask);
+        let value_list_bytes = self.value_list.serialize(u32::from(value_mask));
         let length_so_far = length_so_far + value_list_bytes.len();
         let padding0 = &[0; 3][..(4 - (length_so_far % 4)) % 4];
         let length_so_far = length_so_far + padding0.len();

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -644,6 +644,7 @@ impl TryParse for Screen {
         let (root_depth, remaining) = u8::try_parse(remaining)?;
         let (allowed_depths_len, remaining) = u8::try_parse(remaining)?;
         let (allowed_depths, remaining) = crate::x11_utils::parse_list::<Depth>(remaining, allowed_depths_len.try_to_usize()?)?;
+        let current_input_masks = current_input_masks.into();
         let backing_stores = backing_stores.into();
         let result = Screen { root, default_colormap, white_pixel, black_pixel, current_input_masks, width_in_pixels, height_in_pixels, width_in_millimeters, height_in_millimeters, min_installed_maps, max_installed_maps, root_visual, backing_stores, save_unders, root_depth, allowed_depths };
         Ok((result, remaining))
@@ -1348,6 +1349,7 @@ impl TryParse for KeyPressEvent {
         let (state, remaining) = u16::try_parse(remaining)?;
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
+        let state = state.into();
         let result = KeyPressEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -1607,6 +1609,7 @@ impl TryParse for ButtonPressEvent {
         let (state, remaining) = u16::try_parse(remaining)?;
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
+        let state = state.into();
         let result = ButtonPressEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -1864,6 +1867,7 @@ impl TryParse for MotionNotifyEvent {
         let (same_screen, remaining) = bool::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let detail = detail.into();
+        let state = state.into();
         let result = MotionNotifyEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, same_screen };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -2184,6 +2188,7 @@ impl TryParse for EnterNotifyEvent {
         let (mode, remaining) = u8::try_parse(remaining)?;
         let (same_screen_focus, remaining) = u8::try_parse(remaining)?;
         let detail = detail.into();
+        let state = state.into();
         let mode = mode.into();
         let result = EnterNotifyEvent { response_type, detail, sequence, time, root, event, child, root_x, root_y, event_x, event_y, state, mode, same_screen_focus };
         let _ = remaining;
@@ -4129,6 +4134,7 @@ impl TryParse for ConfigureRequestEvent {
         let (border_width, remaining) = u16::try_parse(remaining)?;
         let (value_mask, remaining) = u16::try_parse(remaining)?;
         let stack_mode = stack_mode.into();
+        let value_mask = value_mask.into();
         let result = ConfigureRequestEvent { response_type, stack_mode, sequence, parent, window, sibling, x, y, width, height, border_width, value_mask };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -6873,6 +6879,7 @@ impl CreateWindowAux {
         let event_mask = if switch_expr & u32::from(CW::EVENT_MASK) != 0 {
             let remaining = outer_remaining;
             let (event_mask, remaining) = u32::try_parse(remaining)?;
+            let event_mask = event_mask.into();
             outer_remaining = remaining;
             Some(event_mask)
         } else {
@@ -6881,6 +6888,7 @@ impl CreateWindowAux {
         let do_not_propogate_mask = if switch_expr & u32::from(CW::DONT_PROPAGATE) != 0 {
             let remaining = outer_remaining;
             let (do_not_propogate_mask, remaining) = u32::try_parse(remaining)?;
+            let do_not_propogate_mask = do_not_propogate_mask.into();
             outer_remaining = remaining;
             Some(do_not_propogate_mask)
         } else {
@@ -7424,6 +7432,7 @@ impl ChangeWindowAttributesAux {
         let event_mask = if switch_expr & u32::from(CW::EVENT_MASK) != 0 {
             let remaining = outer_remaining;
             let (event_mask, remaining) = u32::try_parse(remaining)?;
+            let event_mask = event_mask.into();
             outer_remaining = remaining;
             Some(event_mask)
         } else {
@@ -7432,6 +7441,7 @@ impl ChangeWindowAttributesAux {
         let do_not_propogate_mask = if switch_expr & u32::from(CW::DONT_PROPAGATE) != 0 {
             let remaining = outer_remaining;
             let (do_not_propogate_mask, remaining) = u32::try_parse(remaining)?;
+            let do_not_propogate_mask = do_not_propogate_mask.into();
             outer_remaining = remaining;
             Some(do_not_propogate_mask)
         } else {
@@ -7955,6 +7965,9 @@ impl TryParse for GetWindowAttributesReply {
         let bit_gravity = bit_gravity.into();
         let win_gravity = win_gravity.into();
         let map_state = map_state.into();
+        let all_event_masks = all_event_masks.into();
+        let your_event_mask = your_event_mask.into();
+        let do_not_propagate_mask = do_not_propagate_mask.into();
         let result = GetWindowAttributesReply { backing_store, sequence, length, visual, class, bit_gravity, win_gravity, backing_planes, backing_pixel, save_under, map_is_installed, map_state, override_redirect, colormap, all_event_masks, your_event_mask, do_not_propagate_mask };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -11353,6 +11366,7 @@ impl<'input> SendEventRequest<'input> {
         let _ = remaining;
         let (destination, remaining) = Window::try_parse(value)?;
         let (event_mask, remaining) = u32::try_parse(remaining)?;
+        let event_mask = event_mask.into();
         let (event, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
         let event = <&[u8; 32]>::try_from(event).unwrap();
         let _ = remaining;
@@ -11712,6 +11726,7 @@ impl GrabPointerRequest {
         let _ = remaining;
         let (grab_window, remaining) = Window::try_parse(value)?;
         let (event_mask, remaining) = u16::try_parse(remaining)?;
+        let event_mask = event_mask.into();
         let (pointer_mode, remaining) = u8::try_parse(remaining)?;
         let pointer_mode = pointer_mode.into();
         let (keyboard_mode, remaining) = u8::try_parse(remaining)?;
@@ -12090,6 +12105,7 @@ impl GrabButtonRequest {
         let _ = remaining;
         let (grab_window, remaining) = Window::try_parse(value)?;
         let (event_mask, remaining) = u16::try_parse(remaining)?;
+        let event_mask = event_mask.into();
         let (pointer_mode, remaining) = u8::try_parse(remaining)?;
         let pointer_mode = pointer_mode.into();
         let (keyboard_mode, remaining) = u8::try_parse(remaining)?;
@@ -12100,6 +12116,7 @@ impl GrabButtonRequest {
         let button = button.into();
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (modifiers, remaining) = u16::try_parse(remaining)?;
+        let modifiers = modifiers.into();
         let _ = remaining;
         Ok(GrabButtonRequest {
             owner_events,
@@ -12174,6 +12191,7 @@ impl UngrabButtonRequest {
         let _ = remaining;
         let (grab_window, remaining) = Window::try_parse(value)?;
         let (modifiers, remaining) = u16::try_parse(remaining)?;
+        let modifiers = modifiers.into();
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let _ = remaining;
         Ok(UngrabButtonRequest {
@@ -12247,6 +12265,7 @@ impl ChangeActivePointerGrabRequest {
         let (cursor, remaining) = Cursor::try_parse(value)?;
         let (time, remaining) = Timestamp::try_parse(remaining)?;
         let (event_mask, remaining) = u16::try_parse(remaining)?;
+        let event_mask = event_mask.into();
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let _ = remaining;
         Ok(ChangeActivePointerGrabRequest {
@@ -12696,6 +12715,7 @@ impl GrabKeyRequest {
         let _ = remaining;
         let (grab_window, remaining) = Window::try_parse(value)?;
         let (modifiers, remaining) = u16::try_parse(remaining)?;
+        let modifiers = modifiers.into();
         let (key, remaining) = Keycode::try_parse(remaining)?;
         let (pointer_mode, remaining) = u8::try_parse(remaining)?;
         let pointer_mode = pointer_mode.into();
@@ -12797,6 +12817,7 @@ impl UngrabKeyRequest {
         let _ = remaining;
         let (grab_window, remaining) = Window::try_parse(value)?;
         let (modifiers, remaining) = u16::try_parse(remaining)?;
+        let modifiers = modifiers.into();
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
         let _ = remaining;
         Ok(UngrabKeyRequest {
@@ -13242,6 +13263,7 @@ impl TryParse for QueryPointerReply {
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
+        let mask = mask.into();
         let result = QueryPointerReply { same_screen, sequence, length, root, child, root_x, root_y, win_x, win_y, mask };
         let _ = remaining;
         let remaining = initial_value.get(32 + length as usize * 4..)
@@ -17615,6 +17637,7 @@ impl CopyGCRequest {
         let (src_gc, remaining) = Gcontext::try_parse(value)?;
         let (dst_gc, remaining) = Gcontext::try_parse(remaining)?;
         let (value_mask, remaining) = u32::try_parse(remaining)?;
+        let value_mask = value_mask.into();
         let _ = remaining;
         Ok(CopyGCRequest {
             src_gc,
@@ -21342,6 +21365,7 @@ impl TryParse for Coloritem {
         let (blue, remaining) = u16::try_parse(remaining)?;
         let (flags, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
+        let flags = flags.into();
         let result = Coloritem { pixel, red, green, blue, flags };
         Ok((result, remaining))
     }
@@ -21510,6 +21534,7 @@ impl<'input> StoreNamedColorRequest<'input> {
         }
         let remaining = &[header.minor_opcode];
         let (flags, remaining) = u8::try_parse(remaining)?;
+        let flags = flags.into();
         let _ = remaining;
         let (cmap, remaining) = Colormap::try_parse(value)?;
         let (pixel, remaining) = u32::try_parse(remaining)?;

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -6545,7 +6545,7 @@ impl core::fmt::Debug for WindowClass  {
 /// parent's cursor will cause an immediate change in the displayed cursor.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct CW(u16);
+pub struct CW(u32);
 impl CW {
     pub const BACK_PIXMAP: Self = Self(1 << 0);
     pub const BACK_PIXEL: Self = Self(1 << 1);
@@ -6563,28 +6563,16 @@ impl CW {
     pub const COLORMAP: Self = Self(1 << 13);
     pub const CURSOR: Self = Self(1 << 14);
 }
-impl From<CW> for u16 {
+impl From<CW> for u32 {
     #[inline]
     fn from(input: CW) -> Self {
         input.0
     }
 }
-impl From<CW> for Option<u16> {
-    #[inline]
-    fn from(input: CW) -> Self {
-        Some(input.0)
-    }
-}
-impl From<CW> for u32 {
-    #[inline]
-    fn from(input: CW) -> Self {
-        u32::from(input.0)
-    }
-}
 impl From<CW> for Option<u32> {
     #[inline]
     fn from(input: CW) -> Self {
-        Some(u32::from(input.0))
+        Some(input.0)
     }
 }
 impl From<u8> for CW {
@@ -6596,32 +6584,38 @@ impl From<u8> for CW {
 impl From<u16> for CW {
     #[inline]
     fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for CW {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for CW  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::BACK_PIXMAP.0.into(), "BACK_PIXMAP", "BackPixmap"),
-            (Self::BACK_PIXEL.0.into(), "BACK_PIXEL", "BackPixel"),
-            (Self::BORDER_PIXMAP.0.into(), "BORDER_PIXMAP", "BorderPixmap"),
-            (Self::BORDER_PIXEL.0.into(), "BORDER_PIXEL", "BorderPixel"),
-            (Self::BIT_GRAVITY.0.into(), "BIT_GRAVITY", "BitGravity"),
-            (Self::WIN_GRAVITY.0.into(), "WIN_GRAVITY", "WinGravity"),
-            (Self::BACKING_STORE.0.into(), "BACKING_STORE", "BackingStore"),
-            (Self::BACKING_PLANES.0.into(), "BACKING_PLANES", "BackingPlanes"),
-            (Self::BACKING_PIXEL.0.into(), "BACKING_PIXEL", "BackingPixel"),
-            (Self::OVERRIDE_REDIRECT.0.into(), "OVERRIDE_REDIRECT", "OverrideRedirect"),
-            (Self::SAVE_UNDER.0.into(), "SAVE_UNDER", "SaveUnder"),
-            (Self::EVENT_MASK.0.into(), "EVENT_MASK", "EventMask"),
-            (Self::DONT_PROPAGATE.0.into(), "DONT_PROPAGATE", "DontPropagate"),
-            (Self::COLORMAP.0.into(), "COLORMAP", "Colormap"),
-            (Self::CURSOR.0.into(), "CURSOR", "Cursor"),
+            (Self::BACK_PIXMAP.0, "BACK_PIXMAP", "BackPixmap"),
+            (Self::BACK_PIXEL.0, "BACK_PIXEL", "BackPixel"),
+            (Self::BORDER_PIXMAP.0, "BORDER_PIXMAP", "BorderPixmap"),
+            (Self::BORDER_PIXEL.0, "BORDER_PIXEL", "BorderPixel"),
+            (Self::BIT_GRAVITY.0, "BIT_GRAVITY", "BitGravity"),
+            (Self::WIN_GRAVITY.0, "WIN_GRAVITY", "WinGravity"),
+            (Self::BACKING_STORE.0, "BACKING_STORE", "BackingStore"),
+            (Self::BACKING_PLANES.0, "BACKING_PLANES", "BackingPlanes"),
+            (Self::BACKING_PIXEL.0, "BACKING_PIXEL", "BackingPixel"),
+            (Self::OVERRIDE_REDIRECT.0, "OVERRIDE_REDIRECT", "OverrideRedirect"),
+            (Self::SAVE_UNDER.0, "SAVE_UNDER", "SaveUnder"),
+            (Self::EVENT_MASK.0, "EVENT_MASK", "EventMask"),
+            (Self::DONT_PROPAGATE.0, "DONT_PROPAGATE", "DontPropagate"),
+            (Self::COLORMAP.0, "COLORMAP", "Colormap"),
+            (Self::CURSOR.0, "CURSOR", "Cursor"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(CW, u16);
+bitmask_binop!(CW, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -8726,7 +8720,7 @@ impl crate::x11_utils::VoidRequest for UnmapSubwindowsRequest {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ConfigWindow(u8);
+pub struct ConfigWindow(u16);
 impl ConfigWindow {
     pub const X: Self = Self(1 << 0);
     pub const Y: Self = Self(1 << 1);
@@ -8736,28 +8730,16 @@ impl ConfigWindow {
     pub const SIBLING: Self = Self(1 << 5);
     pub const STACK_MODE: Self = Self(1 << 6);
 }
-impl From<ConfigWindow> for u8 {
+impl From<ConfigWindow> for u16 {
     #[inline]
     fn from(input: ConfigWindow) -> Self {
         input.0
     }
 }
-impl From<ConfigWindow> for Option<u8> {
-    #[inline]
-    fn from(input: ConfigWindow) -> Self {
-        Some(input.0)
-    }
-}
-impl From<ConfigWindow> for u16 {
-    #[inline]
-    fn from(input: ConfigWindow) -> Self {
-        u16::from(input.0)
-    }
-}
 impl From<ConfigWindow> for Option<u16> {
     #[inline]
     fn from(input: ConfigWindow) -> Self {
-        Some(u16::from(input.0))
+        Some(input.0)
     }
 }
 impl From<ConfigWindow> for u32 {
@@ -8775,6 +8757,12 @@ impl From<ConfigWindow> for Option<u32> {
 impl From<u8> for ConfigWindow {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for ConfigWindow {
+    #[inline]
+    fn from(value: u16) -> Self {
         Self(value)
     }
 }
@@ -8792,7 +8780,7 @@ impl core::fmt::Debug for ConfigWindow  {
         pretty_print_bitmask(fmt, self.0.into(), &variants)
     }
 }
-bitmask_binop!(ConfigWindow, u8);
+bitmask_binop!(ConfigWindow, u16);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -23129,7 +23117,7 @@ impl GetKeyboardMappingReply {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct KB(u8);
+pub struct KB(u32);
 impl KB {
     pub const KEY_CLICK_PERCENT: Self = Self(1 << 0);
     pub const BELL_PERCENT: Self = Self(1 << 1);
@@ -23140,64 +23128,52 @@ impl KB {
     pub const KEY: Self = Self(1 << 6);
     pub const AUTO_REPEAT_MODE: Self = Self(1 << 7);
 }
-impl From<KB> for u8 {
+impl From<KB> for u32 {
     #[inline]
     fn from(input: KB) -> Self {
         input.0
     }
 }
-impl From<KB> for Option<u8> {
+impl From<KB> for Option<u32> {
     #[inline]
     fn from(input: KB) -> Self {
         Some(input.0)
     }
 }
-impl From<KB> for u16 {
-    #[inline]
-    fn from(input: KB) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<KB> for Option<u16> {
-    #[inline]
-    fn from(input: KB) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<KB> for u32 {
-    #[inline]
-    fn from(input: KB) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<KB> for Option<u32> {
-    #[inline]
-    fn from(input: KB) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for KB {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for KB {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for KB {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for KB  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::KEY_CLICK_PERCENT.0.into(), "KEY_CLICK_PERCENT", "KeyClickPercent"),
-            (Self::BELL_PERCENT.0.into(), "BELL_PERCENT", "BellPercent"),
-            (Self::BELL_PITCH.0.into(), "BELL_PITCH", "BellPitch"),
-            (Self::BELL_DURATION.0.into(), "BELL_DURATION", "BellDuration"),
-            (Self::LED.0.into(), "LED", "Led"),
-            (Self::LED_MODE.0.into(), "LED_MODE", "LedMode"),
-            (Self::KEY.0.into(), "KEY", "Key"),
-            (Self::AUTO_REPEAT_MODE.0.into(), "AUTO_REPEAT_MODE", "AutoRepeatMode"),
+            (Self::KEY_CLICK_PERCENT.0, "KEY_CLICK_PERCENT", "KeyClickPercent"),
+            (Self::BELL_PERCENT.0, "BELL_PERCENT", "BellPercent"),
+            (Self::BELL_PITCH.0, "BELL_PITCH", "BellPitch"),
+            (Self::BELL_DURATION.0, "BELL_DURATION", "BellDuration"),
+            (Self::LED.0, "LED", "Led"),
+            (Self::LED_MODE.0, "LED_MODE", "LedMode"),
+            (Self::KEY.0, "KEY", "Key"),
+            (Self::AUTO_REPEAT_MODE.0, "AUTO_REPEAT_MODE", "AutoRepeatMode"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(KB, u8);
+bitmask_binop!(KB, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -612,7 +612,7 @@ pub struct Screen {
     pub default_colormap: Colormap,
     pub white_pixel: u32,
     pub black_pixel: u32,
-    pub current_input_masks: u32,
+    pub current_input_masks: EventMask,
     pub width_in_pixels: u16,
     pub height_in_pixels: u16,
     pub width_in_millimeters: u16,
@@ -663,7 +663,7 @@ impl Serialize for Screen {
         self.default_colormap.serialize_into(bytes);
         self.white_pixel.serialize_into(bytes);
         self.black_pixel.serialize_into(bytes);
-        self.current_input_masks.serialize_into(bytes);
+        u32::from(self.current_input_masks).serialize_into(bytes);
         self.width_in_pixels.serialize_into(bytes);
         self.height_in_pixels.serialize_into(bytes);
         self.width_in_millimeters.serialize_into(bytes);
@@ -1329,7 +1329,7 @@ pub struct KeyPressEvent {
     pub root_y: i16,
     pub event_x: i16,
     pub event_y: i16,
-    pub state: u16,
+    pub state: KeyButMask,
     pub same_screen: bool,
 }
 impl TryParse for KeyPressEvent {
@@ -1371,7 +1371,7 @@ impl Serialize for KeyPressEvent {
         let root_y_bytes = self.root_y.serialize();
         let event_x_bytes = self.event_x.serialize();
         let event_y_bytes = self.event_y.serialize();
-        let state_bytes = self.state.serialize();
+        let state_bytes = u16::from(self.state).serialize();
         let same_screen_bytes = self.same_screen.serialize();
         [
             response_type_bytes[0],
@@ -1421,7 +1421,7 @@ impl Serialize for KeyPressEvent {
         self.root_y.serialize_into(bytes);
         self.event_x.serialize_into(bytes);
         self.event_y.serialize_into(bytes);
-        self.state.serialize_into(bytes);
+        u16::from(self.state).serialize_into(bytes);
         self.same_screen.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
     }
@@ -1439,7 +1439,7 @@ impl From<&KeyPressEvent> for [u8; 32] {
         let root_y_bytes = input.root_y.serialize();
         let event_x_bytes = input.event_x.serialize();
         let event_y_bytes = input.event_y.serialize();
-        let state_bytes = input.state.serialize();
+        let state_bytes = u16::from(input.state).serialize();
         let same_screen_bytes = input.same_screen.serialize();
         [
             response_type_bytes[0],
@@ -1589,7 +1589,7 @@ pub struct ButtonPressEvent {
     pub root_y: i16,
     pub event_x: i16,
     pub event_y: i16,
-    pub state: u16,
+    pub state: KeyButMask,
     pub same_screen: bool,
 }
 impl TryParse for ButtonPressEvent {
@@ -1631,7 +1631,7 @@ impl Serialize for ButtonPressEvent {
         let root_y_bytes = self.root_y.serialize();
         let event_x_bytes = self.event_x.serialize();
         let event_y_bytes = self.event_y.serialize();
-        let state_bytes = self.state.serialize();
+        let state_bytes = u16::from(self.state).serialize();
         let same_screen_bytes = self.same_screen.serialize();
         [
             response_type_bytes[0],
@@ -1681,7 +1681,7 @@ impl Serialize for ButtonPressEvent {
         self.root_y.serialize_into(bytes);
         self.event_x.serialize_into(bytes);
         self.event_y.serialize_into(bytes);
-        self.state.serialize_into(bytes);
+        u16::from(self.state).serialize_into(bytes);
         self.same_screen.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
     }
@@ -1699,7 +1699,7 @@ impl From<&ButtonPressEvent> for [u8; 32] {
         let root_y_bytes = input.root_y.serialize();
         let event_x_bytes = input.event_x.serialize();
         let event_y_bytes = input.event_y.serialize();
-        let state_bytes = input.state.serialize();
+        let state_bytes = u16::from(input.state).serialize();
         let same_screen_bytes = input.same_screen.serialize();
         [
             response_type_bytes[0],
@@ -1846,7 +1846,7 @@ pub struct MotionNotifyEvent {
     pub root_y: i16,
     pub event_x: i16,
     pub event_y: i16,
-    pub state: u16,
+    pub state: KeyButMask,
     pub same_screen: bool,
 }
 impl TryParse for MotionNotifyEvent {
@@ -1889,7 +1889,7 @@ impl Serialize for MotionNotifyEvent {
         let root_y_bytes = self.root_y.serialize();
         let event_x_bytes = self.event_x.serialize();
         let event_y_bytes = self.event_y.serialize();
-        let state_bytes = self.state.serialize();
+        let state_bytes = u16::from(self.state).serialize();
         let same_screen_bytes = self.same_screen.serialize();
         [
             response_type_bytes[0],
@@ -1939,7 +1939,7 @@ impl Serialize for MotionNotifyEvent {
         self.root_y.serialize_into(bytes);
         self.event_x.serialize_into(bytes);
         self.event_y.serialize_into(bytes);
-        self.state.serialize_into(bytes);
+        u16::from(self.state).serialize_into(bytes);
         self.same_screen.serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
     }
@@ -1957,7 +1957,7 @@ impl From<&MotionNotifyEvent> for [u8; 32] {
         let root_y_bytes = input.root_y.serialize();
         let event_x_bytes = input.event_x.serialize();
         let event_y_bytes = input.event_y.serialize();
-        let state_bytes = input.state.serialize();
+        let state_bytes = u16::from(input.state).serialize();
         let same_screen_bytes = input.same_screen.serialize();
         [
             response_type_bytes[0],
@@ -2166,7 +2166,7 @@ pub struct EnterNotifyEvent {
     pub root_y: i16,
     pub event_x: i16,
     pub event_y: i16,
-    pub state: u16,
+    pub state: KeyButMask,
     pub mode: NotifyMode,
     pub same_screen_focus: u8,
 }
@@ -2211,7 +2211,7 @@ impl Serialize for EnterNotifyEvent {
         let root_y_bytes = self.root_y.serialize();
         let event_x_bytes = self.event_x.serialize();
         let event_y_bytes = self.event_y.serialize();
-        let state_bytes = self.state.serialize();
+        let state_bytes = u16::from(self.state).serialize();
         let mode_bytes = u8::from(self.mode).serialize();
         let same_screen_focus_bytes = self.same_screen_focus.serialize();
         [
@@ -2262,7 +2262,7 @@ impl Serialize for EnterNotifyEvent {
         self.root_y.serialize_into(bytes);
         self.event_x.serialize_into(bytes);
         self.event_y.serialize_into(bytes);
-        self.state.serialize_into(bytes);
+        u16::from(self.state).serialize_into(bytes);
         u8::from(self.mode).serialize_into(bytes);
         self.same_screen_focus.serialize_into(bytes);
     }
@@ -2280,7 +2280,7 @@ impl From<&EnterNotifyEvent> for [u8; 32] {
         let root_y_bytes = input.root_y.serialize();
         let event_x_bytes = input.event_x.serialize();
         let event_y_bytes = input.event_y.serialize();
-        let state_bytes = input.state.serialize();
+        let state_bytes = u16::from(input.state).serialize();
         let mode_bytes = u8::from(input.mode).serialize();
         let same_screen_focus_bytes = input.same_screen_focus.serialize();
         [
@@ -4116,7 +4116,7 @@ pub struct ConfigureRequestEvent {
     pub width: u16,
     pub height: u16,
     pub border_width: u16,
-    pub value_mask: u16,
+    pub value_mask: ConfigWindow,
 }
 impl TryParse for ConfigureRequestEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4156,7 +4156,7 @@ impl Serialize for ConfigureRequestEvent {
         let width_bytes = self.width.serialize();
         let height_bytes = self.height.serialize();
         let border_width_bytes = self.border_width.serialize();
-        let value_mask_bytes = self.value_mask.serialize();
+        let value_mask_bytes = u16::from(self.value_mask).serialize();
         [
             response_type_bytes[0],
             stack_mode_bytes[0],
@@ -4201,7 +4201,7 @@ impl Serialize for ConfigureRequestEvent {
         self.width.serialize_into(bytes);
         self.height.serialize_into(bytes);
         self.border_width.serialize_into(bytes);
-        self.value_mask.serialize_into(bytes);
+        u16::from(self.value_mask).serialize_into(bytes);
     }
 }
 impl From<&ConfigureRequestEvent> for [u8; 32] {
@@ -4217,7 +4217,7 @@ impl From<&ConfigureRequestEvent> for [u8; 32] {
         let width_bytes = input.width.serialize();
         let height_bytes = input.height.serialize();
         let border_width_bytes = input.border_width.serialize();
-        let value_mask_bytes = input.value_mask.serialize();
+        let value_mask_bytes = u16::from(input.value_mask).serialize();
         [
             response_type_bytes[0],
             stack_mode_bytes[0],
@@ -6776,8 +6776,8 @@ pub struct CreateWindowAux {
     pub backing_pixel: Option<u32>,
     pub override_redirect: Option<Bool32>,
     pub save_under: Option<Bool32>,
-    pub event_mask: Option<u32>,
-    pub do_not_propogate_mask: Option<u32>,
+    pub event_mask: Option<EventMask>,
+    pub do_not_propogate_mask: Option<EventMask>,
     pub colormap: Option<Colormap>,
     pub cursor: Option<Cursor>,
 }
@@ -6957,10 +6957,10 @@ impl CreateWindowAux {
             save_under.serialize_into(bytes);
         }
         if let Some(event_mask) = self.event_mask {
-            event_mask.serialize_into(bytes);
+            u32::from(event_mask).serialize_into(bytes);
         }
         if let Some(do_not_propogate_mask) = self.do_not_propogate_mask {
-            do_not_propogate_mask.serialize_into(bytes);
+            u32::from(do_not_propogate_mask).serialize_into(bytes);
         }
         if let Some(colormap) = self.colormap {
             colormap.serialize_into(bytes);
@@ -7094,13 +7094,13 @@ impl CreateWindowAux {
     }
     /// Set the `event_mask` field of this structure.
     #[must_use]
-    pub fn event_mask<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
+    pub fn event_mask<I>(mut self, value: I) -> Self where I: Into<Option<EventMask>> {
         self.event_mask = value.into();
         self
     }
     /// Set the `do_not_propogate_mask` field of this structure.
     #[must_use]
-    pub fn do_not_propogate_mask<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
+    pub fn do_not_propogate_mask<I>(mut self, value: I) -> Self where I: Into<Option<EventMask>> {
         self.do_not_propogate_mask = value.into();
         self
     }
@@ -7329,8 +7329,8 @@ pub struct ChangeWindowAttributesAux {
     pub backing_pixel: Option<u32>,
     pub override_redirect: Option<Bool32>,
     pub save_under: Option<Bool32>,
-    pub event_mask: Option<u32>,
-    pub do_not_propogate_mask: Option<u32>,
+    pub event_mask: Option<EventMask>,
+    pub do_not_propogate_mask: Option<EventMask>,
     pub colormap: Option<Colormap>,
     pub cursor: Option<Cursor>,
 }
@@ -7510,10 +7510,10 @@ impl ChangeWindowAttributesAux {
             save_under.serialize_into(bytes);
         }
         if let Some(event_mask) = self.event_mask {
-            event_mask.serialize_into(bytes);
+            u32::from(event_mask).serialize_into(bytes);
         }
         if let Some(do_not_propogate_mask) = self.do_not_propogate_mask {
-            do_not_propogate_mask.serialize_into(bytes);
+            u32::from(do_not_propogate_mask).serialize_into(bytes);
         }
         if let Some(colormap) = self.colormap {
             colormap.serialize_into(bytes);
@@ -7647,13 +7647,13 @@ impl ChangeWindowAttributesAux {
     }
     /// Set the `event_mask` field of this structure.
     #[must_use]
-    pub fn event_mask<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
+    pub fn event_mask<I>(mut self, value: I) -> Self where I: Into<Option<EventMask>> {
         self.event_mask = value.into();
         self
     }
     /// Set the `do_not_propogate_mask` field of this structure.
     #[must_use]
-    pub fn do_not_propogate_mask<I>(mut self, value: I) -> Self where I: Into<Option<u32>> {
+    pub fn do_not_propogate_mask<I>(mut self, value: I) -> Self where I: Into<Option<EventMask>> {
         self.do_not_propogate_mask = value.into();
         self
     }
@@ -7931,9 +7931,9 @@ pub struct GetWindowAttributesReply {
     pub map_state: MapState,
     pub override_redirect: bool,
     pub colormap: Colormap,
-    pub all_event_masks: u32,
-    pub your_event_mask: u32,
-    pub do_not_propagate_mask: u16,
+    pub all_event_masks: EventMask,
+    pub your_event_mask: EventMask,
+    pub do_not_propagate_mask: EventMask,
 }
 impl TryParse for GetWindowAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7993,9 +7993,9 @@ impl Serialize for GetWindowAttributesReply {
         let map_state_bytes = u8::from(self.map_state).serialize();
         let override_redirect_bytes = self.override_redirect.serialize();
         let colormap_bytes = self.colormap.serialize();
-        let all_event_masks_bytes = self.all_event_masks.serialize();
-        let your_event_mask_bytes = self.your_event_mask.serialize();
-        let do_not_propagate_mask_bytes = self.do_not_propagate_mask.serialize();
+        let all_event_masks_bytes = u32::from(self.all_event_masks).serialize();
+        let your_event_mask_bytes = u32::from(self.your_event_mask).serialize();
+        let do_not_propagate_mask_bytes = (u32::from(self.do_not_propagate_mask) as u16).serialize();
         [
             response_type_bytes[0],
             backing_store_bytes[0],
@@ -8061,9 +8061,9 @@ impl Serialize for GetWindowAttributesReply {
         u8::from(self.map_state).serialize_into(bytes);
         self.override_redirect.serialize_into(bytes);
         self.colormap.serialize_into(bytes);
-        self.all_event_masks.serialize_into(bytes);
-        self.your_event_mask.serialize_into(bytes);
-        self.do_not_propagate_mask.serialize_into(bytes);
+        u32::from(self.all_event_masks).serialize_into(bytes);
+        u32::from(self.your_event_mask).serialize_into(bytes);
+        (u32::from(self.do_not_propagate_mask) as u16).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
     }
 }
@@ -11325,7 +11325,7 @@ pub const SEND_EVENT_REQUEST: u8 = 25;
 pub struct SendEventRequest<'input> {
     pub propagate: bool,
     pub destination: Window,
-    pub event_mask: u32,
+    pub event_mask: EventMask,
     pub event: Cow<'input, [u8; 32]>,
 }
 impl<'input> SendEventRequest<'input> {
@@ -11334,7 +11334,7 @@ impl<'input> SendEventRequest<'input> {
         let length_so_far = 0;
         let propagate_bytes = self.propagate.serialize();
         let destination_bytes = self.destination.serialize();
-        let event_mask_bytes = self.event_mask.serialize();
+        let event_mask_bytes = u32::from(self.event_mask).serialize();
         let mut request0 = vec![
             SEND_EVENT_REQUEST,
             propagate_bytes[0],
@@ -11665,7 +11665,7 @@ pub const GRAB_POINTER_REQUEST: u8 = 26;
 pub struct GrabPointerRequest {
     pub owner_events: bool,
     pub grab_window: Window,
-    pub event_mask: u16,
+    pub event_mask: EventMask,
     pub pointer_mode: GrabMode,
     pub keyboard_mode: GrabMode,
     pub confine_to: Window,
@@ -11678,7 +11678,7 @@ impl GrabPointerRequest {
         let length_so_far = 0;
         let owner_events_bytes = self.owner_events.serialize();
         let grab_window_bytes = self.grab_window.serialize();
-        let event_mask_bytes = self.event_mask.serialize();
+        let event_mask_bytes = (u32::from(self.event_mask) as u16).serialize();
         let pointer_mode_bytes = u8::from(self.pointer_mode).serialize();
         let keyboard_mode_bytes = u8::from(self.keyboard_mode).serialize();
         let confine_to_bytes = self.confine_to.serialize();
@@ -12042,13 +12042,13 @@ pub const GRAB_BUTTON_REQUEST: u8 = 28;
 pub struct GrabButtonRequest {
     pub owner_events: bool,
     pub grab_window: Window,
-    pub event_mask: u16,
+    pub event_mask: EventMask,
     pub pointer_mode: GrabMode,
     pub keyboard_mode: GrabMode,
     pub confine_to: Window,
     pub cursor: Cursor,
     pub button: ButtonIndex,
-    pub modifiers: u16,
+    pub modifiers: ModMask,
 }
 impl GrabButtonRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12056,13 +12056,13 @@ impl GrabButtonRequest {
         let length_so_far = 0;
         let owner_events_bytes = self.owner_events.serialize();
         let grab_window_bytes = self.grab_window.serialize();
-        let event_mask_bytes = self.event_mask.serialize();
+        let event_mask_bytes = (u32::from(self.event_mask) as u16).serialize();
         let pointer_mode_bytes = u8::from(self.pointer_mode).serialize();
         let keyboard_mode_bytes = u8::from(self.keyboard_mode).serialize();
         let confine_to_bytes = self.confine_to.serialize();
         let cursor_bytes = self.cursor.serialize();
         let button_bytes = u8::from(self.button).serialize();
-        let modifiers_bytes = self.modifiers.serialize();
+        let modifiers_bytes = u16::from(self.modifiers).serialize();
         let mut request0 = vec![
             GRAB_BUTTON_REQUEST,
             owner_events_bytes[0],
@@ -12151,7 +12151,7 @@ pub const UNGRAB_BUTTON_REQUEST: u8 = 29;
 pub struct UngrabButtonRequest {
     pub button: ButtonIndex,
     pub grab_window: Window,
-    pub modifiers: u16,
+    pub modifiers: ModMask,
 }
 impl UngrabButtonRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12159,7 +12159,7 @@ impl UngrabButtonRequest {
         let length_so_far = 0;
         let button_bytes = u8::from(self.button).serialize();
         let grab_window_bytes = self.grab_window.serialize();
-        let modifiers_bytes = self.modifiers.serialize();
+        let modifiers_bytes = u16::from(self.modifiers).serialize();
         let mut request0 = vec![
             UNGRAB_BUTTON_REQUEST,
             button_bytes[0],
@@ -12221,7 +12221,7 @@ pub const CHANGE_ACTIVE_POINTER_GRAB_REQUEST: u8 = 30;
 pub struct ChangeActivePointerGrabRequest {
     pub cursor: Cursor,
     pub time: Timestamp,
-    pub event_mask: u16,
+    pub event_mask: EventMask,
 }
 impl ChangeActivePointerGrabRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12229,7 +12229,7 @@ impl ChangeActivePointerGrabRequest {
         let length_so_far = 0;
         let cursor_bytes = self.cursor.serialize();
         let time_bytes = self.time.serialize();
-        let event_mask_bytes = self.event_mask.serialize();
+        let event_mask_bytes = (u32::from(self.event_mask) as u16).serialize();
         let mut request0 = vec![
             CHANGE_ACTIVE_POINTER_GRAB_REQUEST,
             0,
@@ -12666,7 +12666,7 @@ pub const GRAB_KEY_REQUEST: u8 = 33;
 pub struct GrabKeyRequest {
     pub owner_events: bool,
     pub grab_window: Window,
-    pub modifiers: u16,
+    pub modifiers: ModMask,
     pub key: Keycode,
     pub pointer_mode: GrabMode,
     pub keyboard_mode: GrabMode,
@@ -12677,7 +12677,7 @@ impl GrabKeyRequest {
         let length_so_far = 0;
         let owner_events_bytes = self.owner_events.serialize();
         let grab_window_bytes = self.grab_window.serialize();
-        let modifiers_bytes = self.modifiers.serialize();
+        let modifiers_bytes = u16::from(self.modifiers).serialize();
         let key_bytes = self.key.serialize();
         let pointer_mode_bytes = u8::from(self.pointer_mode).serialize();
         let keyboard_mode_bytes = u8::from(self.keyboard_mode).serialize();
@@ -12778,7 +12778,7 @@ pub const UNGRAB_KEY_REQUEST: u8 = 34;
 pub struct UngrabKeyRequest {
     pub key: Keycode,
     pub grab_window: Window,
-    pub modifiers: u16,
+    pub modifiers: ModMask,
 }
 impl UngrabKeyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12786,7 +12786,7 @@ impl UngrabKeyRequest {
         let length_so_far = 0;
         let key_bytes = self.key.serialize();
         let grab_window_bytes = self.grab_window.serialize();
-        let modifiers_bytes = self.modifiers.serialize();
+        let modifiers_bytes = u16::from(self.modifiers).serialize();
         let mut request0 = vec![
             UNGRAB_KEY_REQUEST,
             key_bytes[0],
@@ -13243,7 +13243,7 @@ pub struct QueryPointerReply {
     pub root_y: i16,
     pub win_x: i16,
     pub win_y: i16,
-    pub mask: u16,
+    pub mask: KeyButMask,
 }
 impl TryParse for QueryPointerReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13284,7 +13284,7 @@ impl Serialize for QueryPointerReply {
         let root_y_bytes = self.root_y.serialize();
         let win_x_bytes = self.win_x.serialize();
         let win_y_bytes = self.win_y.serialize();
-        let mask_bytes = self.mask.serialize();
+        let mask_bytes = u16::from(self.mask).serialize();
         [
             response_type_bytes[0],
             same_screen_bytes[0],
@@ -13329,7 +13329,7 @@ impl Serialize for QueryPointerReply {
         self.root_y.serialize_into(bytes);
         self.win_x.serialize_into(bytes);
         self.win_y.serialize_into(bytes);
-        self.mask.serialize_into(bytes);
+        u16::from(self.mask).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 2]);
     }
 }
@@ -17593,7 +17593,7 @@ pub const COPY_GC_REQUEST: u8 = 57;
 pub struct CopyGCRequest {
     pub src_gc: Gcontext,
     pub dst_gc: Gcontext,
-    pub value_mask: u32,
+    pub value_mask: GC,
 }
 impl CopyGCRequest {
     /// Serialize this request into bytes for the provided connection
@@ -17601,7 +17601,7 @@ impl CopyGCRequest {
         let length_so_far = 0;
         let src_gc_bytes = self.src_gc.serialize();
         let dst_gc_bytes = self.dst_gc.serialize();
-        let value_mask_bytes = self.value_mask.serialize();
+        let value_mask_bytes = u32::from(self.value_mask).serialize();
         let mut request0 = vec![
             COPY_GC_REQUEST,
             0,
@@ -21355,7 +21355,7 @@ pub struct Coloritem {
     pub red: u16,
     pub green: u16,
     pub blue: u16,
-    pub flags: u8,
+    pub flags: ColorFlag,
 }
 impl TryParse for Coloritem {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -21377,7 +21377,7 @@ impl Serialize for Coloritem {
         let red_bytes = self.red.serialize();
         let green_bytes = self.green.serialize();
         let blue_bytes = self.blue.serialize();
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u8::from(self.flags).serialize();
         [
             pixel_bytes[0],
             pixel_bytes[1],
@@ -21399,7 +21399,7 @@ impl Serialize for Coloritem {
         self.red.serialize_into(bytes);
         self.green.serialize_into(bytes);
         self.blue.serialize_into(bytes);
-        self.flags.serialize_into(bytes);
+        u8::from(self.flags).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
     }
 }
@@ -21486,7 +21486,7 @@ pub const STORE_NAMED_COLOR_REQUEST: u8 = 90;
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StoreNamedColorRequest<'input> {
-    pub flags: u8,
+    pub flags: ColorFlag,
     pub cmap: Colormap,
     pub pixel: u32,
     pub name: Cow<'input, [u8]>,
@@ -21495,7 +21495,7 @@ impl<'input> StoreNamedColorRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<PiecewiseBuf<'input>> {
         let length_so_far = 0;
-        let flags_bytes = self.flags.serialize();
+        let flags_bytes = u8::from(self.flags).serialize();
         let cmap_bytes = self.cmap.serialize();
         let pixel_bytes = self.pixel.serialize();
         let name_len = u16::try_from(self.name.len()).expect("`name` has too many elements");

--- a/x11rb-protocol/src/protocol/xselinux.rs
+++ b/x11rb-protocol/src/protocol/xselinux.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `SELinux` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xtest.rs
+++ b/x11rb-protocol/src/protocol/xtest.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Test` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -564,6 +564,7 @@ impl TryParse for AdaptorInfo {
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
         let (formats, remaining) = crate::x11_utils::parse_list::<Format>(remaining, num_formats.try_to_usize()?)?;
+        let type_ = type_.into();
         let result = AdaptorInfo { base_id, num_ports, type_, name, formats };
         Ok((result, remaining))
     }
@@ -780,6 +781,7 @@ impl TryParse for AttributeInfo {
         let offset = remaining.as_ptr() as usize - value.as_ptr() as usize;
         let misalignment = (4 - (offset % 4)) % 4;
         let remaining = remaining.get(misalignment..).ok_or(ParseError::InsufficientData)?;
+        let flags = flags.into();
         let result = AttributeInfo { flags, min, max, name };
         Ok((result, remaining))
     }

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -544,7 +544,7 @@ impl Serialize for Format {
 pub struct AdaptorInfo {
     pub base_id: Port,
     pub num_ports: u16,
-    pub type_: u8,
+    pub type_: Type,
     pub name: Vec<u8>,
     pub formats: Vec<Format>,
 }
@@ -584,7 +584,7 @@ impl Serialize for AdaptorInfo {
         self.num_ports.serialize_into(bytes);
         let num_formats = u16::try_from(self.formats.len()).expect("`formats` has too many elements");
         num_formats.serialize_into(bytes);
-        self.type_.serialize_into(bytes);
+        u8::from(self.type_).serialize_into(bytes);
         bytes.extend_from_slice(&[0; 1]);
         bytes.extend_from_slice(&self.name);
         bytes.extend_from_slice(&[0; 3][..(4 - (bytes.len() % 4)) % 4]);
@@ -763,7 +763,7 @@ impl Image {
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttributeInfo {
-    pub flags: u32,
+    pub flags: AttributeFlag,
     pub min: i32,
     pub max: i32,
     pub name: Vec<u8>,
@@ -795,7 +795,7 @@ impl Serialize for AttributeInfo {
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>) {
         bytes.reserve(16);
-        self.flags.serialize_into(bytes);
+        u32::from(self.flags).serialize_into(bytes);
         self.min.serialize_into(bytes);
         self.max.serialize_into(bytes);
         let size = u32::try_from(self.name.len()).expect("`name` has too many elements");

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -226,63 +226,51 @@ impl core::fmt::Debug for ImageFormatInfoFormat  {
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct AttributeFlag(u8);
+pub struct AttributeFlag(u32);
 impl AttributeFlag {
     pub const GETTABLE: Self = Self(1 << 0);
     pub const SETTABLE: Self = Self(1 << 1);
 }
-impl From<AttributeFlag> for u8 {
+impl From<AttributeFlag> for u32 {
     #[inline]
     fn from(input: AttributeFlag) -> Self {
         input.0
     }
 }
-impl From<AttributeFlag> for Option<u8> {
+impl From<AttributeFlag> for Option<u32> {
     #[inline]
     fn from(input: AttributeFlag) -> Self {
         Some(input.0)
     }
 }
-impl From<AttributeFlag> for u16 {
-    #[inline]
-    fn from(input: AttributeFlag) -> Self {
-        u16::from(input.0)
-    }
-}
-impl From<AttributeFlag> for Option<u16> {
-    #[inline]
-    fn from(input: AttributeFlag) -> Self {
-        Some(u16::from(input.0))
-    }
-}
-impl From<AttributeFlag> for u32 {
-    #[inline]
-    fn from(input: AttributeFlag) -> Self {
-        u32::from(input.0)
-    }
-}
-impl From<AttributeFlag> for Option<u32> {
-    #[inline]
-    fn from(input: AttributeFlag) -> Self {
-        Some(u32::from(input.0))
-    }
-}
 impl From<u8> for AttributeFlag {
     #[inline]
     fn from(value: u8) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u16> for AttributeFlag {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self(value.into())
+    }
+}
+impl From<u32> for AttributeFlag {
+    #[inline]
+    fn from(value: u32) -> Self {
         Self(value)
     }
 }
 impl core::fmt::Debug for AttributeFlag  {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let variants = [
-            (Self::GETTABLE.0.into(), "GETTABLE", "Gettable"),
-            (Self::SETTABLE.0.into(), "SETTABLE", "Settable"),
+            (Self::GETTABLE.0, "GETTABLE", "Gettable"),
+            (Self::SETTABLE.0, "SETTABLE", "Settable"),
         ];
-        pretty_print_bitmask(fmt, self.0.into(), &variants)
+        pretty_print_bitmask(fmt, self.0, &variants)
     }
 }
-bitmask_binop!(AttributeFlag, u8);
+bitmask_binop!(AttributeFlag, u32);
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `Xv` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb-protocol/src/protocol/xvmc.rs
+++ b/x11rb-protocol/src/protocol/xvmc.rs
@@ -4,6 +4,8 @@
 //! Bindings to the `XvMC` X11 extension.
 
 #![allow(clippy::too_many_arguments)]
+// The code generator is simpler if it can always use conversions
+#![allow(clippy::useless_conversion)]
 
 #[allow(unused_imports)]
 use alloc::borrow::Cow;

--- a/x11rb/examples/simple_window_manager.rs
+++ b/x11rb/examples/simple_window_manager.rs
@@ -339,7 +339,7 @@ impl<'a, C: Connection> WmState<'a, C> {
     }
 
     fn handle_button_press(&mut self, event: ButtonPressEvent) {
-        if event.detail != DRAG_BUTTON || event.state != 0 {
+        if event.detail != DRAG_BUTTON || u16::from(event.state) != 0 {
             return;
         }
         if let Some(state) = self.find_window_by_id(event.event) {

--- a/x11rb/examples/tutorial.rs
+++ b/x11rb/examples/tutorial.rs
@@ -1237,7 +1237,7 @@ pub struct RenamedKeyPressEvent {
 // characteristics of the event. With this code, it should be easy to add drawing operations, like
 // those which have been described above.
 
-fn print_modifiers(mask: u16) {
+fn print_modifiers(mask: x11rb::protocol::xproto::KeyButMask) {
     let mods = [
         (KeyButMask::SHIFT, "Shift"),
         (KeyButMask::LOCK, "Lock"),
@@ -1256,7 +1256,7 @@ fn print_modifiers(mask: u16) {
 
     let active = mods
         .iter()
-        .filter(|(m, _)| mask & u16::from(*m) != 0) // FIXME: This should be made nicer
+        .filter(|(m, _)| u16::from(mask) & u16::from(*m) != 0) // FIXME: This should be made nicer
         .map(|(_, name)| name)
         .collect::<Vec<_>>();
     println!("Modifier mask: {:?}", active);

--- a/x11rb/src/protocol/present.rs
+++ b/x11rb/src/protocol/present.rs
@@ -95,12 +95,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn select_input<Conn, A>(conn: &Conn, eid: Event, window: xproto::Window, event_mask: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_input<Conn>(conn: &Conn, eid: Event, window: xproto::Window, event_mask: EventMask) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
 {
-    let event_mask: u32 = event_mask.into();
     let request0 = SelectInputRequest {
         eid,
         window,
@@ -137,9 +135,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         notify_msc(self, window, serial, target_msc, divisor, remainder)
     }
-    fn present_select_input<A>(&self, eid: Event, window: xproto::Window, event_mask: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where
-        A: Into<u32>,
+    fn present_select_input(&self, eid: Event, window: xproto::Window, event_mask: EventMask) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_input(self, eid, window, event_mask)
     }

--- a/x11rb/src/protocol/randr.rs
+++ b/x11rb/src/protocol/randr.rs
@@ -49,12 +49,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn set_screen_config<Conn, A>(conn: &Conn, window: xproto::Window, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, size_id: u16, rotation: A, rate: u16) -> Result<Cookie<'_, Conn, SetScreenConfigReply>, ConnectionError>
+pub fn set_screen_config<Conn>(conn: &Conn, window: xproto::Window, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, size_id: u16, rotation: Rotation, rate: u16) -> Result<Cookie<'_, Conn, SetScreenConfigReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
 {
-    let rotation: u16 = rotation.into();
     let request0 = SetScreenConfigRequest {
         window,
         timestamp,
@@ -68,12 +66,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn select_input<Conn, A>(conn: &Conn, window: xproto::Window, enable: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_input<Conn>(conn: &Conn, window: xproto::Window, enable: NotifyMask) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
 {
-    let enable: u16 = enable.into();
     let request0 = SelectInputRequest {
         window,
         enable,
@@ -305,12 +301,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn set_crtc_config<'c, 'input, Conn, A>(conn: &'c Conn, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: A, outputs: &'input [Output]) -> Result<Cookie<'c, Conn, SetCrtcConfigReply>, ConnectionError>
+pub fn set_crtc_config<'c, 'input, Conn>(conn: &'c Conn, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: Rotation, outputs: &'input [Output]) -> Result<Cookie<'c, Conn, SetCrtcConfigReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
 {
-    let rotation: u16 = rotation.into();
     let request0 = SetCrtcConfigRequest {
         crtc,
         timestamp,
@@ -682,15 +676,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_version(self, major_version, minor_version)
     }
-    fn randr_set_screen_config<A>(&self, window: xproto::Window, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, size_id: u16, rotation: A, rate: u16) -> Result<Cookie<'_, Self, SetScreenConfigReply>, ConnectionError>
-    where
-        A: Into<u16>,
+    fn randr_set_screen_config(&self, window: xproto::Window, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, size_id: u16, rotation: Rotation, rate: u16) -> Result<Cookie<'_, Self, SetScreenConfigReply>, ConnectionError>
     {
         set_screen_config(self, window, timestamp, config_timestamp, size_id, rotation, rate)
     }
-    fn randr_select_input<A>(&self, window: xproto::Window, enable: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where
-        A: Into<u16>,
+    fn randr_select_input(&self, window: xproto::Window, enable: NotifyMask) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_input(self, window, enable)
     }
@@ -760,9 +750,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_crtc_info(self, crtc, config_timestamp)
     }
-    fn randr_set_crtc_config<'c, 'input, A>(&'c self, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: A, outputs: &'input [Output]) -> Result<Cookie<'c, Self, SetCrtcConfigReply>, ConnectionError>
-    where
-        A: Into<u16>,
+    fn randr_set_crtc_config<'c, 'input>(&'c self, crtc: Crtc, timestamp: xproto::Timestamp, config_timestamp: xproto::Timestamp, x: i16, y: i16, mode: Mode, rotation: Rotation, outputs: &'input [Output]) -> Result<Cookie<'c, Self, SetCrtcConfigReply>, ConnectionError>
     {
         set_crtc_config(self, crtc, timestamp, config_timestamp, x, y, mode, rotation, outputs)
     }

--- a/x11rb/src/protocol/screensaver.rs
+++ b/x11rb/src/protocol/screensaver.rs
@@ -59,12 +59,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn select_input<Conn, A>(conn: &Conn, drawable: xproto::Drawable, event_mask: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_input<Conn>(conn: &Conn, drawable: xproto::Drawable, event_mask: Event) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
 {
-    let event_mask: u32 = event_mask.into();
     let request0 = SelectInputRequest {
         drawable,
         event_mask,
@@ -129,9 +127,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         query_info(self, drawable)
     }
-    fn screensaver_select_input<A>(&self, drawable: xproto::Drawable, event_mask: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where
-        A: Into<u32>,
+    fn screensaver_select_input(&self, drawable: xproto::Drawable, event_mask: Event) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_input(self, drawable, event_mask)
     }

--- a/x11rb/src/protocol/xf86vidmode.rs
+++ b/x11rb/src/protocol/xf86vidmode.rs
@@ -54,12 +54,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn mod_mode_line<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn mod_mode_line<'c, 'input, Conn>(conn: &'c Conn, screen: u32, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: ModeFlag, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
 {
-    let flags: u32 = flags.into();
     let request0 = ModModeLineRequest {
         screen,
         hdisplay,
@@ -129,14 +127,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn add_mode_line<'c, 'input, Conn, A, B>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, after_dotclock: Dotclock, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: B, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn add_mode_line<'c, 'input, Conn>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: ModeFlag, after_dotclock: Dotclock, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: ModeFlag, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
-    B: Into<u32>,
 {
-    let flags: u32 = flags.into();
-    let after_flags: u32 = after_flags.into();
     let request0 = AddModeLineRequest {
         screen,
         dotclock,
@@ -168,12 +162,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn delete_mode_line<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn delete_mode_line<'c, 'input, Conn>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: ModeFlag, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
 {
-    let flags: u32 = flags.into();
     let request0 = DeleteModeLineRequest {
         screen,
         dotclock,
@@ -194,12 +186,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn validate_mode_line<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<Cookie<'c, Conn, ValidateModeLineReply>, ConnectionError>
+pub fn validate_mode_line<'c, 'input, Conn>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: ModeFlag, private: &'input [u8]) -> Result<Cookie<'c, Conn, ValidateModeLineReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
 {
-    let flags: u32 = flags.into();
     let request0 = ValidateModeLineRequest {
         screen,
         dotclock,
@@ -220,12 +210,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn switch_to_mode<'c, 'input, Conn, A>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn switch_to_mode<'c, 'input, Conn>(conn: &'c Conn, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: ModeFlag, private: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
 {
-    let flags: u32 = flags.into();
     let request0 = SwitchToModeRequest {
         screen,
         dotclock,
@@ -387,9 +375,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_mode_line(self, screen)
     }
-    fn xf86vidmode_mod_mode_line<'c, 'input, A>(&'c self, screen: u32, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where
-        A: Into<u32>,
+    fn xf86vidmode_mod_mode_line<'c, 'input>(&'c self, screen: u32, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: ModeFlag, private: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         mod_mode_line(self, screen, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private)
     }
@@ -409,28 +395,19 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_all_mode_lines(self, screen)
     }
-    fn xf86vidmode_add_mode_line<'c, 'input, A, B>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, after_dotclock: Dotclock, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: B, private: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where
-        A: Into<u32>,
-        B: Into<u32>,
+    fn xf86vidmode_add_mode_line<'c, 'input>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: ModeFlag, after_dotclock: Dotclock, after_hdisplay: u16, after_hsyncstart: u16, after_hsyncend: u16, after_htotal: u16, after_hskew: u16, after_vdisplay: u16, after_vsyncstart: u16, after_vsyncend: u16, after_vtotal: u16, after_flags: ModeFlag, private: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         add_mode_line(self, screen, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, after_dotclock, after_hdisplay, after_hsyncstart, after_hsyncend, after_htotal, after_hskew, after_vdisplay, after_vsyncstart, after_vsyncend, after_vtotal, after_flags, private)
     }
-    fn xf86vidmode_delete_mode_line<'c, 'input, A>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where
-        A: Into<u32>,
+    fn xf86vidmode_delete_mode_line<'c, 'input>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: ModeFlag, private: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         delete_mode_line(self, screen, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private)
     }
-    fn xf86vidmode_validate_mode_line<'c, 'input, A>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<Cookie<'c, Self, ValidateModeLineReply>, ConnectionError>
-    where
-        A: Into<u32>,
+    fn xf86vidmode_validate_mode_line<'c, 'input>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: ModeFlag, private: &'input [u8]) -> Result<Cookie<'c, Self, ValidateModeLineReply>, ConnectionError>
     {
         validate_mode_line(self, screen, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private)
     }
-    fn xf86vidmode_switch_to_mode<'c, 'input, A>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: A, private: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where
-        A: Into<u32>,
+    fn xf86vidmode_switch_to_mode<'c, 'input>(&'c self, screen: u32, dotclock: Dotclock, hdisplay: u16, hsyncstart: u16, hsyncend: u16, htotal: u16, hskew: u16, vdisplay: u16, vsyncstart: u16, vsyncend: u16, vtotal: u16, flags: ModeFlag, private: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         switch_to_mode(self, screen, dotclock, hdisplay, hsyncstart, hsyncend, htotal, hskew, vdisplay, vsyncstart, vsyncend, vtotal, flags, private)
     }

--- a/x11rb/src/protocol/xfixes.rs
+++ b/x11rb/src/protocol/xfixes.rs
@@ -66,12 +66,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn select_selection_input<Conn, A>(conn: &Conn, window: xproto::Window, selection: xproto::Atom, event_mask: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_selection_input<Conn>(conn: &Conn, window: xproto::Window, selection: xproto::Atom, event_mask: SelectionEventMask) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
 {
-    let event_mask: u32 = event_mask.into();
     let request0 = SelectSelectionInputRequest {
         window,
         selection,
@@ -82,12 +80,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn select_cursor_input<Conn, A>(conn: &Conn, window: xproto::Window, event_mask: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn select_cursor_input<Conn>(conn: &Conn, window: xproto::Window, event_mask: CursorNotifyMask) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
 {
-    let event_mask: u32 = event_mask.into();
     let request0 = SelectCursorInputRequest {
         window,
         event_mask,
@@ -460,12 +456,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn create_pointer_barrier<'c, 'input, Conn, A>(conn: &'c Conn, barrier: Barrier, window: xproto::Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: A, devices: &'input [u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn create_pointer_barrier<'c, 'input, Conn>(conn: &'c Conn, barrier: Barrier, window: xproto::Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: BarrierDirections, devices: &'input [u16]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
 {
-    let directions: u32 = directions.into();
     let request0 = CreatePointerBarrierRequest {
         barrier,
         window,
@@ -503,15 +497,11 @@ pub trait ConnectionExt: RequestConnection {
     {
         change_save_set(self, mode, target, map, window)
     }
-    fn xfixes_select_selection_input<A>(&self, window: xproto::Window, selection: xproto::Atom, event_mask: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where
-        A: Into<u32>,
+    fn xfixes_select_selection_input(&self, window: xproto::Window, selection: xproto::Atom, event_mask: SelectionEventMask) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_selection_input(self, window, selection, event_mask)
     }
-    fn xfixes_select_cursor_input<A>(&self, window: xproto::Window, event_mask: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where
-        A: Into<u32>,
+    fn xfixes_select_cursor_input(&self, window: xproto::Window, event_mask: CursorNotifyMask) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         select_cursor_input(self, window, event_mask)
     }
@@ -629,9 +619,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         show_cursor(self, window)
     }
-    fn xfixes_create_pointer_barrier<'c, 'input, A>(&'c self, barrier: Barrier, window: xproto::Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: A, devices: &'input [u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where
-        A: Into<u32>,
+    fn xfixes_create_pointer_barrier<'c, 'input>(&'c self, barrier: Barrier, window: xproto::Window, x1: u16, y1: u16, x2: u16, y2: u16, directions: BarrierDirections, devices: &'input [u16]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         create_pointer_barrier(self, barrier, window, x1, y1, x2, y2, directions, devices)
     }

--- a/x11rb/src/protocol/xinput.rs
+++ b/x11rb/src/protocol/xinput.rs
@@ -223,14 +223,12 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn grab_device_key<'c, 'input, Conn, A, B, C>(conn: &'c Conn, grab_window: xproto::Window, modifiers: A, modifier_device: B, grabbed_device: u8, key: C, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn grab_device_key<'c, 'input, Conn, A, B>(conn: &'c Conn, grab_window: xproto::Window, modifiers: xproto::ModMask, modifier_device: A, grabbed_device: u8, key: B, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
+    A: Into<u8>,
     B: Into<u8>,
-    C: Into<u8>,
 {
-    let modifiers: u16 = modifiers.into();
     let modifier_device: u8 = modifier_device.into();
     let key: u8 = key.into();
     let request0 = GrabDeviceKeyRequest {
@@ -249,14 +247,12 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn ungrab_device_key<Conn, A, B, C>(conn: &Conn, grab_window: xproto::Window, modifiers: A, modifier_device: B, key: C, grabbed_device: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_device_key<Conn, A, B>(conn: &Conn, grab_window: xproto::Window, modifiers: xproto::ModMask, modifier_device: A, key: B, grabbed_device: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
+    A: Into<u8>,
     B: Into<u8>,
-    C: Into<u8>,
 {
-    let modifiers: u16 = modifiers.into();
     let modifier_device: u8 = modifier_device.into();
     let key: u8 = key.into();
     let request0 = UngrabDeviceKeyRequest {
@@ -271,15 +267,13 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn grab_device_button<'c, 'input, Conn, A, B, C>(conn: &'c Conn, grab_window: xproto::Window, grabbed_device: u8, modifier_device: A, modifiers: B, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, button: C, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn grab_device_button<'c, 'input, Conn, A, B>(conn: &'c Conn, grab_window: xproto::Window, grabbed_device: u8, modifier_device: A, modifiers: xproto::ModMask, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, button: B, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<u8>,
-    B: Into<u16>,
-    C: Into<u8>,
+    B: Into<u8>,
 {
     let modifier_device: u8 = modifier_device.into();
-    let modifiers: u16 = modifiers.into();
     let button: u8 = button.into();
     let request0 = GrabDeviceButtonRequest {
         grab_window,
@@ -297,14 +291,12 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn ungrab_device_button<Conn, A, B, C>(conn: &Conn, grab_window: xproto::Window, modifiers: A, modifier_device: B, button: C, grabbed_device: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_device_button<Conn, A, B>(conn: &Conn, grab_window: xproto::Window, modifiers: xproto::ModMask, modifier_device: A, button: B, grabbed_device: u8) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
+    A: Into<u8>,
     B: Into<u8>,
-    C: Into<u8>,
 {
-    let modifiers: u16 = modifiers.into();
     let modifier_device: u8 = modifier_device.into();
     let button: u8 = button.into();
     let request0 = UngrabDeviceButtonRequest {
@@ -378,12 +370,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn change_feedback_control<Conn, A>(conn: &Conn, mask: A, device_id: u8, feedback_id: u8, feedback: FeedbackCtl) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn change_feedback_control<Conn>(conn: &Conn, mask: ChangeFeedbackControlMask, device_id: u8, feedback_id: u8, feedback: FeedbackCtl) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
 {
-    let mask: u32 = mask.into();
     let request0 = ChangeFeedbackControlRequest {
         mask,
         device_id,
@@ -1041,35 +1031,31 @@ pub trait ConnectionExt: RequestConnection {
     {
         ungrab_device(self, time, device_id)
     }
-    fn xinput_grab_device_key<'c, 'input, A, B, C>(&'c self, grab_window: xproto::Window, modifiers: A, modifier_device: B, grabbed_device: u8, key: C, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_grab_device_key<'c, 'input, A, B>(&'c self, grab_window: xproto::Window, modifiers: xproto::ModMask, modifier_device: A, grabbed_device: u8, key: B, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
-        A: Into<u16>,
+        A: Into<u8>,
         B: Into<u8>,
-        C: Into<u8>,
     {
         grab_device_key(self, grab_window, modifiers, modifier_device, grabbed_device, key, this_device_mode, other_device_mode, owner_events, classes)
     }
-    fn xinput_ungrab_device_key<A, B, C>(&self, grab_window: xproto::Window, modifiers: A, modifier_device: B, key: C, grabbed_device: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_ungrab_device_key<A, B>(&self, grab_window: xproto::Window, modifiers: xproto::ModMask, modifier_device: A, key: B, grabbed_device: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
-        A: Into<u16>,
+        A: Into<u8>,
         B: Into<u8>,
-        C: Into<u8>,
     {
         ungrab_device_key(self, grab_window, modifiers, modifier_device, key, grabbed_device)
     }
-    fn xinput_grab_device_button<'c, 'input, A, B, C>(&'c self, grab_window: xproto::Window, grabbed_device: u8, modifier_device: A, modifiers: B, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, button: C, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
+    fn xinput_grab_device_button<'c, 'input, A, B>(&'c self, grab_window: xproto::Window, grabbed_device: u8, modifier_device: A, modifiers: xproto::ModMask, this_device_mode: xproto::GrabMode, other_device_mode: xproto::GrabMode, button: B, owner_events: bool, classes: &'input [EventClass]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     where
         A: Into<u8>,
-        B: Into<u16>,
-        C: Into<u8>,
+        B: Into<u8>,
     {
         grab_device_button(self, grab_window, grabbed_device, modifier_device, modifiers, this_device_mode, other_device_mode, button, owner_events, classes)
     }
-    fn xinput_ungrab_device_button<A, B, C>(&self, grab_window: xproto::Window, modifiers: A, modifier_device: B, button: C, grabbed_device: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xinput_ungrab_device_button<A, B>(&self, grab_window: xproto::Window, modifiers: xproto::ModMask, modifier_device: A, button: B, grabbed_device: u8) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
-        A: Into<u16>,
+        A: Into<u8>,
         B: Into<u8>,
-        C: Into<u8>,
     {
         ungrab_device_button(self, grab_window, modifiers, modifier_device, button, grabbed_device)
     }
@@ -1094,9 +1080,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_feedback_control(self, device_id)
     }
-    fn xinput_change_feedback_control<A>(&self, mask: A, device_id: u8, feedback_id: u8, feedback: FeedbackCtl) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where
-        A: Into<u32>,
+    fn xinput_change_feedback_control(&self, mask: ChangeFeedbackControlMask, device_id: u8, feedback_id: u8, feedback: FeedbackCtl) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         change_feedback_control(self, mask, device_id, feedback_id, feedback)
     }

--- a/x11rb/src/protocol/xkb.rs
+++ b/x11rb/src/protocol/xkb.rs
@@ -47,18 +47,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn select_events<'c, 'input, Conn, A, B, C, D>(conn: &'c Conn, device_spec: DeviceSpec, clear: A, select_all: B, affect_map: C, map: D, details: &'input SelectEventsAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn select_events<'c, 'input, Conn>(conn: &'c Conn, device_spec: DeviceSpec, clear: EventType, select_all: EventType, affect_map: MapPart, map: MapPart, details: &'input SelectEventsAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
-    B: Into<u16>,
-    C: Into<u16>,
-    D: Into<u16>,
 {
-    let clear: u16 = clear.into();
-    let select_all: u16 = select_all.into();
-    let affect_map: u16 = affect_map.into();
-    let map: u16 = map.into();
     let request0 = SelectEventsRequest {
         device_spec,
         clear,
@@ -105,16 +97,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn latch_lock_state<Conn, A, B, C>(conn: &Conn, device_spec: DeviceSpec, affect_mod_locks: A, mod_locks: B, lock_group: bool, group_lock: Group, affect_mod_latches: C, latch_group: bool, group_latch: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn latch_lock_state<Conn>(conn: &Conn, device_spec: DeviceSpec, affect_mod_locks: xproto::ModMask, mod_locks: xproto::ModMask, lock_group: bool, group_lock: Group, affect_mod_latches: xproto::ModMask, latch_group: bool, group_latch: u16) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u8>,
-    B: Into<u8>,
-    C: Into<u8>,
 {
-    let affect_mod_locks: u8 = affect_mod_locks.into();
-    let mod_locks: u8 = mod_locks.into();
-    let affect_mod_latches: u8 = affect_mod_latches.into();
     let request0 = LatchLockStateRequest {
         device_spec,
         affect_mod_locks,
@@ -142,42 +128,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn set_controls<'c, 'input, Conn, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(conn: &'c Conn, device_spec: DeviceSpec, affect_internal_real_mods: A, internal_real_mods: B, affect_ignore_lock_real_mods: C, ignore_lock_real_mods: D, affect_internal_virtual_mods: E, internal_virtual_mods: F, affect_ignore_lock_virtual_mods: G, ignore_lock_virtual_mods: H, mouse_keys_dflt_btn: u8, groups_wrap: u8, access_x_options: I, affect_enabled_controls: J, enabled_controls: K, change_controls: L, repeat_delay: u16, repeat_interval: u16, slow_keys_delay: u16, debounce_delay: u16, mouse_keys_delay: u16, mouse_keys_interval: u16, mouse_keys_time_to_max: u16, mouse_keys_max_speed: u16, mouse_keys_curve: i16, access_x_timeout: u16, access_x_timeout_mask: M, access_x_timeout_values: N, access_x_timeout_options_mask: O, access_x_timeout_options_values: P, per_key_repeat: &'input [u8; 32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_controls<'c, 'input, Conn>(conn: &'c Conn, device_spec: DeviceSpec, affect_internal_real_mods: xproto::ModMask, internal_real_mods: xproto::ModMask, affect_ignore_lock_real_mods: xproto::ModMask, ignore_lock_real_mods: xproto::ModMask, affect_internal_virtual_mods: VMod, internal_virtual_mods: VMod, affect_ignore_lock_virtual_mods: VMod, ignore_lock_virtual_mods: VMod, mouse_keys_dflt_btn: u8, groups_wrap: u8, access_x_options: AXOption, affect_enabled_controls: BoolCtrl, enabled_controls: BoolCtrl, change_controls: Control, repeat_delay: u16, repeat_interval: u16, slow_keys_delay: u16, debounce_delay: u16, mouse_keys_delay: u16, mouse_keys_interval: u16, mouse_keys_time_to_max: u16, mouse_keys_max_speed: u16, mouse_keys_curve: i16, access_x_timeout: u16, access_x_timeout_mask: BoolCtrl, access_x_timeout_values: BoolCtrl, access_x_timeout_options_mask: AXOption, access_x_timeout_options_values: AXOption, per_key_repeat: &'input [u8; 32]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u8>,
-    B: Into<u8>,
-    C: Into<u8>,
-    D: Into<u8>,
-    E: Into<u16>,
-    F: Into<u16>,
-    G: Into<u16>,
-    H: Into<u16>,
-    I: Into<u16>,
-    J: Into<u32>,
-    K: Into<u32>,
-    L: Into<u32>,
-    M: Into<u32>,
-    N: Into<u32>,
-    O: Into<u16>,
-    P: Into<u16>,
 {
-    let affect_internal_real_mods: u8 = affect_internal_real_mods.into();
-    let internal_real_mods: u8 = internal_real_mods.into();
-    let affect_ignore_lock_real_mods: u8 = affect_ignore_lock_real_mods.into();
-    let ignore_lock_real_mods: u8 = ignore_lock_real_mods.into();
-    let affect_internal_virtual_mods: u16 = affect_internal_virtual_mods.into();
-    let internal_virtual_mods: u16 = internal_virtual_mods.into();
-    let affect_ignore_lock_virtual_mods: u16 = affect_ignore_lock_virtual_mods.into();
-    let ignore_lock_virtual_mods: u16 = ignore_lock_virtual_mods.into();
-    let access_x_options: u16 = access_x_options.into();
-    let affect_enabled_controls: u32 = affect_enabled_controls.into();
-    let enabled_controls: u32 = enabled_controls.into();
-    let change_controls: u32 = change_controls.into();
-    let access_x_timeout_mask: u32 = access_x_timeout_mask.into();
-    let access_x_timeout_values: u32 = access_x_timeout_values.into();
-    let access_x_timeout_options_mask: u16 = access_x_timeout_options_mask.into();
-    let access_x_timeout_options_values: u16 = access_x_timeout_options_values.into();
     let request0 = SetControlsRequest {
         device_spec,
         affect_internal_real_mods,
@@ -215,16 +169,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn get_map<Conn, A, B, C>(conn: &Conn, device_spec: DeviceSpec, full: A, partial: B, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, first_key_action: xproto::Keycode, n_key_actions: u8, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, virtual_mods: C, first_key_explicit: xproto::Keycode, n_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Conn, GetMapReply>, ConnectionError>
+pub fn get_map<Conn>(conn: &Conn, device_spec: DeviceSpec, full: MapPart, partial: MapPart, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, first_key_action: xproto::Keycode, n_key_actions: u8, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, virtual_mods: VMod, first_key_explicit: xproto::Keycode, n_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Conn, GetMapReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
-    B: Into<u16>,
-    C: Into<u16>,
 {
-    let full: u16 = full.into();
-    let partial: u16 = partial.into();
-    let virtual_mods: u16 = virtual_mods.into();
     let request0 = GetMapRequest {
         device_spec,
         full,
@@ -250,14 +198,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn set_map<'c, 'input, Conn, A, B>(conn: &'c Conn, device_spec: DeviceSpec, flags: A, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: B, values: &'input SetMapAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_map<'c, 'input, Conn>(conn: &'c Conn, device_spec: DeviceSpec, flags: SetMapFlags, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: VMod, values: &'input SetMapAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
-    B: Into<u16>,
 {
-    let flags: u16 = flags.into();
-    let virtual_mods: u16 = virtual_mods.into();
     let request0 = SetMapRequest {
         device_spec,
         flags,
@@ -291,12 +235,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn get_compat_map<Conn, A>(conn: &Conn, device_spec: DeviceSpec, groups: A, get_all_si: bool, first_si: u16, n_si: u16) -> Result<Cookie<'_, Conn, GetCompatMapReply>, ConnectionError>
+pub fn get_compat_map<Conn>(conn: &Conn, device_spec: DeviceSpec, groups: SetOfGroup, get_all_si: bool, first_si: u16, n_si: u16) -> Result<Cookie<'_, Conn, GetCompatMapReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u8>,
 {
-    let groups: u8 = groups.into();
     let request0 = GetCompatMapRequest {
         device_spec,
         groups,
@@ -309,12 +251,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn set_compat_map<'c, 'input, Conn, A>(conn: &'c Conn, device_spec: DeviceSpec, recompute_actions: bool, truncate_si: bool, groups: A, first_si: u16, si: &'input [SymInterpret], group_maps: &'input [ModDef]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_compat_map<'c, 'input, Conn>(conn: &'c Conn, device_spec: DeviceSpec, recompute_actions: bool, truncate_si: bool, groups: SetOfGroup, first_si: u16, si: &'input [SymInterpret], group_maps: &'input [ModDef]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u8>,
 {
-    let groups: u8 = groups.into();
     let request0 = SetCompatMapRequest {
         device_spec,
         recompute_actions,
@@ -385,26 +325,12 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn set_named_indicator<Conn, A, B, C, D, E, F, G, H>(conn: &Conn, device_spec: DeviceSpec, led_class: LedClass, led_id: A, indicator: xproto::Atom, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: B, map_which_groups: C, map_groups: D, map_which_mods: E, map_real_mods: F, map_vmods: G, map_ctrls: H) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn set_named_indicator<Conn, A>(conn: &Conn, device_spec: DeviceSpec, led_class: LedClass, led_id: A, indicator: xproto::Atom, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: IMFlag, map_which_groups: IMGroupsWhich, map_groups: SetOfGroups, map_which_mods: IMModsWhich, map_real_mods: xproto::ModMask, map_vmods: VMod, map_ctrls: BoolCtrl) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<IDSpec>,
-    B: Into<u8>,
-    C: Into<u8>,
-    D: Into<u8>,
-    E: Into<u8>,
-    F: Into<u8>,
-    G: Into<u16>,
-    H: Into<u32>,
 {
     let led_id: IDSpec = led_id.into();
-    let map_flags: u8 = map_flags.into();
-    let map_which_groups: u8 = map_which_groups.into();
-    let map_groups: u8 = map_groups.into();
-    let map_which_mods: u8 = map_which_mods.into();
-    let map_real_mods: u8 = map_real_mods.into();
-    let map_vmods: u16 = map_vmods.into();
-    let map_ctrls: u32 = map_ctrls.into();
     let request0 = SetNamedIndicatorRequest {
         device_spec,
         led_class,
@@ -427,12 +353,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn get_names<Conn, A>(conn: &Conn, device_spec: DeviceSpec, which: A) -> Result<Cookie<'_, Conn, GetNamesReply>, ConnectionError>
+pub fn get_names<Conn>(conn: &Conn, device_spec: DeviceSpec, which: NameDetail) -> Result<Cookie<'_, Conn, GetNamesReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
 {
-    let which: u32 = which.into();
     let request0 = GetNamesRequest {
         device_spec,
         which,
@@ -442,14 +366,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn set_names<'c, 'input, Conn, A, B>(conn: &'c Conn, device_spec: DeviceSpec, virtual_mods: A, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: B, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &'input SetNamesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_names<'c, 'input, Conn>(conn: &'c Conn, device_spec: DeviceSpec, virtual_mods: VMod, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: SetOfGroup, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &'input SetNamesAux) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
-    B: Into<u8>,
 {
-    let virtual_mods: u16 = virtual_mods.into();
-    let group_names: u8 = group_names.into();
     let request0 = SetNamesRequest {
         device_spec,
         virtual_mods,
@@ -471,20 +391,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn per_client_flags<Conn, A, B, C, D, E>(conn: &Conn, device_spec: DeviceSpec, change: A, value: B, ctrls_to_change: C, auto_ctrls: D, auto_ctrls_values: E) -> Result<Cookie<'_, Conn, PerClientFlagsReply>, ConnectionError>
+pub fn per_client_flags<Conn>(conn: &Conn, device_spec: DeviceSpec, change: PerClientFlag, value: PerClientFlag, ctrls_to_change: BoolCtrl, auto_ctrls: BoolCtrl, auto_ctrls_values: BoolCtrl) -> Result<Cookie<'_, Conn, PerClientFlagsReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
-    B: Into<u32>,
-    C: Into<u32>,
-    D: Into<u32>,
-    E: Into<u32>,
 {
-    let change: u32 = change.into();
-    let value: u32 = value.into();
-    let ctrls_to_change: u32 = ctrls_to_change.into();
-    let auto_ctrls: u32 = auto_ctrls.into();
-    let auto_ctrls_values: u32 = auto_ctrls_values.into();
     let request0 = PerClientFlagsRequest {
         device_spec,
         change,
@@ -511,14 +421,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn get_kbd_by_name<Conn, A, B>(conn: &Conn, device_spec: DeviceSpec, need: A, want: B, load: bool) -> Result<Cookie<'_, Conn, GetKbdByNameReply>, ConnectionError>
+pub fn get_kbd_by_name<Conn>(conn: &Conn, device_spec: DeviceSpec, need: GBNDetail, want: GBNDetail, load: bool) -> Result<Cookie<'_, Conn, GetKbdByNameReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
-    B: Into<u16>,
 {
-    let need: u16 = need.into();
-    let want: u16 = want.into();
     let request0 = GetKbdByNameRequest {
         device_spec,
         need,
@@ -530,13 +436,11 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn get_device_info<Conn, A, B>(conn: &Conn, device_spec: DeviceSpec, wanted: A, all_buttons: bool, first_button: u8, n_buttons: u8, led_class: LedClass, led_id: B) -> Result<Cookie<'_, Conn, GetDeviceInfoReply>, ConnectionError>
+pub fn get_device_info<Conn, A>(conn: &Conn, device_spec: DeviceSpec, wanted: XIFeature, all_buttons: bool, first_button: u8, n_buttons: u8, led_class: LedClass, led_id: A) -> Result<Cookie<'_, Conn, GetDeviceInfoReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
-    B: Into<IDSpec>,
+    A: Into<IDSpec>,
 {
-    let wanted: u16 = wanted.into();
     let led_id: IDSpec = led_id.into();
     let request0 = GetDeviceInfoRequest {
         device_spec,
@@ -552,12 +456,10 @@ where
     conn.send_request_with_reply(&slices, fds)
 }
 
-pub fn set_device_info<'c, 'input, Conn, A>(conn: &'c Conn, device_spec: DeviceSpec, first_btn: u8, change: A, btn_actions: &'input [Action], leds: &'input [DeviceLedInfo]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn set_device_info<'c, 'input, Conn>(conn: &'c Conn, device_spec: DeviceSpec, first_btn: u8, change: XIFeature, btn_actions: &'input [Action], leds: &'input [DeviceLedInfo]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
 {
-    let change: u16 = change.into();
     let request0 = SetDeviceInfoRequest {
         device_spec,
         first_btn,
@@ -592,12 +494,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         use_extension(self, wanted_major, wanted_minor)
     }
-    fn xkb_select_events<'c, 'input, A, B, C, D>(&'c self, device_spec: DeviceSpec, clear: A, select_all: B, affect_map: C, map: D, details: &'input SelectEventsAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where
-        A: Into<u16>,
-        B: Into<u16>,
-        C: Into<u16>,
-        D: Into<u16>,
+    fn xkb_select_events<'c, 'input>(&'c self, device_spec: DeviceSpec, clear: EventType, select_all: EventType, affect_map: MapPart, map: MapPart, details: &'input SelectEventsAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         select_events(self, device_spec, clear, select_all, affect_map, map, details)
     }
@@ -609,11 +506,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_state(self, device_spec)
     }
-    fn xkb_latch_lock_state<A, B, C>(&self, device_spec: DeviceSpec, affect_mod_locks: A, mod_locks: B, lock_group: bool, group_lock: Group, affect_mod_latches: C, latch_group: bool, group_latch: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where
-        A: Into<u8>,
-        B: Into<u8>,
-        C: Into<u8>,
+    fn xkb_latch_lock_state(&self, device_spec: DeviceSpec, affect_mod_locks: xproto::ModMask, mod_locks: xproto::ModMask, lock_group: bool, group_lock: Group, affect_mod_latches: xproto::ModMask, latch_group: bool, group_latch: u16) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         latch_lock_state(self, device_spec, affect_mod_locks, mod_locks, lock_group, group_lock, affect_mod_latches, latch_group, group_latch)
     }
@@ -621,51 +514,23 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_controls(self, device_spec)
     }
-    fn xkb_set_controls<'c, 'input, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>(&'c self, device_spec: DeviceSpec, affect_internal_real_mods: A, internal_real_mods: B, affect_ignore_lock_real_mods: C, ignore_lock_real_mods: D, affect_internal_virtual_mods: E, internal_virtual_mods: F, affect_ignore_lock_virtual_mods: G, ignore_lock_virtual_mods: H, mouse_keys_dflt_btn: u8, groups_wrap: u8, access_x_options: I, affect_enabled_controls: J, enabled_controls: K, change_controls: L, repeat_delay: u16, repeat_interval: u16, slow_keys_delay: u16, debounce_delay: u16, mouse_keys_delay: u16, mouse_keys_interval: u16, mouse_keys_time_to_max: u16, mouse_keys_max_speed: u16, mouse_keys_curve: i16, access_x_timeout: u16, access_x_timeout_mask: M, access_x_timeout_values: N, access_x_timeout_options_mask: O, access_x_timeout_options_values: P, per_key_repeat: &'input [u8; 32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where
-        A: Into<u8>,
-        B: Into<u8>,
-        C: Into<u8>,
-        D: Into<u8>,
-        E: Into<u16>,
-        F: Into<u16>,
-        G: Into<u16>,
-        H: Into<u16>,
-        I: Into<u16>,
-        J: Into<u32>,
-        K: Into<u32>,
-        L: Into<u32>,
-        M: Into<u32>,
-        N: Into<u32>,
-        O: Into<u16>,
-        P: Into<u16>,
+    fn xkb_set_controls<'c, 'input>(&'c self, device_spec: DeviceSpec, affect_internal_real_mods: xproto::ModMask, internal_real_mods: xproto::ModMask, affect_ignore_lock_real_mods: xproto::ModMask, ignore_lock_real_mods: xproto::ModMask, affect_internal_virtual_mods: VMod, internal_virtual_mods: VMod, affect_ignore_lock_virtual_mods: VMod, ignore_lock_virtual_mods: VMod, mouse_keys_dflt_btn: u8, groups_wrap: u8, access_x_options: AXOption, affect_enabled_controls: BoolCtrl, enabled_controls: BoolCtrl, change_controls: Control, repeat_delay: u16, repeat_interval: u16, slow_keys_delay: u16, debounce_delay: u16, mouse_keys_delay: u16, mouse_keys_interval: u16, mouse_keys_time_to_max: u16, mouse_keys_max_speed: u16, mouse_keys_curve: i16, access_x_timeout: u16, access_x_timeout_mask: BoolCtrl, access_x_timeout_values: BoolCtrl, access_x_timeout_options_mask: AXOption, access_x_timeout_options_values: AXOption, per_key_repeat: &'input [u8; 32]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_controls(self, device_spec, affect_internal_real_mods, internal_real_mods, affect_ignore_lock_real_mods, ignore_lock_real_mods, affect_internal_virtual_mods, internal_virtual_mods, affect_ignore_lock_virtual_mods, ignore_lock_virtual_mods, mouse_keys_dflt_btn, groups_wrap, access_x_options, affect_enabled_controls, enabled_controls, change_controls, repeat_delay, repeat_interval, slow_keys_delay, debounce_delay, mouse_keys_delay, mouse_keys_interval, mouse_keys_time_to_max, mouse_keys_max_speed, mouse_keys_curve, access_x_timeout, access_x_timeout_mask, access_x_timeout_values, access_x_timeout_options_mask, access_x_timeout_options_values, per_key_repeat)
     }
-    fn xkb_get_map<A, B, C>(&self, device_spec: DeviceSpec, full: A, partial: B, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, first_key_action: xproto::Keycode, n_key_actions: u8, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, virtual_mods: C, first_key_explicit: xproto::Keycode, n_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Self, GetMapReply>, ConnectionError>
-    where
-        A: Into<u16>,
-        B: Into<u16>,
-        C: Into<u16>,
+    fn xkb_get_map(&self, device_spec: DeviceSpec, full: MapPart, partial: MapPart, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, first_key_action: xproto::Keycode, n_key_actions: u8, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, virtual_mods: VMod, first_key_explicit: xproto::Keycode, n_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8) -> Result<Cookie<'_, Self, GetMapReply>, ConnectionError>
     {
         get_map(self, device_spec, full, partial, first_type, n_types, first_key_sym, n_key_syms, first_key_action, n_key_actions, first_key_behavior, n_key_behaviors, virtual_mods, first_key_explicit, n_key_explicit, first_mod_map_key, n_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys)
     }
-    fn xkb_set_map<'c, 'input, A, B>(&'c self, device_spec: DeviceSpec, flags: A, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: B, values: &'input SetMapAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where
-        A: Into<u16>,
-        B: Into<u16>,
+    fn xkb_set_map<'c, 'input>(&'c self, device_spec: DeviceSpec, flags: SetMapFlags, min_key_code: xproto::Keycode, max_key_code: xproto::Keycode, first_type: u8, n_types: u8, first_key_sym: xproto::Keycode, n_key_syms: u8, total_syms: u16, first_key_action: xproto::Keycode, n_key_actions: u8, total_actions: u16, first_key_behavior: xproto::Keycode, n_key_behaviors: u8, total_key_behaviors: u8, first_key_explicit: xproto::Keycode, n_key_explicit: u8, total_key_explicit: u8, first_mod_map_key: xproto::Keycode, n_mod_map_keys: u8, total_mod_map_keys: u8, first_v_mod_map_key: xproto::Keycode, n_v_mod_map_keys: u8, total_v_mod_map_keys: u8, virtual_mods: VMod, values: &'input SetMapAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_map(self, device_spec, flags, min_key_code, max_key_code, first_type, n_types, first_key_sym, n_key_syms, total_syms, first_key_action, n_key_actions, total_actions, first_key_behavior, n_key_behaviors, total_key_behaviors, first_key_explicit, n_key_explicit, total_key_explicit, first_mod_map_key, n_mod_map_keys, total_mod_map_keys, first_v_mod_map_key, n_v_mod_map_keys, total_v_mod_map_keys, virtual_mods, values)
     }
-    fn xkb_get_compat_map<A>(&self, device_spec: DeviceSpec, groups: A, get_all_si: bool, first_si: u16, n_si: u16) -> Result<Cookie<'_, Self, GetCompatMapReply>, ConnectionError>
-    where
-        A: Into<u8>,
+    fn xkb_get_compat_map(&self, device_spec: DeviceSpec, groups: SetOfGroup, get_all_si: bool, first_si: u16, n_si: u16) -> Result<Cookie<'_, Self, GetCompatMapReply>, ConnectionError>
     {
         get_compat_map(self, device_spec, groups, get_all_si, first_si, n_si)
     }
-    fn xkb_set_compat_map<'c, 'input, A>(&'c self, device_spec: DeviceSpec, recompute_actions: bool, truncate_si: bool, groups: A, first_si: u16, si: &'input [SymInterpret], group_maps: &'input [ModDef]) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where
-        A: Into<u8>,
+    fn xkb_set_compat_map<'c, 'input>(&'c self, device_spec: DeviceSpec, recompute_actions: bool, truncate_si: bool, groups: SetOfGroup, first_si: u16, si: &'input [SymInterpret], group_maps: &'input [ModDef]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_compat_map(self, device_spec, recompute_actions, truncate_si, groups, first_si, si, group_maps)
     }
@@ -687,39 +552,21 @@ pub trait ConnectionExt: RequestConnection {
     {
         get_named_indicator(self, device_spec, led_class, led_id, indicator)
     }
-    fn xkb_set_named_indicator<A, B, C, D, E, F, G, H>(&self, device_spec: DeviceSpec, led_class: LedClass, led_id: A, indicator: xproto::Atom, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: B, map_which_groups: C, map_groups: D, map_which_mods: E, map_real_mods: F, map_vmods: G, map_ctrls: H) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn xkb_set_named_indicator<A>(&self, device_spec: DeviceSpec, led_class: LedClass, led_id: A, indicator: xproto::Atom, set_state: bool, on: bool, set_map: bool, create_map: bool, map_flags: IMFlag, map_which_groups: IMGroupsWhich, map_groups: SetOfGroups, map_which_mods: IMModsWhich, map_real_mods: xproto::ModMask, map_vmods: VMod, map_ctrls: BoolCtrl) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<IDSpec>,
-        B: Into<u8>,
-        C: Into<u8>,
-        D: Into<u8>,
-        E: Into<u8>,
-        F: Into<u8>,
-        G: Into<u16>,
-        H: Into<u32>,
     {
         set_named_indicator(self, device_spec, led_class, led_id, indicator, set_state, on, set_map, create_map, map_flags, map_which_groups, map_groups, map_which_mods, map_real_mods, map_vmods, map_ctrls)
     }
-    fn xkb_get_names<A>(&self, device_spec: DeviceSpec, which: A) -> Result<Cookie<'_, Self, GetNamesReply>, ConnectionError>
-    where
-        A: Into<u32>,
+    fn xkb_get_names(&self, device_spec: DeviceSpec, which: NameDetail) -> Result<Cookie<'_, Self, GetNamesReply>, ConnectionError>
     {
         get_names(self, device_spec, which)
     }
-    fn xkb_set_names<'c, 'input, A, B>(&'c self, device_spec: DeviceSpec, virtual_mods: A, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: B, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &'input SetNamesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where
-        A: Into<u16>,
-        B: Into<u8>,
+    fn xkb_set_names<'c, 'input>(&'c self, device_spec: DeviceSpec, virtual_mods: VMod, first_type: u8, n_types: u8, first_kt_levelt: u8, n_kt_levels: u8, indicators: u32, group_names: SetOfGroup, n_radio_groups: u8, first_key: xproto::Keycode, n_keys: u8, n_key_aliases: u8, total_kt_level_names: u16, values: &'input SetNamesAux) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_names(self, device_spec, virtual_mods, first_type, n_types, first_kt_levelt, n_kt_levels, indicators, group_names, n_radio_groups, first_key, n_keys, n_key_aliases, total_kt_level_names, values)
     }
-    fn xkb_per_client_flags<A, B, C, D, E>(&self, device_spec: DeviceSpec, change: A, value: B, ctrls_to_change: C, auto_ctrls: D, auto_ctrls_values: E) -> Result<Cookie<'_, Self, PerClientFlagsReply>, ConnectionError>
-    where
-        A: Into<u32>,
-        B: Into<u32>,
-        C: Into<u32>,
-        D: Into<u32>,
-        E: Into<u32>,
+    fn xkb_per_client_flags(&self, device_spec: DeviceSpec, change: PerClientFlag, value: PerClientFlag, ctrls_to_change: BoolCtrl, auto_ctrls: BoolCtrl, auto_ctrls_values: BoolCtrl) -> Result<Cookie<'_, Self, PerClientFlagsReply>, ConnectionError>
     {
         per_client_flags(self, device_spec, change, value, ctrls_to_change, auto_ctrls, auto_ctrls_values)
     }
@@ -727,23 +574,17 @@ pub trait ConnectionExt: RequestConnection {
     {
         list_components(self, device_spec, max_names)
     }
-    fn xkb_get_kbd_by_name<A, B>(&self, device_spec: DeviceSpec, need: A, want: B, load: bool) -> Result<Cookie<'_, Self, GetKbdByNameReply>, ConnectionError>
-    where
-        A: Into<u16>,
-        B: Into<u16>,
+    fn xkb_get_kbd_by_name(&self, device_spec: DeviceSpec, need: GBNDetail, want: GBNDetail, load: bool) -> Result<Cookie<'_, Self, GetKbdByNameReply>, ConnectionError>
     {
         get_kbd_by_name(self, device_spec, need, want, load)
     }
-    fn xkb_get_device_info<A, B>(&self, device_spec: DeviceSpec, wanted: A, all_buttons: bool, first_button: u8, n_buttons: u8, led_class: LedClass, led_id: B) -> Result<Cookie<'_, Self, GetDeviceInfoReply>, ConnectionError>
+    fn xkb_get_device_info<A>(&self, device_spec: DeviceSpec, wanted: XIFeature, all_buttons: bool, first_button: u8, n_buttons: u8, led_class: LedClass, led_id: A) -> Result<Cookie<'_, Self, GetDeviceInfoReply>, ConnectionError>
     where
-        A: Into<u16>,
-        B: Into<IDSpec>,
+        A: Into<IDSpec>,
     {
         get_device_info(self, device_spec, wanted, all_buttons, first_button, n_buttons, led_class, led_id)
     }
-    fn xkb_set_device_info<'c, 'input, A>(&'c self, device_spec: DeviceSpec, first_btn: u8, change: A, btn_actions: &'input [Action], leds: &'input [DeviceLedInfo]) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where
-        A: Into<u16>,
+    fn xkb_set_device_info<'c, 'input>(&'c self, device_spec: DeviceSpec, first_btn: u8, change: XIFeature, btn_actions: &'input [Action], leds: &'input [DeviceLedInfo]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         set_device_info(self, device_spec, first_btn, change, btn_actions, leds)
     }

--- a/x11rb/src/protocol/xproto.rs
+++ b/x11rb/src/protocol/xproto.rs
@@ -1013,15 +1013,13 @@ where
 ///     free(event);
 /// }
 /// ```
-pub fn send_event<Conn, A, B, C>(conn: &Conn, propagate: bool, destination: A, event_mask: B, event: C) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn send_event<Conn, A, B>(conn: &Conn, propagate: bool, destination: A, event_mask: EventMask, event: B) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<Window>,
-    B: Into<u32>,
-    C: Into<[u8; 32]>,
+    B: Into<[u8; 32]>,
 {
     let destination: Window = destination.into();
-    let event_mask: u32 = event_mask.into();
     let event = Cow::Owned(event.into());
     let request0 = SendEventRequest {
         propagate,
@@ -1105,15 +1103,13 @@ where
 ///     }
 /// }
 /// ```
-pub fn grab_pointer<Conn, A, B, C, D>(conn: &Conn, owner_events: bool, grab_window: Window, event_mask: A, pointer_mode: GrabMode, keyboard_mode: GrabMode, confine_to: B, cursor: C, time: D) -> Result<Cookie<'_, Conn, GrabPointerReply>, ConnectionError>
+pub fn grab_pointer<Conn, A, B, C>(conn: &Conn, owner_events: bool, grab_window: Window, event_mask: EventMask, pointer_mode: GrabMode, keyboard_mode: GrabMode, confine_to: A, cursor: B, time: C) -> Result<Cookie<'_, Conn, GrabPointerReply>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
-    B: Into<Window>,
-    C: Into<Cursor>,
-    D: Into<Timestamp>,
+    A: Into<Window>,
+    B: Into<Cursor>,
+    C: Into<Timestamp>,
 {
-    let event_mask: u16 = event_mask.into();
     let confine_to: Window = confine_to.into();
     let cursor: Cursor = cursor.into();
     let time: Timestamp = time.into();
@@ -1236,18 +1232,14 @@ where
 /// * `Value` - TODO: reasons?
 /// * `Cursor` - The specified `cursor` does not exist.
 /// * `Window` - The specified `window` does not exist.
-pub fn grab_button<Conn, A, B, C, D>(conn: &Conn, owner_events: bool, grab_window: Window, event_mask: A, pointer_mode: GrabMode, keyboard_mode: GrabMode, confine_to: B, cursor: C, button: ButtonIndex, modifiers: D) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn grab_button<Conn, A, B>(conn: &Conn, owner_events: bool, grab_window: Window, event_mask: EventMask, pointer_mode: GrabMode, keyboard_mode: GrabMode, confine_to: A, cursor: B, button: ButtonIndex, modifiers: ModMask) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
-    B: Into<Window>,
-    C: Into<Cursor>,
-    D: Into<u16>,
+    A: Into<Window>,
+    B: Into<Cursor>,
 {
-    let event_mask: u16 = event_mask.into();
     let confine_to: Window = confine_to.into();
     let cursor: Cursor = cursor.into();
-    let modifiers: u16 = modifiers.into();
     let request0 = GrabButtonRequest {
         owner_events,
         grab_window,
@@ -1264,12 +1256,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn ungrab_button<Conn, A>(conn: &Conn, button: ButtonIndex, grab_window: Window, modifiers: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_button<Conn>(conn: &Conn, button: ButtonIndex, grab_window: Window, modifiers: ModMask) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
 {
-    let modifiers: u16 = modifiers.into();
     let request0 = UngrabButtonRequest {
         button,
         grab_window,
@@ -1280,16 +1270,14 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn change_active_pointer_grab<Conn, A, B, C>(conn: &Conn, cursor: A, time: B, event_mask: C) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn change_active_pointer_grab<Conn, A, B>(conn: &Conn, cursor: A, time: B, event_mask: EventMask) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<Cursor>,
     B: Into<Timestamp>,
-    C: Into<u16>,
 {
     let cursor: Cursor = cursor.into();
     let time: Timestamp = time.into();
-    let event_mask: u16 = event_mask.into();
     let request0 = ChangeActivePointerGrabRequest {
         cursor,
         time,
@@ -1454,13 +1442,11 @@ where
 /// # See
 ///
 /// * `GrabKeyboard`: request
-pub fn grab_key<Conn, A, B>(conn: &Conn, owner_events: bool, grab_window: Window, modifiers: A, key: B, pointer_mode: GrabMode, keyboard_mode: GrabMode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn grab_key<Conn, A>(conn: &Conn, owner_events: bool, grab_window: Window, modifiers: ModMask, key: A, pointer_mode: GrabMode, keyboard_mode: GrabMode) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u16>,
-    B: Into<Keycode>,
+    A: Into<Keycode>,
 {
-    let modifiers: u16 = modifiers.into();
     let key: Keycode = key.into();
     let request0 = GrabKeyRequest {
         owner_events,
@@ -1500,14 +1486,12 @@ where
 ///
 /// * `GrabKey`: request
 /// * `xev`: program
-pub fn ungrab_key<Conn, A, B>(conn: &Conn, key: A, grab_window: Window, modifiers: B) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn ungrab_key<Conn, A>(conn: &Conn, key: A, grab_window: Window, modifiers: ModMask) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
     A: Into<Keycode>,
-    B: Into<u16>,
 {
     let key: Keycode = key.into();
-    let modifiers: u16 = modifiers.into();
     let request0 = UngrabKeyRequest {
         key,
         grab_window,
@@ -2100,12 +2084,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn copy_gc<Conn, A>(conn: &Conn, src_gc: Gcontext, dst_gc: Gcontext, value_mask: A) -> Result<VoidCookie<'_, Conn>, ConnectionError>
+pub fn copy_gc<Conn>(conn: &Conn, src_gc: Gcontext, dst_gc: Gcontext, value_mask: GC) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u32>,
 {
-    let value_mask: u32 = value_mask.into();
     let request0 = CopyGCRequest {
         src_gc,
         dst_gc,
@@ -2807,12 +2789,10 @@ where
     conn.send_request_without_reply(&slices, fds)
 }
 
-pub fn store_named_color<'c, 'input, Conn, A>(conn: &'c Conn, flags: A, cmap: Colormap, pixel: u32, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
+pub fn store_named_color<'c, 'input, Conn>(conn: &'c Conn, flags: ColorFlag, cmap: Colormap, pixel: u32, name: &'input [u8]) -> Result<VoidCookie<'c, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
-    A: Into<u8>,
 {
-    let flags: u8 = flags.into();
     let request0 = StoreNamedColorRequest {
         flags,
         cmap,
@@ -4058,11 +4038,10 @@ pub trait ConnectionExt: RequestConnection {
     ///     free(event);
     /// }
     /// ```
-    fn send_event<A, B, C>(&self, propagate: bool, destination: A, event_mask: B, event: C) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn send_event<A, B>(&self, propagate: bool, destination: A, event_mask: EventMask, event: B) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<Window>,
-        B: Into<u32>,
-        C: Into<[u8; 32]>,
+        B: Into<[u8; 32]>,
     {
         send_event(self, propagate, destination, event_mask, event)
     }
@@ -4137,12 +4116,11 @@ pub trait ConnectionExt: RequestConnection {
     ///     }
     /// }
     /// ```
-    fn grab_pointer<A, B, C, D>(&self, owner_events: bool, grab_window: Window, event_mask: A, pointer_mode: GrabMode, keyboard_mode: GrabMode, confine_to: B, cursor: C, time: D) -> Result<Cookie<'_, Self, GrabPointerReply>, ConnectionError>
+    fn grab_pointer<A, B, C>(&self, owner_events: bool, grab_window: Window, event_mask: EventMask, pointer_mode: GrabMode, keyboard_mode: GrabMode, confine_to: A, cursor: B, time: C) -> Result<Cookie<'_, Self, GrabPointerReply>, ConnectionError>
     where
-        A: Into<u16>,
-        B: Into<Window>,
-        C: Into<Cursor>,
-        D: Into<Timestamp>,
+        A: Into<Window>,
+        B: Into<Cursor>,
+        C: Into<Timestamp>,
     {
         grab_pointer(self, owner_events, grab_window, event_mask, pointer_mode, keyboard_mode, confine_to, cursor, time)
     }
@@ -4242,26 +4220,21 @@ pub trait ConnectionExt: RequestConnection {
     /// * `Value` - TODO: reasons?
     /// * `Cursor` - The specified `cursor` does not exist.
     /// * `Window` - The specified `window` does not exist.
-    fn grab_button<A, B, C, D>(&self, owner_events: bool, grab_window: Window, event_mask: A, pointer_mode: GrabMode, keyboard_mode: GrabMode, confine_to: B, cursor: C, button: ButtonIndex, modifiers: D) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn grab_button<A, B>(&self, owner_events: bool, grab_window: Window, event_mask: EventMask, pointer_mode: GrabMode, keyboard_mode: GrabMode, confine_to: A, cursor: B, button: ButtonIndex, modifiers: ModMask) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
-        A: Into<u16>,
-        B: Into<Window>,
-        C: Into<Cursor>,
-        D: Into<u16>,
+        A: Into<Window>,
+        B: Into<Cursor>,
     {
         grab_button(self, owner_events, grab_window, event_mask, pointer_mode, keyboard_mode, confine_to, cursor, button, modifiers)
     }
-    fn ungrab_button<A>(&self, button: ButtonIndex, grab_window: Window, modifiers: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where
-        A: Into<u16>,
+    fn ungrab_button(&self, button: ButtonIndex, grab_window: Window, modifiers: ModMask) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         ungrab_button(self, button, grab_window, modifiers)
     }
-    fn change_active_pointer_grab<A, B, C>(&self, cursor: A, time: B, event_mask: C) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn change_active_pointer_grab<A, B>(&self, cursor: A, time: B, event_mask: EventMask) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<Cursor>,
         B: Into<Timestamp>,
-        C: Into<u16>,
     {
         change_active_pointer_grab(self, cursor, time, event_mask)
     }
@@ -4399,10 +4372,9 @@ pub trait ConnectionExt: RequestConnection {
     /// # See
     ///
     /// * `GrabKeyboard`: request
-    fn grab_key<A, B>(&self, owner_events: bool, grab_window: Window, modifiers: A, key: B, pointer_mode: GrabMode, keyboard_mode: GrabMode) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn grab_key<A>(&self, owner_events: bool, grab_window: Window, modifiers: ModMask, key: A, pointer_mode: GrabMode, keyboard_mode: GrabMode) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
-        A: Into<u16>,
-        B: Into<Keycode>,
+        A: Into<Keycode>,
     {
         grab_key(self, owner_events, grab_window, modifiers, key, pointer_mode, keyboard_mode)
     }
@@ -4431,10 +4403,9 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `GrabKey`: request
     /// * `xev`: program
-    fn ungrab_key<A, B>(&self, key: A, grab_window: Window, modifiers: B) -> Result<VoidCookie<'_, Self>, ConnectionError>
+    fn ungrab_key<A>(&self, key: A, grab_window: Window, modifiers: ModMask) -> Result<VoidCookie<'_, Self>, ConnectionError>
     where
         A: Into<Keycode>,
-        B: Into<u16>,
     {
         ungrab_key(self, key, grab_window, modifiers)
     }
@@ -4825,9 +4796,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         change_gc(self, gc, value_list)
     }
-    fn copy_gc<A>(&self, src_gc: Gcontext, dst_gc: Gcontext, value_mask: A) -> Result<VoidCookie<'_, Self>, ConnectionError>
-    where
-        A: Into<u32>,
+    fn copy_gc(&self, src_gc: Gcontext, dst_gc: Gcontext, value_mask: GC) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         copy_gc(self, src_gc, dst_gc, value_mask)
     }
@@ -5168,9 +5137,7 @@ pub trait ConnectionExt: RequestConnection {
     {
         store_colors(self, cmap, items)
     }
-    fn store_named_color<'c, 'input, A>(&'c self, flags: A, cmap: Colormap, pixel: u32, name: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
-    where
-        A: Into<u8>,
+    fn store_named_color<'c, 'input>(&'c self, flags: ColorFlag, cmap: Colormap, pixel: u32, name: &'input [u8]) -> Result<VoidCookie<'c, Self>, ConnectionError>
     {
         store_named_color(self, flags, cmap, pixel, name)
     }

--- a/x11rb/tests/regression_tests.rs
+++ b/x11rb/tests/regression_tests.rs
@@ -260,13 +260,13 @@ fn test_send_event() -> Result<(), ConnectionError> {
     let conn = FakeConnection::default();
     let propagate = true;
     let destination: u32 = 0x1337;
-    let event_mask: u32 = 7;
+    let event_mask = x11rb_protocol::protocol::xproto::EventMask::BUTTON3_MOTION;
     conn.send_event(propagate, destination, event_mask, event)?;
 
     let mut expected = vec![x11rb::protocol::xproto::SEND_EVENT_REQUEST, propagate as _];
     expected.extend(&((12u16 + 32u16) / 4).to_ne_bytes());
     expected.extend(&destination.to_ne_bytes());
-    expected.extend(&event_mask.to_ne_bytes());
+    expected.extend(&u32::from(event_mask).to_ne_bytes());
     expected.extend(buffer.iter());
     conn.check_requests(&[(false, expected)]);
     Ok(())

--- a/x11rb/tests/request_parsing_tests.rs
+++ b/x11rb/tests/request_parsing_tests.rs
@@ -152,7 +152,7 @@ fn test_change_window_attributes() {
         ChangeWindowAttributesRequest {
             window: 0x0513,
             value_list: Cow::Owned(ChangeWindowAttributesAux {
-                event_mask: Some(EventMask::PROPERTY_CHANGE.into()),
+                event_mask: Some(EventMask::PROPERTY_CHANGE),
                 ..Default::default()
             }),
         }


### PR DESCRIPTION
This is an idea that I had in the context of #543.

Right now, e.g. `change_active_pointer_grab` has this signature:
```rust
pub fn change_active_pointer_grab<Conn, A, B, C>(conn: &Conn, cursor: A, time: B, event_mask: C) -> Result<VoidCookie<'_, Conn>, ConnectionError>
where
    Conn: RequestConnection + ?Sized,
    A: Into<Cursor>,
    B: Into<Timestamp>,
    C: Into<u16>;
```
This commit changes it to this instead:
```rust
pub fn change_active_pointer_grab<Conn, A, B>(conn: &Conn, cursor: A, time: B, event_mask: EventMask) -> Result<VoidCookie<'_, Conn>, ConnectionError>
where
    Conn: RequestConnection + ?Sized,
    A: Into<Cursor>,
    B: Into<Timestamp>;
```
The `event_mask` argument changes from `impl Into<u16>` to `EventMask`.

This uses the `mask` property of the relevant XML:
```
  <request name="ChangeActivePointerGrab" opcode="30">
    <pad bytes="1" />
    <field type="CURSOR" name="cursor" altenum="Cursor" />
    <field type="TIMESTAMP" name="time" altenum="Time" />
    <field type="CARD16" name="event_mask" mask="EventMask" />
    <pad bytes="2" />
  </request>
```
"Back in the days", we considered enums to be exhaustive and thus could not represent such masks (since they are logical or combinations of the enum fields). Now that we no longer expect enums to be exhaustive, we can do this change.

Why would one do that? Well, programmer comfort! Previously, there was no indication what values are possible in such an argument. Now the request "links to" the `EventMask` enum and hopefully this makes it easier to figure out which values are valid.