### PR TITLE
Simplify/prettify tutorial example

### DIFF
--- a/x11rb/examples/tutorial.rs
+++ b/x11rb/examples/tutorial.rs
@@ -1238,28 +1238,7 @@ pub struct RenamedKeyPressEvent {
 // those which have been described above.
 
 fn print_modifiers(mask: x11rb::protocol::xproto::KeyButMask) {
-    let mods = [
-        (KeyButMask::SHIFT, "Shift"),
-        (KeyButMask::LOCK, "Lock"),
-        (KeyButMask::CONTROL, "Ctrl"),
-        (KeyButMask::MOD1, "Alt"),
-        (KeyButMask::MOD2, "Mod2"),
-        (KeyButMask::MOD3, "Mod3"),
-        (KeyButMask::MOD4, "Mod4"),
-        (KeyButMask::MOD5, "Mod5"),
-        (KeyButMask::BUTTON1, "Button1"),
-        (KeyButMask::BUTTON2, "Button2"),
-        (KeyButMask::BUTTON3, "Button3"),
-        (KeyButMask::BUTTON4, "Button4"),
-        (KeyButMask::BUTTON5, "Button5"),
-    ];
-
-    let active = mods
-        .iter()
-        .filter(|(m, _)| u16::from(mask) & u16::from(*m) != 0) // FIXME: This should be made nicer
-        .map(|(_, name)| name)
-        .collect::<Vec<_>>();
-    println!("Modifier mask: {:?}", active);
+    println!("Modifier mask: {:#?}", mask);
 }
 
 fn example7() -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
The recent commit 6db1a8a72 made the code in the print_modifiers()
example a bit uglier. That code position already had a "FIXME: This
should be made nicer" comment.

Turns out that we already made this nicer a while back and the Debug
impl for bitmasks decodes the bitmask and prints the individual members.
That is exactly what print_modifiers() needs.

Example of output before this commit:

  Modifier mask: ["Shift", "Ctrl", "Button1"]

Example of output after this commit:

  Modifier mask: Shift | Control | Button1

The commit uses the alternate form of the debug output (modifier #)
since that one writes e.g. "Shift" instead of "SHIFT" and that is closer
to the previous output.

Signed-off-by: Uli Schlachter <psychon@znc.in>