### PR TITLE
Less unwrap()s in examples

### DIFF
--- a/x11rb/examples/list_fonts.rs
+++ b/x11rb/examples/list_fonts.rs
@@ -4,12 +4,12 @@ extern crate x11rb;
 
 use x11rb::protocol::xproto::{ConnectionExt, FontDraw};
 
-fn main() {
-    let (conn, _) = connect(None).unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (conn, _) = connect(None)?;
 
     println!("DIR  MIN  MAX EXIST DFLT PROP ASC DESC NAME");
-    for reply in conn.list_fonts_with_info(u16::max_value(), b"*").unwrap() {
-        let reply = reply.unwrap();
+    for reply in conn.list_fonts_with_info(u16::max_value(), b"*")? {
+        let reply = reply?;
 
         let dir = if reply.draw_direction == FontDraw::LEFT_TO_RIGHT {
             "-->"
@@ -44,6 +44,7 @@ fn main() {
             name
         );
     }
+    Ok(())
 }
 
 include!("integration_test_util/connect.rs");

--- a/x11rb/examples/simple_window.rs
+++ b/x11rb/examples/simple_window.rs
@@ -7,35 +7,35 @@ use x11rb::protocol::Event;
 use x11rb::resource_manager::new_from_default;
 use x11rb::wrapper::ConnectionExt as _;
 
-fn main() {
-    let (conn, screen_num) = x11rb::connect(None).unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (conn, screen_num) = x11rb::connect(None)?;
 
     // The following is only needed for start_timeout_thread(), which is used for 'tests'
     let conn1 = std::sync::Arc::new(conn);
     let conn = &*conn1;
 
     let screen = &conn.setup().roots[screen_num];
-    let win_id = conn.generate_id().unwrap();
-    let gc_id = conn.generate_id().unwrap();
-    let resource_db = new_from_default(conn).unwrap();
-    let cursor_handle = CursorHandle::new(conn, screen_num, &resource_db).unwrap();
+    let win_id = conn.generate_id()?;
+    let gc_id = conn.generate_id()?;
+    let resource_db = new_from_default(conn)?;
+    let cursor_handle = CursorHandle::new(conn, screen_num, &resource_db)?;
 
-    let wm_protocols = conn.intern_atom(false, b"WM_PROTOCOLS").unwrap();
-    let wm_delete_window = conn.intern_atom(false, b"WM_DELETE_WINDOW").unwrap();
-    let net_wm_name = conn.intern_atom(false, b"_NET_WM_NAME").unwrap();
-    let utf8_string = conn.intern_atom(false, b"UTF8_STRING").unwrap();
-    let wm_protocols = wm_protocols.reply().unwrap().atom;
-    let wm_delete_window = wm_delete_window.reply().unwrap().atom;
-    let net_wm_name = net_wm_name.reply().unwrap().atom;
-    let utf8_string = utf8_string.reply().unwrap().atom;
-    let cursor_handle = cursor_handle.reply().unwrap();
+    let wm_protocols = conn.intern_atom(false, b"WM_PROTOCOLS")?;
+    let wm_delete_window = conn.intern_atom(false, b"WM_DELETE_WINDOW")?;
+    let net_wm_name = conn.intern_atom(false, b"_NET_WM_NAME")?;
+    let utf8_string = conn.intern_atom(false, b"UTF8_STRING")?;
+    let wm_protocols = wm_protocols.reply()?.atom;
+    let wm_delete_window = wm_delete_window.reply()?.atom;
+    let net_wm_name = net_wm_name.reply()?.atom;
+    let utf8_string = utf8_string.reply()?.atom;
+    let cursor_handle = cursor_handle.reply()?;
 
     let win_aux = CreateWindowAux::new()
         .event_mask(EventMask::EXPOSURE | EventMask::STRUCTURE_NOTIFY | EventMask::NO_EVENT)
         .background_pixel(screen.white_pixel)
         .win_gravity(Gravity::NORTH_WEST)
         // Just because, we set the cursor to "wait"
-        .cursor(cursor_handle.load_cursor(conn, "wait").unwrap());
+        .cursor(cursor_handle.load_cursor(conn, "wait")?);
 
     let gc_aux = CreateGCAux::new().foreground(screen.black_pixel);
 
@@ -53,8 +53,7 @@ fn main() {
         WindowClass::INPUT_OUTPUT,
         0,
         &win_aux,
-    )
-    .unwrap();
+    )?;
 
     util::start_timeout_thread(conn1.clone(), win_id);
 
@@ -65,32 +64,28 @@ fn main() {
         AtomEnum::WM_NAME,
         AtomEnum::STRING,
         title.as_bytes(),
-    )
-    .unwrap();
+    )?;
     conn.change_property8(
         PropMode::REPLACE,
         win_id,
         net_wm_name,
         utf8_string,
         title.as_bytes(),
-    )
-    .unwrap();
+    )?;
     conn.change_property32(
         PropMode::REPLACE,
         win_id,
         wm_protocols,
         AtomEnum::ATOM,
         &[wm_delete_window],
-    )
-    .unwrap();
+    )?;
     conn.change_property8(
         PropMode::REPLACE,
         win_id,
         AtomEnum::WM_CLASS,
         AtomEnum::STRING,
         b"simple_window\0simple_window\0",
-    )
-    .unwrap();
+    )?;
     conn.change_property8(
         PropMode::REPLACE,
         win_id,
@@ -101,23 +96,21 @@ fn main() {
             .to_str()
             .unwrap_or("[Invalid]")
             .as_bytes(),
-    )
-    .unwrap();
+    )?;
 
     let reply = conn
-        .get_property(false, win_id, AtomEnum::WM_NAME, AtomEnum::STRING, 0, 1024)
-        .unwrap();
-    let reply = reply.reply().unwrap();
+        .get_property(false, win_id, AtomEnum::WM_NAME, AtomEnum::STRING, 0, 1024)?
+        .reply()?;
     assert_eq!(reply.value, title.as_bytes());
 
-    conn.create_gc(gc_id, win_id, &gc_aux).unwrap();
+    conn.create_gc(gc_id, win_id, &gc_aux)?;
 
-    conn.map_window(win_id).unwrap();
+    conn.map_window(win_id)?;
 
-    conn.flush().unwrap();
+    conn.flush()?;
 
     loop {
-        let event = conn.wait_for_event().unwrap();
+        let event = conn.wait_for_event()?;
         println!("{:?})", event);
         match event {
             Event::Expose(event) => {
@@ -140,9 +133,8 @@ fn main() {
                             y: -10,
                         },
                     ];
-                    conn.poly_line(CoordMode::ORIGIN, win_id, gc_id, &points)
-                        .unwrap();
-                    conn.flush().unwrap();
+                    conn.poly_line(CoordMode::ORIGIN, win_id, gc_id, &points)?;
+                    conn.flush()?;
                 }
             }
             Event::ConfigureNotify(event) => {
@@ -153,7 +145,7 @@ fn main() {
                 let data = event.data.as_data32();
                 if event.format == 32 && event.window == win_id && data[0] == wm_delete_window {
                     println!("Window was asked to close");
-                    return;
+                    return Ok(());
                 }
             }
             Event::Error(_) => println!("Got an unexpected error"),


### PR DESCRIPTION
I wanted to remove some unnecessary unwrap()s in examples and also found a place where x11rb::atom_manager is useful.