### PR TITLE
Simplify DefaultStream

### DIFF
--- a/x11rb-async/src/rust_connection/mod.rs
+++ b/x11rb-async/src/rust_connection/mod.rs
@@ -90,13 +90,10 @@ impl RustConnection {
         let addrs = x11rb_protocol::parse_display::parse_display(display_name)?;
 
         // Connect to the stream.
-        let (stream, screen) = nb_connect::connect(&addrs).await?;
+        let (stream, screen, (family, address)) = nb_connect::connect(&addrs).await?;
 
         // Wrap the stream in a connection.
         let stream = StreamAdaptor::new(stream)?;
-
-        // Get the peer address of the socket.
-        let (family, address) = stream.get_ref().peer_addr()?;
 
         // Use this to get authority information.
         let (auth_name, auth_data) = blocking::unblock(move || {

--- a/x11rb-async/src/rust_connection/nb_connect.rs
+++ b/x11rb-async/src/rust_connection/nb_connect.rs
@@ -53,14 +53,13 @@ pub(super) async fn connect(
 async fn connect_to_addr(addr: ConnectAddress<'_>) -> io::Result<(DefaultStream, PeerAddr)> {
     let start = Instant::now();
     match connect_to_addr_impl(&addr).await {
-        Ok(stream) => {
+        Ok(result) => {
             tracing::trace!(
                 "Connected to X11 server via {:?} in {:?}",
                 addr,
                 start.elapsed()
             );
-            let peer_addr = stream.peer_addr()?;
-            Ok((stream, peer_addr))
+            Ok(result)
         }
         Err(e) => {
             tracing::debug!("Failed to connect to X11 server via {:?}: {:?}", addr, e);
@@ -69,7 +68,7 @@ async fn connect_to_addr(addr: ConnectAddress<'_>) -> io::Result<(DefaultStream,
     }
 }
 
-async fn connect_to_addr_impl(addr: &ConnectAddress<'_>) -> io::Result<DefaultStream> {
+async fn connect_to_addr_impl(addr: &ConnectAddress<'_>) -> io::Result<(DefaultStream, PeerAddr)> {
     match addr {
         ConnectAddress::Hostname(host, port) => {
             let mut err = None;

--- a/x11rb/src/rust_connection/mod.rs
+++ b/x11rb/src/rust_connection/mod.rs
@@ -122,7 +122,7 @@ impl RustConnection<DefaultStream> {
         for addr in parsed_display.connect_instruction() {
             let start = Instant::now();
             match DefaultStream::connect(&addr) {
-                Ok(stream) => {
+                Ok((stream, (family, address))) => {
                     crate::trace!(
                         "Connected to X11 server via {:?} in {:?}",
                         addr,
@@ -130,7 +130,6 @@ impl RustConnection<DefaultStream> {
                     );
 
                     // we found a stream, get auth information
-                    let (family, address) = stream.peer_addr()?;
                     let (auth_name, auth_data) = get_auth(family, &address, parsed_display.display)
                         // Ignore all errors while determining auth; instead we just try without auth info.
                         .unwrap_or(None)


### PR DESCRIPTION
Everything we do on the stream is sending / receiving bytes and FDs. That is also possible on an OwnedFd. Thus, we do not need the enum that remembers what kind of stream we have and we can just shove everything into OwnedFd. (Except on Windows, where TcpStream is used instead)

One complication is the public function peer_addr(). However, consumers only ever call this function right after connect(). Thus, to be able to remove peer_addr(), the connection functions are extended to return this information.