### PR TITLE
x11rb-async: Use "tracing"

### DIFF
--- a/x11rb-async/Cargo.toml
+++ b/x11rb-async/Cargo.toml
@@ -18,6 +18,7 @@ async-lock = "2.7.0"
 blocking = "1.3.0"
 event-listener = "2.5.3"
 futures-lite = "1"
+tracing = { version = "0.1", default-features = false }
 x11rb = { version = "0.11.1", path = "../x11rb", default-features = false }
 x11rb-protocol = { version = "0.11.1", path = "../x11rb-protocol" }
 
@@ -94,3 +95,4 @@ allow-unsafe-code = ["x11rb/allow-unsafe-code"]
 async-executor = "1.5.0"
 async-io = "1.12.0"
 bytemuck = "1.12.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
This commit makes x11rb-async use the tracing crate. The tracing that is done is modelled after what is done in x11rb, but this time it is not optional, but a required dependency.