### PR TITLE
Update our dependencies were possible

### DIFF
--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-roxmltree = "0.16.0"
+roxmltree = "0.18.0"
 xcbgen = { path = "../xcbgen-rs" }

--- a/x11rb-async/Cargo.toml
+++ b/x11rb-async/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["xcb", "x11", "async"]
 
 [dependencies]
-async-io = "1.12.0"
+async-io = "1.13.0"
 async-lock = "2.7.0"
 blocking = "1.3.0"
 event-listener = "2.5.3"

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -24,7 +24,7 @@ exclude = [
 x11rb-protocol = { version = "0.12.0", path = "../x11rb-protocol" }
 libc = { version = "0.2", optional = true }
 libloading = { version = "0.8.0", optional = true }
-once_cell = { version = "1.16", optional = true }
+once_cell = { version = "1.17", optional = true }
 gethostname = "0.3.0"
 as-raw-xcb-connection = { version = "1.0", optional = true }
 tracing = { version = "0.1", optional = true, default-features = false }
@@ -42,7 +42,7 @@ version = "0.3"
 features = ["winsock2"]
 
 [dev-dependencies]
-polling = "2.7.0"
+polling = "2.8.0"
 tracing-subscriber = "0.3"
 
 [features]

--- a/xcbgen-rs/Cargo.toml
+++ b/xcbgen-rs/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-once_cell = "1.16.0"
-roxmltree = "0.16.0"
+once_cell = "1.17.0"
+roxmltree = "0.18.0"


### PR DESCRIPTION
criterion 0.5, cairo-rs 0.17, and gethostname 0.4 are not compatible with our MSRV.
