### PR TITLE
Update crate dependencies

### DIFF
--- a/cairo-example/Cargo.toml
+++ b/cairo-example/Cargo.toml
@@ -11,5 +11,5 @@ path = "../x11rb"
 features = ["allow-unsafe-code", "render"]
 
 [dependencies.cairo-rs]
-version = "0.15"
+version = "0.16"
 features = ["xcb"]

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-roxmltree = "0.15.0"
+roxmltree = "0.16.0"
 xcbgen = { path = "../xcbgen-rs" }

--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -18,10 +18,10 @@ keywords = ["xcb", "X11"]
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 
 [target.'cfg(unix)'.dependencies.nix]
-version = "0.25"
+version = "0.26"
 default-features = false
 features = ["fs"]
 optional = true

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -24,11 +24,11 @@ exclude = [
 x11rb-protocol = { version = "0.11.0", path = "../x11rb-protocol" }
 libc = { version = "0.2", optional = true }
 libloading = { version = "0.7.0", optional = true }
-once_cell = { version = "1.14.0", optional = true }
-gethostname = "0.2.1"
+once_cell = { version = "1.16", optional = true }
+gethostname = "0.3.0"
 
 [target.'cfg(unix)'.dependencies.nix]
-version = "0.25"
+version = "0.26"
 default-features = false
 features = ["socket", "uio", "poll"]
 

--- a/xcbgen-rs/Cargo.toml
+++ b/xcbgen-rs/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-once_cell = "1.14.0"
-roxmltree = "0.15.0"
+once_cell = "1.16.0"
+roxmltree = "0.16.0"

--- a/xtrace-example/Cargo.toml
+++ b/xtrace-example/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-smol = "1.2.5"
+smol = "1.3"
 
 [dependencies.x11rb-protocol]
 path = "../x11rb-protocol"


### PR DESCRIPTION
This updates all dependencies to their latest version, with one exception. Updating gethostname to the latest version failed to build locally:

  error: package `gethostname v0.4.1` cannot be built because it
  requires rustc 1.64 or newer, while the currently active rustc version
  is 1.63.0

Signed-off-by: Uli Schlachter <psychon@znc.in>