### PR TITLE
ci: remove MIPS64 test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -176,13 +176,9 @@ jobs:
 
   non-amd64-test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - cross_target: mips64-unknown-linux-gnuabi64
-          - cross_target: powerpc-unknown-linux-gnu
     env:
-      CROSS_TARGET: ${{ matrix.cross_target }}
+      # used to test big endian and lack of 64-bit atomics
+      CROSS_TARGET: powerpc-unknown-linux-gnu
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
The target has been demoted from tier 2 to tier 3 in Rust 1.72 (https://github.com/rust-lang/compiler-team/issues/648, https://github.com/rust-lang/rust/pull/115238).

PowerPC is also big endian, so it serves the purpose of the MIPS64 test.