### PR TITLE
Add functions to bitmask_binop

### DIFF
--- a/x11rb-protocol/src/x11_utils.rs
+++ b/x11rb-protocol/src/x11_utils.rs
@@ -646,12 +646,20 @@ macro_rules! bitmask_binop {
             }
         }
         impl $t {
-            //! Check if this object has all bits set that are also set in `flag`.
-            //!
-            //! `flag` can be a single enum variant or a whole other mask.
+            /// Check if this object has all bits set that are also set in `flag`.
+            ///
+            /// `flag` can be a single enum variant or a whole other mask.
             pub fn contains(self, flag: impl Into<$u>) -> bool {
                 let flag = flag.into();
                 (<$u>::from(self) & flag) == flag
+            }
+
+            /// Check if this object has some bits set that are also set in `flag`.
+            ///
+            /// `flag` can be a single enum variant or a whole other mask.
+            pub fn intersects(self, flag: impl Into<$u>) -> bool {
+                let flag = flag.into();
+                (<$u>::from(self) & flag) != 0
             }
         }
     };

--- a/x11rb-protocol/src/x11_utils.rs
+++ b/x11rb-protocol/src/x11_utils.rs
@@ -575,7 +575,7 @@ impl<T: Serialize> Serialize for [T] {
     }
 }
 
