### PR TITLE
added method to obtain flag's internal value

### DIFF
--- a/x11rb-protocol/src/x11_utils.rs
+++ b/x11rb-protocol/src/x11_utils.rs
@@ -679,6 +679,11 @@ macro_rules! bitmask_binop {
                 let flag = flag.into();
                 (<$u>::from(self) & flag) != 0
             }
+
+            /// Returns the internal value of the object.
+            pub fn bits(self) -> $u {
+                self.0
+            }
         }
     };
 }


### PR DESCRIPTION
This adds additional functionality similar to bitflags where a consumer of the library can retrieve the raw internal value of the flag object. This is useful when creating our own internal representations of X bitmasks, as we can directly construct a bitmask from the raw value.