### PR TITLE
Add (optional) tracing support to x11rb

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  MOST_FEATURES: all-extensions cursor image
+  MOST_FEATURES: all-extensions cursor image tracing tracing-subscriber/env-filter
   # According to code coverage changes, sometimes $XENVIRONMENT is set and
   # sometimes not. Try to make this consistent to stabilise coverage reports.
   # Example: https://app.codecov.io/gh/psychon/x11rb/compare/726/changes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,15 +19,15 @@ test_script:
   # Build once with the 'allow-unsafe-code' feature to
   # check that this works fine. Use 'check' instead of 'build' because
   # a full build requires the libxcb library
-  - cargo check --verbose --package x11rb --all-targets --features all-extensions,cursor,image
+  - cargo check --verbose --package x11rb --all-targets --features all-extensions,cursor,image,tracing,tracing-subscriber/env-filter
 
   # Also build once without any feature
   - cargo check --verbose --package x11rb --all-targets
 
   # We do not have libxcb and thus cannot build XCBConnection
-  - cargo build --verbose --package x11rb --all-targets --features all-extensions,cursor,image
-  - cargo test --verbose --package x11rb --features all-extensions,cursor,image
-  - cargo doc --verbose --package x11rb --features all-extensions,cursor,image
+  - cargo build --verbose --package x11rb --all-targets --features all-extensions,cursor,image,tracing,tracing-subscriber/env-filter
+  - cargo test --verbose --package x11rb --features all-extensions,cursor,image,tracing,tracing-subscriber/env-filter
+  - cargo doc --verbose --package x11rb --features all-extensions,cursor,image,tracing,tracing-subscriber/env-filter
 
   # Start an X11 server in the background
   - ps: $Server = Start-Process -PassThru -FilePath C:\cygwin64\bin\Xvfb.exe -ArgumentList "-listen tcp :0"
@@ -40,7 +40,7 @@ test_script:
   # time soon. Requirements include "must fail if the command fails".
   - ps: >-
       Get-ChildItem x11rb\examples | Where {$_.extension -eq ".rs"} | Where {$_.BaseName -ne "tutorial"} | Where {$_.BaseName -ne "shared_memory"} | Foreach-Object {
-        $cmd = "cargo run --verbose --package x11rb --features all-extensions,cursor,image --example $($_.BaseName) 2>&1"
+        $cmd = "cargo run --verbose --package x11rb --features all-extensions,cursor,image,tracing,tracing-subscriber/env-filter --example $($_.BaseName) 2>&1"
         Write-Host -ForegroundColor Yellow $cmd
         $backupErrorActionPreference = $script:ErrorActionPreference
         $script:ErrorActionPreference = "Continue"

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -27,6 +27,7 @@ libloading = { version = "0.7.0", optional = true }
 once_cell = { version = "1.16", optional = true }
 gethostname = "0.3.0"
 as-raw-xcb-connection = { version = "1.0", optional = true }
+tracing = { version = "0.1", optional = true, default-features = false }
 
 [target.'cfg(unix)'.dependencies.nix]
 version = "0.26"
@@ -42,6 +43,7 @@ features = ["winsock2"]
 
 [dev-dependencies]
 polling = "2.7.0"
+tracing-subscriber = "0.3"
 
 [features]
 # Without this feature, all uses of `unsafe` in the crate are forbidden via
@@ -147,7 +149,7 @@ required-features = ["shape"]
 
 [[example]]
 name = "simple_window"
-required-features = ["cursor", "resource_manager"]
+required-features = ["cursor", "resource_manager", "tracing", "tracing-subscriber/env-filter"]
 
 [[example]]
 name = "display_ppm"

--- a/x11rb/examples/simple_window.rs
+++ b/x11rb/examples/simple_window.rs
@@ -16,7 +16,18 @@ x11rb::atom_manager! {
     }
 }
 
