### PR TITLE
Tutorial: Fix a clippy warning

### DIFF
--- a/x11rb/examples/tutorial.rs
+++ b/x11rb/examples/tutorial.rs
@@ -2842,7 +2842,7 @@ fn example_input_masks<C: Connection>(conn: &C, screen_num: usize) {
 // shown above:
 
 #[allow(unused)]
-fn example_visual_colormap_entries<C: Connection>(visual: &Visualtype) -> u16 {
+fn example_visual_colormap_entries(visual: &Visualtype) -> u16 {
     visual.colormap_entries
 }
 


### PR DESCRIPTION
```
warning: type parameter goes unused in function definition
    --> x11rb/examples/tutorial.rs:2845:35
     |
2845 | fn example_visual_colormap_entries<C: Connection>(visual: &Visualtype) -> u16 {
     |                                   ^^^^^^^^^^^^^^^
     |
     = help: consider removing the parameter
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_type_parameters
     = note: `#[warn(clippy::extra_unused_type_parameters)]` on by default
```