### PR TITLE
Improve error messages for $DISPLAY parsing failures

### DIFF
--- a/x11rb-async/src/rust_connection/mod.rs
+++ b/x11rb-async/src/rust_connection/mod.rs
@@ -87,8 +87,7 @@ impl RustConnection {
         ConnectError,
     > {
         // Parse the display name.
-        let addrs = x11rb_protocol::parse_display::parse_display(display_name)
-            .ok_or(ConnectError::DisplayParsingError)?;
+        let addrs = x11rb_protocol::parse_display::parse_display(display_name)?;
 
         // Connect to the stream.
         let (stream, screen) = nb_connect::connect(&addrs).await?;

--- a/x11rb-protocol/src/errors.rs
+++ b/x11rb-protocol/src/errors.rs
@@ -84,7 +84,7 @@ pub enum DisplayParsingError {
     DisplayNotSet,
 
     /// The given value could not be parsed. The input to parsing is provided.
-    MalformedValue(alloc::string::String),
+    MalformedValue(alloc::boxed::Box<str>),
 
     /// The value of `$DISPLAY` is not valid unicode
     NotUnicode,

--- a/x11rb-protocol/src/parse_display/mod.rs
+++ b/x11rb-protocol/src/parse_display/mod.rs
@@ -76,7 +76,7 @@ fn parse_display_impl(
     dpy_name: &str,
     file_exists: impl Fn(&str) -> bool,
 ) -> Result<ParsedDisplay, DisplayParsingError> {
-    let malformed = || DisplayParsingError::MalformedValue(dpy_name.to_string());
+    let malformed = || DisplayParsingError::MalformedValue(dpy_name.to_string().into());
     let map_malformed = |_| malformed();
 
     if dpy_name.starts_with('/') {
@@ -140,13 +140,15 @@ fn parse_display_direct_path(
                 host: path.to_string(),
                 protocol: Some("unix".to_string()),
                 display: 0,
-                screen: screen
-                    .parse()
-                    .map_err(|_| DisplayParsingError::MalformedValue(dpy_name.to_string()))?,
+                screen: screen.parse().map_err(|_| {
+                    DisplayParsingError::MalformedValue(dpy_name.to_string().into())
+                })?,
             });
         }
     }
-    Err(DisplayParsingError::MalformedValue(dpy_name.to_string()))
+    Err(DisplayParsingError::MalformedValue(
+        dpy_name.to_string().into(),
+    ))
 }
 
 #[cfg(test)]
@@ -230,7 +232,7 @@ mod test {
         assert_eq!(
             do_parse_display(non_existing_file),
             Err(DisplayParsingError::MalformedValue(
-                non_existing_file.to_string()
+                non_existing_file.to_string().into()
             )),
             "Unexpectedly parsed: {}",
             non_existing_file
@@ -568,7 +570,9 @@ mod test {
         ] {
             assert_eq!(
                 do_parse_display(input),
-                Err(DisplayParsingError::MalformedValue(input.to_string())),
+                Err(DisplayParsingError::MalformedValue(
+                    input.to_string().into()
+                )),
                 "Unexpectedly parsed: {}",
                 input
             );

--- a/x11rb/examples/integration_test_util/connect.rs
+++ b/x11rb/examples/integration_test_util/connect.rs
@@ -13,7 +13,7 @@ pub fn connect(
         let dpy_name = dpy_name
             .map(std::ffi::CString::new)
             .transpose()
-            .map_err(|_| x11rb::errors::ConnectError::DisplayParsingError)?;
+            .map_err(|_| x11rb::errors::DisplayParsingError::Unknown)?;
         let dpy_name = dpy_name.as_deref();
         x11rb::xcb_ffi::XCBConnection::connect(dpy_name)
     }

--- a/x11rb/src/errors.rs
+++ b/x11rb/src/errors.rs
@@ -2,7 +2,7 @@
 
 use crate::x11_utils::X11Error;
 
-pub use x11rb_protocol::errors::{ConnectError, IdsExhausted, ParseError};
+pub use x11rb_protocol::errors::{ConnectError, DisplayParsingError, IdsExhausted, ParseError};
 
 /// An error occurred  while dynamically loading libxcb.
 #[cfg(feature = "dl-libxcb")]

--- a/x11rb/src/rust_connection/mod.rs
+++ b/x11rb/src/rust_connection/mod.rs
@@ -10,6 +10,7 @@ use crate::connection::{
     compute_length_field, Connection, ReplyOrError, RequestConnection, RequestKind,
 };
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
+use crate::errors::DisplayParsingError;
 pub use crate::errors::{ConnectError, ConnectionError, ParseError, ReplyError, ReplyOrIdError};
 use crate::extension_manager::ExtensionManager;
 use crate::protocol::bigreq::{ConnectionExt as _, EnableReply};
@@ -112,8 +113,7 @@ impl RustConnection<DefaultStream> {
     /// If no `dpy_name` is provided, the value from `$DISPLAY` is used.
     pub fn connect(dpy_name: Option<&str>) -> Result<(Self, usize), ConnectError> {
         // Parse display information
-        let parsed_display = x11rb_protocol::parse_display::parse_display(dpy_name)
-            .ok_or(ConnectError::DisplayParsingError)?;
+        let parsed_display = x11rb_protocol::parse_display::parse_display(dpy_name)?;
         let screen = parsed_display.screen.into();
 
         // Establish connection by iterating over ConnectAddresses until we find one that
@@ -156,7 +156,7 @@ impl RustConnection<DefaultStream> {
         // none of the addresses worked
         Err(match error {
             Some(e) => ConnectError::IoError(e),
-            None => ConnectError::DisplayParsingError,
+            None => DisplayParsingError::Unknown.into(),
         })
     }
 }

--- a/x11rb/src/xcb_ffi/mod.rs
+++ b/x11rb/src/xcb_ffi/mod.rs
@@ -17,6 +17,7 @@ use crate::connection::{
     compute_length_field, Connection, ReplyOrError, RequestConnection, RequestKind,
 };
 use crate::cookie::{Cookie, CookieWithFds, VoidCookie};
+use crate::errors::DisplayParsingError;
 pub use crate::errors::{ConnectError, ConnectionError, ParseError, ReplyError, ReplyOrIdError};
 use crate::extension_manager::ExtensionManager;
 use crate::protocol::xproto::Setup;
@@ -82,7 +83,7 @@ impl XCBConnection {
         match error {
             ERROR => IOError::new(ErrorKind::Other, ConnectionError::UnknownError).into(),
             MEM_INSUFFICIENT => ConnectError::InsufficientMemory,
-            PARSE_ERR => ConnectError::DisplayParsingError,
+            PARSE_ERR => DisplayParsingError::Unknown.into(),
             INVALID_SCREEN => ConnectError::InvalidScreen,
             _ => ConnectError::UnknownError,
             // Not possible here: EXT_NOTSUPPORTED, REQ_LEN_EXCEED, FDPASSING_FAILED


### PR DESCRIPTION
So far, when we fail to parse $DISPLAY, the error message "Display parsing error" would be generated. That's not saying too much helpful things, besides "could you please tell me what value $DISPLAY is set to?".

This commit changes the code to instead have an enumeration of error cases. When parsing actually fails, the value that was attempted to be parsed is now also included in the error message.

This would have made [0] much more obvious.

[0]: https://github.com/quininer/x11-clipboard/issues/38