### PR TITLE
Get rid of unwrap() for array parsing in generated code

### DIFF
--- a/x11rb-protocol/src/protocol/glx.rs
+++ b/x11rb-protocol/src/protocol/glx.rs
@@ -2075,8 +2075,7 @@ impl TryParse for VendorPrivateWithReplyReply {
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
         let (retval, remaining) = u32::try_parse(remaining)?;
-        let (data1, remaining) = crate::x11_utils::parse_u8_list(remaining, 24)?;
-        let data1 = <[u8; 24]>::try_from(data1).unwrap();
+        let (data1, remaining) = crate::x11_utils::parse_u8_array::<24>(remaining)?;
         let (data2, remaining) = crate::x11_utils::parse_u8_list(remaining, u32::from(length).checked_mul(4u32).ok_or(ParseError::InvalidExpression)?.try_to_usize()?)?;
         let data2 = data2.to_vec();
         if response_type != 1 {

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -3529,8 +3529,7 @@ impl TryParse for KbdFeedbackState {
         let (click, remaining) = u8::try_parse(remaining)?;
         let (percent, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
-        let (auto_repeats, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
-        let auto_repeats = <[u8; 32]>::try_from(auto_repeats).unwrap();
+        let (auto_repeats, remaining) = crate::x11_utils::parse_u8_array::<32>(remaining)?;
         let class_id = class_id.into();
         let result = KbdFeedbackState { class_id, feedback_id, len, pitch, duration, led_mask, led_values, global_auto_repeat, click, percent, auto_repeats };
         Ok((result, remaining))
@@ -3935,8 +3934,7 @@ impl TryParse for FeedbackStateDataKeyboard {
         let (click, remaining) = u8::try_parse(remaining)?;
         let (percent, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
-        let (auto_repeats, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
-        let auto_repeats = <[u8; 32]>::try_from(auto_repeats).unwrap();
+        let (auto_repeats, remaining) = crate::x11_utils::parse_u8_array::<32>(remaining)?;
         let result = FeedbackStateDataKeyboard { pitch, duration, led_mask, led_values, global_auto_repeat, click, percent, auto_repeats };
         Ok((result, remaining))
     }
@@ -6233,8 +6231,7 @@ impl TryParse for KeyState {
         let (len, remaining) = u8::try_parse(remaining)?;
         let (num_keys, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
-        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
-        let keys = <[u8; 32]>::try_from(keys).unwrap();
+        let (keys, remaining) = crate::x11_utils::parse_u8_array::<32>(remaining)?;
         let class_id = class_id.into();
         let result = KeyState { class_id, len, num_keys, keys };
         Ok((result, remaining))
@@ -6309,8 +6306,7 @@ impl TryParse for ButtonState {
         let (len, remaining) = u8::try_parse(remaining)?;
         let (num_buttons, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
-        let (buttons, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
-        let buttons = <[u8; 32]>::try_from(buttons).unwrap();
+        let (buttons, remaining) = crate::x11_utils::parse_u8_array::<32>(remaining)?;
         let class_id = class_id.into();
         let result = ButtonState { class_id, len, num_buttons, buttons };
         Ok((result, remaining))
@@ -6495,8 +6491,7 @@ impl TryParse for InputStateDataKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_keys, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
-        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
-        let keys = <[u8; 32]>::try_from(keys).unwrap();
+        let (keys, remaining) = crate::x11_utils::parse_u8_array::<32>(remaining)?;
         let result = InputStateDataKey { num_keys, keys };
         Ok((result, remaining))
     }
@@ -6559,8 +6554,7 @@ impl TryParse for InputStateDataButton {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_buttons, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
-        let (buttons, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
-        let buttons = <[u8; 32]>::try_from(buttons).unwrap();
+        let (buttons, remaining) = crate::x11_utils::parse_u8_array::<32>(remaining)?;
         let result = InputStateDataButton { num_buttons, buttons };
         Ok((result, remaining))
     }
@@ -15505,10 +15499,8 @@ impl TryParse for DeviceStateNotifyEvent {
         let (num_buttons, remaining) = u8::try_parse(remaining)?;
         let (num_valuators, remaining) = u8::try_parse(remaining)?;
         let (classes_reported, remaining) = u8::try_parse(remaining)?;
-        let (buttons, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
-        let buttons = <[u8; 4]>::try_from(buttons).unwrap();
-        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
-        let keys = <[u8; 4]>::try_from(keys).unwrap();
+        let (buttons, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
+        let (keys, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
         let (valuators_0, remaining) = u32::try_parse(remaining)?;
         let (valuators_1, remaining) = u32::try_parse(remaining)?;
         let (valuators_2, remaining) = u32::try_parse(remaining)?;
@@ -15991,8 +15983,7 @@ impl TryParse for DeviceKeyStateNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 28)?;
-        let keys = <[u8; 28]>::try_from(keys).unwrap();
+        let (keys, remaining) = crate::x11_utils::parse_u8_array::<28>(remaining)?;
         let result = DeviceKeyStateNotifyEvent { response_type, device_id, sequence, keys };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -16112,8 +16103,7 @@ impl TryParse for DeviceButtonStateNotifyEvent {
         let (response_type, remaining) = u8::try_parse(remaining)?;
         let (device_id, remaining) = u8::try_parse(remaining)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
-        let (buttons, remaining) = crate::x11_utils::parse_u8_list(remaining, 28)?;
-        let buttons = <[u8; 28]>::try_from(buttons).unwrap();
+        let (buttons, remaining) = crate::x11_utils::parse_u8_array::<28>(remaining)?;
         let result = DeviceButtonStateNotifyEvent { response_type, device_id, sequence, buttons };
         let _ = remaining;
         let remaining = initial_value.get(32..)

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -2336,8 +2336,7 @@ pub struct KeyName {
 }
 impl TryParse for KeyName {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
-        let name = <[u8; 4]>::try_from(name).unwrap();
+        let (name, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
         let result = KeyName { name };
         Ok((result, remaining))
     }
@@ -2366,10 +2365,8 @@ pub struct KeyAlias {
 }
 impl TryParse for KeyAlias {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (real, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
-        let real = <[u8; 4]>::try_from(real).unwrap();
-        let (alias, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
-        let alias = <[u8; 4]>::try_from(alias).unwrap();
+        let (real, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
+        let (alias, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
         let result = KeyAlias { real, alias };
         Ok((result, remaining))
     }
@@ -2574,8 +2571,7 @@ pub struct KeySymMap {
 }
 impl TryParse for KeySymMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (kt_index, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
-        let kt_index = <[u8; 4]>::try_from(kt_index).unwrap();
+        let (kt_index, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
         let (group_info, remaining) = u8::try_parse(remaining)?;
         let (width, remaining) = u8::try_parse(remaining)?;
         let (n_syms, remaining) = u16::try_parse(remaining)?;
@@ -3322,8 +3318,7 @@ pub struct Key {
 }
 impl TryParse for Key {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (name, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
-        let name = <[u8; 4]>::try_from(name).unwrap();
+        let (name, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
         let (gap, remaining) = i16::try_parse(remaining)?;
         let (shape_ndx, remaining) = u8::try_parse(remaining)?;
         let (color_ndx, remaining) = u8::try_parse(remaining)?;
@@ -3365,10 +3360,8 @@ pub struct OverlayKey {
 }
 impl TryParse for OverlayKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
-        let (over, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
-        let over = <[u8; 4]>::try_from(over).unwrap();
-        let (under, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
-        let under = <[u8; 4]>::try_from(under).unwrap();
+        let (over, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
+        let (under, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
         let result = OverlayKey { over, under };
         Ok((result, remaining))
     }
@@ -5008,8 +5001,7 @@ impl TryParse for SAActionMessage {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
         let (flags, remaining) = u8::try_parse(remaining)?;
-        let (message, remaining) = crate::x11_utils::parse_u8_list(remaining, 6)?;
-        let message = <[u8; 6]>::try_from(message).unwrap();
+        let (message, remaining) = crate::x11_utils::parse_u8_array::<6>(remaining)?;
         let type_ = type_.into();
         let flags = flags.into();
         let result = SAActionMessage { type_, flags, message };
@@ -5411,8 +5403,7 @@ pub struct SIAction {
 impl TryParse for SIAction {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
-        let (data, remaining) = crate::x11_utils::parse_u8_list(remaining, 7)?;
-        let data = <[u8; 7]>::try_from(data).unwrap();
+        let (data, remaining) = crate::x11_utils::parse_u8_array::<7>(remaining)?;
         let type_ = type_.into();
         let result = SIAction { type_, data };
         Ok((result, remaining))
@@ -7223,8 +7214,7 @@ impl TryParse for GetControlsReply {
         let (access_x_timeout_mask, remaining) = u32::try_parse(remaining)?;
         let (access_x_timeout_values, remaining) = u32::try_parse(remaining)?;
         let (enabled_controls, remaining) = u32::try_parse(remaining)?;
-        let (per_key_repeat, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
-        let per_key_repeat = <[u8; 32]>::try_from(per_key_repeat).unwrap();
+        let (per_key_repeat, remaining) = crate::x11_utils::parse_u8_array::<32>(remaining)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -7609,8 +7599,7 @@ impl<'input> SetControlsRequest<'input> {
         let access_x_timeout_options_mask = access_x_timeout_options_mask.into();
         let (access_x_timeout_options_values, remaining) = u16::try_parse(remaining)?;
         let access_x_timeout_options_values = access_x_timeout_options_values.into();
-        let (per_key_repeat, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
-        let per_key_repeat = <&[u8; 32]>::try_from(per_key_repeat).unwrap();
+        let (per_key_repeat, remaining) = crate::x11_utils::parse_u8_array_ref::<32>(remaining)?;
         let _ = remaining;
         Ok(SetControlsRequest {
             device_spec,
@@ -14259,8 +14248,7 @@ impl TryParse for ActionMessageEvent {
         let (key_event_follows, remaining) = bool::try_parse(remaining)?;
         let (mods, remaining) = u8::try_parse(remaining)?;
         let (group, remaining) = u8::try_parse(remaining)?;
-        let (message, remaining) = crate::x11_utils::parse_u8_list(remaining, 8)?;
-        let message = <[u8; 8]>::try_from(message).unwrap();
+        let (message, remaining) = crate::x11_utils::parse_u8_array::<8>(remaining)?;
         let remaining = remaining.get(10..).ok_or(ParseError::InsufficientData)?;
         let mods = mods.into();
         let group = group.into();

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -2467,8 +2467,7 @@ impl TryParse for KeymapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
         let (response_type, remaining) = u8::try_parse(remaining)?;
-        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 31)?;
-        let keys = <[u8; 31]>::try_from(keys).unwrap();
+        let (keys, remaining) = crate::x11_utils::parse_u8_array::<31>(remaining)?;
         let result = KeymapNotifyEvent { response_type, keys };
         let _ = remaining;
         let remaining = initial_value.get(32..)
@@ -5791,8 +5790,7 @@ pub struct ClientMessageData([u8; 20]);
 impl ClientMessageData {
     pub fn as_data8(&self) -> [u8; 20] {
         fn do_the_parse(remaining: &[u8]) -> Result<[u8; 20], ParseError> {
-            let (data8, remaining) = crate::x11_utils::parse_u8_list(remaining, 20)?;
-            let data8 = <[u8; 20]>::try_from(data8).unwrap();
+            let (data8, remaining) = crate::x11_utils::parse_u8_array::<20>(remaining)?;
             let _ = remaining;
             Ok(data8)
         }
@@ -11369,8 +11367,7 @@ impl<'input> SendEventRequest<'input> {
         let (destination, remaining) = Window::try_parse(value)?;
         let (event_mask, remaining) = u32::try_parse(remaining)?;
         let event_mask = event_mask.into();
-        let (event, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
-        let event = <&[u8; 32]>::try_from(event).unwrap();
+        let (event, remaining) = crate::x11_utils::parse_u8_array_ref::<32>(remaining)?;
         let _ = remaining;
         Ok(SendEventRequest {
             propagate,
@@ -14139,8 +14136,7 @@ impl TryParse for QueryKeymapReply {
         let remaining = remaining.get(1..).ok_or(ParseError::InsufficientData)?;
         let (sequence, remaining) = u16::try_parse(remaining)?;
         let (length, remaining) = u32::try_parse(remaining)?;
-        let (keys, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
-        let keys = <[u8; 32]>::try_from(keys).unwrap();
+        let (keys, remaining) = crate::x11_utils::parse_u8_array::<32>(remaining)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }
@@ -23647,8 +23643,7 @@ impl TryParse for GetKeyboardControlReply {
         let (bell_pitch, remaining) = u16::try_parse(remaining)?;
         let (bell_duration, remaining) = u16::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (auto_repeats, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
-        let auto_repeats = <[u8; 32]>::try_from(auto_repeats).unwrap();
+        let (auto_repeats, remaining) = crate::x11_utils::parse_u8_array::<32>(remaining)?;
         if response_type != 1 {
             return Err(ParseError::InvalidValue);
         }

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -854,8 +854,7 @@ impl TryParse for ImageFormatInfo {
         let (type_, remaining) = u8::try_parse(remaining)?;
         let (byte_order, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
-        let (guid, remaining) = crate::x11_utils::parse_u8_list(remaining, 16)?;
-        let guid = <[u8; 16]>::try_from(guid).unwrap();
+        let (guid, remaining) = crate::x11_utils::parse_u8_array::<16>(remaining)?;
         let (bpp, remaining) = u8::try_parse(remaining)?;
         let (num_planes, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
@@ -875,8 +874,7 @@ impl TryParse for ImageFormatInfo {
         let (vvert_y_period, remaining) = u32::try_parse(remaining)?;
         let (vvert_u_period, remaining) = u32::try_parse(remaining)?;
         let (vvert_v_period, remaining) = u32::try_parse(remaining)?;
-        let (vcomp_order, remaining) = crate::x11_utils::parse_u8_list(remaining, 32)?;
-        let vcomp_order = <[u8; 32]>::try_from(vcomp_order).unwrap();
+        let (vcomp_order, remaining) = crate::x11_utils::parse_u8_array::<32>(remaining)?;
         let (vscanline_order, remaining) = u8::try_parse(remaining)?;
         let remaining = remaining.get(11..).ok_or(ParseError::InsufficientData)?;
         let type_ = type_.into();

--- a/x11rb-protocol/src/protocol/xvmc.rs
+++ b/x11rb-protocol/src/protocol/xvmc.rs
@@ -842,8 +842,7 @@ impl TryParse for CreateSubpictureReply {
         let (height_actual, remaining) = u16::try_parse(remaining)?;
         let (num_palette_entries, remaining) = u16::try_parse(remaining)?;
         let (entry_bytes, remaining) = u16::try_parse(remaining)?;
-        let (component_order, remaining) = crate::x11_utils::parse_u8_list(remaining, 4)?;
-        let component_order = <[u8; 4]>::try_from(component_order).unwrap();
+        let (component_order, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
         let remaining = remaining.get(12..).ok_or(ParseError::InsufficientData)?;
         let (priv_data, remaining) = crate::x11_utils::parse_list::<u32>(remaining, length.try_to_usize()?)?;
         if response_type != 1 {

--- a/x11rb-protocol/src/x11_utils.rs
+++ b/x11rb-protocol/src/x11_utils.rs
@@ -553,12 +553,32 @@ where
 }
 
 /// Parse a list of `u8` from the given data.
+#[inline]
 pub(crate) fn parse_u8_list(data: &[u8], list_length: usize) -> Result<(&[u8], &[u8]), ParseError> {
     if data.len() < list_length {
         Err(ParseError::InsufficientData)
     } else {
         Ok(data.split_at(list_length))
     }
+}
+
+/// Parse an array of `u8` from the given data.
+#[inline]
+pub(crate) fn parse_u8_array_ref<const N: usize>(
+    data: &[u8],
+) -> Result<(&[u8; N], &[u8]), ParseError> {
+    let (slice, remaining) = parse_u8_list(data, N)?;
+    let slice = slice
+        .try_into()
+        .expect("Cannot fail since slice has expected length");
+    Ok((slice, remaining))
+}
+
+/// Parse an array of `u8` from the given data.
+#[inline]
+pub(crate) fn parse_u8_array<const N: usize>(data: &[u8]) -> Result<([u8; N], &[u8]), ParseError> {
+    let (array, remaining) = parse_u8_array_ref(data)?;
+    Ok((*array, remaining))
 }
 
 impl<T: Serialize> Serialize for [T] {


### PR DESCRIPTION
The generated code for parsing an array first got a slice of the expected length and then used the TryFrom trait to get an array. For example:
```
  let (data1, remaining) = crate::x11_utils::parse_u8_list(remaining, 24)?;
  let data1 = <[u8; 24]>::try_from(data1).unwrap();
```
This commit introduces a helper function that produces an array directly. The above becomes:
```
  let (data1, remaining) = crate::x11_utils::parse_u8_array::<24>(remaining)?;
```
The goal here is to remove some unwrap()s in the generated code, but this also helps shortening the code.

There are two new helper function: parse_u8_array parses an array while parse_u8_array_ref returns a reference to an array. Both cases are needed in the generated code.

Signed-off-by: Uli Schlachter <psychon@znc.in>