### PR TITLE
Update the changelog for next release (0.11.1)

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,3 +1,10 @@
+# Version 0.11.1 (2023-XX-XX)
+
+Fixes:
+* Fix connection breakage after sending 2^16 requests without a reply.
+* Enable features on docs.rs to have better docs.
+* Fix dl-libxcb feature on NetBSD not finding libxcb.so.
+
 # Version 0.11.0 (2022-11-18)
 
 New features:


### PR DESCRIPTION
Hi,

I created a `v0.11` branch based on the tag `v0.11.0` and cherry picked commits  63870ceeb6a1e702f4aefebd0628b2de507184ee d379c2b39c7a277516e08b522831d881e96db6fb 15636e983d231e251b494500ea23d2d2e7e384c7 into that branch. This PR then adds a changelog update to the branch.

If this is fine and approved, I would then do a new release soon-ish and merge the `v0.11` branch into `master` (without another PR review).

This branch-dance is necessary since at least a5b5f77156503618079251f573b63591aa264420 and bf0544dd4fb3d5121a896616455a3a33b0bc0994 seem like breaking changes to me. Thus, I only cherry-picked the obvious fixed into this branch. Feel free to tell me I missed something.

The AppVeyor build for this PR will fail since I did not cherry-pick 154945c1a818207460c74275ef1bbf5dac9ecf5f. I will thus merge this PR by hand after it is approved.