### PR TITLE
Use rustix instead of gethostname on Unix

### DIFF
--- a/x11rb-async/Cargo.toml
+++ b/x11rb-async/Cargo.toml
@@ -24,11 +24,6 @@ tracing = { version = "0.1", default-features = false }
 x11rb = { version = "0.12.0", path = "../x11rb", default-features = false }
 x11rb-protocol = { version = "0.12.0", path = "../x11rb-protocol" }
 
-[target.'cfg(unix)'.dev-dependencies.rustix]
-version = "0.38"
-default-features = false
-features = ["pipe"]
-
 [features]
 # Enable this feature to enable all the X11 extensions
 all-extensions = [
@@ -99,8 +94,12 @@ all-features = true
 
 [dev-dependencies]
 async-executor = "1.5.0"
-libc = "0.2.147"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[target.'cfg(unix)'.dev-dependencies.rustix]
+version = "0.38"
+default-features = false
+features = ["mm", "pipe"]
 
 [[example]]
 name = "shared_memory_async"

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -19,12 +19,15 @@ x11rb-protocol = { version = "0.12.0", path = "../x11rb-protocol" }
 libc = { version = "0.2", optional = true }
 libloading = { version = "0.8.0", optional = true }
 once_cell = { version = "1.17", optional = true }
-gethostname = "0.3.0"
 as-raw-xcb-connection = { version = "1.0", optional = true }
 tracing = { version = "0.1", optional = true, default-features = false }
-rustix = { version = "0.38", default-features = false, features = ["std", "event", "fs", "net"] }
+rustix = { version = "0.38", default-features = false, features = ["std", "event", "fs", "net", "system"] }
+
+[target.'cfg(not(unix))'.dependencies]
+gethostname = "0.3.0"
 
 [dev-dependencies]
+gethostname = "0.3.0"
 polling = "2.8.0"
 tracing-subscriber = "0.3"
 

--- a/x11rb/src/lib.rs
+++ b/x11rb/src/lib.rs
@@ -175,6 +175,7 @@ mod test;
 
 use errors::ConnectError;
 use protocol::xproto::{Keysym, Timestamp};
+use std::ffi::OsString;
 
 /// Establish a new connection to an X11 server.
 ///
@@ -205,3 +206,15 @@ pub const CURRENT_TIME: Timestamp = 0;
 
 /// This constant can be used to fill unused entries in `Keysym` tables
 pub const NO_SYMBOL: Keysym = 0;
+
+#[cfg(not(unix))]
+fn hostname() -> OsString {
+    gethostname::gethostname()
+}
+
+#[cfg(unix)]
+fn hostname() -> OsString {
+    use std::os::unix::ffi::OsStringExt;
+
+    OsString::from_vec(rustix::system::uname().nodename().to_bytes().to_vec())
+}

--- a/x11rb/src/resource_manager/mod.rs
+++ b/x11rb/src/resource_manager/mod.rs
@@ -64,6 +64,6 @@ pub fn new_from_resource_manager(conn: &impl Connection) -> Result<Option<Databa
 pub fn new_from_default(conn: &impl Connection) -> Result<Database, ReplyError> {
     Ok(Database::new_from_default(
         &send_request(conn)?,
-        gethostname::gethostname(),
+        crate::hostname(),
     ))
 }

--- a/x11rb/src/rust_connection/stream.rs
+++ b/x11rb/src/rust_connection/stream.rs
@@ -520,10 +520,9 @@ mod peer_addr {
 
     // Get xauth information representing a local connection
     pub(super) fn local() -> PeerAddr {
-        let hostname = gethostname::gethostname()
+        let hostname = crate::hostname()
             .to_str()
-            .map(|name| name.as_bytes().to_vec())
-            .unwrap_or_else(Vec::new);
+            .map_or_else(Vec::new, |s| s.as_bytes().to_vec());
         (Family::LOCAL, hostname)
     }
 


### PR DESCRIPTION
This eliminates the last libc-based dependency from the pure Rust implementation of x11rb.