### PR TITLE
Fix dl-libxcb feature on OpenBSD and NetBSD

### DIFF
--- a/x11rb/src/xcb_ffi/raw_ffi/ffi.rs
+++ b/x11rb/src/xcb_ffi/raw_ffi/ffi.rs
@@ -32,10 +32,14 @@ pub(crate) mod libxcb_library {
         #[inline(never)]
         unsafe fn load() -> Result<Self, LibxcbLoadError> {
             // TODO: Names for non-unix platforms
-            #[cfg(unix)]
-            const LIB_NAME: &str = "libxcb.so.1";
             #[cfg(not(unix))]
             compile_error!("dl-libxcb feature is not supported on non-unix");
+            #[cfg(all(unix, not(any(target_os = "openbsd", target_os = "netbsd"))))]
+            const LIB_NAME: &str = "libxcb.so.1";
+            // libtool turns -version-info differently into SONAMES on Open and NetBSD.
+            // Also, the library is apparently not in the default search path, hence use a full path.
+            #[cfg(any(target_os = "openbsd", target_os = "netbsd"))]
+            const LIB_NAME: &str = "/usr/X11R7/lib/libxcb.so.2";
 
             let library = libloading::Library::new(LIB_NAME)
                 .map_err(|e| LibxcbLoadError::OpenLibError(LIB_NAME.into(), e.to_string()))?;


### PR DESCRIPTION
Turns out that libtool uses a different logic for turning its "-version-info" into a file name on OpenBSD and NetBSD than on Linux, Darwin, and FreeBSD. On the affected BSDs, this just takes "current", which is the first argument to "-version-info". Everywhere else, the logic is "current - age".

Since libxcb uses "-version-info 2:0:1", this means that we end up with libxcb.so.2 on OpenBSD and NetBSD instead of the libxcb.so.1 that the code expects. Thus, we failed to load libxcb.

Fix this by correcting the library name on OpenBSD and NetBSD.

Fixes: https://github.com/psychon/x11rb/issues/785
Signed-off-by: Uli Schlachter <psychon@znc.in>

---

@ids1024 Since you say you have a NetBSD VM, could you give this PR a try?