### PR TITLE
Some small cleanups

### DIFF
--- a/x11rb-async/src/rust_connection/stream.rs
+++ b/x11rb-async/src/rust_connection/stream.rs
@@ -145,10 +145,6 @@ impl<S: X11rbStream> X11rbStream for StreamAdaptor<S> {
         self.get_ref().write(buf, fds)
     }
 
-    fn read_exact(&self, buf: &mut [u8], fd_storage: &mut Vec<RawFdContainer>) -> io::Result<()> {
-        self.get_ref().read_exact(buf, fd_storage)
-    }
-
     fn write_vectored(
         &self,
         bufs: &[io::IoSlice<'_>],

--- a/x11rb/examples/xeyes.rs
+++ b/x11rb/examples/xeyes.rs
@@ -35,7 +35,7 @@ fn draw_eyes<C: Connection>(
     conn.poly_fill_arc(win_id, black, &[arc1, arc2])?;
 
     // Draw the white inner part
-    for mut arc in [&mut arc1, &mut arc2].iter_mut() {
+    for arc in [&mut arc1, &mut arc2].iter_mut() {
         arc.x += EYE_SIZE;
         arc.y += EYE_SIZE;
         arc.width -= 2 * EYE_SIZE as u16;


### PR DESCRIPTION
Remove unused read_exact() method in Stream trait

Since commit c4511939f59 this function is unused. In that commit,
read_setup() was removed from x11rb and the implementation (a loop
containing poll() and read()) was instead open-coded in
RustConnection::connect_to_stream_with_auth_info().

--------

Remove unnecessary "mut" in example

The unused_mut lint triggered:

    warning: variable does not need to be mutable
      --> x11rb/examples/xeyes.rs:38:9
       |
    38 |     for mut arc in [&mut arc1, &mut arc2].iter_mut() {
       |         ----^^^
       |         |
       |         help: remove this `mut`
       |
       = note: `#[warn(unused_mut)]` on by default
