### PR TITLE
Properly add x11rb-async to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,8 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
-    - name: Clear src/protocol directories in x11rb and x11rb-protocol
-      run: rm -rf x11rb/src/protocol/ x11rb-protocol/src/protocol/
+    - name: Clear src/protocol directories in x11rb, x11rb-async and x11rb-protocol
+      run: rm -rf x11rb/src/protocol/ x11rb-async/src/protocol/ x11rb-protocol/src/protocol/
     - name: Run code generator
       run: make
     - name: Check for changes
@@ -183,8 +183,10 @@ jobs:
       run: rustup target add "$CROSS_TARGET"
     - name: Install cross
       uses: taiki-e/install-action@cross
-    - name: cargo test
+    - name: cargo test on x11rb
       run: cross test --target "$CROSS_TARGET" --verbose --package x11rb --features "$MOST_FEATURES"
+    - name: cargo test on x11rb-async
+      run: cross test --target "$CROSS_TARGET" --verbose --package x11rb-async --features "all-extensions"
 
   # future-proof against issue #721
   non-linux-unix-test:


### PR DESCRIPTION
- The code gen tests would not have complained if x11rb-async/src/protocol generated a file that is not re-generated by the code generator
- x11rb-async was not tested on our MSRV
- Only x11rb's tests were ran on big-endian, not all tests

-----

This was noticed in https://github.com/psychon/x11rb/pull/818 and it turns out that x11rb-async doesn't compile with our MSRV anyway:

```
error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
  --> x11rb-async/src/rust_connection/extensions.rs:57:10
   |
57 |     ) -> Result<Option<ExtensionInformation>, ConnectionError> {
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: hidden type `impl Future` captures lifetime smaller than the function body
  --> x11rb-async/src/rust_connection/extensions.rs:57:10
   |
57 |     ) -> Result<Option<ExtensionInformation>, ConnectionError> {
   |          ^^^
```

Dunno what to do about this.