### PR TITLE
Remove unused dev-dependencies from x11rb-async

### DIFF
--- a/x11rb-async/Cargo.toml
+++ b/x11rb-async/Cargo.toml
@@ -92,5 +92,3 @@ allow-unsafe-code = ["x11rb/allow-unsafe-code"]
 
 [dev-dependencies]
 async-executor = "1.5.0"
-async-io = "1.12.0"
-bytemuck = "1.12.3"


### PR DESCRIPTION
async-io is actually used, but is already a dependency, so no need to also use it as a dev-dependency.

bytemock is genuinely unused.