### PR TITLE
Link license files to all published crates.

### DIFF
--- a/x11rb-async/LICENSE-APACHE
+++ b/x11rb-async/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/x11rb-async/LICENSE-MIT
+++ b/x11rb-async/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/x11rb-protocol/LICENSE-APACHE
+++ b/x11rb-protocol/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/x11rb-protocol/LICENSE-MIT
+++ b/x11rb-protocol/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/x11rb/LICENSE-APACHE
+++ b/x11rb/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/x11rb/LICENSE-MIT
+++ b/x11rb/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
This ensures that the archives redistributed on crates.io or by other downstream users comply with the terms of MIT and Apache-2.0, specifically with the requirement to include full license and copyright notices.

The absence of the license texts could become a hindrance for further downstream redistribution, such as packaging for Linux distributions. In fact, presence of the necessary license files in each crate is a standard check for us in Fedora.