### PR TITLE
GH Workflow: Add actions-rs/clippy-check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,20 +31,31 @@ jobs:
     - name: Check for changes
       run: if ! git diff --exit-code; then exit 1; fi
 
+  clippy:
+     runs-on: ubuntu-latest
+     steps:
+       - uses: actions/checkout@v2
+       - name: Install clippy
+         uses: actions-rs/toolchain@v1
+         with:
+           profile: minimal
+           toolchain: beta
+           override: true
+           components: clippy
+       - uses: actions-rs/clippy-check@v1
+         with:
+           token: ${{ secrets.GITHUB_TOKEN }}
+           args: --workspace --all-targets --all-features
+
   clippy-rustfmt:
      runs-on: ubuntu-latest
-     strategy:
-       matrix:
-         include:
-           - rust: stable
-           - rust: beta
      steps:
        - uses: actions/checkout@v2
        - name: Install rustfmt and clippy
          uses: actions-rs/toolchain@v1
          with:
            profile: minimal
-           toolchain: ${{ matrix.rust }}
+           toolchain: stable
            override: true
            components: rustfmt, clippy
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,7 +7,7 @@ pull_request_rules:
       - status-success=big-endian-test
       - status-success=msrv-check
       - status-success=build (stable)
-      - status-success=clippy-rustfmt (stable)
+      - status-success=clippy-rustfmt
       - status-success=code_gen
     actions:
       merge:


### PR DESCRIPTION
This commit adds a workflow running actions-rs/clippy-check with the beta toolchain. This workflow will post lints as annotations to the pushed commit.

This commit also changes or clippy-rustfmt run to only run the stable toolchain.

The thinking here is: New clippy betas usually bring new lints. These new complaints make our CI needlessly fail. But making these complaints non-fatal means that they are likely just ignored since no one looks at build logs. By instead having annotations, the linting results are still visible without causing build failures at random times.

Signed-off-by: Uli Schlachter <psychon@znc.in>

-------

No idea whether this actually works as expected...