### PR TITLE
Provide $DISPLAY parsing on no_std

### DIFF
--- a/x11rb-protocol/src/lib.rs
+++ b/x11rb-protocol/src/lib.rs
@@ -56,7 +56,6 @@ pub mod resource_manager;
 mod test;
 mod utils;
 pub mod wrapper;
-#[cfg(feature = "std")]
 pub mod xauth;
 
 pub use utils::RawFdContainer;

--- a/x11rb-protocol/src/parse_display/connect_instruction.rs
+++ b/x11rb-protocol/src/parse_display/connect_instruction.rs
@@ -3,8 +3,8 @@
 
 use super::ParsedDisplay;
 use alloc::format;
+use alloc::string::String;
 use alloc::vec::Vec;
-use std::path::PathBuf;
 
 /// A possible address for an X11 server.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -16,7 +16,7 @@ pub enum ConnectAddress<'a> {
     ///
     /// First, the given path should be attempted in the abstract namespace. Only if that fails,
     /// then the named socket with the given name should be tried.
-    Socket(PathBuf),
+    Socket(String),
 }
 
 /// Get an iterator over all of the addresses we should target with a
@@ -40,7 +40,7 @@ pub(super) fn connect_addresses(p: &ParsedDisplay) -> impl Iterator<Item = Conne
     } else {
         if protocol.is_none() || protocol.as_deref() == Some("unix") {
             let file_name = format!("/tmp/.X11-unix/X{}", display);
-            targets.push(ConnectAddress::Socket(file_name.into()));
+            targets.push(ConnectAddress::Socket(file_name));
         }
 
         if protocol.is_none() && host.is_empty() {
@@ -59,7 +59,6 @@ mod tests {
     // make sure iterator properties are clean
     use super::{super::parse_display, ConnectAddress};
     use alloc::{vec, vec::Vec};
-    use std::path::PathBuf;
 
     #[test]
     fn basic_test() {
@@ -70,7 +69,7 @@ mod tests {
         assert_eq!(
             ci,
             vec![
-                ConnectAddress::Socket(PathBuf::from("/tmp/.X11-unix/X0")),
+                ConnectAddress::Socket("/tmp/.X11-unix/X0".into()),
                 ConnectAddress::Hostname("localhost", 6000),
             ]
         );
@@ -93,9 +92,6 @@ mod tests {
 
         let ci = ci.collect::<Vec<_>>();
 
-        assert_eq!(
-            ci,
-            vec![ConnectAddress::Socket(PathBuf::from("/tmp/.X11-unix/X0")),]
-        );
+        assert_eq!(ci, vec![ConnectAddress::Socket("/tmp/.X11-unix/X0".into())]);
     }
 }

--- a/x11rb/src/rust_connection/stream.rs
+++ b/x11rb/src/rust_connection/stream.rs
@@ -1,7 +1,5 @@
 use std::io::{IoSlice, Result};
 use std::net::{Ipv4Addr, SocketAddr, TcpStream};
-#[cfg(any(target_os = "linux", target_os = "android"))]
-use std::os::unix::ffi::OsStrExt as _;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 #[cfg(unix)]
@@ -166,7 +164,7 @@ impl DefaultStream {
             ConnectAddress::Socket(path) => {
                 // Try abstract unix socket first. If that fails, fall back to normal unix socket
                 #[cfg(any(target_os = "linux", target_os = "android"))]
-                if let Ok(stream) = connect_abstract_unix_stream(path.as_os_str().as_bytes()) {
+                if let Ok(stream) = connect_abstract_unix_stream(path.as_bytes()) {
                     // TODO: Does it make sense to add a constructor similar to from_unix_stream()?
                     // If this is done: Move the set_nonblocking() from
                     // connect_abstract_unix_stream() to that new function.


### PR DESCRIPTION
Most of the code in `x11rb-protocol/src/parse_display/*` already works without std. This commit adds a small nudge to make this fully no-std (except for one function which needs `std::env::var()` to look up `$DISPLAY` in the env).

Additionally, this removes a duplicate `cfg(feature = std)` check.

I actually tried: Our no-std-checks in CI works. If I really do something that needs `std` without the necessary `cfg`, things fail. Previously, there was just a `#![cfg(feature = "std")]` that caused the whole `parse_display` module to be skipped without this feature.