### PR TITLE
x11rb-async: Break when drive future is dropped

### DIFF
--- a/x11rb-async/tests/connection_break_on_drop.rs
+++ b/x11rb-async/tests/connection_break_on_drop.rs
@@ -1,0 +1,61 @@
+use futures_lite::future::Ready;
+
+use x11rb::errors::ConnectionError;
+use x11rb::protocol::xproto::Setup;
+use x11rb::rust_connection::{PollMode, Stream};
+use x11rb::utils::RawFdContainer;
+use x11rb_async::connection::Connection;
+use x11rb_async::rust_connection::{RustConnection, StreamBase};
+
+#[derive(Debug)]
+struct FakeStream;
+
+impl Stream for FakeStream {
+    fn poll(&self, _: PollMode) -> Result<(), std::io::Error> {
+        unimplemented!()
+    }
+    fn read(&self, _: &mut [u8], _: &mut Vec<RawFdContainer>) -> Result<usize, std::io::Error> {
+        unimplemented!()
+    }
+    fn write(&self, _: &[u8], _: &mut Vec<RawFdContainer>) -> Result<usize, std::io::Error> {
+        unimplemented!()
+    }
+}
+
+impl StreamBase<'_> for FakeStream {
+    type Readable = Ready<std::io::Result<()>>;
+    type Writable = Ready<std::io::Result<()>>;
+
+    fn readable(&self) -> Self::Readable {
+        unimplemented!()
+    }
+
+    fn writable(&self) -> Self::Writable {
+        unimplemented!()
+    }
+}
+
+#[test]
+fn connection_breaks_on_immediate_drop() {
+    let setup = {
+        let mut setup = Setup::default();
+        setup.resource_id_mask = (1 << 8) - 1;
+        setup
+    };
+    let (conn, driver) = RustConnection::for_connected_stream(FakeStream, setup).unwrap();
+
+    // Drop the driver future. This should break the connection.
+    drop(driver);
+
+    // Check that waiting for input now errors.
+    match async_io::block_on(conn.wait_for_event()) {
+        Err(ConnectionError::IoError(err)) => {
+            assert_eq!(err.kind(), std::io::ErrorKind::Other);
+            assert_eq!(
+                err.into_inner().unwrap().to_string(),
+                "Driving future was dropped"
+            );
+        }
+        _ => unreachable!(),
+    }
+}

--- a/x11rb-async/tests/connection_break_on_drop.rs
+++ b/x11rb-async/tests/connection_break_on_drop.rs
@@ -37,10 +37,9 @@ impl StreamBase<'_> for FakeStream {
 
 #[test]
 fn connection_breaks_on_immediate_drop() {
-    let setup = {
-        let mut setup = Setup::default();
-        setup.resource_id_mask = (1 << 8) - 1;
-        setup
+    let setup = Setup {
+        resource_id_mask: (1 << 8) - 1,
+        ..Default::default()
     };
     let (conn, driver) = RustConnection::for_connected_stream(FakeStream, setup).unwrap();
 


### PR DESCRIPTION
This commit changes the implementation of timeouts in the xclock_utc example of x11rb-async. Previously, it simply called exit(0) on timeout. This commit changes things to cancel the drive future on a timeout.

From the point of view of the driving future, this simply means that the future is suddenly dropped and no longer polled. This means that x11rb-async stops reading input from the X11 connection, but sending would just work.

For the xclock_utc example, this means that the clock would still tick, but it would no longer redraw itself in response to expose events and would not react to resizes. This is quite confusing behaviour.

Now we come to what I actually want to achieve (the above is just preparation to show how confusing this case can be and to have a test case):

A new object is added and saved in the future used by drive(). When this object is dropped, it marks the connection as broken by setting an AtomicBool and wakes up all futures waiting for input. The function wait_for_incoming() is updated to check this flag. Its return type gets an extra Result and a dropped driving future is turned into an I/O error.

Example output of the xclock_utc example on a timeout:
```
Cancelling drive task due to $X11RB_EXAMPLE_TIMEOUT
Fatal Error: Driving future was dropped
```

------

This is what I actually wanted to do / achieve when starting to "mess" with this code.

Is there anything else that should be done with this code before a release? I guess "more examples", but that would turn into lots of copy&paste with the already existing examples. I am not sure how nice that is (yay, function colors...).

Alternatively: More unit tests. But for that I also do not have a good idea (and tests for async code can easily turn out ugly, I imagine).

So... I guess I am mostly fine with x11rb-async then?