### PR TITLE
Simplify call to Path::exists()

### DIFF
--- a/x11rb-protocol/src/parse_display/mod.rs
+++ b/x11rb-protocol/src/parse_display/mod.rs
@@ -43,8 +43,7 @@ impl ParsedDisplay {
 #[cfg(feature = "std")]
 pub fn parse_display(dpy_name: Option<&str>) -> Option<ParsedDisplay> {
     fn file_exists(path: &str) -> bool {
-        let path: &std::path::Path = path.as_ref();
-        path.exists()
+        std::path::Path::new(path).exists()
     }
 
     parse_display_with_file_exists_callback(dpy_name, file_exists)


### PR DESCRIPTION
Somehow I missed that Path::new() exists when looking at the docs and instead went with the way more complicated AsRef route. Simplify this code by using Path::new() instead.

Thanks a lot to @eduardosm for the suggestion.