### PR TITLE
Pin log 0.4.18 in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -167,6 +167,8 @@ jobs:
       run: cargo build --package x11rb-protocol --verbose --lib --all-features
     - name: cargo check x11rb with all features
       run: cargo build --package x11rb --verbose --lib --all-features
+    - name: Pin last log release supporting our msrv of Rust 1.56
+      run: cargo update --package log --precise 0.4.18
     - name: cargo check x11rb-async with all features
       run: cargo build --package x11rb-async --verbose --lib --all-features
 


### PR DESCRIPTION
log 0.4.19 increased its MSRV to Rust 1.60, which is higher than our MSRV of 1.56. Thus, pin log 0.4.18 in our msrv-check CI build.

Fixes: https://github.com/psychon/x11rb/issues/850