### PR TITLE
Add "rust-version" to Cargo.toml

### DIFF
--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
 repository = "https://github.com/psychon/x11rb"
 readme = "../README.md"
 edition = "2018"
+rust-version = "1.46"
 license = "MIT OR Apache-2.0"
 keywords = ["xcb", "X11"]
 

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
 repository = "https://github.com/psychon/x11rb"
 readme = "../README.md"
 edition = "2018"
+rust-version = "1.46"
 license = "MIT OR Apache-2.0"
 keywords = ["xcb", "X11"]
 exclude = [


### PR DESCRIPTION
Per [1], there is no harm in adding this field to Cargo.toml:

    The first version of Cargo that supports this field was released with
    Rust 1.56.0. In older releases, the field will be ignored, and Cargo
    will display a warning.

[1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field

Signed-off-by: Uli Schlachter <psychon@znc.in>