### PR TITLE
Make Image::put() automatically call Image::native()

### DIFF
--- a/x11rb/src/image.rs
+++ b/x11rb/src/image.rs
@@ -722,7 +722,24 @@ impl<'a> Image<'a> {
     /// The server's maximum request size is honored. This means that a too large `PutImage`
     /// request is automatically split up into smaller pieces. Thus, if this function returns an
     /// error, the image could already be partially sent.
+    ///
+    /// Before uploading, the image is translated into the server's native format via
+    /// [`Image::native`]. This may convert the image to another format, which can be slow. If you
+    /// intend to upload the same image multiple times, it is likely more efficient to call
+    /// [`Image::native`] once initially so that the conversion is not repeated on each upload.
     pub fn put<'c, Conn: Connection>(
+        &self,
+        conn: &'c Conn,
+        drawable: Drawable,
+        gc: Gcontext,
+        dst_x: i16,
+        dst_y: i16,
+    ) -> Result<Vec<VoidCookie<'c, Conn>>, ConnectionError> {
+        self.native(conn.setup())?
+            .put_impl(conn, drawable, gc, dst_x, dst_y)
+    }
+
+    fn put_impl<'c, Conn: Connection>(
         &self,
         conn: &'c Conn,
         drawable: Drawable,


### PR DESCRIPTION
The fact that Image::put() only splits the image up so that it is below the maximum request size is a foot gun. People expect things like the byte order to be honored. Thus, this commit makes put() first call native() to convert the image to the X11 server's expected representation before doing the upload on the result.

In case the image is already in the expected format, this should be quite cheap. native() has to look up the expected format, which is done by find_format(). This looks up an entry in a list with few entries, on my computer just 7 formats. Then, convert() is called, which should immediately see that the image is already in the expected format and return Cow::Borrowed(self). Thus, the performance impact of this should be negligible (and PutImage is always quite slow anyway).

Fixes: https://github.com/psychon/x11rb/issues/867