### PR TITLE
Fix a complaint from clippy

### DIFF
--- a/x11rb/tests/resource_manager.rs
+++ b/x11rb/tests/resource_manager.rs
@@ -93,7 +93,7 @@ mod test {
     fn include_loop() {
         let dir = get_temporary_dir("include_loop");
         let file = write_file(
-            &dir,
+            dir,
             "loop.xresources",
             b"First: 1\n! Provoke an endless chain of self-inclusion\n#include \"loop.xresources\"\nSecond: 2\n",
         );


### PR DESCRIPTION
```
error: the borrowed expression implements the required traits
  --> x11rb/tests/resource_manager.rs:96:13
   |
96 |             &dir,
   |             ^^^^ help: change this to: `dir`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
   = note: `-D clippy::needless-borrow` implied by `-D warnings`
```
-----
No idea why beta clippy only cares about this one instance. This file is full of more cases of the same, I think. But whatever.

New Rust release, new PR to please the clippy god.

Edit: Ah, I know why. Otherwise one gets "use of moved value"-errors.