-// This macro is used by the generated code to implement `std::ops::BitOr` and
+// This macro is used by the generated code to implement e.g. `std::ops::BitOr` and
 // `std::ops::BitOrAssign`.
 macro_rules! bitmask_binop {
     ($t:ty, $u:ty) => {
@@ -595,6 +595,11 @@ macro_rules! bitmask_binop {
             type Output = $t;
             fn bitor(self, other: $t) -> Self::Output {
                 <$t>::from(self) | other
+            }
+        }
+        impl core::ops::BitOrAssign for $t {
+            fn bitor_assign(&mut self, other: $t) {
+                *self = *self | Self::from(other)
             }
         }
         impl core::ops::BitOrAssign<$t> for $u {
@@ -625,6 +630,11 @@ macro_rules! bitmask_binop {
                 <$t>::from(self) & other
             }
         }
+        impl core::ops::BitAndAssign for $t {
+            fn bitand_assign(&mut self, other: $t) {
+                self.0 &= other
+            }
+        }
         impl core::ops::BitAndAssign<$t> for $u {
             fn bitand_assign(&mut self, other: $t) {
                 *self &= Self::from(other)
@@ -633,6 +643,15 @@ macro_rules! bitmask_binop {
         impl core::ops::BitAndAssign<$u> for $t {
             fn bitand_assign(&mut self, other: $u) {
                 self.0 &= other
+            }
+        }
+        impl $t {
+            //! Check if this object has all bits set that are also set in `flag`.
+            //!
+            //! `flag` can be a single enum variant or a whole other mask.
+            pub fn contains(self, flag: impl Into<$u>) -> bool {
+                let flag = flag.into();
+                (<$u>::from(self) & flag) == flag
             }
         }
     };

--- a/x11rb-protocol/tests/enum_tests.rs
+++ b/x11rb-protocol/tests/enum_tests.rs
@@ -83,3 +83,25 @@ fn test_contains() {
     assert!(!mask.contains(16u32));
     assert!(!mask.contains(20u32));
 }
+
+#[test]
+fn test_intersects() {
+    let mask = EventMask::KEY_PRESS;
+    assert!(mask.intersects(EventMask::KEY_PRESS));
+    assert!(!mask.intersects(EventMask::NO_EVENT));
+    assert!(mask.intersects(EventMask::KEY_PRESS | EventMask::BUTTON_PRESS));
+    assert!(!mask.intersects(EventMask::BUTTON_PRESS));
+
+    let mask = EventMask::KEY_PRESS | EventMask::BUTTON_PRESS;
+    assert!(mask.intersects(EventMask::KEY_PRESS));
+    assert!(mask.intersects(EventMask::BUTTON_PRESS));
+    assert!(mask.intersects(EventMask::KEY_PRESS | EventMask::BUTTON_PRESS));
+    assert!(!mask.intersects(EventMask::ENTER_WINDOW));
+    assert!(mask.intersects(EventMask::ENTER_WINDOW | EventMask::BUTTON_PRESS));
+
+    assert!(mask.intersects(1u32));
+    assert!(mask.intersects(4u32));
+    assert!(mask.intersects(5u32));
+    assert!(!mask.intersects(16u32));
+    assert!(mask.intersects(20u32));
+}

--- a/x11rb-protocol/tests/enum_tests.rs
+++ b/x11rb-protocol/tests/enum_tests.rs
@@ -1,0 +1,85 @@
+use x11rb_protocol::protocol::xproto::EventMask;
+
+#[test]
+fn test_conversion() {
+    assert_eq!(0, u32::from(EventMask::NO_EVENT));
+    assert_eq!(1, u32::from(EventMask::KEY_PRESS));
+    assert_eq!(4, u32::from(EventMask::BUTTON_PRESS));
+    assert_eq!(Some(16u32), EventMask::ENTER_WINDOW.into());
+    assert_eq!(EventMask::NO_EVENT, 0u8.into());
+    assert_eq!(EventMask::KEY_PRESS, 1u8.into());
+}
+
+#[test]
+fn test_bit_or() {
+    assert_eq!(
+        EventMask::KEY_PRESS,
+        EventMask::KEY_PRESS | EventMask::NO_EVENT
+    );
+    assert_eq!(EventMask::KEY_PRESS, 1 | EventMask::NO_EVENT);
+    assert_eq!(EventMask::KEY_PRESS, EventMask::NO_EVENT | 1);
+
+    let mut mask = EventMask::KEY_PRESS;
+    mask |= EventMask::BUTTON_PRESS;
+    assert_eq!(5, u32::from(mask));
+
+    let mut mask = EventMask::KEY_PRESS;
+    mask |= 4u32;
+    assert_eq!(5, u32::from(mask));
+
+    let mut mask = 1u32;
+    mask |= EventMask::BUTTON_PRESS;
+    assert_eq!(5, u32::from(mask));
+}
+
+#[test]
+fn test_bit_and() {
+    assert_eq!(
+        EventMask::NO_EVENT,
+        EventMask::KEY_PRESS & EventMask::NO_EVENT
+    );
+    assert_eq!(
+        EventMask::KEY_PRESS,
+        EventMask::KEY_PRESS & EventMask::KEY_PRESS
+    );
+    assert_eq!(
+        EventMask::KEY_PRESS,
+        EventMask::from(5u32) & EventMask::KEY_PRESS
+    );
+    assert_eq!(EventMask::KEY_PRESS, 5 & EventMask::KEY_PRESS);
+    assert_eq!(EventMask::KEY_PRESS, EventMask::KEY_PRESS & 5);
+
+    let mut mask = EventMask::from(5u32);
+    mask &= EventMask::BUTTON_PRESS;
+    assert_eq!(EventMask::BUTTON_PRESS, mask);
+
+    let mut mask = EventMask::from(5u32);
+    mask &= 4u32;
+    assert_eq!(EventMask::BUTTON_PRESS, mask);
+
+    let mut mask = 7u32;
+    mask &= EventMask::from(21u32);
+    assert_eq!(5, u32::from(mask));
+}
+
+#[test]
+fn test_contains() {
+    let mask = EventMask::KEY_PRESS;
+    assert!(mask.contains(EventMask::KEY_PRESS));
+    assert!(mask.contains(EventMask::NO_EVENT));
+    assert!(!mask.contains(EventMask::KEY_PRESS | EventMask::BUTTON_PRESS));
+    assert!(!mask.contains(EventMask::BUTTON_PRESS));
+
+    let mask = EventMask::KEY_PRESS | EventMask::BUTTON_PRESS;
+    assert!(mask.contains(EventMask::KEY_PRESS));
+    assert!(mask.contains(EventMask::BUTTON_PRESS));
+    assert!(mask.contains(EventMask::KEY_PRESS | EventMask::BUTTON_PRESS));
+    assert!(!mask.contains(EventMask::ENTER_WINDOW));
+    assert!(!mask.contains(EventMask::ENTER_WINDOW | EventMask::BUTTON_PRESS));
+
+    assert!(mask.contains(1u32));
+    assert!(mask.contains(4u32));
+    assert!(mask.contains(5u32));
+    assert!(!mask.contains(16u32));
+    assert!(!mask.contains(20u32));
+}

--- a/x11rb-protocol/tests/enum_tests.rs
+++ b/x11rb-protocol/tests/enum_tests.rs
@@ -29,7 +29,7 @@ fn test_bit_or() {
 
     let mut mask = 1u32;
     mask |= EventMask::BUTTON_PRESS;
-    assert_eq!(5, u32::from(mask));
+    assert_eq!(5, mask);
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_bit_and() {
 
     let mut mask = 7u32;
     mask &= EventMask::from(21u32);
-    assert_eq!(5, u32::from(mask));
+    assert_eq!(5, mask);
 }
 
 #[test]


### PR DESCRIPTION
The bitmask_binop macro is invoked for enumerations that "look like" bit masks. This commit adds a contains() associated function that checks if "this" mask has all bits set for a given mask.

Additionally, this adds implementations for BitOrAssign and BitAndAssign for such an enum with itself. E.g. previously EventMask::NO_EVENT | EventMask::KEY_PRESS would not compile.

Finally, this adds some superficial tests for the bitmask_binop functions.

Signed-off-by: Uli Schlachter <psychon@znc.in>

----

@Riey FYI