### PR TITLE
x11rb-protocol: Remove unused rustix dependency

### DIFF
--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -20,15 +20,9 @@ serde = { version = "1", features = ["derive"], optional = true }
 [dev-dependencies]
 criterion = "0.4"
 
-[target.'cfg(unix)'.dependencies.rustix]
-version = "0.38"
-default-features = false
-features = ["std"]
-optional = true
-
 [features]
 default = ["std"]
-std = ["rustix"]
+std = []
 
 # Enable utility functions in `x11rb::resource_manager` for querying the
 # resource databases.


### PR DESCRIPTION
This dependency was added in commit fff41699d3a when nix was replaced with rustix. However, commit a20217f208f updated to rustix 0.38 and replaced the only use of rustix with std::os::unix::io::OwnedFd. Thus, this dependency is no longer used.