### PR TITLE
Fix rustdoc warning

### DIFF
--- a/x11rb-protocol/src/lib.rs
+++ b/x11rb-protocol/src/lib.rs
@@ -9,7 +9,7 @@
 #![forbid(
     missing_copy_implementations,
     missing_debug_implementations,
-    private_doc_tests,
+    rustdoc::private_doc_tests,
     //single_use_lifetimes,
     trivial_casts,
     trivial_numeric_casts,

--- a/x11rb/src/lib.rs
+++ b/x11rb/src/lib.rs
@@ -117,7 +117,7 @@
 #![forbid(
     missing_copy_implementations,
     missing_debug_implementations,
-    private_doc_tests,
+    rustdoc::private_doc_tests,
     rust_2018_idioms,
     //single_use_lifetimes,
     trivial_casts,


### PR DESCRIPTION
```
warning: lint `private_doc_tests` has been renamed to `rustdoc::private_doc_tests`
  --> x11rb-protocol/src/lib.rs:12:5
   |
12 |     private_doc_tests,
   |     ^^^^^^^^^^^^^^^^^ help: use the new name: `rustdoc::private_doc_tests`
   |
   = note: `#[warn(renamed_and_removed_lints)]` on by default
```
Signed-off-by: Uli Schlachter <psychon@znc.in>