### PR TITLE
Fix sending large requests

### DIFF
--- a/x11rb-async/Cargo.toml
+++ b/x11rb-async/Cargo.toml
@@ -21,6 +21,10 @@ futures-lite = "1"
 x11rb = { version = "0.11.1", path = "../x11rb", default-features = false }
 x11rb-protocol = { version = "0.11.1", path = "../x11rb-protocol" }
 
+[target.'cfg(unix)'.dev-dependencies.nix]
+version = "0.26"
+default-features = false
+
 [features]
 # Enable this feature to enable all the X11 extensions
 all-extensions = [

--- a/x11rb-async/src/rust_connection/write_buffer.rs
+++ b/x11rb-async/src/rust_connection/write_buffer.rs
@@ -156,7 +156,7 @@ impl WriteBufferInner {
         // Otherwise, write directly to the stream.
         let mut partial: &[u8] = &[];
         super::write_with(stream, |stream| {
-            while total_len > 0 && !partial.is_empty() {
+            while total_len > 0 || !partial.is_empty() {
                 // If the partial buffer is non-empty, write it.
                 if !partial.is_empty() {
                     let n = stream.write(partial, fds)?;

--- a/x11rb-async/src/rust_connection/write_buffer.rs
+++ b/x11rb-async/src/rust_connection/write_buffer.rs
@@ -156,7 +156,7 @@ impl WriteBufferInner {
         // Otherwise, write directly to the stream.
         let mut partial: &[u8] = &[];
         super::write_with(stream, |stream| {
-            while total_len > 0 || !partial.is_empty() {
+            while total_len > 0 || !partial.is_empty() || !fds.is_empty() {
                 // If the partial buffer is non-empty, write it.
                 if !partial.is_empty() {
                     let n = stream.write(partial, fds)?;

--- a/x11rb-async/src/rust_connection/write_buffer.rs
+++ b/x11rb-async/src/rust_connection/write_buffer.rs
@@ -156,7 +156,7 @@ impl WriteBufferInner {
         // Otherwise, write directly to the stream.
         let mut partial: &[u8] = &[];
         super::write_with(stream, |stream| {
-            while total_len > 0 || !partial.is_empty() || !fds.is_empty() {
+            while total_len > 0 || !partial.is_empty() {
                 // If the partial buffer is non-empty, write it.
                 if !partial.is_empty() {
                     let n = stream.write(partial, fds)?;
@@ -185,6 +185,13 @@ impl WriteBufferInner {
                         }
                     }
                 }
+            }
+
+            if !fds.is_empty() {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Left over FDs after sending the request",
+                ));
             }
 
             Ok(())

--- a/x11rb-async/tests/connection_regression_tests.rs
+++ b/x11rb-async/tests/connection_regression_tests.rs
@@ -110,8 +110,9 @@ fn retry_for_left_over_fds() {
     let length = 16384 * 2;
     match send_request_via_connection(FakeStream(Default::default()), length, fds) {
         Some(ConnectionError::IoError(e)) => {
-            assert_eq!(e.kind(), std::io::ErrorKind::WriteZero);
-        },
+            assert_eq!(e.kind(), std::io::ErrorKind::Other);
+            assert_eq!(e.to_string(), "Left over FDs after sending the request");
+        }
         e => panic!("Unexpected error: {:?}", e),
     }
 }

--- a/x11rb/src/rust_connection/mod.rs
+++ b/x11rb/src/rust_connection/mod.rs
@@ -334,7 +334,7 @@ impl<S: Stream> RustConnection<S> {
         mut fds: Vec<RawFdContainer>,
     ) -> std::io::Result<MutexGuardInner<'a>> {
         let mut partial_buf: &[u8] = &[];
-        while !partial_buf.is_empty() || !bufs.is_empty() || !fds.is_empty() {
+        while !partial_buf.is_empty() || !bufs.is_empty() {
             self.stream.poll(PollMode::ReadAndWritable)?;
             let write_result = if !partial_buf.is_empty() {
                 // "inner" is held, passed into this function, so this should never be held
@@ -385,6 +385,12 @@ impl<S: Stream> RustConnection<S> {
                 }
                 Err(e) => return Err(e),
             }
+        }
+        if !fds.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "Left over FDs after sending the request",
+            ));
         }
         Ok(inner)
     }


### PR DESCRIPTION
This fixes #810. The individual commit messages are:

    Add a test capturing a bug in x11rb-async
    
    We got a bug report about large requests not being written to the
    stream. I managed to trace this down to a bug in WriteBuffer: Trying to
    send something larger than the buffer size silently does nothing due to
    a logic bug.
    
    This commit adds a test that reproduces the problem. This test currently
    fails with:
    
    ---- connection_sends_large_request stdout ----
    thread 'connection_sends_large_request' panicked at 'assertion failed: `(left == right)`
      left: `0`,
     right: `32768`', x11rb-async/tests/connection_regression_tests.rs:84:5
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    
-----

    Fix a logic error in WriteBuffer
    
    The write buffer should continue writing as long as there are more bytes from
    the input *or* a partial write caused data to be split out from the input.
    Instead of the "or", the code contained an "and". Since "partial" is initially
    empty, this caused the code to just not write anything at all.
