### PR TITLE
Fix clippy complaint in generator/ and x11rb-protocol/benches/

### DIFF
--- a/generator/src/generator/special_cases.rs
+++ b/generator/src/generator/special_cases.rs
@@ -30,7 +30,7 @@ pub(super) fn handle_request(request_def: &xcbdefs::RequestDef, out: &mut Output
 /// ```
 /// // First, we have to 'invent' a GetPropertyReply.
 /// let reply = x11rb_protocol::protocol::xproto::GetPropertyReply {{
-///     format: {},
+///     format: {width},
 ///     sequence: 0,
 ///     length: 0, // This value is incorrect
 ///     type_: 0, // This value is incorrect

--- a/x11rb-protocol/benches/proto_connection.rs
+++ b/x11rb-protocol/benches/proto_connection.rs
@@ -76,7 +76,7 @@ fn enqueue_packet_test(c: &mut Criterion) {
                     v[0] = ind;
 
                     // copy our_seqno to bytes 3 and 4
-                    (&mut v[2..4]).copy_from_slice(&our_seqno.to_ne_bytes());
+                    v[2..4].copy_from_slice(&our_seqno.to_ne_bytes());
 
                     v
                 };
@@ -190,7 +190,7 @@ fn send_and_receive_request(c: &mut Criterion) {
                     let seq_trunc = seq as u16;
 
                     // insert the sequence number at positions 2 and 3
-                    (&mut packet[2..4]).copy_from_slice(&seq_trunc.to_ne_bytes());
+                    packet[2..4].copy_from_slice(&seq_trunc.to_ne_bytes());
 
                     // enqueue the packet
                     conn.enqueue_packet(black_box(replace(&mut packet, vec![0u8; 32])));


### PR DESCRIPTION
```
error: named argument `width` is not used by name
  --> generator/src/generator/special_cases.rs:44:21
   |
33 | ///     format: {},
   |                 -- this formatting argument uses named argument `width` by position
...
44 |                     width = width,
   |                     ^^^^^ this named argument is referred to by position in formatting string
   |
   = note: `-D named-arguments-used-positionally` implied by `-D warnings`
help: use the named argument by name to avoid ambiguity
   |
33 | ///     format: {width},
   |                  +++++
```
Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

Now also fixes:

    error: this expression borrows a value the compiler would automatically borrow
      --> x11rb-protocol/benches/proto_connection.rs:79:21
       |
    79 |                     (&mut v[2..4]).copy_from_slice(&our_seqno.to_ne_bytes());
       |                     ^^^^^^^^^^^^^^ help: change this to: `v[2..4]`
       |
       = note: `-D clippy::needless-borrow` implied by `-D warnings`
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