+fn init_tracing() {
+    use tracing_subscriber::prelude::*;
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_tracing();
+
     let (conn, screen_num) = x11rb::connect(None)?;
 
     // The following is only needed for start_timeout_thread(), which is used for 'tests'
@@ -113,7 +124,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         let event = conn.wait_for_event()?;
-        println!("{:?})", event);
+        tracing::event!(tracing::Level::DEBUG, "Got event {event:?}");
         match event {
             Event::Expose(event) => {
                 if event.count == 0 {
@@ -147,12 +158,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let data = event.data.as_data32();
                 if event.format == 32 && event.window == win_id && data[0] == atoms.WM_DELETE_WINDOW
                 {
-                    println!("Window was asked to close");
+                    tracing::event!(tracing::Level::INFO, "Window was asked to close");
                     return Ok(());
                 }
             }
-            Event::Error(_) => println!("Got an unexpected error"),
-            _ => println!("Got an unknown event"),
+            Event::Error(err) => {
+                tracing::event!(tracing::Level::ERROR, "Got an unexpected error: {err:?}")
+            }
+            event => tracing::event!(tracing::Level::INFO, "Got an unhandled event: {event:?}"),
         }
     }
 }

--- a/x11rb/examples/simple_window.rs
+++ b/x11rb/examples/simple_window.rs
@@ -124,7 +124,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         let event = conn.wait_for_event()?;
-        tracing::event!(tracing::Level::DEBUG, "Got event {event:?}");
+        tracing::debug!("Got event {event:?}");
         match event {
             Event::Expose(event) => {
                 if event.count == 0 {
@@ -158,14 +158,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let data = event.data.as_data32();
                 if event.format == 32 && event.window == win_id && data[0] == atoms.WM_DELETE_WINDOW
                 {
-                    tracing::event!(tracing::Level::INFO, "Window was asked to close");
+                    tracing::info!("Window was asked to close");
                     return Ok(());
                 }
             }
             Event::Error(err) => {
-                tracing::event!(tracing::Level::ERROR, "Got an unexpected error: {err:?}")
+                tracing::error!("Got an unexpected error: {err:?}")
             }
-            event => tracing::event!(tracing::Level::INFO, "Got an unhandled event: {event:?}"),
+            event => tracing::info!("Got an unhandled event: {event:?}"),
         }
     }
 }

