### PR TITLE
Improve Image::get()

### DIFF
--- a/x11rb/src/image.rs
+++ b/x11rb/src/image.rs
@@ -706,7 +706,7 @@ impl<'a> Image<'a> {
             format.scanline_pad.try_into()?,
             reply.depth,
             format.bits_per_pixel.try_into()?,
-            ImageOrder::MsbFirst,
+            setup.image_byte_order.try_into()?,
             Cow::Owned(reply.data),
         )
     }


### PR DESCRIPTION
This fixes the byte order issue mentioned in #836 and additionally changes the API so that the visual ID is also returned (in addition to the image).