### PR TITLE
Add Image::into_owned()

### DIFF
--- a/x11rb/src/image.rs
+++ b/x11rb/src/image.rs
@@ -959,6 +959,19 @@ impl<'a> Image<'a> {
             }
         }
     }
+
+    /// Get a version of this image with `'static` lifetime.
+    ///
+    /// If the image was constructed from a `Cow::Borrowed`, this clones the contained data.
+    /// Otherwise, this simply returns `self`.
+    pub fn into_owned(self) -> Image<'static> {
+        // It would be great if we could just implement ToOwned, but that requires implementing
+        // Borrow, which we cannot do. Thus, this function exists as a work-around.
+        Image {
+            data: self.data.into_owned().into(),
+            ..self
+        }
+    }
 }
 
 fn compute_depth_1_address(x: usize, order: ImageOrder) -> (usize, usize) {
@@ -1010,6 +1023,33 @@ mod test_image {
         assert_eq!(image.bits_per_pixel(), BitsPerPixel::B8);
         assert_eq!(image.byte_order(), ImageOrder::MsbFirst);
         assert_eq!(image.data(), [42, 125]);
+    }
+
+    #[test]
+    fn test_into_owned_keeps_owned_data() {
+        fn with_data(data: Cow<'_, [u8]>) -> *const u8 {
+            let orig_ptr = data.as_ptr();
+            let image = Image::new(
+                1,
+                1,
+                ScanlinePad::Pad8,
+                1,
+                BitsPerPixel::B1,
+                ImageOrder::MsbFirst,
+                data,
+            )
+            .unwrap();
+            assert_eq!(image.data().as_ptr(), orig_ptr);
+            image.into_owned().data().as_ptr()
+        }
+
+        // Cow::Borrowed is copied
+        let data = vec![0];
+        let orig_ptr = data.as_ptr();
+        assert_ne!(with_data(Cow::Borrowed(&data)), orig_ptr);
+
+        // Cow::Owned is kept
+        assert_eq!(with_data(Cow::Owned(data)), orig_ptr);
     }
 
     #[test]


### PR DESCRIPTION
A x11rb::image::Image<'a> can either borrow the image data from elsewhere (&'a [u8] via Cow::Borrowed) or can own the image data (Vec<u8> via Cow::Owned). For this reason, the Image struct has a lifetime 'a.

Escaping from this lifetime is currently a bit hard. This commit introduces a new function Image::into_owned() which returns an Image<'static>. The output image should be fully equivalent to the input, instead that a Cow::Borrowed() is turned into a Cow::Owned via into_owned().

Without this new function, users wanting this behaviour would need a complicated call to Image::new() fetching all the various fields of the Image and forwarding them.

-----

This function would have been useful for #867. That's where I got the idea from. 