### PR TITLE
Implement AsRawXcbConnection for XCBConnection

### DIFF
--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -27,6 +27,7 @@ libloading = { version = "0.7.0", optional = true }
 once_cell = { version = "1.16", optional = true }
 gethostname = "0.3.0"
 raw-window-handle = { version = "0.5.0", optional = true }
+as-raw-xcb-connection = { version = "1.0", optional = true }
 
 [target.'cfg(unix)'.dependencies.nix]
 version = "0.26"
@@ -43,7 +44,7 @@ features = ["winsock2"]
 [features]
 # Without this feature, all uses of `unsafe` in the crate are forbidden via
 # #![deny(unsafe_code)]. This has the effect of disabling the XCB FFI bindings.
-allow-unsafe-code = ["libc"]
+allow-unsafe-code = ["libc", "as-raw-xcb-connection"]
 
 # Enable utility functions in `x11rb::cursor` for loading mouse cursors.
 cursor = ["render", "resource_manager"]

--- a/x11rb/src/xcb_ffi/mod.rs
+++ b/x11rb/src/xcb_ffi/mod.rs
@@ -616,6 +616,13 @@ unsafe impl raw_window_handle::HasRawWindowHandle
     }
 }
 
+// SAFETY: We provide a valid xcb_connection_t that is valid for as long as required by the trait.
+unsafe impl as_raw_xcb_connection::AsRawXcbConnection for XCBConnection {
+    fn as_raw_xcb_connection(&self) -> *mut as_raw_xcb_connection::xcb_connection_t {
+        self.get_raw_xcb_connection().cast()
+    }
+}
+
 /// Reconstruct a partial sequence number based on a recently received 'full' sequence number.
 ///
 /// The new sequence number may be before or after the `recent` sequence number.


### PR DESCRIPTION
There is a new crate as-raw-xcb-connection providing a trait for getting a raw pointer for a libxcb xcb_connection_t. Implement this trait for XCBConnection.

Signed-off-by: Uli Schlachter <psychon@znc.in>

---

This is a draft since I want to wait for version 1.0 of AsRawXcbConnection before merging. See https://github.com/psychon/as-raw-xcb-connection/issues/1