### PR TITLE
Use extern "C" for dynamic link pointers

### DIFF
--- a/x11rb/src/xcb_ffi/raw_ffi/ffi.rs
+++ b/x11rb/src/xcb_ffi/raw_ffi/ffi.rs
@@ -103,7 +103,7 @@ macro_rules! make_ffi_fn_defs {
         struct LibxcbFuncs {
             $(
                 $(#[$fn_attr])*
-                $fn_name: fn($($fn_arg_name: $fn_arg_type),*) $(-> $fn_ret_ty)?,
+                $fn_name: unsafe extern "C" fn($($fn_arg_name: $fn_arg_type),*) $(-> $fn_ret_ty)?,
             )*
         }
 


### PR DESCRIPTION
Tell me if I'm wrong, but I think that the pointers in the `ExternFuncs` needs to be `extern "C"`, since they point to C functions.