### PR TITLE
Enable x11rb-protocol features on docs.rs

### DIFF
--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -96,6 +96,12 @@ xtest = []
 xv = ["shm"]
 xvmc = ["xv"]
 
+[package.metadata.docs.rs]
+features = [
+    "all-extensions",
+    "resource_manager",
+]
+
 [[bench]]
 name = "proto_connection"
 harness = false


### PR DESCRIPTION
I just came across [1] and noticed that the page seemed a bit empty. We already enable all extensions in x11rb, but this bit apparently didn't make it into x11rb-protocol yet...

[1]: https://docs.rs/x11rb-protocol/latest/x11rb_protocol/protocol/index.html

Signed-off-by: Uli Schlachter <psychon@znc.in>