### PR TITLE
Enable x11rb-async features on docs.rs

### DIFF
--- a/x11rb-async/Cargo.toml
+++ b/x11rb-async/Cargo.toml
@@ -91,6 +91,12 @@ xvmc = ["x11rb-protocol/xvmc", "xv"]
 
 allow-unsafe-code = ["x11rb/allow-unsafe-code"]
 
+[package.metadata.docs.rs]
+features = [
+    "all-extensions",
+    "allow-unsafe-code",
+]
+
 [dev-dependencies]
 async-executor = "1.5.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
I came across commit d379c2b39c7a which does the very same thing for x11rb-protocol: Enable more features when building on docs.rs so that the documentation is more useful.