### PR TITLE
ci: Use install-action for cross

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -200,7 +200,7 @@ jobs:
     - name: Install cross rust
       run: rustup target add "$CROSS_TARGET"
     - name: Install cross
-      run: cargo install cross --force
+      uses: taiki-e/install-action@cross
     - name: cargo test
       run: cross test --target "$CROSS_TARGET" --verbose --package x11rb --features "$MOST_FEATURES"
 


### PR DESCRIPTION
This PR fixes the CI failures in the big endian tests by using `taiki-e/install-action` for cross instead of `cargo install`. This circumvents cross-rs/cross#1177.