### PR TITLE
Reduce some info-level logs to debug-level

### DIFF
--- a/x11rb-async/src/rust_connection/mod.rs
+++ b/x11rb-async/src/rust_connection/mod.rs
@@ -367,7 +367,7 @@ impl<S: Stream + Send + Sync> RustConnection<S> {
 
         // Start prefetching if necessary.
         if *mrl == MaxRequestBytes::Unknown {
-            tracing::info!("Prefetching maximum request length");
+            tracing::debug!("Prefetching maximum request length");
             let cookie = crate::protocol::bigreq::enable(self)
                 .await
                 .map(|cookie| {
@@ -645,7 +645,7 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
                             .unwrap_or(std::usize::MAX);
 
                         *mrl = MaxRequestBytes::Known(total);
-                        tracing::info!("Maximum request length is {} bytes", total);
+                        tracing::debug!("Maximum request length is {} bytes", total);
                         total
                     }
                 }
@@ -717,7 +717,7 @@ impl<S: Stream + Send + Sync> Connection for RustConnection<S> {
                     .await?
                     .is_some()
                 {
-                    tracing::info!("XIDs are exhausted; fetching free range via XC-MISC");
+                    tracing::debug!("XIDs are exhausted; fetching free range via XC-MISC");
 
                     // Update the ID range.
                     id_allocator

--- a/x11rb-async/src/rust_connection/mod.rs
+++ b/x11rb-async/src/rust_connection/mod.rs
@@ -717,7 +717,7 @@ impl<S: Stream + Send + Sync> Connection for RustConnection<S> {
                     .await?
                     .is_some()
                 {
-                    tracing::debug!("XIDs are exhausted; fetching free range via XC-MISC");
+                    tracing::info!("XIDs are exhausted; fetching free range via XC-MISC");
 
                     // Update the ID range.
                     id_allocator


### PR DESCRIPTION
Seeing this in my application log for example:
```
2023-07-16T02:36:03.197682Z  INFO maximum_request_bytes: x11rb_async::rust_connection: Prefetching maximum request length
2023-07-16T02:36:03.197866Z  INFO maximum_request_bytes: x11rb_async::rust_connection: Maximum request length is 16777212 bytes
```