### PR TITLE
Add a fallback for AtomicU64 for 32 bit platforms

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -174,10 +174,15 @@ jobs:
     - name: cargo check protocol without default features
       run: cargo build --manifest-path x11rb-protocol/Cargo.toml --no-default-features --features=all-extensions
 
-  big-endian-test:
+  non-amd64-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - cross_target: mips64-unknown-linux-gnuabi64
+          - cross_target: powerpc-unknown-linux-gnu
     env:
-      CROSS_TARGET: mips64-unknown-linux-gnuabi64
+      CROSS_TARGET: ${{ matrix.cross_target }}
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
@@ -187,6 +192,8 @@ jobs:
       uses: taiki-e/install-action@cross
     - name: cargo test on x11rb
       run: cross test --target "$CROSS_TARGET" --verbose --package x11rb --features "$MOST_FEATURES"
+    - name: cargo test on x11rb with extra features
+      run: cross test --target "$CROSS_TARGET" --verbose --package x11rb --features "$MOST_FEATURES dl-libxcb"
     - name: cargo test on x11rb-async
       run: cross test --target "$CROSS_TARGET" --verbose --package x11rb-async --features "all-extensions"
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,8 @@ pull_request_rules:
       - label!=no-mergify
       - "#approved-reviews-by>=1"
       - status-success=continuous-integration/appveyor/pr
-      - status-success=big-endian-test
+      - status-success=non-amd64-test (powerpc-unknown-linux-gnu)
+      - status-success=non-amd64-test (mips64-unknown-linux-gnuabi64)
       - status-success=msrv-check
       - status-success=build (stable)
       - status-success=clippy-rustfmt

--- a/x11rb/build.rs
+++ b/x11rb/build.rs
@@ -1,0 +1,55 @@
+// The build constants emitted by this script are NOT public API.
+
+fn main() {
+    // Get the current Rust version.
+    let rust_version = Version::get();
+
+    // If we in a version prior to Rust 1.61, we can't use the "target_has_atomic" feature.
+    //
+    // This feature was stabilized in Rust 1.60, but some nightlies will claim to be 1.60
+    // but not have the feature. Rust 1.61 lets us safely target nightlies without this feature.
+    //
+    // We use a negative implementation of the cfg guard, rather than emitting, say, a
+    // "x11rb_has_target_has_atomic" cfg guard. This is because some non-Cargo build systems
+    // will not run the build script. In this case, it is best to assume that we are targeting
+    // the latest stable version of Rust, where this feature is available. In this case, the absence
+    // of this cfg guard will indicate the available feature.
+    //
+    // TODO(notgull): Once the MSRV is raised to 1.60 or higher, this entire build script can be deleted.
+    if rust_version.major < 1 || (rust_version.major == 1 && rust_version.minor < 61) {
+        println!("cargo:rustc-cfg=x11rb_no_target_has_atomic");
+    }
+}
+
+struct Version {
+    major: usize,
+    minor: usize,
+}
+
+impl Version {
+    fn get() -> Self {
+        let rustc = std::env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+        let output = std::process::Command::new(rustc)
+            .args(["--version", "--verbose"])
+            .output()
+            .expect("failed to execute rustc");
+
+        let stdout = std::str::from_utf8(&output.stdout).expect("rustc stdout is not utf8");
+
+        // Find the line with the "release" tag
+        let release = stdout
+            .lines()
+            .find_map(|line| line.strip_prefix("release: "))
+            .expect("rustc output does not contain release tag");
+
+        // Strip off the extra channel info.
+        let release = release.split('-').next().unwrap();
+
+        // Split into semver components.
+        let mut release = release.splitn(3, '.');
+        let major = release.next().unwrap().parse().unwrap();
+        let minor = release.next().unwrap().parse().unwrap();
+
+        Version { major, minor }
+    }
+}

--- a/x11rb/src/xcb_ffi/atomic_u64.rs
+++ b/x11rb/src/xcb_ffi/atomic_u64.rs
@@ -1,0 +1,35 @@
+//! Either `AtomicU64` or emulating `AtomicU64` through a `Mutex`.
+
+// Use the `AtomicU64` from the standard library if we're on a platform that supports atomic
+// 64-bit operations. If we can't tell, just fall back to the `Mutex` implementation anyways.
+#[cfg(all(not(x11rb_no_target_has_atomic), target_has_atomic = "64"))]
+pub(crate) use std::sync::atomic::AtomicU64;
+
+#[cfg(any(x11rb_no_target_has_atomic, not(target_has_atomic = "64")))]
+mod impl_ {
+    use std::sync::atomic::Ordering;
+    use std::sync::Mutex;
+
+    #[derive(Debug)]
+    pub(crate) struct AtomicU64(Mutex<u64>);
+
+    impl AtomicU64 {
+        pub(crate) fn new(val: u64) -> Self {
+            Self(Mutex::new(val))
+        }
+
+        pub(crate) fn load(&self, _: Ordering) -> u64 {
+            *self.0.lock().unwrap()
+        }
+
+        pub(crate) fn fetch_max(&self, val: u64, _: Ordering) -> u64 {
+            let mut lock = self.0.lock().unwrap();
+            let old = *lock;
+            *lock = old.max(val);
+            old
+        }
+    }
+}
+
+#[cfg(any(x11rb_no_target_has_atomic, not(target_has_atomic = "64")))]
+pub(crate) use self::impl_::AtomicU64;

--- a/x11rb/src/xcb_ffi/mod.rs
+++ b/x11rb/src/xcb_ffi/mod.rs
@@ -9,10 +9,7 @@ use std::os::raw::c_int;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::ptr::{null, null_mut};
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Mutex,
-};
+use std::sync::{atomic::Ordering, Mutex};
 
 use libc::c_void;
 
@@ -28,9 +25,11 @@ use crate::x11_utils::{ExtensionInformation, TryParse, TryParseFd};
 
 use x11rb_protocol::{DiscardMode, SequenceNumber};
 
+mod atomic_u64;
 mod pending_errors;
 mod raw_ffi;
 
+use atomic_u64::AtomicU64;
 #[cfg(all(not(test), feature = "dl-libxcb"))]
 pub use raw_ffi::libxcb_library::load_libxcb;
 


### PR DESCRIPTION
This PR adds a fallback `AtomicU64` that is activated on 32 bit platforms. There is a slight performance degradation due to the Mutex, but I'm not sure that there's a way around that. Closes #834.