### PR TITLE
Bring back `assert!`ions lost in ecdc4055234f341eafb22e76e49a638d0f8c5f9c

### DIFF
--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -1820,7 +1820,7 @@ impl CreatePictureAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        let _ = value_mask;
+        assert_eq!(self.switch_expr(), u32::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(repeat) = self.repeat {
             u32::from(repeat).serialize_into(bytes);
         }
@@ -2226,7 +2226,7 @@ impl ChangePictureAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        let _ = value_mask;
+        assert_eq!(self.switch_expr(), u32::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(repeat) = self.repeat {
             u32::from(repeat).serialize_into(bytes);
         }

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -727,7 +727,7 @@ impl SetAttributesAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        let _ = value_mask;
+        assert_eq!(self.switch_expr(), u32::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(background_pixmap) = self.background_pixmap {
             background_pixmap.serialize_into(bytes);
         }

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -1228,7 +1228,7 @@ impl CreateAlarmAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        let _ = value_mask;
+        assert_eq!(self.switch_expr(), u32::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(counter) = self.counter {
             counter.serialize_into(bytes);
         }
@@ -1467,7 +1467,7 @@ impl ChangeAlarmAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        let _ = value_mask;
+        assert_eq!(self.switch_expr(), u32::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(counter) = self.counter {
             counter.serialize_into(bytes);
         }

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -860,7 +860,7 @@ impl InputInfoInfo {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
-        let _ = class_id;
+        assert_eq!(self.switch_expr(), u8::from(class_id), "switch `info` has an inconsistent discriminant");
         match self {
             InputInfoInfo::Key(key) => key.serialize_into(bytes),
             InputInfoInfo::Button(button) => button.serialize_into(bytes),
@@ -4336,7 +4336,7 @@ impl FeedbackStateData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
-        let _ = class_id;
+        assert_eq!(self.switch_expr(), u8::from(class_id), "switch `data` has an inconsistent discriminant");
         match self {
             FeedbackStateData::Keyboard(keyboard) => keyboard.serialize_into(bytes),
             FeedbackStateData::Pointer(pointer) => pointer.serialize_into(bytes),
@@ -5248,7 +5248,7 @@ impl FeedbackCtlData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
-        let _ = class_id;
+        assert_eq!(self.switch_expr(), u8::from(class_id), "switch `data` has an inconsistent discriminant");
         match self {
             FeedbackCtlData::Keyboard(keyboard) => keyboard.serialize_into(bytes),
             FeedbackCtlData::Pointer(pointer) => pointer.serialize_into(bytes),
@@ -6732,7 +6732,7 @@ impl InputStateData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, class_id: u8) {
-        let _ = class_id;
+        assert_eq!(self.switch_expr(), u8::from(class_id), "switch `data` has an inconsistent discriminant");
         match self {
             InputStateData::Key(key) => key.serialize_into(bytes),
             InputStateData::Button(button) => button.serialize_into(bytes),
@@ -7852,7 +7852,7 @@ impl DeviceStateData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, control_id: u16) {
-        let _ = control_id;
+        assert_eq!(self.switch_expr(), u16::from(control_id), "switch `data` has an inconsistent discriminant");
         match self {
             DeviceStateData::Resolution(resolution) => resolution.serialize_into(bytes),
             DeviceStateData::AbsCalib(abs_calib) => abs_calib.serialize_into(bytes),
@@ -8673,7 +8673,7 @@ impl DeviceCtlData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, control_id: u16) {
-        let _ = control_id;
+        assert_eq!(self.switch_expr(), u16::from(control_id), "switch `data` has an inconsistent discriminant");
         match self {
             DeviceCtlData::Resolution(resolution) => resolution.serialize_into(bytes),
             DeviceCtlData::AbsCalib(abs_calib) => abs_calib.serialize_into(bytes),
@@ -9148,8 +9148,7 @@ impl ChangeDevicePropertyAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
-        let _ = format;
-        let _ = num_items;
+        assert_eq!(self.switch_expr(), u8::from(format), "switch `items` has an inconsistent discriminant");
         match self {
             ChangeDevicePropertyAux::Data8(data8) => {
                 assert_eq!(data8.len(), usize::try_from(num_items).unwrap(), "`data8` has an incorrect length");
@@ -9524,8 +9523,7 @@ impl GetDevicePropertyItems {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
-        let _ = format;
-        let _ = num_items;
+        assert_eq!(self.switch_expr(), u8::from(format), "switch `items` has an inconsistent discriminant");
         match self {
             GetDevicePropertyItems::Data8(data8) => {
                 assert_eq!(data8.len(), usize::try_from(num_items).unwrap(), "`data8` has an incorrect length");
@@ -10699,7 +10697,7 @@ impl HierarchyChangeData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, type_: u16) {
-        let _ = type_;
+        assert_eq!(self.switch_expr(), u16::from(type_), "switch `data` has an inconsistent discriminant");
         match self {
             HierarchyChangeData::AddMaster(add_master) => add_master.serialize_into(bytes),
             HierarchyChangeData::RemoveMaster(remove_master) => remove_master.serialize_into(bytes),
@@ -12469,7 +12467,7 @@ impl DeviceClassData {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, type_: u16) {
-        let _ = type_;
+        assert_eq!(self.switch_expr(), u16::from(type_), "switch `data` has an inconsistent discriminant");
         match self {
             DeviceClassData::Key(key) => key.serialize_into(bytes),
             DeviceClassData::Button(button) => button.serialize_into(bytes),
@@ -14162,8 +14160,7 @@ impl XIChangePropertyAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
-        let _ = format;
-        let _ = num_items;
+        assert_eq!(self.switch_expr(), u8::from(format), "switch `items` has an inconsistent discriminant");
         match self {
             XIChangePropertyAux::Data8(data8) => {
                 assert_eq!(data8.len(), usize::try_from(num_items).unwrap(), "`data8` has an incorrect length");
@@ -14537,8 +14534,7 @@ impl XIGetPropertyItems {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, format: u8, num_items: u32) {
-        let _ = format;
-        let _ = num_items;
+        assert_eq!(self.switch_expr(), u8::from(format), "switch `items` has an inconsistent discriminant");
         match self {
             XIGetPropertyItems::Data8(data8) => {
                 assert_eq!(data8.len(), usize::try_from(num_items).unwrap(), "`data8` has an incorrect length");

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -6442,9 +6442,7 @@ impl SelectEventsAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, affect_which: u16, clear: u16, select_all: u16) {
-        let _ = affect_which;
-        let _ = clear;
-        let _ = select_all;
+        assert_eq!(self.switch_expr(), u16::from(affect_which) & ((!u16::from(clear)) & (!u16::from(select_all))), "switch `details` has an inconsistent discriminant");
         if let Some(ref bitcase1) = self.bitcase1 {
             bitcase1.serialize_into(bytes);
         }
@@ -7991,16 +7989,7 @@ impl GetMapMap {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) {
-        let _ = present;
-        let _ = n_types;
-        let _ = n_key_syms;
-        let _ = n_key_actions;
-        let _ = total_actions;
-        let _ = total_key_behaviors;
-        let _ = virtual_mods;
-        let _ = total_key_explicit;
-        let _ = total_mod_map_keys;
-        let _ = total_v_mod_map_keys;
+        assert_eq!(self.switch_expr(), u16::from(present), "switch `map` has an inconsistent discriminant");
         if let Some(ref types_rtrn) = self.types_rtrn {
             assert_eq!(types_rtrn.len(), usize::try_from(n_types).unwrap(), "`types_rtrn` has an incorrect length");
             types_rtrn.serialize_into(bytes);
@@ -8327,16 +8316,7 @@ impl SetMapAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) {
-        let _ = present;
-        let _ = n_types;
-        let _ = n_key_syms;
-        let _ = n_key_actions;
-        let _ = total_actions;
-        let _ = total_key_behaviors;
-        let _ = virtual_mods;
-        let _ = total_key_explicit;
-        let _ = total_mod_map_keys;
-        let _ = total_v_mod_map_keys;
+        assert_eq!(self.switch_expr(), u16::from(present), "switch `values` has an inconsistent discriminant");
         if let Some(ref types) = self.types {
             assert_eq!(types.len(), usize::try_from(n_types).unwrap(), "`types` has an incorrect length");
             types.serialize_into(bytes);
@@ -9878,14 +9858,7 @@ impl GetNamesValueList {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) {
-        let _ = which;
-        let _ = n_types;
-        let _ = indicators;
-        let _ = virtual_mods;
-        let _ = group_names;
-        let _ = n_keys;
-        let _ = n_key_aliases;
-        let _ = n_radio_groups;
+        assert_eq!(self.switch_expr(), u32::from(which), "switch `value_list` has an inconsistent discriminant");
         if let Some(keycodes_name) = self.keycodes_name {
             keycodes_name.serialize_into(bytes);
         }
@@ -10251,14 +10224,7 @@ impl SetNamesAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) {
-        let _ = which;
-        let _ = n_types;
-        let _ = indicators;
-        let _ = virtual_mods;
-        let _ = group_names;
-        let _ = n_keys;
-        let _ = n_key_aliases;
-        let _ = n_radio_groups;
+        assert_eq!(self.switch_expr(), u32::from(which), "switch `values` has an inconsistent discriminant");
         if let Some(keycodes_name) = self.keycodes_name {
             keycodes_name.serialize_into(bytes);
         }
@@ -11242,16 +11208,7 @@ impl GetKbdByNameRepliesTypesMap {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) {
-        let _ = present;
-        let _ = n_types;
-        let _ = n_key_syms;
-        let _ = n_key_actions;
-        let _ = total_actions;
-        let _ = total_key_behaviors;
-        let _ = virtual_mods;
-        let _ = total_key_explicit;
-        let _ = total_mod_map_keys;
-        let _ = total_v_mod_map_keys;
+        assert_eq!(self.switch_expr(), u16::from(present), "switch `map` has an inconsistent discriminant");
         if let Some(ref types_rtrn) = self.types_rtrn {
             assert_eq!(types_rtrn.len(), usize::try_from(n_types).unwrap(), "`types_rtrn` has an incorrect length");
             types_rtrn.serialize_into(bytes);
@@ -11751,14 +11708,7 @@ impl GetKbdByNameRepliesKeyNamesValueList {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) {
-        let _ = which;
-        let _ = n_types;
-        let _ = indicators;
-        let _ = virtual_mods;
-        let _ = group_names;
-        let _ = n_keys;
-        let _ = n_key_aliases;
-        let _ = n_radio_groups;
+        assert_eq!(self.switch_expr(), u32::from(which), "switch `value_list` has an inconsistent discriminant");
         if let Some(keycodes_name) = self.keycodes_name {
             keycodes_name.serialize_into(bytes);
         }

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -6924,7 +6924,7 @@ impl CreateWindowAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        let _ = value_mask;
+        assert_eq!(self.switch_expr(), u32::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(background_pixmap) = self.background_pixmap {
             background_pixmap.serialize_into(bytes);
         }
@@ -7477,7 +7477,7 @@ impl ChangeWindowAttributesAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        let _ = value_mask;
+        assert_eq!(self.switch_expr(), u32::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(background_pixmap) = self.background_pixmap {
             background_pixmap.serialize_into(bytes);
         }
@@ -8935,7 +8935,7 @@ impl ConfigureWindowAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u16) {
-        let _ = value_mask;
+        assert_eq!(self.switch_expr(), u16::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(x) = self.x {
             x.serialize_into(bytes);
         }
@@ -16537,7 +16537,7 @@ impl CreateGCAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        let _ = value_mask;
+        assert_eq!(self.switch_expr(), u32::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(function) = self.function {
             u32::from(function).serialize_into(bytes);
         }
@@ -17174,7 +17174,7 @@ impl ChangeGCAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        let _ = value_mask;
+        assert_eq!(self.switch_expr(), u32::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(function) = self.function {
             u32::from(function).serialize_into(bytes);
         }
@@ -23393,7 +23393,7 @@ impl ChangeKeyboardControlAux {
         result
     }
     fn serialize_into(&self, bytes: &mut Vec<u8>, value_mask: u32) {
-        let _ = value_mask;
+        assert_eq!(self.switch_expr(), u32::from(value_mask), "switch `value_list` has an inconsistent discriminant");
         if let Some(key_click_percent) = self.key_click_percent {
             key_click_percent.serialize_into(bytes);
         }


### PR DESCRIPTION
Fixes https://github.com/psychon/x11rb/issues/764