### PR TITLE
Add raw-window-handle feature

### DIFF
--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -26,6 +26,7 @@ libc = { version = "0.2", optional = true }
 libloading = { version = "0.7.0", optional = true }
 once_cell = { version = "1.16", optional = true }
 gethostname = "0.3.0"
+raw-window-handle = { version = "0.5.0", optional = true }
 
 [target.'cfg(unix)'.dependencies.nix]
 version = "0.26"

--- a/x11rb/src/xcb_ffi/mod.rs
+++ b/x11rb/src/xcb_ffi/mod.rs
@@ -592,6 +592,30 @@ impl AsRawFd for XCBConnection {
     }
 }
 
+#[cfg(feature = "raw-window-handle")]
+unsafe impl raw_window_handle::HasRawDisplayHandle for XCBConnection {
+    #[inline]
+    fn raw_display_handle(&self) -> raw_window_handle::RawDisplayHandle {
+        let mut handle = raw_window_handle::XcbDisplayHandle::empty();
+        handle.connection = self.get_raw_xcb_connection();
+
+        raw_window_handle::RawDisplayHandle::Xcb(handle)
+    }
+}
+
+#[cfg(feature = "raw-window-handle")]
+unsafe impl raw_window_handle::HasRawWindowHandle
+    for crate::protocol::xproto::WindowWrapper<'_, XCBConnection>
+{
+    #[inline]
+    fn raw_window_handle(&self) -> raw_window_handle::RawWindowHandle {
+        let mut handle = raw_window_handle::XcbWindowHandle::empty();
+        handle.window = self.window();
+
+        raw_window_handle::RawWindowHandle::Xcb(handle)
+    }
+}
+
 /// Reconstruct a partial sequence number based on a recently received 'full' sequence number.
 ///
 /// The new sequence number may be before or after the `recent` sequence number.


### PR DESCRIPTION
This PR adds a `raw-window-handle` feature that implements `raw_window_handle::HasRawDisplayHandle` for `XCBConnection`.