### PR TITLE
Silence some unhelpful clippy warning

### DIFF
--- a/x11rb/src/properties.rs
+++ b/x11rb/src/properties.rs
@@ -24,6 +24,7 @@ macro_rules! property_cookie {
         {
             /// Get the reply that the server sent.
             pub fn reply(self) -> Result<Option<$struct_name>, ReplyError> {
+                #[allow(clippy::redundant_closure_call)]
                 Ok($from_reply(self.0.reply()?)?)
             }
 


### PR DESCRIPTION
This code has a macro for generating some code. In one place, this macro is called with a function as argument. On two other places, the macro is called with closures. These closure calls cause a warning from clippy.

This commit silences this warning by just #[allow]ing it.
```
warning: try not to call a closure in the expression where it is declared
   --> x11rb/src/properties.rs:27:20
    |
27  |                   Ok($from_reply(self.0.reply()?)?)
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
162 | / property_cookie! {
163 | |     /// A cookie for getting a window's `WM_SIZE_HINTS` property.
164 | |     pub struct WmSizeHintsCookie: WmSizeHints,
165 | |     |reply| WmSizeHints::from_reply(&reply),
166 | | }
    | |_- in this macro invocation
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_call
    = note: `#[warn(clippy::redundant_closure_call)]` on by default
    = note: this warning originates in the macro `property_cookie` (in Nightly builds, run with -Z macro-backtrace for more info)
```