### PR TITLE
Use VecDeque::binary_search

### DIFF
--- a/x11rb-protocol/src/connection/mod.rs
+++ b/x11rb-protocol/src/connection/mod.rs
@@ -122,8 +122,8 @@ impl Connection {
 
     /// Ignore the reply for a request that was previously sent.
     pub fn discard_reply(&mut self, seqno: SequenceNumber, mode: DiscardMode) {
-        if let Some(entry) = self.sent_requests.iter_mut().find(|r| r.seqno == seqno) {
-            entry.discard_mode = Some(mode);
+        if let Ok(index) = self.sent_requests.binary_search_by_key(&seqno, |r| r.seqno) {
+            self.sent_requests[index].discard_mode = Some(mode);
         }
         match mode {
             DiscardMode::DiscardReplyAndError => self.pending_replies.retain(|r| r.0 != seqno),


### PR DESCRIPTION
The first commit adds a new criterion benchmark. The second commit has the following commit message:

Use VecDeque::binary_search

So far, x11rb_protocol::connection::Connection::discard_reply() did a
linear search for the correct entry in the list of sent requests.
However, since this list is sorted, we can do a binary search instead.

This has the following positive effect on the newly added criterion
benchmark (at least on my machine):
```
discard_reply/discard oldest
                        time:   [12.132 µs 12.484 µs 12.788 µs]
                        change: [-7.0027% +0.7822% +9.6974%] (p = 0.85 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) low severe
discard_reply/discard newest
                        time:   [12.206 µs 12.534 µs 12.824 µs]
                        change: [-40.279% -35.461% -30.479%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) low severe
discard_reply/discard all forward
                        time:   [491.37 µs 491.71 µs 492.04 µs]
                        change: [-97.216% -97.210% -97.203%] (p = 0.00 < 0.05)
                        Performance has improved.
discard_reply/discard all backward
                        time:   [496.59 µs 496.92 µs 497.20 µs]
                        change: [-97.223% -97.190% -97.171%] (p = 0.00 < 0.05)
                        Performance has improved.
```
"discard oldest" is the best case for the old linear search: It would
immediately find the correct entry. The binary search must do more work
for this case. Yet, criterion did not detect a change in performance.
Everything else improved.
