### PR TITLE
Bump `libloading` to v0.8

### DIFF
--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 [dependencies]
 x11rb-protocol = { version = "0.12.0", path = "../x11rb-protocol" }
 libc = { version = "0.2", optional = true }
-libloading = { version = "0.7.0", optional = true }
+libloading = { version = "0.8.0", optional = true }
 once_cell = { version = "1.16", optional = true }
 gethostname = "0.3.0"
 as-raw-xcb-connection = { version = "1.0", optional = true }


### PR DESCRIPTION
No breaking changes for `x11rb`: https://docs.rs/libloading/0.8.0/libloading/changelog/r0_8_0/index.html.