### PR TITLE
Improve request tracing printing

### DIFF
--- a/x11rb-async/src/rust_connection/mod.rs
+++ b/x11rb-async/src/rust_connection/mod.rs
@@ -16,7 +16,7 @@ use crate::{Cookie, CookieWithFds, VoidCookie};
 use x11rb_protocol::connection::{Connection as ProtoConnection, PollReply, ReplyFdKind};
 use x11rb_protocol::id_allocator::IdAllocator;
 use x11rb_protocol::protocol::bigreq::EnableReply;
-use x11rb_protocol::protocol::xproto::Setup;
+use x11rb_protocol::protocol::xproto::{Setup, QUERY_EXTENSION_REQUEST};
 use x11rb_protocol::x11_utils::{ExtensionInformation, TryParse, TryParseFd, X11Error};
 use x11rb_protocol::xauth::get_auth;
 use x11rb_protocol::{DiscardMode, RawFdContainer, SequenceNumber};
@@ -265,7 +265,7 @@ impl<S: Stream + Send + Sync> RustConnection<S> {
                     // QueryExtension is used by the extension manager. We would deadlock if we
                     // tried to lock it again. Hence, this case is hardcoded here.
                     let major_opcode = bufs[0][0];
-                    if major_opcode == 98 {
+                    if major_opcode == QUERY_EXTENSION_REQUEST {
                         tracing::event!(LEVEL, "Sending QueryExtension request");
                     } else {
                         let extensions = self.extensions.read().await;


### PR DESCRIPTION
To avoid a deadlock, the QueryExtension requests sent by the extension manager need to be handled specially in the tracing code. This commit cleans that up a bit.

In x11rb-async, the magic number 98 is replaced with the corresponding constant from x11rb-protocol.

x11rb previously used try_lock() and just guessed that the only reason why this could fail is a QueryExtension request. That's a bit ugly and weird. This commit instead switches the code to the same approach as used in x11rb-async: Hardcode QueryExtension as a special case and use lock() for everything else.