### PR TITLE
Fix a clippy::needless_pass_by_ref_mut warning

### DIFF
--- a/xtrace-example/src/connection_inner.rs
+++ b/xtrace-example/src/connection_inner.rs
@@ -149,7 +149,7 @@ impl ConnectionInner {
 
     /// Handle an X11 event sent by the server
     pub fn server_event(&mut self, packet: &[u8]) {
-        fn do_parse(inner: &mut ConnectionInner, packet: &[u8]) -> Result<(), ParseError> {
+        fn do_parse(inner: &ConnectionInner, packet: &[u8]) -> Result<(), ParseError> {
             let event = Event::parse(packet, &inner.ext_info)?;
             println!(
                 "server ({}): {:?}",


### PR DESCRIPTION
warning: this argument is a mutable reference, but not used mutably
     --> xtrace-example/src/connection_inner.rs:152:28
      |
  152 |         fn do_parse(inner: &mut ConnectionInner, packet: &[u8]) -> Result<(), ParseError> {
      |                            ^^^^^^^^^^^^^^^^^^^^ help: consider changing to: `&ConnectionInner`
      |
      = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_pass_by_ref_mut
      = note: `#[warn(clippy::needless_pass_by_ref_mut)]` on by default