### PR TITLE
Fix the MSRV build for x11rb-async

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,6 +167,8 @@ jobs:
       run: cargo build --package x11rb-protocol --verbose --lib --all-features
     - name: cargo check x11rb with all features
       run: cargo build --package x11rb --verbose --lib --all-features
+    - name: cargo check x11rb-async with all features
+      run: cargo build --package x11rb-async --verbose --lib --all-features
 
     # build no_std
     - name: cargo check protocol without default features

--- a/x11rb-async/src/rust_connection/extensions.rs
+++ b/x11rb-async/src/rust_connection/extensions.rs
@@ -3,6 +3,7 @@
 use crate::connection::Connection;
 use crate::Cookie;
 use std::collections::hash_map::{Entry, HashMap};
+use std::future::Future;
 use x11rb::errors::{ConnectionError, ReplyError};
 use x11rb_protocol::protocol::xproto::QueryExtensionReply;
 use x11rb_protocol::x11_utils::{ExtInfoProvider, ExtensionInformation};
@@ -30,82 +31,99 @@ impl Extensions {
     }
 
     /// Prefetch information for a given extension, if this was not yet done.
-    pub(super) async fn prefetch<C: Connection>(
-        &mut self,
-        conn: &C,
+    // n.b. notgull: Apparently the resolver for 1.56 is too weak to figure out the lifetimes
+    // here on its own. Manually specifying them like this seems to solve the issue.
+    pub(super) fn prefetch<'f, 't, 'c, C: Connection>(
+        &'t mut self,
+        conn: &'c C,
         name: &'static str,
-    ) -> Result<(), ConnectionError> {
-        // Check if there is already a cache entry.
-        if let Entry::Vacant(entry) = self.0.entry(name) {
-            tracing::debug!("Prefetching information about '{}' extension", name);
+    ) -> impl Future<Output = Result<(), ConnectionError>> + 'f
+    where
+        'c: 'f,
+        't: 'f,
+    {
+        async move {
+            // Check if there is already a cache entry.
+            if let Entry::Vacant(entry) = self.0.entry(name) {
+                tracing::debug!("Prefetching information about '{}' extension", name);
 
-            // Send a QueryExtension request.
-            let cookie = crate::protocol::xproto::query_extension(conn, name.as_bytes()).await?;
+                // Send a QueryExtension request.
+                let cookie =
+                    crate::protocol::xproto::query_extension(conn, name.as_bytes()).await?;
 
-            // Add the extension to the cache.
-            entry.insert(ExtensionState::Loading(cookie.sequence_number()));
+                // Add the extension to the cache.
+                entry.insert(ExtensionState::Loading(cookie.sequence_number()));
 
-            std::mem::forget(cookie);
+                std::mem::forget(cookie);
+            }
+
+            Ok(())
         }
-
-        Ok(())
     }
 
     /// Get information about an X11 extension.
-    pub(super) async fn information<C: Connection>(
-        &mut self,
-        conn: &C,
+    // n.b. notgull: Apparently the resolver for 1.56 is too weak to figure out the lifetimes
+    // here on its own. Manually specifying them like this seems to solve the issue.
+    pub(super) fn information<'f, 't, 'c, C: Connection>(
+        &'t mut self,
+        conn: &'c C,
         name: &'static str,
-    ) -> Result<Option<ExtensionInformation>, ConnectionError> {
-        // Prefetch the implementation in case this was not yet done
-        self.prefetch(conn, name).await?;
+    ) -> impl Future<Output = Result<Option<ExtensionInformation>, ConnectionError>> + 'f
+    where
+        'c: 'f,
+        't: 'f,
+    {
+        async move {
+            // Prefetch the implementation in case this was not yet done
+            self.prefetch(conn, name).await?;
 
-        // Get the entry from the cache
-        let mut entry = match self.0.entry(name) {
-            Entry::Occupied(o) => o,
-            _ => unreachable!("We just prefetched this."),
-        };
+            // Get the entry from the cache
+            let mut entry = match self.0.entry(name) {
+                Entry::Occupied(o) => o,
+                _ => unreachable!("We just prefetched this."),
+            };
 
-        // Complete the request if we need to.
-        match entry.get() {
-            ExtensionState::Loaded(info) => Ok(*info),
+            // Complete the request if we need to.
+            match entry.get() {
+                ExtensionState::Loaded(info) => Ok(*info),
 
-            ExtensionState::Loading(cookie) => {
-                tracing::debug!("Waiting for QueryInfo reply for '{}' extension", name);
+                ExtensionState::Loading(cookie) => {
+                    tracing::debug!("Waiting for QueryInfo reply for '{}' extension", name);
 
-                // Load the extension information.
-                let cookie = Cookie::<'_, _, QueryExtensionReply>::new(conn, *cookie);
+                    // Load the extension information.
+                    let cookie = Cookie::<'_, _, QueryExtensionReply>::new(conn, *cookie);
 
-                // Get the reply.
-                let reply = cookie.reply().await.map_err(|e| {
-                    tracing::warn!(
-                        "Got error {:?} for QueryInfo reply for '{}' extension",
-                        e,
-                        name
-                    );
-                    match e {
-                        ReplyError::ConnectionError(e) => e,
-                        ReplyError::X11Error(_) => ConnectionError::UnknownError,
-                    }
-                })?;
+                    // Get the reply.
+                    let reply = cookie.reply().await.map_err(|e| {
+                        tracing::warn!(
+                            "Got error {:?} for QueryInfo reply for '{}' extension",
+                            e,
+                            name
+                        );
+                        match e {
+                            ReplyError::ConnectionError(e) => e,
+                            ReplyError::X11Error(_) => ConnectionError::UnknownError,
+                        }
+                    })?;
 
-                let ext_info = if reply.present {
-                    let info = ExtensionInformation {
-                        major_opcode: reply.major_opcode,
-                        first_event: reply.first_event,
-                        first_error: reply.first_error,
+                    let ext_info = if reply.present {
+                        let info = ExtensionInformation {
+                            major_opcode: reply.major_opcode,
+                            first_event: reply.first_event,
+                            first_error: reply.first_error,
+                        };
+                        tracing::debug!("Extension '{}' is present: {:?}", name, info);
+                        Some(info)
+                    } else {
+                        tracing::debug!("Extension '{}' is not present", name);
+                        None
                     };
-                    tracing::debug!("Extension '{}' is present: {:?}", name, info);
-                    Some(info)
-                } else {
-                    tracing::debug!("Extension '{}' is not present", name);
-                    None
-                };
 
-                // Update the cache.
-                *entry.get_mut() = ExtensionState::Loaded(ext_info);
+                    // Update the cache.
+                    *entry.get_mut() = ExtensionState::Loaded(ext_info);
 
-                Ok(ext_info)
+                    Ok(ext_info)
+                }
             }
         }
     }


### PR DESCRIPTION
Apparently the lifetime resolver in 1.56 is too weak to figure out the lifetimes of the async function on its own. Oh well, it's easy enough to specify them manually. Closes #823.