--- a/x11rb/src/extension_manager.rs
+++ b/x11rb/src/extension_manager.rs
@@ -86,7 +86,7 @@ impl ExtensionManager {
         conn: &C,
         extension_name: &'static str,
     ) -> Result<Option<ExtensionInformation>, ConnectionError> {
-        let span = crate::debug_span!("Querying extension information");
+        let span = crate::debug_span!("extension_information", extension_name);
         let _guard = span.enter();
         let entry = self.prefetch_extension_information_aux(conn, extension_name)?;
         match entry {

--- a/x11rb/src/extension_manager.rs
+++ b/x11rb/src/extension_manager.rs
@@ -37,7 +37,10 @@ impl ExtensionManager {
             // Extension already checked, return the cached value
             HashMapEntry::Occupied(entry) => Ok(entry.into_mut()),
             HashMapEntry::Vacant(entry) => {
-                crate::debug!("Prefetching information about '{}' extension", extension_name);
+                crate::debug!(
+                    "Prefetching information about '{}' extension",
+                    extension_name
+                );
                 let cookie = conn.query_extension(extension_name.as_bytes())?;
                 Ok(entry.insert(CheckState::Prefetched(cookie.into_sequence_number())))
             }
@@ -62,7 +65,11 @@ impl ExtensionManager {
         extension_name: &'static str,
         info: Option<ExtensionInformation>,
     ) {
-        crate::debug!("Inserting '{}' extension information directly: {:?}", extension_name, info);
+        crate::debug!(
+            "Inserting '{}' extension information directly: {:?}",
+            extension_name,
+            info
+        );
         let state = match info {
             Some(info) => CheckState::Present(info),
             None => CheckState::Missing,
@@ -84,10 +91,17 @@ impl ExtensionManager {
         let entry = self.prefetch_extension_information_aux(conn, extension_name)?;
         match entry {
             CheckState::Prefetched(sequence_number) => {
-                crate::debug!("Waiting for QueryInfo reply for '{}' extension", extension_name);
+                crate::debug!(
+                    "Waiting for QueryInfo reply for '{}' extension",
+                    extension_name
+                );
                 match Cookie::<C, QueryExtensionReply>::new(conn, *sequence_number).reply() {
                     Err(err) => {
-                        crate::warning!("Got error {:?} for QueryInfo reply for '{}' extension", err, extension_name);
+                        crate::warning!(
+                            "Got error {:?} for QueryInfo reply for '{}' extension",
+                            err,
+                            extension_name
+                        );
                         *entry = CheckState::Error;
                         match err {
                             ReplyError::ConnectionError(e) => Err(e),

--- a/x11rb/src/extension_manager.rs
+++ b/x11rb/src/extension_manager.rs
@@ -86,8 +86,7 @@ impl ExtensionManager {
         conn: &C,
         extension_name: &'static str,
     ) -> Result<Option<ExtensionInformation>, ConnectionError> {
-        let span = crate::debug_span!("extension_information", extension_name);
-        let _guard = span.enter();
+        let _guard = crate::debug_span!("extension_information", extension_name).entered();
         let entry = self.prefetch_extension_information_aux(conn, extension_name)?;
         match entry {
             CheckState::Prefetched(sequence_number) => {

--- a/x11rb/src/lib.rs
+++ b/x11rb/src/lib.rs
@@ -146,6 +146,9 @@ pub mod reexports {
     pub use x11rb_protocol;
 }
 
+mod tracing;
+pub(crate) use crate::tracing::*;
+
 pub mod utils;
 #[cfg(feature = "allow-unsafe-code")]
 pub mod xcb_ffi;

--- a/x11rb/src/rust_connection/mod.rs
+++ b/x11rb/src/rust_connection/mod.rs
@@ -286,7 +286,7 @@ impl<S: Stream> RustConnection<S> {
         fds: Vec<RawFdContainer>,
         kind: ReplyFdKind,
     ) -> Result<SequenceNumber, ConnectionError> {
-        let span = crate::debug_span!("Sending request");
+        let span = crate::debug_span!("send_request");
         let _guard = span.enter();
 
         {
@@ -646,7 +646,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
     }
 
     fn wait_for_reply(&self, sequence: SequenceNumber) -> Result<Option<Vec<u8>>, ConnectionError> {
-        let span = crate::debug_span!("Waiting for reply", sequence);
+        let span = crate::debug_span!("wait_for_reply", sequence);
         let _enter = span.enter();
 
         let mut inner = self.inner.lock().unwrap();
@@ -667,7 +667,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
         &self,
         sequence: SequenceNumber,
     ) -> Result<Option<Buffer>, ConnectionError> {
-        let span = crate::debug_span!("Checking for error", sequence);
+        let span = crate::debug_span!("check_for_raw_error", sequence);
         let _enter = span.enter();
 
         let mut inner = self.inner.lock().unwrap();
@@ -694,7 +694,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
         &self,
         sequence: SequenceNumber,
     ) -> Result<ReplyOrError<BufWithFds, Buffer>, ConnectionError> {
-        let span = crate::debug_span!("Waiting for reply", sequence);
+        let span = crate::debug_span!("wait_for_reply_with_fds_raw", sequence);
         let _enter = span.enter();
 
         let mut inner = self.inner.lock().unwrap();
@@ -723,7 +723,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
         match max_bytes {
             Unknown => unreachable!("We just prefetched this"),
             Requested(seqno) => {
-                let span = crate::info_span!("Waiting for maximum request length reply");
+                let span = crate::info_span!("maximum_request_bytes");
                 let _guard = span.enter();
 
                 let length = seqno
@@ -769,7 +769,7 @@ impl<S: Stream> Connection for RustConnection<S> {
     fn wait_for_raw_event_with_sequence(
         &self,
     ) -> Result<RawEventAndSeqNumber<Vec<u8>>, ConnectionError> {
-        let span = crate::trace_span!("Wait for event");
+        let span = crate::trace_span!("wait_for_raw_event_with_sequence");
         let _guard = span.enter();
 
         let mut inner = self.inner.lock().unwrap();
@@ -784,7 +784,7 @@ impl<S: Stream> Connection for RustConnection<S> {
     fn poll_for_raw_event_with_sequence(
         &self,
     ) -> Result<Option<RawEventAndSeqNumber<Vec<u8>>>, ConnectionError> {
-        let span = crate::trace_span!("Poll for event");
+        let span = crate::trace_span!("poll_for_raw_event_with_sequence");
         let _guard = span.enter();
 
         let mut inner = self.inner.lock().unwrap();

--- a/x11rb/src/rust_connection/mod.rs
+++ b/x11rb/src/rust_connection/mod.rs
@@ -4,6 +4,7 @@ use std::convert::TryInto;
 use std::io::IoSlice;
 use std::mem::drop;
 use std::sync::{Condvar, Mutex, MutexGuard, TryLockError};
+use std::time::Instant;
 
 use crate::connection::{
     compute_length_field, Connection, ReplyOrError, RequestConnection, RequestKind,
@@ -119,10 +120,14 @@ impl RustConnection<DefaultStream> {
         // works.
         let mut error = None;
         for addr in parsed_display.connect_instruction() {
-            crate::trace!("Connecting to X11 server via {:?}", addr);
+            let start = Instant::now();
             match DefaultStream::connect(&addr) {
                 Ok(stream) => {
-                    crate::trace!("Connected to X11 server via {:?}", addr);
+                    crate::trace!(
+                        "Connected to X11 server via {:?} in {:?}",
+                        addr,
+                        start.elapsed()
+                    );
 
                     // we found a stream, get auth information
                     let (family, address) = stream.peer_addr()?;

--- a/x11rb/src/rust_connection/mod.rs
+++ b/x11rb/src/rust_connection/mod.rs
@@ -291,8 +291,7 @@ impl<S: Stream> RustConnection<S> {
         fds: Vec<RawFdContainer>,
         kind: ReplyFdKind,
     ) -> Result<SequenceNumber, ConnectionError> {
-        let span = crate::debug_span!("send_request");
-        let _guard = span.enter();
+        let _guard = crate::debug_span!("send_request").entered();
 
         {
             let major_opcode = bufs[0][0];
@@ -651,8 +650,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
     }
 
     fn wait_for_reply(&self, sequence: SequenceNumber) -> Result<Option<Vec<u8>>, ConnectionError> {
-        let span = crate::debug_span!("wait_for_reply", sequence);
-        let _enter = span.enter();
+        let _guard = crate::debug_span!("wait_for_reply", sequence).entered();
 
         let mut inner = self.inner.lock().unwrap();
         inner = self.flush_impl(inner)?;
@@ -672,8 +670,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
         &self,
         sequence: SequenceNumber,
     ) -> Result<Option<Buffer>, ConnectionError> {
-        let span = crate::debug_span!("check_for_raw_error", sequence);
-        let _enter = span.enter();
+        let _guard = crate::debug_span!("check_for_raw_error", sequence).entered();
 
         let mut inner = self.inner.lock().unwrap();
         if inner.inner.prepare_check_for_reply_or_error(sequence) {
@@ -699,8 +696,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
         &self,
         sequence: SequenceNumber,
     ) -> Result<ReplyOrError<BufWithFds, Buffer>, ConnectionError> {
-        let span = crate::debug_span!("wait_for_reply_with_fds_raw", sequence);
-        let _enter = span.enter();
+        let _guard = crate::debug_span!("wait_for_reply_with_fds_raw", sequence).entered();
 
         let mut inner = self.inner.lock().unwrap();
         // Ensure the request is sent
@@ -728,8 +724,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
         match max_bytes {
             Unknown => unreachable!("We just prefetched this"),
             Requested(seqno) => {
-                let span = crate::info_span!("maximum_request_bytes");
-                let _guard = span.enter();
+                let _guard = crate::info_span!("maximum_request_bytes").entered();
 
                 let length = seqno
                     // If prefetching the request succeeded, get a cookie
@@ -774,8 +769,7 @@ impl<S: Stream> Connection for RustConnection<S> {
     fn wait_for_raw_event_with_sequence(
         &self,
     ) -> Result<RawEventAndSeqNumber<Vec<u8>>, ConnectionError> {
-        let span = crate::trace_span!("wait_for_raw_event_with_sequence");
-        let _guard = span.enter();
+        let _guard = crate::trace_span!("wait_for_raw_event_with_sequence").entered();
 
         let mut inner = self.inner.lock().unwrap();
         loop {
@@ -789,8 +783,7 @@ impl<S: Stream> Connection for RustConnection<S> {
     fn poll_for_raw_event_with_sequence(
         &self,
     ) -> Result<Option<RawEventAndSeqNumber<Vec<u8>>>, ConnectionError> {
-        let span = crate::trace_span!("poll_for_raw_event_with_sequence");
-        let _guard = span.enter();
+        let _guard = crate::trace_span!("poll_for_raw_event_with_sequence").entered();
 
         let mut inner = self.inner.lock().unwrap();
         if let Some(event) = inner.inner.poll_for_event_with_sequence() {

--- a/x11rb/src/rust_connection/mod.rs
+++ b/x11rb/src/rust_connection/mod.rs
@@ -603,7 +603,11 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
     }
 
     fn discard_reply(&self, sequence: SequenceNumber, _kind: RequestKind, mode: DiscardMode) {
-        crate::debug!("Discarding reply to request {} in mode {:?}", sequence, mode);
+        crate::debug!(
+            "Discarding reply to request {} in mode {:?}",
+            sequence,
+            mode
+        );
         self.inner
             .lock()
             .unwrap()

--- a/x11rb/src/rust_connection/mod.rs
+++ b/x11rb/src/rust_connection/mod.rs
@@ -119,10 +119,10 @@ impl RustConnection<DefaultStream> {
         // works.
         let mut error = None;
         for addr in parsed_display.connect_instruction() {
-            crate::trace!("Connecting to X11 server via {addr:?}");
+            crate::trace!("Connecting to X11 server via {:?}", addr);
             match DefaultStream::connect(&addr) {
                 Ok(stream) => {
-                    crate::trace!("Connected to X11 server via {addr:?}");
+                    crate::trace!("Connected to X11 server via {:?}", addr);
 
                     // we found a stream, get auth information
                     let (family, address) = stream.peer_addr()?;
@@ -130,7 +130,7 @@ impl RustConnection<DefaultStream> {
                         // Ignore all errors while determining auth; instead we just try without auth info.
                         .unwrap_or(None)
                         .unwrap_or_else(|| (Vec::new(), Vec::new()));
-                    crate::trace!("Picked authentication via auth mechanism {auth_name:?}");
+                    crate::trace!("Picked authentication via auth mechanism {:?}", auth_name);
 
                     // finish connecting to server
                     return Ok((
@@ -141,7 +141,7 @@ impl RustConnection<DefaultStream> {
                     ));
                 }
                 Err(e) => {
-                    crate::debug!("Failed to connect to X11 server via {addr:?}: {e:?}");
+                    crate::debug!("Failed to connect to X11 server via {:?}: {:?}", addr, e);
                     error = Some(e);
                     continue;
                 }
@@ -229,7 +229,7 @@ impl<S: Stream> RustConnection<S> {
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
                 Err(e) => return Err(e.into()),
             };
-            crate::trace!("Read {adv} bytes");
+            crate::trace!("Read {} bytes", adv);
 
             // advance the internal buffer
             if connect.advance(adv) {
@@ -293,7 +293,7 @@ impl<S: Stream> RustConnection<S> {
             let major_opcode = bufs[0][0];
             let minor_opcode = bufs[0][1];
             if major_opcode < 128 {
-                crate::debug!("Sending xproto request {major_opcode}");
+                crate::debug!("Sending xproto request {}", major_opcode);
             } else {
                 use x11rb_protocol::x11_utils::ExtInfoProvider;
                 let ext_mgr = self.extension_manager.lock().unwrap();
@@ -603,7 +603,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
     }
 
     fn discard_reply(&self, sequence: SequenceNumber, _kind: RequestKind, mode: DiscardMode) {
-        crate::debug!("Discarding reply to request {sequence} in mode {mode:?}");
+        crate::debug!("Discarding reply to request {} in mode {:?}", sequence, mode);
         self.inner
             .lock()
             .unwrap()
@@ -738,7 +738,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
                     .unwrap_or(usize::max_value());
                 let length = length * 4;
                 *max_bytes = Known(length);
-                crate::info!("Maximum request length is {length} bytes");
+                crate::info!("Maximum request length is {} bytes", length);
                 length
             }
             Known(length) => *length,

--- a/x11rb/src/rust_connection/packet_reader.rs
+++ b/x11rb/src/rust_connection/packet_reader.rs
@@ -62,7 +62,7 @@ impl PacketReader {
                         ));
                     }
                     Ok(n) => {
-                        crate::trace!("Read {n} bytes directly into large packet");
+                        crate::trace!("Read {} bytes directly into large packet", n);
                         if let Some(packet) = self.inner.advance(n) {
                             out_packets.push(packet);
                         }
@@ -84,7 +84,7 @@ impl PacketReader {
                     Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => break,
                     Err(e) => return Err(e),
                 };
-                crate::trace!("Read {nread} bytes into read buffer");
+                crate::trace!("Read {} bytes into read buffer", nread);
 
                 // begin reading that data into packets
                 let mut src = &self.read_buffer[..nread];

--- a/x11rb/src/rust_connection/packet_reader.rs
+++ b/x11rb/src/rust_connection/packet_reader.rs
@@ -44,18 +44,25 @@ impl PacketReader {
         out_packets: &mut Vec<Vec<u8>>,
         fd_storage: &mut Vec<RawFdContainer>,
     ) -> Result<()> {
+        let original_length = out_packets.len();
         loop {
             // if the necessary packet size is larger than our buffer, just fill straight
             // into the buffer
             if self.inner.remaining_capacity() >= self.read_buffer.len() {
+                crate::trace!(
+                    "Trying to read large packet with {} bytes remaining",
+                    self.inner.remaining_capacity()
+                );
                 match stream.read(self.inner.buffer(), fd_storage) {
                     Ok(0) => {
+                        crate::error!("Large read returned zero");
                         return Err(Error::new(
                             ErrorKind::UnexpectedEof,
                             "The X11 server closed the connection",
                         ));
                     }
                     Ok(n) => {
+                        crate::trace!("Read {n} bytes directly into large packet");
                         if let Some(packet) = self.inner.advance(n) {
                             out_packets.push(packet);
                         }
@@ -67,6 +74,7 @@ impl PacketReader {
                 // read into our buffer
                 let nread = match stream.read(&mut self.read_buffer, fd_storage) {
                     Ok(0) => {
+                        crate::error!("Buffered read returned zero");
                         return Err(Error::new(
                             ErrorKind::UnexpectedEof,
                             "The X11 server closed the connection",
@@ -76,6 +84,7 @@ impl PacketReader {
                     Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => break,
                     Err(e) => return Err(e),
                 };
+                crate::trace!("Read {nread} bytes into read buffer");
 
                 // begin reading that data into packets
                 let mut src = &self.read_buffer[..nread];
@@ -96,6 +105,10 @@ impl PacketReader {
                 }
             }
         }
+        crate::trace!(
+            "Read {} complete packet(s)",
+            out_packets.len() - original_length
+        );
 
         Ok(())
     }

--- a/x11rb/src/rust_connection/stream.rs
+++ b/x11rb/src/rust_connection/stream.rs
@@ -191,11 +191,11 @@ enum DefaultStreamInner {
 
 impl DefaultStream {
     /// Try to connect to the X11 server described by the given arguments.
-    pub fn connect(addr: ConnectAddress<'_>) -> Result<Self> {
+    pub fn connect(addr: &ConnectAddress<'_>) -> Result<Self> {
         match addr {
             ConnectAddress::Hostname(host, port) => {
                 // connect over TCP
-                let stream = TcpStream::connect((host, port))?;
+                let stream = TcpStream::connect((*host, *port))?;
                 Self::from_tcp_stream(stream)
             }
             #[cfg(unix)]

--- a/x11rb/src/rust_connection/write_buffer.rs
+++ b/x11rb/src/rust_connection/write_buffer.rs
@@ -25,6 +25,11 @@ impl WriteBuffer {
 
     fn flush_buffer(&mut self, stream: &impl Stream) -> std::io::Result<()> {
         while self.needs_flush() {
+            crate::trace!(
+                "Trying to flush {} bytes of data and {} FDs",
+                self.data_buf.len(),
+                self.fd_buf.len()
+            );
             let (data_buf_1, data_buf_2) = self.data_buf.as_slices();
             let data_bufs = [IoSlice::new(data_buf_1), IoSlice::new(data_buf_2)];
             match stream.write_vectored(&data_bufs, &mut self.fd_buf) {
@@ -43,6 +48,7 @@ impl WriteBuffer {
                     }
                 }
                 Ok(n) => {
+                    crate::trace!("Flushing wrote {n} bytes of data");
                     let _ = self.data_buf.drain(..n);
                 }
                 Err(e) => return Err(e),
@@ -64,6 +70,11 @@ impl WriteBuffer {
         F: FnOnce(&mut VecDeque<u8>),
         G: FnOnce(&W, &mut Vec<RawFdContainer>) -> std::io::Result<usize>,
     {
+        crate::trace!(
+            "Writing {} FDs and {} bytes of data",
+            fds.len(),
+            to_write_length
+        );
         self.fd_buf.append(fds);
 
         // Is there enough buffer space left for this write?
@@ -77,12 +88,14 @@ impl WriteBuffer {
                         if available_buf == 0 {
                             // Buffer filled and cannot flush anything without
                             // blocking, so return `WouldBlock`.
+                            crate::trace!("Writing failed due to full buffer: {e:?}");
                             return Err(e);
                         } else {
                             let n_to_write = first_buffer.len().min(available_buf);
                             self.data_buf.extend(&first_buffer[..n_to_write]);
                             // Return `Ok` because some or all data has been buffered,
                             // so from the outside it is seen as a successful write.
+                            crate::trace!("Writing appended {n_to_write} bytes to the buffer");
                             return Ok(n_to_write);
                         }
                     } else {
@@ -98,9 +111,11 @@ impl WriteBuffer {
             // is copied into the buffer, since that would just mean that the large write gets
             // split into multiple smaller ones.
             assert!(self.data_buf.is_empty());
+            crate::trace!("Large write is written directly to the stream");
             write_inner(stream, &mut self.fd_buf)
         } else {
             // At this point there is enough space available in the buffer.
+            crate::trace!("Data to write is appended to the buffer");
             write_buffer(&mut self.data_buf);
             Ok(to_write_length)
         }

--- a/x11rb/src/rust_connection/write_buffer.rs
+++ b/x11rb/src/rust_connection/write_buffer.rs
@@ -48,7 +48,7 @@ impl WriteBuffer {
                     }
                 }
                 Ok(n) => {
-                    crate::trace!("Flushing wrote {n} bytes of data");
+                    crate::trace!("Flushing wrote {} bytes of data", n);
                     let _ = self.data_buf.drain(..n);
                 }
                 Err(e) => return Err(e),
@@ -88,14 +88,14 @@ impl WriteBuffer {
                         if available_buf == 0 {
                             // Buffer filled and cannot flush anything without
                             // blocking, so return `WouldBlock`.
-                            crate::trace!("Writing failed due to full buffer: {e:?}");
+                            crate::trace!("Writing failed due to full buffer: {:?}", e);
                             return Err(e);
                         } else {
                             let n_to_write = first_buffer.len().min(available_buf);
                             self.data_buf.extend(&first_buffer[..n_to_write]);
                             // Return `Ok` because some or all data has been buffered,
                             // so from the outside it is seen as a successful write.
-                            crate::trace!("Writing appended {n_to_write} bytes to the buffer");
+                            crate::trace!("Writing appended {} bytes to the buffer", n_to_write);
                             return Ok(n_to_write);
                         }
                     } else {

--- a/x11rb/src/tracing.rs
+++ b/x11rb/src/tracing.rs
@@ -43,9 +43,12 @@ pub(crate) mod implementation {
 #[cfg(not(feature = "tracing"))]
 pub(crate) mod implementation {
     macro_rules! event {
+        ( $lvl:expr, { $($fields:tt)+ }, $($arg:tt)+ ) => {
+            let _ = format_args!($($arg)+);
+        };
         ( $lvl:expr, $($arg:tt)+ ) => {
-            let _ = ($($arg)+);
-        }
+            let _ = format_args!($($arg)+);
+        };
     }
 
     pub(crate) struct Span;

--- a/x11rb/src/tracing.rs
+++ b/x11rb/src/tracing.rs
@@ -1,0 +1,121 @@
+//! Wrapper around tracing so that tracing can be an optional dependency.
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+pub(crate) enum Level {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+#[cfg(feature = "tracing")]
+pub(crate) mod implementation {
+    impl super::Level {
+        pub(crate) const fn to_tracing(self) -> tracing::Level {
+            match self {
+                Self::Error => tracing::Level::ERROR,
+                Self::Warn => tracing::Level::WARN,
+                Self::Info => tracing::Level::INFO,
+                Self::Debug => tracing::Level::DEBUG,
+                Self::Trace => tracing::Level::TRACE,
+            }
+        }
+    }
+
+    macro_rules! event {
+        ( $lvl:expr, $($arg:tt)+ ) => {
+            tracing::event!($crate::tracing::Level::to_tracing($lvl), $($arg)+)
+        }
+    }
+
+    macro_rules! span {
+        ( $lvl:expr, $name:expr, $($fields:tt)* ) => {
+            tracing::span!($crate::tracing::Level::to_tracing($lvl), $name, $($fields)*)
+        }
+    }
+
+    pub(crate) use event;
+    pub(crate) use span;
+}
+
+#[cfg(not(feature = "tracing"))]
+pub(crate) mod implementation {
+    macro_rules! event {
+        ( $lvl:expr, $($arg:tt)+ ) => {
+            let _ = ($($arg)+);
+        }
+    }
+
+    pub(crate) struct Span;
+    pub(crate) struct Entered<'a>(&'a Span);
+
+    impl Span {
+        pub(crate) fn enter(&self) -> Entered<'_> {
+            Entered(self)
+        }
+    }
+
+    macro_rules! span {
+        ( $lvl:expr, $name:expr, $($fields:tt)* ) => {
+            $crate::tracing::implementation::Span
+        };
+    }
+
+    pub(crate) use event;
+    pub(crate) use span;
+}
+
+macro_rules! error {
+    ( $($arg:tt)+ ) => { $crate::tracing::implementation::event!($crate::tracing::Level::Error, $($arg)+) };
+}
+macro_rules! warning {
+    ( $($arg:tt)+ ) => { $crate::tracing::implementation::event!($crate::tracing::Level::Warn, $($arg)+) };
+}
+macro_rules! info {
+    ( $($arg:tt)+ ) => { $crate::tracing::implementation::event!($crate::tracing::Level::Info, $($arg)+) };
+}
+macro_rules! debug {
+    ( $($arg:tt)+ ) => { $crate::tracing::implementation::event!($crate::tracing::Level::Debug, $($arg)+) };
+}
+macro_rules! trace {
+    ( $($arg:tt)+ ) => { $crate::tracing::implementation::event!($crate::tracing::Level::Trace, $($arg)+) };
+}
+
+pub(crate) use debug;
+pub(crate) use error;
+pub(crate) use info;
+pub(crate) use trace;
+pub(crate) use warning;
+
+#[allow(unused_macros)]
+macro_rules! error_span {
+    ( $name:expr ) => { $crate::tracing::implementation::span!($crate::tracing::Level::Error, $name, ) };
+    ( $name:expr, $($fields:tt)* ) => { $crate::tracing::implementation::span!($crate::tracing::Level::Error, $name, $($fields)*) };
+}
+#[allow(unused_macros)]
+macro_rules! warning_span {
+    ( $name:expr ) => { $crate::tracing::implementation::span!($crate::tracing::Level::Warn, $name, ) };
+    ( $name:expr, $($fields:tt)* ) => { $crate::tracing::implementation::span!($crate::tracing::Level::Warn, $name, $($fields)*) };
+}
+macro_rules! info_span {
+    ( $name:expr ) => { $crate::tracing::implementation::span!($crate::tracing::Level::Info, $name, ) };
+    ( $name:expr, $($fields:tt)* ) => { $crate::tracing::implementation::span!($crate::tracing::Level::Info, $name, $($fields)*) };
+}
+macro_rules! debug_span {
+    ( $name:expr ) => { $crate::tracing::implementation::span!($crate::tracing::Level::Debug, $name, ) };
+    ( $name:expr, $($fields:tt)* ) => { $crate::tracing::implementation::span!($crate::tracing::Level::Debug, $name, $($fields)*) };
+}
+macro_rules! trace_span {
+    ( $name:expr ) => { $crate::tracing::implementation::span!($crate::tracing::Level::Trace, $name, ) };
+    ( $name:expr, $($fields:tt)* ) => { $crate::tracing::implementation::span!($crate::tracing::Level::Trace, $name, $($fields)*) };
+}
+
+pub(crate) use debug_span;
+#[allow(unused_imports)]
+pub(crate) use error_span;
+pub(crate) use info_span;
+pub(crate) use trace_span;
+#[allow(unused_imports)]
+pub(crate) use warning_span;

--- a/x11rb/src/tracing.rs
+++ b/x11rb/src/tracing.rs
@@ -52,11 +52,11 @@ pub(crate) mod implementation {
     }
 
     pub(crate) struct Span;
-    pub(crate) struct Entered<'a>(&'a Span);
+    pub(crate) struct EnteredSpan;
 
     impl Span {
-        pub(crate) fn enter(&self) -> Entered<'_> {
-            Entered(self)
+        pub(crate) fn entered(&self) -> EnteredSpan {
+            EnteredSpan
         }
     }
 


### PR DESCRIPTION
This commit adds optional support for the tracing crate to x11rb and updates the `simple_window` example to use this.

Example output on level `trace` (this is the `cursor` support initialising its information about the RENDER extension):

![foo](https://user-images.githubusercontent.com/89482/233675504-33145fc6-4494-4f75-871e-8df353cc56c9.png)

The same thing on `debug` is slightly less noisy:

![foo2](https://user-images.githubusercontent.com/89482/233675780-8f2dee28-dedc-4597-b30e-75558ba6f00d.png)
