### PR TITLE
Gate some commonly unused traits behind a feature

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  MOST_FEATURES: all-extensions cursor extra-traits image tracing tracing-subscriber/env-filter
+  MOST_FEATURES: all-extensions cursor extra-traits image request-parsing tracing tracing-subscriber/env-filter
   # According to code coverage changes, sometimes $XENVIRONMENT is set and
   # sometimes not. Try to make this consistent to stabilise coverage reports.
   # Example: https://app.codecov.io/gh/psychon/x11rb/compare/726/changes

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  MOST_FEATURES: all-extensions cursor image tracing tracing-subscriber/env-filter
+  MOST_FEATURES: all-extensions cursor extra-traits image tracing tracing-subscriber/env-filter
   # According to code coverage changes, sometimes $XENVIRONMENT is set and
   # sometimes not. Try to make this consistent to stabilise coverage reports.
   # Example: https://app.codecov.io/gh/psychon/x11rb/compare/726/changes
@@ -59,6 +59,12 @@ jobs:
        # clippy
        - name: clippy x11rb without features
          run: cargo clippy -p x11rb --all-targets -- -D warnings ${{ matrix.clippy_args }}
+
+       - name: clippy x11rb without default features
+         run: cargo clippy -p x11rb --all-targets -- -D warnings ${{ matrix.clippy_args }} --no-default-features 
+
+       - name: clippy x11rb-protocol with request parsing
+         run: cargo clippy -p x11rb-protocol --all-targets -- -D warnings ${{ matrix.clippy_args }} --features request-parsing
 
        - name: clippy x11rb with allow-unsafe-code but without dl-libxcb
          run: cargo clippy -p x11rb --all-targets --features "allow-unsafe-code" -- -D warnings ${{ matrix.clippy_args }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,10 +61,10 @@ jobs:
          run: cargo clippy -p x11rb --all-targets -- -D warnings ${{ matrix.clippy_args }}
 
        - name: clippy x11rb without default features
-         run: cargo clippy -p x11rb --all-targets -- -D warnings ${{ matrix.clippy_args }} --no-default-features 
+         run: cargo clippy -p x11rb --no-default-features --all-targets -- -D warnings ${{ matrix.clippy_args }}
 
        - name: clippy x11rb-protocol with request parsing
-         run: cargo clippy -p x11rb-protocol --all-targets -- -D warnings ${{ matrix.clippy_args }} --features request-parsing
+         run: cargo clippy -p x11rb-protocol --all-targets --features request-parsing -- -D warnings ${{ matrix.clippy_args }}
 
        - name: clippy x11rb with allow-unsafe-code but without dl-libxcb
          run: cargo clippy -p x11rb --all-targets --features "allow-unsafe-code" -- -D warnings ${{ matrix.clippy_args }}

--- a/generator/src/generator/namespace/helpers.rs
+++ b/generator/src/generator/namespace/helpers.rs
@@ -12,6 +12,22 @@ pub(crate) struct EnumInfo {
     pub(super) wire_size: Option<(u8, u8)>,
 }
 
+pub(super) fn default_debug_impl(name: &str, out: &mut crate::generator::Output) {
+    outln!(out, "#[cfg(not(feature = \"extra-traits\"))]");
+    outln!(out, "impl core::fmt::Debug for {} {{", name);
+    out.indented(|out| {
+        outln!(
+            out,
+            "fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {{"
+        );
+        out.indented(|out| {
+            outln!(out, "f.debug_struct(\"{}\").finish_non_exhaustive()", name);
+        });
+        outln!(out, "}}");
+    });
+    outln!(out, "}}");
+}
+
 /// Caches to avoid repeating some operations.
 #[derive(Default)]
 pub(crate) struct Caches {
@@ -248,9 +264,6 @@ impl Derives {
 
     pub(super) fn to_list(self) -> Vec<&'static str> {
         let mut list = Vec::new();
-        if self.debug {
-            list.push("Debug");
-        }
         if self.clone {
             list.push("Clone");
         }
@@ -259,6 +272,14 @@ impl Derives {
         }
         if self.default_ {
             list.push("Default");
+        }
+        list
+    }
+
+    pub(super) fn extra_traits_list(self) -> Vec<&'static str> {
+        let mut list = Vec::new();
+        if self.debug {
+            list.push("Debug");
         }
         if self.partial_eq {
             list.push("PartialEq");

--- a/generator/src/generator/namespace/request.rs
+++ b/generator/src/generator/namespace/request.rs
@@ -951,7 +951,7 @@ fn emit_request_struct(
         );
         outln!(
             out,
-            "#[cfg(feature = \"extra-traits\")]"
+            "#[cfg(feature = \"request-parsing\")]"
         );
         if gathered.has_fds() {
             outln!(

--- a/generator/src/generator/namespace/request.rs
+++ b/generator/src/generator/namespace/request.rs
@@ -949,6 +949,10 @@ fn emit_request_struct(
             "/// Parse this request given its header, its body, and any fds that go along \
              with it"
         );
+        outln!(
+            out,
+            "#[cfg(feature = \"extra-traits\")]"
+        );
         if gathered.has_fds() {
             outln!(
                 out,

--- a/generator/src/generator/namespace/struct_type.rs
+++ b/generator/src/generator/namespace/struct_type.rs
@@ -48,9 +48,17 @@ pub(super) fn emit_struct_type(
     if let Some(doc) = doc {
         generator.emit_doc(doc, out, Some(&deducible_fields));
     }
+    let extras = derives.extra_traits_list();
     let derives = derives.to_list();
     if !derives.is_empty() {
         outln!(out, "#[derive({})]", derives.join(", "));
+    }
+    if !extras.is_empty() {
+        outln!(
+            out,
+            "#[cfg_attr(feature = \"extra-traits\", derive({}))]",
+            extras.join(", ")
+        );
     }
     if !has_fds {
         outln!(
@@ -74,6 +82,8 @@ pub(super) fn emit_struct_type(
         }
     }
     outln!(out, "}}");
+
+    super::helpers::default_debug_impl(name, out);
 
     if generate_try_parse {
         let input_name = if !matches!(parse_size_constraint, StructSizeConstraint::None) {

--- a/generator/src/generator/namespace/switch.rs
+++ b/generator/src/generator/namespace/switch.rs
@@ -123,12 +123,20 @@ pub(super) fn emit_switch_type(
     for case in switch.cases.iter() {
         generator.filter_derives_for_fields(&mut derives, &case.fields.borrow(), false);
     }
+    let extras = derives.extra_traits_list();
     let mut derives = derives.to_list();
     if switch.kind == xcbdefs::SwitchKind::BitCase {
         derives.push("Default");
     }
     if !derives.is_empty() {
         outln!(out, "#[derive({})]", derives.join(", "));
+    }
+    if !extras.is_empty() {
+        outln!(
+            out,
+            "#[cfg_attr(feature = \"extra-traits\", derive({}))]",
+            extras.join(", ")
+        );
     }
     outln!(
         out,
@@ -214,6 +222,8 @@ pub(super) fn emit_switch_type(
         outln!(out.indent(), "InvalidValue({}),", switch_expr_type);
         outln!(out, "}}");
     }
+
+    super::helpers::default_debug_impl(name, out);
 
     if generate_try_parse {
         emit_switch_try_parse(generator, switch, name, &case_infos, switch_expr_type, out);

--- a/generator/src/generator/namespace/switch.rs
+++ b/generator/src/generator/namespace/switch.rs
@@ -398,6 +398,10 @@ fn emit_switch_try_parse(
             .collect::<Vec<_>>();
         outln!(
             out.indent(),
+            "#[cfg_attr(not(feature = \"request-parsing\"), allow(dead_code))]"
+        );
+        outln!(
+            out.indent(),
             "fn try_parse(value: &[u8], {}) -> Result<(Self, &[u8]), ParseError> {{",
             p.join(", "),
         );

--- a/generator/src/generator/requests_replies.rs
+++ b/generator/src/generator/requests_replies.rs
@@ -203,6 +203,7 @@ pub(super) fn generate(out: &mut Output, module: &xcbdefs::Module, mut enum_case
             out,
             "#[allow(clippy::cognitive_complexity, clippy::single_match)]"
         );
+        outln!(out, "#[cfg(feature = \"extra-traits\")]");
         outln!(out, "pub fn parse(");
         out.indented(|out| {
             outln!(out, "header: RequestHeader,");

--- a/generator/src/generator/requests_replies.rs
+++ b/generator/src/generator/requests_replies.rs
@@ -203,7 +203,7 @@ pub(super) fn generate(out: &mut Output, module: &xcbdefs::Module, mut enum_case
             out,
             "#[allow(clippy::cognitive_complexity, clippy::single_match)]"
         );
-        outln!(out, "#[cfg(feature = \"extra-traits\")]");
+        outln!(out, "#[cfg(feature = \"request-parsing\")]");
         outln!(out, "pub fn parse(");
         out.indented(|out| {
             outln!(out, "header: RequestHeader,");

--- a/x11rb-async/Cargo.toml
+++ b/x11rb-async/Cargo.toml
@@ -58,6 +58,7 @@ all-extensions = [
     "xvmc"
 ]
 
+# Enable extra traits on protocol types.
 extra-traits = ["x11rb-protocol/extra-traits"]
 
 composite = ["x11rb-protocol/composite", "xfixes"]

--- a/x11rb-async/Cargo.toml
+++ b/x11rb-async/Cargo.toml
@@ -22,7 +22,7 @@ event-listener = "2.5.3"
 futures-lite = "1"
 tracing = { version = "0.1", default-features = false }
 x11rb = { version = "0.12.0", path = "../x11rb", default-features = false }
-x11rb-protocol = { version = "0.12.0", path = "../x11rb-protocol" }
+x11rb-protocol = { version = "0.12.0", default-features = false, features = ["std"], path = "../x11rb-protocol" }
 
 [features]
 # Enable this feature to enable all the X11 extensions
@@ -57,6 +57,8 @@ all-extensions = [
     "xv",
     "xvmc"
 ]
+
+extra-traits = ["x11rb-protocol/extra-traits"]
 
 composite = ["x11rb-protocol/composite", "xfixes"]
 damage = ["x11rb-protocol/damage", "xfixes"]

--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -21,8 +21,11 @@ serde = { version = "1", features = ["derive"], optional = true }
 criterion = "0.5"
 
 [features]
-default = ["std"]
+default = ["extra-traits", "std"]
 std = []
+
+# Enable extra traits for the X11 types
+extra-traits = []
 
 # Enable utility functions in `x11rb::resource_manager` for querying the
 # resource databases.

--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -27,6 +27,11 @@ std = []
 # Enable extra traits for the X11 types
 extra-traits = []
 
+# Enable parsing for requests.
+# 
+# This adds a lot of extra code that isn't used in the common case.
+request-parsing = []
+
 # Enable utility functions in `x11rb::resource_manager` for querying the
 # resource databases.
 resource_manager = ["std"]

--- a/x11rb-protocol/src/protocol/bigreq.rs
+++ b/x11rb-protocol/src/protocol/bigreq.rs
@@ -69,7 +69,7 @@ impl EnableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ENABLE_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/bigreq.rs
+++ b/x11rb-protocol/src/protocol/bigreq.rs
@@ -69,6 +69,7 @@ impl EnableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ENABLE_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/bigreq.rs
+++ b/x11rb-protocol/src/protocol/bigreq.rs
@@ -42,9 +42,16 @@ pub const ENABLE_REQUEST: u8 = 0;
 /// 262140 bytes in length.  When enabled, if the 16-bit length field is zero, it
 /// is immediately followed by a 32-bit length field specifying the length of the
 /// request in 4-byte units.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnableRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EnableRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EnableRequest").finish_non_exhaustive()
+    }
+}
 impl EnableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -88,12 +95,19 @@ impl crate::x11_utils::ReplyRequest for EnableRequest {
 /// # Fields
 ///
 /// * `maximum_request_length` - The maximum length of requests supported by the server, in 4-byte units.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnableReply {
     pub sequence: u16,
     pub length: u32,
     pub maximum_request_length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EnableReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EnableReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for EnableReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/composite.rs
+++ b/x11rb-protocol/src/protocol/composite.rs
@@ -148,7 +148,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -333,7 +333,7 @@ impl RedirectWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != REDIRECT_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -417,7 +417,7 @@ impl RedirectSubwindowsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != REDIRECT_SUBWINDOWS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -499,7 +499,7 @@ impl UnredirectWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNREDIRECT_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -581,7 +581,7 @@ impl UnredirectSubwindowsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNREDIRECT_SUBWINDOWS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -652,7 +652,7 @@ impl CreateRegionFromBorderClipRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REGION_FROM_BORDER_CLIP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -721,7 +721,7 @@ impl NameWindowPixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != NAME_WINDOW_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -784,7 +784,7 @@ impl GetOverlayWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_OVERLAY_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -933,7 +933,7 @@ impl ReleaseOverlayWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != RELEASE_OVERLAY_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/composite.rs
+++ b/x11rb-protocol/src/protocol/composite.rs
@@ -108,11 +108,18 @@ pub const QUERY_VERSION_REQUEST: u8 = 0;
 ///
 /// * `client_major_version` - The major version supported by the client.
 /// * `client_minor_version` - The minor version supported by the client.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -177,13 +184,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 ///
 /// * `major_version` - The major version chosen by the server.
 /// * `minor_version` - The minor version chosen by the server.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -278,11 +292,18 @@ pub const REDIRECT_WINDOW_REQUEST: u8 = 1;
 /// * `update` - Whether contents are automatically mirrored to the parent window.  If one client
 /// already specifies an update type of Manual, any attempt by another to specify a
 /// mode of Manual so will result in an Access error.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RedirectWindowRequest {
     pub window: xproto::Window,
     pub update: Redirect,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RedirectWindowRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RedirectWindowRequest").finish_non_exhaustive()
+    }
 }
 impl RedirectWindowRequest {
     /// Serialize this request into bytes for the provided connection
@@ -354,11 +375,18 @@ pub const REDIRECT_SUBWINDOWS_REQUEST: u8 = 2;
 /// * `update` - Whether contents are automatically mirrored to the parent window.  If one client
 /// already specifies an update type of Manual, any attempt by another to specify a
 /// mode of Manual so will result in an Access error.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RedirectSubwindowsRequest {
     pub window: xproto::Window,
     pub update: Redirect,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RedirectSubwindowsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RedirectSubwindowsRequest").finish_non_exhaustive()
+    }
 }
 impl RedirectSubwindowsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -428,11 +456,18 @@ pub const UNREDIRECT_WINDOW_REQUEST: u8 = 3;
 /// current client, or a Value error results.
 /// * `update` - The update type passed to RedirectWindows.  If this does not match the
 /// previously requested update type, a Value error results.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnredirectWindowRequest {
     pub window: xproto::Window,
     pub update: Redirect,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UnredirectWindowRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UnredirectWindowRequest").finish_non_exhaustive()
+    }
 }
 impl UnredirectWindowRequest {
     /// Serialize this request into bytes for the provided connection
@@ -502,11 +537,18 @@ pub const UNREDIRECT_SUBWINDOWS_REQUEST: u8 = 4;
 /// results.
 /// * `update` - The update type passed to RedirectSubWindows.  If this does not match
 /// the previously requested update type, a Value error results.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnredirectSubwindowsRequest {
     pub window: xproto::Window,
     pub update: Redirect,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UnredirectSubwindowsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UnredirectSubwindowsRequest").finish_non_exhaustive()
+    }
 }
 impl UnredirectSubwindowsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -565,11 +607,18 @@ impl crate::x11_utils::VoidRequest for UnredirectSubwindowsRequest {
 
 /// Opcode for the CreateRegionFromBorderClip request
 pub const CREATE_REGION_FROM_BORDER_CLIP_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRegionFromBorderClipRequest {
     pub region: xfixes::Region,
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateRegionFromBorderClipRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateRegionFromBorderClipRequest").finish_non_exhaustive()
+    }
 }
 impl CreateRegionFromBorderClipRequest {
     /// Serialize this request into bytes for the provided connection
@@ -626,11 +675,18 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromBorderClipRequest {
 
 /// Opcode for the NameWindowPixmap request
 pub const NAME_WINDOW_PIXMAP_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NameWindowPixmapRequest {
     pub window: xproto::Window,
     pub pixmap: xproto::Pixmap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for NameWindowPixmapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NameWindowPixmapRequest").finish_non_exhaustive()
+    }
 }
 impl NameWindowPixmapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -687,10 +743,17 @@ impl crate::x11_utils::VoidRequest for NameWindowPixmapRequest {
 
 /// Opcode for the GetOverlayWindow request
 pub const GET_OVERLAY_WINDOW_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOverlayWindowRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetOverlayWindowRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetOverlayWindowRequest").finish_non_exhaustive()
+    }
 }
 impl GetOverlayWindowRequest {
     /// Serialize this request into bytes for the provided connection
@@ -739,12 +802,19 @@ impl crate::x11_utils::ReplyRequest for GetOverlayWindowRequest {
     type Reply = GetOverlayWindowReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOverlayWindowReply {
     pub sequence: u16,
     pub length: u32,
     pub overlay_win: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetOverlayWindowReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetOverlayWindowReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetOverlayWindowReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -821,10 +891,17 @@ impl Serialize for GetOverlayWindowReply {
 
 /// Opcode for the ReleaseOverlayWindow request
 pub const RELEASE_OVERLAY_WINDOW_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReleaseOverlayWindowRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ReleaseOverlayWindowRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ReleaseOverlayWindowRequest").finish_non_exhaustive()
+    }
 }
 impl ReleaseOverlayWindowRequest {
     /// Serialize this request into bytes for the provided connection

--- a/x11rb-protocol/src/protocol/composite.rs
+++ b/x11rb-protocol/src/protocol/composite.rs
@@ -148,6 +148,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -332,6 +333,7 @@ impl RedirectWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != REDIRECT_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -415,6 +417,7 @@ impl RedirectSubwindowsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != REDIRECT_SUBWINDOWS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -496,6 +499,7 @@ impl UnredirectWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNREDIRECT_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -577,6 +581,7 @@ impl UnredirectSubwindowsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNREDIRECT_SUBWINDOWS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -647,6 +652,7 @@ impl CreateRegionFromBorderClipRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REGION_FROM_BORDER_CLIP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -715,6 +721,7 @@ impl NameWindowPixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != NAME_WINDOW_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -777,6 +784,7 @@ impl GetOverlayWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_OVERLAY_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -925,6 +933,7 @@ impl ReleaseOverlayWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != RELEASE_OVERLAY_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/damage.rs
+++ b/x11rb-protocol/src/protocol/damage.rs
@@ -158,7 +158,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -367,7 +367,7 @@ impl CreateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -442,7 +442,7 @@ impl DestroyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -524,7 +524,7 @@ impl SubtractRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SUBTRACT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -604,7 +604,7 @@ impl AddRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ADD_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/damage.rs
+++ b/x11rb-protocol/src/protocol/damage.rs
@@ -158,6 +158,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -366,6 +367,7 @@ impl CreateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -440,6 +442,7 @@ impl DestroyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -521,6 +524,7 @@ impl SubtractRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SUBTRACT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -600,6 +604,7 @@ impl AddRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ADD_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/damage.rs
+++ b/x11rb-protocol/src/protocol/damage.rs
@@ -118,11 +118,18 @@ pub const QUERY_VERSION_REQUEST: u8 = 0;
 ///
 /// * `client_major_version` - The major version supported by the client.
 /// * `client_minor_version` - The minor version supported by the client.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -187,13 +194,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 ///
 /// * `major_version` - The major version chosen by the server.
 /// * `minor_version` - The minor version chosen by the server.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -306,12 +320,19 @@ pub const CREATE_REQUEST: u8 = 1;
 /// `xcb_generate_id`.
 /// * `drawable` - The ID of the drawable to be monitored.
 /// * `level` - The level of detail to be provided in Damage events.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRequest {
     pub damage: Damage,
     pub drawable: xproto::Drawable,
     pub level: ReportLevel,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateRequest").finish_non_exhaustive()
+    }
 }
 impl CreateRequest {
     /// Serialize this request into bytes for the provided connection
@@ -385,10 +406,17 @@ pub const DESTROY_REQUEST: u8 = 2;
 /// # Fields
 ///
 /// * `damage` - The ID you provided to `xcb_create_damage`.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyRequest {
     pub damage: Damage,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -447,12 +475,19 @@ pub const SUBTRACT_REQUEST: u8 = 3;
 /// # Fields
 ///
 /// * `damage` - The ID you provided to `xcb_create_damage`.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SubtractRequest {
     pub damage: Damage,
     pub repair: xfixes::Region,
     pub parts: xfixes::Region,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SubtractRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SubtractRequest").finish_non_exhaustive()
+    }
 }
 impl SubtractRequest {
     /// Serialize this request into bytes for the provided connection
@@ -525,11 +560,18 @@ pub const ADD_REQUEST: u8 = 4;
 /// # Fields
 ///
 /// * `damage` - The ID you provided to `xcb_create_damage`.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddRequest {
     pub drawable: xproto::Drawable,
     pub region: xfixes::Region,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AddRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AddRequest").finish_non_exhaustive()
+    }
 }
 impl AddRequest {
     /// Serialize this request into bytes for the provided connection
@@ -602,7 +644,8 @@ pub const NOTIFY_EVENT: u8 = 0;
 /// # See
 ///
 /// * `Create`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyEvent {
     pub response_type: u8,
@@ -613,6 +656,12 @@ pub struct NotifyEvent {
     pub timestamp: xproto::Timestamp,
     pub area: xproto::Rectangle,
     pub geometry: xproto::Rectangle,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for NotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for NotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/dbe.rs
+++ b/x11rb-protocol/src/protocol/dbe.rs
@@ -340,7 +340,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -517,7 +517,7 @@ impl AllocateBackBufferRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ALLOCATE_BACK_BUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -590,7 +590,7 @@ impl DeallocateBackBufferRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DEALLOCATE_BACK_BUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -663,7 +663,7 @@ impl<'input> SwapBuffersRequest<'input> {
         ([request0.into(), actions_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SWAP_BUFFERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -727,7 +727,7 @@ impl BeginIdiomRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != BEGIN_IDIOM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -780,7 +780,7 @@ impl EndIdiomRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != END_IDIOM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -845,7 +845,7 @@ impl<'input> GetVisualInfoRequest<'input> {
         ([request0.into(), drawables_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VISUAL_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -992,7 +992,7 @@ impl GetBackBufferAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_BACK_BUFFER_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/dbe.rs
+++ b/x11rb-protocol/src/protocol/dbe.rs
@@ -340,6 +340,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -516,6 +517,7 @@ impl AllocateBackBufferRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ALLOCATE_BACK_BUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -588,6 +590,7 @@ impl DeallocateBackBufferRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DEALLOCATE_BACK_BUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -660,6 +663,7 @@ impl<'input> SwapBuffersRequest<'input> {
         ([request0.into(), actions_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SWAP_BUFFERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -723,6 +727,7 @@ impl BeginIdiomRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != BEGIN_IDIOM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -775,6 +780,7 @@ impl EndIdiomRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != END_IDIOM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -839,6 +845,7 @@ impl<'input> GetVisualInfoRequest<'input> {
         ([request0.into(), drawables_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VISUAL_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -985,6 +992,7 @@ impl GetBackBufferAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_BACK_BUFFER_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/dbe.rs
+++ b/x11rb-protocol/src/protocol/dbe.rs
@@ -109,11 +109,18 @@ impl core::fmt::Debug for SwapAction  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwapInfo {
     pub window: xproto::Window,
     pub swap_action: SwapAction,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SwapInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SwapInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for SwapInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -149,10 +156,17 @@ impl Serialize for SwapInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BufferAttributes {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BufferAttributes {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BufferAttributes").finish_non_exhaustive()
+    }
 }
 impl TryParse for BufferAttributes {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -178,12 +192,19 @@ impl Serialize for BufferAttributes {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VisualInfo {
     pub visual_id: xproto::Visualid,
     pub depth: u8,
     pub perf_level: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for VisualInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VisualInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for VisualInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -221,10 +242,17 @@ impl Serialize for VisualInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VisualInfos {
     pub infos: Vec<VisualInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for VisualInfos {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VisualInfos").finish_non_exhaustive()
+    }
 }
 impl TryParse for VisualInfos {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -276,11 +304,18 @@ pub const QUERY_VERSION_REQUEST: u8 = 0;
 ///
 /// * `major_version` - The major version of the extension. Check that it is compatible with the XCB_DBE_MAJOR_VERSION that your code is compiled with.
 /// * `minor_version` - The minor version of the extension. Check that it is compatible with the XCB_DBE_MINOR_VERSION that your code is compiled with.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u8,
     pub minor_version: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -333,13 +368,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u8,
     pub minor_version: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -428,12 +470,19 @@ pub const ALLOCATE_BACK_BUFFER_REQUEST: u8 = 1;
 /// * `window` - The window to which to add the back buffer.
 /// * `buffer` - The buffer id to associate with the back buffer.
 /// * `swap_action` - The swap action most likely to be used to present this back buffer. This is only a hint, and does not preclude the use of other swap actions.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocateBackBufferRequest {
     pub window: xproto::Window,
     pub buffer: BackBuffer,
     pub swap_action: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AllocateBackBufferRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllocateBackBufferRequest").finish_non_exhaustive()
+    }
 }
 impl AllocateBackBufferRequest {
     /// Serialize this request into bytes for the provided connection
@@ -505,10 +554,17 @@ pub const DEALLOCATE_BACK_BUFFER_REQUEST: u8 = 2;
 /// # Fields
 ///
 /// * `buffer` - The back buffer to deallocate.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeallocateBackBufferRequest {
     pub buffer: BackBuffer,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeallocateBackBufferRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeallocateBackBufferRequest").finish_non_exhaustive()
+    }
 }
 impl DeallocateBackBufferRequest {
     /// Serialize this request into bytes for the provided connection
@@ -565,10 +621,17 @@ pub const SWAP_BUFFERS_REQUEST: u8 = 3;
 /// # Fields
 ///
 /// * `actions` - List of windows on which to swap buffers.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwapBuffersRequest<'input> {
     pub actions: Cow<'input, [SwapInfo]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SwapBuffersRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SwapBuffersRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SwapBuffersRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -633,9 +696,16 @@ pub const BEGIN_IDIOM_REQUEST: u8 = 4;
 /// Begins a logical swap block.
 ///
 /// Creates a block of operations intended to occur together. This may be needed if window presentation requires changing buffers unknown to this extension, such as depth or stencil buffers.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BeginIdiomRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BeginIdiomRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BeginIdiomRequest").finish_non_exhaustive()
+    }
+}
 impl BeginIdiomRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -678,9 +748,16 @@ impl crate::x11_utils::VoidRequest for BeginIdiomRequest {
 /// Opcode for the EndIdiom request
 pub const END_IDIOM_REQUEST: u8 = 5;
 /// Ends a logical swap block.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EndIdiomRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EndIdiomRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EndIdiomRequest").finish_non_exhaustive()
+    }
+}
 impl EndIdiomRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -723,10 +800,17 @@ impl crate::x11_utils::VoidRequest for EndIdiomRequest {
 /// Opcode for the GetVisualInfo request
 pub const GET_VISUAL_INFO_REQUEST: u8 = 6;
 /// Requests visuals that support double buffering.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVisualInfoRequest<'input> {
     pub drawables: Cow<'input, [xproto::Drawable]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for GetVisualInfoRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetVisualInfoRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> GetVisualInfoRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -787,12 +871,19 @@ impl<'input> crate::x11_utils::ReplyRequest for GetVisualInfoRequest<'input> {
     type Reply = GetVisualInfoReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVisualInfoReply {
     pub sequence: u16,
     pub length: u32,
     pub supported_visuals: Vec<VisualInfos>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetVisualInfoReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetVisualInfoReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetVisualInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -860,10 +951,17 @@ pub const GET_BACK_BUFFER_ATTRIBUTES_REQUEST: u8 = 7;
 ///
 /// * `buffer` - The back buffer to query.
 /// * `attributes` - The attributes of `buffer`.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBackBufferAttributesRequest {
     pub buffer: BackBuffer,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetBackBufferAttributesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetBackBufferAttributesRequest").finish_non_exhaustive()
+    }
 }
 impl GetBackBufferAttributesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -912,12 +1010,19 @@ impl crate::x11_utils::ReplyRequest for GetBackBufferAttributesRequest {
     type Reply = GetBackBufferAttributesReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBackBufferAttributesReply {
     pub sequence: u16,
     pub length: u32,
     pub attributes: BufferAttributes,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetBackBufferAttributesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetBackBufferAttributesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetBackBufferAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/dpms.rs
+++ b/x11rb-protocol/src/protocol/dpms.rs
@@ -38,11 +38,18 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 
 /// Opcode for the GetVersion request
 pub const GET_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetVersionRequest").finish_non_exhaustive()
+    }
 }
 impl GetVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -94,13 +101,20 @@ impl crate::x11_utils::ReplyRequest for GetVersionRequest {
     type Reply = GetVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub server_major_version: u16,
     pub server_minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -158,9 +172,16 @@ impl Serialize for GetVersionReply {
 
 /// Opcode for the Capable request
 pub const CAPABLE_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CapableRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CapableRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CapableRequest").finish_non_exhaustive()
+    }
+}
 impl CapableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -201,12 +222,19 @@ impl crate::x11_utils::ReplyRequest for CapableRequest {
     type Reply = CapableReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CapableReply {
     pub sequence: u16,
     pub length: u32,
     pub capable: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CapableReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CapableReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for CapableReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -283,9 +311,16 @@ impl Serialize for CapableReply {
 
 /// Opcode for the GetTimeouts request
 pub const GET_TIMEOUTS_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTimeoutsRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTimeoutsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTimeoutsRequest").finish_non_exhaustive()
+    }
+}
 impl GetTimeoutsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -326,7 +361,8 @@ impl crate::x11_utils::ReplyRequest for GetTimeoutsRequest {
     type Reply = GetTimeoutsReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTimeoutsReply {
     pub sequence: u16,
@@ -334,6 +370,12 @@ pub struct GetTimeoutsReply {
     pub standby_timeout: u16,
     pub suspend_timeout: u16,
     pub off_timeout: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTimeoutsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTimeoutsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetTimeoutsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -416,12 +458,19 @@ impl Serialize for GetTimeoutsReply {
 
 /// Opcode for the SetTimeouts request
 pub const SET_TIMEOUTS_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetTimeoutsRequest {
     pub standby_timeout: u16,
     pub suspend_timeout: u16,
     pub off_timeout: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetTimeoutsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetTimeoutsRequest").finish_non_exhaustive()
+    }
 }
 impl SetTimeoutsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -481,9 +530,16 @@ impl crate::x11_utils::VoidRequest for SetTimeoutsRequest {
 
 /// Opcode for the Enable request
 pub const ENABLE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnableRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EnableRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EnableRequest").finish_non_exhaustive()
+    }
+}
 impl EnableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -525,9 +581,16 @@ impl crate::x11_utils::VoidRequest for EnableRequest {
 
 /// Opcode for the Disable request
 pub const DISABLE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DisableRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DisableRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DisableRequest").finish_non_exhaustive()
+    }
+}
 impl DisableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -626,10 +689,17 @@ impl core::fmt::Debug for DPMSMode  {
 
 /// Opcode for the ForceLevel request
 pub const FORCE_LEVEL_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ForceLevelRequest {
     pub power_level: DPMSMode,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ForceLevelRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ForceLevelRequest").finish_non_exhaustive()
+    }
 }
 impl ForceLevelRequest {
     /// Serialize this request into bytes for the provided connection
@@ -680,9 +750,16 @@ impl crate::x11_utils::VoidRequest for ForceLevelRequest {
 
 /// Opcode for the Info request
 pub const INFO_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InfoRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InfoRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InfoRequest").finish_non_exhaustive()
+    }
+}
 impl InfoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -723,13 +800,20 @@ impl crate::x11_utils::ReplyRequest for InfoRequest {
     type Reply = InfoReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InfoReply {
     pub sequence: u16,
     pub length: u32,
     pub power_level: DPMSMode,
     pub state: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InfoReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InfoReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for InfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -856,10 +940,17 @@ bitmask_binop!(EventMask, u32);
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputRequest {
     pub event_mask: EventMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectInputRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectInputRequest").finish_non_exhaustive()
+    }
 }
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
@@ -910,7 +1001,8 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 
 /// Opcode for the InfoNotify event
 pub const INFO_NOTIFY_EVENT: u16 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InfoNotifyEvent {
     pub response_type: u8,
@@ -921,6 +1013,12 @@ pub struct InfoNotifyEvent {
     pub timestamp: xproto::Timestamp,
     pub power_level: DPMSMode,
     pub state: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InfoNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InfoNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for InfoNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/dpms.rs
+++ b/x11rb-protocol/src/protocol/dpms.rs
@@ -74,7 +74,7 @@ impl GetVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -200,7 +200,7 @@ impl CapableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CAPABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -340,7 +340,7 @@ impl GetTimeoutsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TIMEOUTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -503,7 +503,7 @@ impl SetTimeoutsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_TIMEOUTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -561,7 +561,7 @@ impl EnableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ENABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -613,7 +613,7 @@ impl DisableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DISABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -729,7 +729,7 @@ impl ForceLevelRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FORCE_LEVEL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -784,7 +784,7 @@ impl InfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -982,7 +982,7 @@ impl SelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/dpms.rs
+++ b/x11rb-protocol/src/protocol/dpms.rs
@@ -74,6 +74,7 @@ impl GetVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -199,6 +200,7 @@ impl CapableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CAPABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -338,6 +340,7 @@ impl GetTimeoutsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TIMEOUTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -500,6 +503,7 @@ impl SetTimeoutsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_TIMEOUTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -557,6 +561,7 @@ impl EnableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ENABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -608,6 +613,7 @@ impl DisableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DISABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -723,6 +729,7 @@ impl ForceLevelRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FORCE_LEVEL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -777,6 +784,7 @@ impl InfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -974,6 +982,7 @@ impl SelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/dri2.rs
+++ b/x11rb-protocol/src/protocol/dri2.rs
@@ -203,7 +203,8 @@ impl core::fmt::Debug for EventType  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DRI2Buffer {
     pub attachment: Attachment,
@@ -211,6 +212,12 @@ pub struct DRI2Buffer {
     pub pitch: u32,
     pub cpp: u32,
     pub flags: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DRI2Buffer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DRI2Buffer").finish_non_exhaustive()
+    }
 }
 impl TryParse for DRI2Buffer {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -265,11 +272,18 @@ impl Serialize for DRI2Buffer {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttachFormat {
     pub attachment: Attachment,
     pub format: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AttachFormat {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AttachFormat").finish_non_exhaustive()
+    }
 }
 impl TryParse for AttachFormat {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -305,11 +319,18 @@ impl Serialize for AttachFormat {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -365,13 +386,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -433,11 +461,18 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the Connect request
 pub const CONNECT_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConnectRequest {
     pub window: xproto::Window,
     pub driver_type: DriverType,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ConnectRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ConnectRequest").finish_non_exhaustive()
+    }
 }
 impl ConnectRequest {
     /// Serialize this request into bytes for the provided connection
@@ -494,7 +529,8 @@ impl crate::x11_utils::ReplyRequest for ConnectRequest {
     type Reply = ConnectReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConnectReply {
     pub sequence: u16,
@@ -502,6 +538,12 @@ pub struct ConnectReply {
     pub driver_name: Vec<u8>,
     pub alignment_pad: Vec<u8>,
     pub device_name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ConnectReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ConnectReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ConnectReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -585,11 +627,18 @@ impl ConnectReply {
 
 /// Opcode for the Authenticate request
 pub const AUTHENTICATE_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AuthenticateRequest {
     pub window: xproto::Window,
     pub magic: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AuthenticateRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AuthenticateRequest").finish_non_exhaustive()
+    }
 }
 impl AuthenticateRequest {
     /// Serialize this request into bytes for the provided connection
@@ -645,12 +694,19 @@ impl crate::x11_utils::ReplyRequest for AuthenticateRequest {
     type Reply = AuthenticateReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AuthenticateReply {
     pub sequence: u16,
     pub length: u32,
     pub authenticated: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AuthenticateReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AuthenticateReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for AuthenticateReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -705,10 +761,17 @@ impl Serialize for AuthenticateReply {
 
 /// Opcode for the CreateDrawable request
 pub const CREATE_DRAWABLE_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateDrawableRequest {
     pub drawable: xproto::Drawable,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateDrawableRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateDrawableRequest").finish_non_exhaustive()
+    }
 }
 impl CreateDrawableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -758,10 +821,17 @@ impl crate::x11_utils::VoidRequest for CreateDrawableRequest {
 
 /// Opcode for the DestroyDrawable request
 pub const DESTROY_DRAWABLE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyDrawableRequest {
     pub drawable: xproto::Drawable,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyDrawableRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyDrawableRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyDrawableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -811,12 +881,19 @@ impl crate::x11_utils::VoidRequest for DestroyDrawableRequest {
 
 /// Opcode for the GetBuffers request
 pub const GET_BUFFERS_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBuffersRequest<'input> {
     pub drawable: xproto::Drawable,
     pub count: u32,
     pub attachments: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for GetBuffersRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetBuffersRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> GetBuffersRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -893,7 +970,8 @@ impl<'input> crate::x11_utils::ReplyRequest for GetBuffersRequest<'input> {
     type Reply = GetBuffersReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBuffersReply {
     pub sequence: u16,
@@ -901,6 +979,12 @@ pub struct GetBuffersReply {
     pub width: u32,
     pub height: u32,
     pub buffers: Vec<DRI2Buffer>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetBuffersReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetBuffersReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetBuffersReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -964,13 +1048,20 @@ impl GetBuffersReply {
 
 /// Opcode for the CopyRegion request
 pub const COPY_REGION_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyRegionRequest {
     pub drawable: xproto::Drawable,
     pub region: u32,
     pub dest: u32,
     pub src: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CopyRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CopyRegionRequest").finish_non_exhaustive()
+    }
 }
 impl CopyRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1040,11 +1131,18 @@ impl crate::x11_utils::ReplyRequest for CopyRegionRequest {
     type Reply = CopyRegionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyRegionReply {
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CopyRegionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CopyRegionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for CopyRegionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1092,12 +1190,19 @@ impl Serialize for CopyRegionReply {
 
 /// Opcode for the GetBuffersWithFormat request
 pub const GET_BUFFERS_WITH_FORMAT_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBuffersWithFormatRequest<'input> {
     pub drawable: xproto::Drawable,
     pub count: u32,
     pub attachments: Cow<'input, [AttachFormat]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for GetBuffersWithFormatRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetBuffersWithFormatRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> GetBuffersWithFormatRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1174,7 +1279,8 @@ impl<'input> crate::x11_utils::ReplyRequest for GetBuffersWithFormatRequest<'inp
     type Reply = GetBuffersWithFormatReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBuffersWithFormatReply {
     pub sequence: u16,
@@ -1182,6 +1288,12 @@ pub struct GetBuffersWithFormatReply {
     pub width: u32,
     pub height: u32,
     pub buffers: Vec<DRI2Buffer>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetBuffersWithFormatReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetBuffersWithFormatReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetBuffersWithFormatReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1245,7 +1357,8 @@ impl GetBuffersWithFormatReply {
 
 /// Opcode for the SwapBuffers request
 pub const SWAP_BUFFERS_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwapBuffersRequest {
     pub drawable: xproto::Drawable,
@@ -1255,6 +1368,12 @@ pub struct SwapBuffersRequest {
     pub divisor_lo: u32,
     pub remainder_hi: u32,
     pub remainder_lo: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SwapBuffersRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SwapBuffersRequest").finish_non_exhaustive()
+    }
 }
 impl SwapBuffersRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1345,13 +1464,20 @@ impl crate::x11_utils::ReplyRequest for SwapBuffersRequest {
     type Reply = SwapBuffersReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwapBuffersReply {
     pub sequence: u16,
     pub length: u32,
     pub swap_hi: u32,
     pub swap_lo: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SwapBuffersReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SwapBuffersReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SwapBuffersReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1413,10 +1539,17 @@ impl Serialize for SwapBuffersReply {
 
 /// Opcode for the GetMSC request
 pub const GET_MSC_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMSCRequest {
     pub drawable: xproto::Drawable,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMSCRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMSCRequest").finish_non_exhaustive()
+    }
 }
 impl GetMSCRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1465,7 +1598,8 @@ impl crate::x11_utils::ReplyRequest for GetMSCRequest {
     type Reply = GetMSCReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMSCReply {
     pub sequence: u16,
@@ -1476,6 +1610,12 @@ pub struct GetMSCReply {
     pub msc_lo: u32,
     pub sbc_hi: u32,
     pub sbc_lo: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMSCReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMSCReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMSCReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1565,7 +1705,8 @@ impl Serialize for GetMSCReply {
 
 /// Opcode for the WaitMSC request
 pub const WAIT_MSC_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaitMSCRequest {
     pub drawable: xproto::Drawable,
@@ -1575,6 +1716,12 @@ pub struct WaitMSCRequest {
     pub divisor_lo: u32,
     pub remainder_hi: u32,
     pub remainder_lo: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for WaitMSCRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("WaitMSCRequest").finish_non_exhaustive()
+    }
 }
 impl WaitMSCRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1665,7 +1812,8 @@ impl crate::x11_utils::ReplyRequest for WaitMSCRequest {
     type Reply = WaitMSCReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaitMSCReply {
     pub sequence: u16,
@@ -1676,6 +1824,12 @@ pub struct WaitMSCReply {
     pub msc_lo: u32,
     pub sbc_hi: u32,
     pub sbc_lo: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for WaitMSCReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("WaitMSCReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for WaitMSCReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1765,12 +1919,19 @@ impl Serialize for WaitMSCReply {
 
 /// Opcode for the WaitSBC request
 pub const WAIT_SBC_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaitSBCRequest {
     pub drawable: xproto::Drawable,
     pub target_sbc_hi: u32,
     pub target_sbc_lo: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for WaitSBCRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("WaitSBCRequest").finish_non_exhaustive()
+    }
 }
 impl WaitSBCRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1833,7 +1994,8 @@ impl crate::x11_utils::ReplyRequest for WaitSBCRequest {
     type Reply = WaitSBCReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaitSBCReply {
     pub sequence: u16,
@@ -1844,6 +2006,12 @@ pub struct WaitSBCReply {
     pub msc_lo: u32,
     pub sbc_hi: u32,
     pub sbc_lo: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for WaitSBCReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("WaitSBCReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for WaitSBCReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1933,11 +2101,18 @@ impl Serialize for WaitSBCReply {
 
 /// Opcode for the SwapInterval request
 pub const SWAP_INTERVAL_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwapIntervalRequest {
     pub drawable: xproto::Drawable,
     pub interval: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SwapIntervalRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SwapIntervalRequest").finish_non_exhaustive()
+    }
 }
 impl SwapIntervalRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1994,11 +2169,18 @@ impl crate::x11_utils::VoidRequest for SwapIntervalRequest {
 
 /// Opcode for the GetParam request
 pub const GET_PARAM_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetParamRequest {
     pub drawable: xproto::Drawable,
     pub param: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetParamRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetParamRequest").finish_non_exhaustive()
+    }
 }
 impl GetParamRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2054,7 +2236,8 @@ impl crate::x11_utils::ReplyRequest for GetParamRequest {
     type Reply = GetParamReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetParamReply {
     pub is_param_recognized: bool,
@@ -2062,6 +2245,12 @@ pub struct GetParamReply {
     pub length: u32,
     pub value_hi: u32,
     pub value_lo: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetParamReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetParamReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetParamReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2124,7 +2313,8 @@ impl Serialize for GetParamReply {
 
 /// Opcode for the BufferSwapComplete event
 pub const BUFFER_SWAP_COMPLETE_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BufferSwapCompleteEvent {
     pub response_type: u8,
@@ -2136,6 +2326,12 @@ pub struct BufferSwapCompleteEvent {
     pub msc_hi: u32,
     pub msc_lo: u32,
     pub sbc: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BufferSwapCompleteEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BufferSwapCompleteEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for BufferSwapCompleteEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2276,12 +2472,19 @@ impl From<BufferSwapCompleteEvent> for [u8; 32] {
 
 /// Opcode for the InvalidateBuffers event
 pub const INVALIDATE_BUFFERS_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InvalidateBuffersEvent {
     pub response_type: u8,
     pub sequence: u16,
     pub drawable: xproto::Drawable,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InvalidateBuffersEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InvalidateBuffersEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for InvalidateBuffersEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/dri2.rs
+++ b/x11rb-protocol/src/protocol/dri2.rs
@@ -359,7 +359,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -502,7 +502,7 @@ impl ConnectRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CONNECT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -669,7 +669,7 @@ impl AuthenticateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != AUTHENTICATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -798,7 +798,7 @@ impl CreateDrawableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_DRAWABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -859,7 +859,7 @@ impl DestroyDrawableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_DRAWABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -931,7 +931,7 @@ impl<'input> GetBuffersRequest<'input> {
         ([request0.into(), attachments_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_BUFFERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1106,7 +1106,7 @@ impl CopyRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COPY_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1242,7 +1242,7 @@ impl<'input> GetBuffersWithFormatRequest<'input> {
         ([request0.into(), attachments_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_BUFFERS_WITH_FORMAT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1435,7 +1435,7 @@ impl SwapBuffersRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SWAP_BUFFERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1582,7 +1582,7 @@ impl GetMSCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MSC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1785,7 +1785,7 @@ impl WaitMSCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != WAIT_MSC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1976,7 +1976,7 @@ impl WaitSBCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != WAIT_SBC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2153,7 +2153,7 @@ impl SwapIntervalRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SWAP_INTERVAL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2222,7 +2222,7 @@ impl GetParamRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PARAM_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/dri2.rs
+++ b/x11rb-protocol/src/protocol/dri2.rs
@@ -359,6 +359,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -501,6 +502,7 @@ impl ConnectRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CONNECT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -667,6 +669,7 @@ impl AuthenticateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != AUTHENTICATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -795,6 +798,7 @@ impl CreateDrawableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_DRAWABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -855,6 +859,7 @@ impl DestroyDrawableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_DRAWABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -926,6 +931,7 @@ impl<'input> GetBuffersRequest<'input> {
         ([request0.into(), attachments_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_BUFFERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1100,6 +1106,7 @@ impl CopyRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COPY_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1235,6 +1242,7 @@ impl<'input> GetBuffersWithFormatRequest<'input> {
         ([request0.into(), attachments_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_BUFFERS_WITH_FORMAT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1427,6 +1435,7 @@ impl SwapBuffersRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SWAP_BUFFERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1573,6 +1582,7 @@ impl GetMSCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MSC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1775,6 +1785,7 @@ impl WaitMSCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != WAIT_MSC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1965,6 +1976,7 @@ impl WaitSBCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != WAIT_SBC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2141,6 +2153,7 @@ impl SwapIntervalRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SWAP_INTERVAL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2209,6 +2222,7 @@ impl GetParamRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PARAM_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/dri3.rs
+++ b/x11rb-protocol/src/protocol/dri3.rs
@@ -78,6 +78,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -220,6 +221,7 @@ impl OpenRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != OPEN_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -398,6 +400,7 @@ impl PixmapFromBufferRequest {
         ([request0.into()], vec![self.pixmap_fd])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request_fd(header: RequestHeader, value: &[u8], fds: &mut Vec<RawFdContainer>) -> Result<Self, ParseError> {
         if header.minor_opcode != PIXMAP_FROM_BUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -475,6 +478,7 @@ impl BufferFromPixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != BUFFER_FROM_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -657,6 +661,7 @@ impl FenceFromFDRequest {
         ([request0.into()], vec![self.fence_fd])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request_fd(header: RequestHeader, value: &[u8], fds: &mut Vec<RawFdContainer>) -> Result<Self, ParseError> {
         if header.minor_opcode != FENCE_FROM_FD_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -731,6 +736,7 @@ impl FDFromFenceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FD_FROM_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -888,6 +894,7 @@ impl GetSupportedModifiersRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SUPPORTED_MODIFIERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1128,6 +1135,7 @@ impl PixmapFromBuffersRequest {
         ([request0.into()], self.buffers)
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request_fd(header: RequestHeader, value: &[u8], fds: &mut Vec<RawFdContainer>) -> Result<Self, ParseError> {
         if header.minor_opcode != PIXMAP_FROM_BUFFERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1224,6 +1232,7 @@ impl BuffersFromPixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != BUFFERS_FROM_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1390,6 +1399,7 @@ impl SetDRMDeviceInUseRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DRM_DEVICE_IN_USE_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/dri3.rs
+++ b/x11rb-protocol/src/protocol/dri3.rs
@@ -78,7 +78,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -221,7 +221,7 @@ impl OpenRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != OPEN_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -400,7 +400,7 @@ impl PixmapFromBufferRequest {
         ([request0.into()], vec![self.pixmap_fd])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request_fd(header: RequestHeader, value: &[u8], fds: &mut Vec<RawFdContainer>) -> Result<Self, ParseError> {
         if header.minor_opcode != PIXMAP_FROM_BUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -478,7 +478,7 @@ impl BufferFromPixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != BUFFER_FROM_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -661,7 +661,7 @@ impl FenceFromFDRequest {
         ([request0.into()], vec![self.fence_fd])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request_fd(header: RequestHeader, value: &[u8], fds: &mut Vec<RawFdContainer>) -> Result<Self, ParseError> {
         if header.minor_opcode != FENCE_FROM_FD_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -736,7 +736,7 @@ impl FDFromFenceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FD_FROM_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -894,7 +894,7 @@ impl GetSupportedModifiersRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SUPPORTED_MODIFIERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1135,7 +1135,7 @@ impl PixmapFromBuffersRequest {
         ([request0.into()], self.buffers)
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request_fd(header: RequestHeader, value: &[u8], fds: &mut Vec<RawFdContainer>) -> Result<Self, ParseError> {
         if header.minor_opcode != PIXMAP_FROM_BUFFERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1232,7 +1232,7 @@ impl BuffersFromPixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != BUFFERS_FROM_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1399,7 +1399,7 @@ impl SetDRMDeviceInUseRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DRM_DEVICE_IN_USE_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/dri3.rs
+++ b/x11rb-protocol/src/protocol/dri3.rs
@@ -38,11 +38,18 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 3);
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -98,13 +105,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -166,11 +180,18 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the Open request
 pub const OPEN_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenRequest {
     pub drawable: xproto::Drawable,
     pub provider: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for OpenRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OpenRequest").finish_non_exhaustive()
+    }
 }
 impl OpenRequest {
     /// Serialize this request into bytes for the provided connection
@@ -226,12 +247,18 @@ impl crate::x11_utils::ReplyFDsRequest for OpenRequest {
     type Reply = OpenReply;
 }
 
-#[derive(Debug)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 pub struct OpenReply {
     pub nfd: u8,
     pub sequence: u16,
     pub length: u32,
     pub device_fd: RawFdContainer,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for OpenReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OpenReply").finish_non_exhaustive()
+    }
 }
 impl TryParseFd for OpenReply {
     fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
@@ -308,7 +335,7 @@ impl Serialize for OpenReply {
 
 /// Opcode for the PixmapFromBuffer request
 pub const PIXMAP_FROM_BUFFER_REQUEST: u8 = 2;
-#[derive(Debug)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 pub struct PixmapFromBufferRequest {
     pub pixmap: xproto::Pixmap,
     pub drawable: xproto::Drawable,
@@ -319,6 +346,12 @@ pub struct PixmapFromBufferRequest {
     pub depth: u8,
     pub bpp: u8,
     pub pixmap_fd: RawFdContainer,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PixmapFromBufferRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PixmapFromBufferRequest").finish_non_exhaustive()
+    }
 }
 impl PixmapFromBufferRequest {
     /// Serialize this request into bytes for the provided connection
@@ -408,10 +441,17 @@ impl crate::x11_utils::VoidRequest for PixmapFromBufferRequest {
 
 /// Opcode for the BufferFromPixmap request
 pub const BUFFER_FROM_PIXMAP_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BufferFromPixmapRequest {
     pub pixmap: xproto::Pixmap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BufferFromPixmapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BufferFromPixmapRequest").finish_non_exhaustive()
+    }
 }
 impl BufferFromPixmapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -460,7 +500,7 @@ impl crate::x11_utils::ReplyFDsRequest for BufferFromPixmapRequest {
     type Reply = BufferFromPixmapReply;
 }
 
-#[derive(Debug)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 pub struct BufferFromPixmapReply {
     pub nfd: u8,
     pub sequence: u16,
@@ -472,6 +512,12 @@ pub struct BufferFromPixmapReply {
     pub depth: u8,
     pub bpp: u8,
     pub pixmap_fd: RawFdContainer,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BufferFromPixmapReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BufferFromPixmapReply").finish_non_exhaustive()
+    }
 }
 impl TryParseFd for BufferFromPixmapReply {
     fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
@@ -566,12 +612,18 @@ impl Serialize for BufferFromPixmapReply {
 
 /// Opcode for the FenceFromFD request
 pub const FENCE_FROM_FD_REQUEST: u8 = 4;
-#[derive(Debug)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 pub struct FenceFromFDRequest {
     pub drawable: xproto::Drawable,
     pub fence: u32,
     pub initially_triggered: bool,
     pub fence_fd: RawFdContainer,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FenceFromFDRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FenceFromFDRequest").finish_non_exhaustive()
+    }
 }
 impl FenceFromFDRequest {
     /// Serialize this request into bytes for the provided connection
@@ -639,11 +691,18 @@ impl crate::x11_utils::VoidRequest for FenceFromFDRequest {
 
 /// Opcode for the FDFromFence request
 pub const FD_FROM_FENCE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FDFromFenceRequest {
     pub drawable: xproto::Drawable,
     pub fence: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FDFromFenceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FDFromFenceRequest").finish_non_exhaustive()
+    }
 }
 impl FDFromFenceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -699,12 +758,18 @@ impl crate::x11_utils::ReplyFDsRequest for FDFromFenceRequest {
     type Reply = FDFromFenceReply;
 }
 
-#[derive(Debug)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 pub struct FDFromFenceReply {
     pub nfd: u8,
     pub sequence: u16,
     pub length: u32,
     pub fence_fd: RawFdContainer,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FDFromFenceReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FDFromFenceReply").finish_non_exhaustive()
+    }
 }
 impl TryParseFd for FDFromFenceReply {
     fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
@@ -781,12 +846,19 @@ impl Serialize for FDFromFenceReply {
 
 /// Opcode for the GetSupportedModifiers request
 pub const GET_SUPPORTED_MODIFIERS_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSupportedModifiersRequest {
     pub window: u32,
     pub depth: u8,
     pub bpp: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSupportedModifiersRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSupportedModifiersRequest").finish_non_exhaustive()
+    }
 }
 impl GetSupportedModifiersRequest {
     /// Serialize this request into bytes for the provided connection
@@ -846,13 +918,20 @@ impl crate::x11_utils::ReplyRequest for GetSupportedModifiersRequest {
     type Reply = GetSupportedModifiersReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSupportedModifiersReply {
     pub sequence: u16,
     pub length: u32,
     pub window_modifiers: Vec<u64>,
     pub screen_modifiers: Vec<u64>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSupportedModifiersReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSupportedModifiersReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetSupportedModifiersReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -930,7 +1009,7 @@ impl GetSupportedModifiersReply {
 
 /// Opcode for the PixmapFromBuffers request
 pub const PIXMAP_FROM_BUFFERS_REQUEST: u8 = 7;
-#[derive(Debug)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 pub struct PixmapFromBuffersRequest {
     pub pixmap: xproto::Pixmap,
     pub window: xproto::Window,
@@ -948,6 +1027,12 @@ pub struct PixmapFromBuffersRequest {
     pub bpp: u8,
     pub modifier: u64,
     pub buffers: Vec<RawFdContainer>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PixmapFromBuffersRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PixmapFromBuffersRequest").finish_non_exhaustive()
+    }
 }
 impl PixmapFromBuffersRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1105,10 +1190,17 @@ impl crate::x11_utils::VoidRequest for PixmapFromBuffersRequest {
 
 /// Opcode for the BuffersFromPixmap request
 pub const BUFFERS_FROM_PIXMAP_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BuffersFromPixmapRequest {
     pub pixmap: xproto::Pixmap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BuffersFromPixmapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BuffersFromPixmapRequest").finish_non_exhaustive()
+    }
 }
 impl BuffersFromPixmapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1157,7 +1249,7 @@ impl crate::x11_utils::ReplyFDsRequest for BuffersFromPixmapRequest {
     type Reply = BuffersFromPixmapReply;
 }
 
-#[derive(Debug)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 pub struct BuffersFromPixmapReply {
     pub sequence: u16,
     pub length: u32,
@@ -1169,6 +1261,12 @@ pub struct BuffersFromPixmapReply {
     pub strides: Vec<u32>,
     pub offsets: Vec<u32>,
     pub buffers: Vec<RawFdContainer>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BuffersFromPixmapReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BuffersFromPixmapReply").finish_non_exhaustive()
+    }
 }
 impl TryParseFd for BuffersFromPixmapReply {
     fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
@@ -1246,12 +1344,19 @@ impl BuffersFromPixmapReply {
 
 /// Opcode for the SetDRMDeviceInUse request
 pub const SET_DRM_DEVICE_IN_USE_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDRMDeviceInUseRequest {
     pub window: xproto::Window,
     pub drm_major: u32,
     pub drm_minor: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetDRMDeviceInUseRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDRMDeviceInUseRequest").finish_non_exhaustive()
+    }
 }
 impl SetDRMDeviceInUseRequest {
     /// Serialize this request into bytes for the provided connection

--- a/x11rb-protocol/src/protocol/ge.rs
+++ b/x11rb-protocol/src/protocol/ge.rs
@@ -36,11 +36,18 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -92,13 +99,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u16,
     pub minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/ge.rs
+++ b/x11rb-protocol/src/protocol/ge.rs
@@ -72,6 +72,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/ge.rs
+++ b/x11rb-protocol/src/protocol/ge.rs
@@ -72,7 +72,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/glx.rs
+++ b/x11rb-protocol/src/protocol/glx.rs
@@ -101,7 +101,8 @@ pub const GLX_BAD_PROFILE_ARB_ERROR: u8 = 13;
 
 /// Opcode for the PbufferClobber event
 pub const PBUFFER_CLOBBER_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PbufferClobberEvent {
     pub response_type: u8,
@@ -116,6 +117,12 @@ pub struct PbufferClobberEvent {
     pub width: u16,
     pub height: u16,
     pub count: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PbufferClobberEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PbufferClobberEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for PbufferClobberEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -267,7 +274,8 @@ impl From<PbufferClobberEvent> for [u8; 32] {
 
 /// Opcode for the BufferSwapComplete event
 pub const BUFFER_SWAP_COMPLETE_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BufferSwapCompleteEvent {
     pub response_type: u8,
@@ -279,6 +287,12 @@ pub struct BufferSwapCompleteEvent {
     pub msc_hi: u32,
     pub msc_lo: u32,
     pub sbc: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BufferSwapCompleteEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BufferSwapCompleteEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for BufferSwapCompleteEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -524,11 +538,18 @@ impl core::fmt::Debug for PBCDT  {
 
 /// Opcode for the Render request
 pub const RENDER_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RenderRequest<'input> {
     pub context_tag: ContextTag,
     pub data: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for RenderRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RenderRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> RenderRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -590,13 +611,20 @@ impl<'input> crate::x11_utils::VoidRequest for RenderRequest<'input> {
 
 /// Opcode for the RenderLarge request
 pub const RENDER_LARGE_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RenderLargeRequest<'input> {
     pub context_tag: ContextTag,
     pub request_num: u16,
     pub request_total: u16,
     pub data: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for RenderLargeRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RenderLargeRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> RenderLargeRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -677,7 +705,8 @@ impl<'input> crate::x11_utils::VoidRequest for RenderLargeRequest<'input> {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextRequest {
     pub context: Context,
@@ -685,6 +714,12 @@ pub struct CreateContextRequest {
     pub screen: u32,
     pub share_list: Context,
     pub is_direct: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateContextRequest").finish_non_exhaustive()
+    }
 }
 impl CreateContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -763,10 +798,17 @@ impl crate::x11_utils::VoidRequest for CreateContextRequest {
 
 /// Opcode for the DestroyContext request
 pub const DESTROY_CONTEXT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyContextRequest {
     pub context: Context,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyContextRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -816,12 +858,19 @@ impl crate::x11_utils::VoidRequest for DestroyContextRequest {
 
 /// Opcode for the MakeCurrent request
 pub const MAKE_CURRENT_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MakeCurrentRequest {
     pub drawable: Drawable,
     pub context: Context,
     pub old_context_tag: ContextTag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MakeCurrentRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MakeCurrentRequest").finish_non_exhaustive()
+    }
 }
 impl MakeCurrentRequest {
     /// Serialize this request into bytes for the provided connection
@@ -884,12 +933,19 @@ impl crate::x11_utils::ReplyRequest for MakeCurrentRequest {
     type Reply = MakeCurrentReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MakeCurrentReply {
     pub sequence: u16,
     pub length: u32,
     pub context_tag: ContextTag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MakeCurrentReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MakeCurrentReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for MakeCurrentReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -966,10 +1022,17 @@ impl Serialize for MakeCurrentReply {
 
 /// Opcode for the IsDirect request
 pub const IS_DIRECT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsDirectRequest {
     pub context: Context,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IsDirectRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IsDirectRequest").finish_non_exhaustive()
+    }
 }
 impl IsDirectRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1018,12 +1081,19 @@ impl crate::x11_utils::ReplyRequest for IsDirectRequest {
     type Reply = IsDirectReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsDirectReply {
     pub sequence: u16,
     pub length: u32,
     pub is_direct: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IsDirectReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IsDirectReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for IsDirectReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1100,11 +1170,18 @@ impl Serialize for IsDirectReply {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1160,13 +1237,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1246,10 +1330,17 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the WaitGL request
 pub const WAIT_GL_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaitGLRequest {
     pub context_tag: ContextTag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for WaitGLRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("WaitGLRequest").finish_non_exhaustive()
+    }
 }
 impl WaitGLRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1299,10 +1390,17 @@ impl crate::x11_utils::VoidRequest for WaitGLRequest {
 
 /// Opcode for the WaitX request
 pub const WAIT_X_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WaitXRequest {
     pub context_tag: ContextTag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for WaitXRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("WaitXRequest").finish_non_exhaustive()
+    }
 }
 impl WaitXRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1352,13 +1450,20 @@ impl crate::x11_utils::VoidRequest for WaitXRequest {
 
 /// Opcode for the CopyContext request
 pub const COPY_CONTEXT_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyContextRequest {
     pub src: Context,
     pub dest: Context,
     pub mask: u32,
     pub src_context_tag: ContextTag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CopyContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CopyContextRequest").finish_non_exhaustive()
+    }
 }
 impl CopyContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1514,11 +1619,18 @@ impl core::fmt::Debug for GC  {
 
 /// Opcode for the SwapBuffers request
 pub const SWAP_BUFFERS_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwapBuffersRequest {
     pub context_tag: ContextTag,
     pub drawable: Drawable,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SwapBuffersRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SwapBuffersRequest").finish_non_exhaustive()
+    }
 }
 impl SwapBuffersRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1575,7 +1687,8 @@ impl crate::x11_utils::VoidRequest for SwapBuffersRequest {
 
 /// Opcode for the UseXFont request
 pub const USE_X_FONT_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UseXFontRequest {
     pub context_tag: ContextTag,
@@ -1583,6 +1696,12 @@ pub struct UseXFontRequest {
     pub first: u32,
     pub count: u32,
     pub list_base: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UseXFontRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UseXFontRequest").finish_non_exhaustive()
+    }
 }
 impl UseXFontRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1660,13 +1779,20 @@ impl crate::x11_utils::VoidRequest for UseXFontRequest {
 
 /// Opcode for the CreateGLXPixmap request
 pub const CREATE_GLX_PIXMAP_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateGLXPixmapRequest {
     pub screen: u32,
     pub visual: xproto::Visualid,
     pub pixmap: xproto::Pixmap,
     pub glx_pixmap: Pixmap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateGLXPixmapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateGLXPixmapRequest").finish_non_exhaustive()
+    }
 }
 impl CreateGLXPixmapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1737,10 +1863,17 @@ impl crate::x11_utils::VoidRequest for CreateGLXPixmapRequest {
 
 /// Opcode for the GetVisualConfigs request
 pub const GET_VISUAL_CONFIGS_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVisualConfigsRequest {
     pub screen: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetVisualConfigsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetVisualConfigsRequest").finish_non_exhaustive()
+    }
 }
 impl GetVisualConfigsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1789,13 +1922,20 @@ impl crate::x11_utils::ReplyRequest for GetVisualConfigsRequest {
     type Reply = GetVisualConfigsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVisualConfigsReply {
     pub sequence: u16,
     pub num_visuals: u32,
     pub num_properties: u32,
     pub property_list: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetVisualConfigsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetVisualConfigsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetVisualConfigsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1857,10 +1997,17 @@ impl GetVisualConfigsReply {
 
 /// Opcode for the DestroyGLXPixmap request
 pub const DESTROY_GLX_PIXMAP_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyGLXPixmapRequest {
     pub glx_pixmap: Pixmap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyGLXPixmapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyGLXPixmapRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyGLXPixmapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1910,12 +2057,19 @@ impl crate::x11_utils::VoidRequest for DestroyGLXPixmapRequest {
 
 /// Opcode for the VendorPrivate request
 pub const VENDOR_PRIVATE_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VendorPrivateRequest<'input> {
     pub vendor_code: u32,
     pub context_tag: ContextTag,
     pub data: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for VendorPrivateRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VendorPrivateRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> VendorPrivateRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1985,12 +2139,19 @@ impl<'input> crate::x11_utils::VoidRequest for VendorPrivateRequest<'input> {
 
 /// Opcode for the VendorPrivateWithReply request
 pub const VENDOR_PRIVATE_WITH_REPLY_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VendorPrivateWithReplyRequest<'input> {
     pub vendor_code: u32,
     pub context_tag: ContextTag,
     pub data: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for VendorPrivateWithReplyRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VendorPrivateWithReplyRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> VendorPrivateWithReplyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2059,13 +2220,20 @@ impl<'input> crate::x11_utils::ReplyRequest for VendorPrivateWithReplyRequest<'i
     type Reply = VendorPrivateWithReplyReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VendorPrivateWithReplyReply {
     pub sequence: u16,
     pub retval: u32,
     pub data1: [u8; 24],
     pub data2: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for VendorPrivateWithReplyReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VendorPrivateWithReplyReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for VendorPrivateWithReplyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2128,10 +2296,17 @@ impl VendorPrivateWithReplyReply {
 
 /// Opcode for the QueryExtensionsString request
 pub const QUERY_EXTENSIONS_STRING_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionsStringRequest {
     pub screen: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryExtensionsStringRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryExtensionsStringRequest").finish_non_exhaustive()
+    }
 }
 impl QueryExtensionsStringRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2180,12 +2355,19 @@ impl crate::x11_utils::ReplyRequest for QueryExtensionsStringRequest {
     type Reply = QueryExtensionsStringReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionsStringReply {
     pub sequence: u16,
     pub length: u32,
     pub n: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryExtensionsStringReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryExtensionsStringReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryExtensionsStringReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2264,11 +2446,18 @@ impl Serialize for QueryExtensionsStringReply {
 
 /// Opcode for the QueryServerString request
 pub const QUERY_SERVER_STRING_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryServerStringRequest {
     pub screen: u32,
     pub name: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryServerStringRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryServerStringRequest").finish_non_exhaustive()
+    }
 }
 impl QueryServerStringRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2324,12 +2513,19 @@ impl crate::x11_utils::ReplyRequest for QueryServerStringRequest {
     type Reply = QueryServerStringReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryServerStringReply {
     pub sequence: u16,
     pub length: u32,
     pub string: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryServerStringReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryServerStringReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryServerStringReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2392,12 +2588,19 @@ impl QueryServerStringReply {
 
 /// Opcode for the ClientInfo request
 pub const CLIENT_INFO_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientInfoRequest<'input> {
     pub major_version: u32,
     pub minor_version: u32,
     pub string: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ClientInfoRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ClientInfoRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ClientInfoRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2474,10 +2677,17 @@ impl<'input> crate::x11_utils::VoidRequest for ClientInfoRequest<'input> {
 
 /// Opcode for the GetFBConfigs request
 pub const GET_FB_CONFIGS_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFBConfigsRequest {
     pub screen: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetFBConfigsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetFBConfigsRequest").finish_non_exhaustive()
+    }
 }
 impl GetFBConfigsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2526,13 +2736,20 @@ impl crate::x11_utils::ReplyRequest for GetFBConfigsRequest {
     type Reply = GetFBConfigsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFBConfigsReply {
     pub sequence: u16,
     pub num_fb_configs: u32,
     pub num_properties: u32,
     pub property_list: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetFBConfigsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetFBConfigsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetFBConfigsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2594,7 +2811,8 @@ impl GetFBConfigsReply {
 
 /// Opcode for the CreatePixmap request
 pub const CREATE_PIXMAP_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePixmapRequest<'input> {
     pub screen: u32,
@@ -2602,6 +2820,12 @@ pub struct CreatePixmapRequest<'input> {
     pub pixmap: xproto::Pixmap,
     pub glx_pixmap: Pixmap,
     pub attribs: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreatePixmapRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreatePixmapRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreatePixmapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2696,10 +2920,17 @@ impl<'input> crate::x11_utils::VoidRequest for CreatePixmapRequest<'input> {
 
 /// Opcode for the DestroyPixmap request
 pub const DESTROY_PIXMAP_REQUEST: u8 = 23;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyPixmapRequest {
     pub glx_pixmap: Pixmap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyPixmapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyPixmapRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyPixmapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2749,7 +2980,8 @@ impl crate::x11_utils::VoidRequest for DestroyPixmapRequest {
 
 /// Opcode for the CreateNewContext request
 pub const CREATE_NEW_CONTEXT_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateNewContextRequest {
     pub context: Context,
@@ -2758,6 +2990,12 @@ pub struct CreateNewContextRequest {
     pub render_type: u32,
     pub share_list: Context,
     pub is_direct: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateNewContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateNewContextRequest").finish_non_exhaustive()
+    }
 }
 impl CreateNewContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2843,10 +3081,17 @@ impl crate::x11_utils::VoidRequest for CreateNewContextRequest {
 
 /// Opcode for the QueryContext request
 pub const QUERY_CONTEXT_REQUEST: u8 = 25;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryContextRequest {
     pub context: Context,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryContextRequest").finish_non_exhaustive()
+    }
 }
 impl QueryContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2895,12 +3140,19 @@ impl crate::x11_utils::ReplyRequest for QueryContextRequest {
     type Reply = QueryContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryContextReply {
     pub sequence: u16,
     pub length: u32,
     pub attribs: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2962,13 +3214,20 @@ impl QueryContextReply {
 
 /// Opcode for the MakeContextCurrent request
 pub const MAKE_CONTEXT_CURRENT_REQUEST: u8 = 26;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MakeContextCurrentRequest {
     pub old_context_tag: ContextTag,
     pub drawable: Drawable,
     pub read_drawable: Drawable,
     pub context: Context,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MakeContextCurrentRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MakeContextCurrentRequest").finish_non_exhaustive()
+    }
 }
 impl MakeContextCurrentRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3038,12 +3297,19 @@ impl crate::x11_utils::ReplyRequest for MakeContextCurrentRequest {
     type Reply = MakeContextCurrentReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MakeContextCurrentReply {
     pub sequence: u16,
     pub length: u32,
     pub context_tag: ContextTag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MakeContextCurrentReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MakeContextCurrentReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for MakeContextCurrentReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3120,13 +3386,20 @@ impl Serialize for MakeContextCurrentReply {
 
 /// Opcode for the CreatePbuffer request
 pub const CREATE_PBUFFER_REQUEST: u8 = 27;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePbufferRequest<'input> {
     pub screen: u32,
     pub fbconfig: Fbconfig,
     pub pbuffer: Pbuffer,
     pub attribs: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreatePbufferRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreatePbufferRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreatePbufferRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3213,10 +3486,17 @@ impl<'input> crate::x11_utils::VoidRequest for CreatePbufferRequest<'input> {
 
 /// Opcode for the DestroyPbuffer request
 pub const DESTROY_PBUFFER_REQUEST: u8 = 28;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyPbufferRequest {
     pub pbuffer: Pbuffer,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyPbufferRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyPbufferRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyPbufferRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3266,10 +3546,17 @@ impl crate::x11_utils::VoidRequest for DestroyPbufferRequest {
 
 /// Opcode for the GetDrawableAttributes request
 pub const GET_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 29;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDrawableAttributesRequest {
     pub drawable: Drawable,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDrawableAttributesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDrawableAttributesRequest").finish_non_exhaustive()
+    }
 }
 impl GetDrawableAttributesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3318,12 +3605,19 @@ impl crate::x11_utils::ReplyRequest for GetDrawableAttributesRequest {
     type Reply = GetDrawableAttributesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDrawableAttributesReply {
     pub sequence: u16,
     pub length: u32,
     pub attribs: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDrawableAttributesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDrawableAttributesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDrawableAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3385,11 +3679,18 @@ impl GetDrawableAttributesReply {
 
 /// Opcode for the ChangeDrawableAttributes request
 pub const CHANGE_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 30;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDrawableAttributesRequest<'input> {
     pub drawable: Drawable,
     pub attribs: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeDrawableAttributesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeDrawableAttributesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeDrawableAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3460,7 +3761,8 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeDrawableAttributesRequest<'
 
 /// Opcode for the CreateWindow request
 pub const CREATE_WINDOW_REQUEST: u8 = 31;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateWindowRequest<'input> {
     pub screen: u32,
@@ -3468,6 +3770,12 @@ pub struct CreateWindowRequest<'input> {
     pub window: xproto::Window,
     pub glx_window: Window,
     pub attribs: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateWindowRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateWindowRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateWindowRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3562,10 +3870,17 @@ impl<'input> crate::x11_utils::VoidRequest for CreateWindowRequest<'input> {
 
 /// Opcode for the DeleteWindow request
 pub const DELETE_WINDOW_REQUEST: u8 = 32;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteWindowRequest {
     pub glxwindow: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeleteWindowRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeleteWindowRequest").finish_non_exhaustive()
+    }
 }
 impl DeleteWindowRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3615,7 +3930,8 @@ impl crate::x11_utils::VoidRequest for DeleteWindowRequest {
 
 /// Opcode for the SetClientInfoARB request
 pub const SET_CLIENT_INFO_ARB_REQUEST: u8 = 33;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetClientInfoARBRequest<'input> {
     pub major_version: u32,
@@ -3623,6 +3939,12 @@ pub struct SetClientInfoARBRequest<'input> {
     pub gl_versions: Cow<'input, [u32]>,
     pub gl_extension_string: Cow<'input, [u8]>,
     pub glx_extension_string: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetClientInfoARBRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetClientInfoARBRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetClientInfoARBRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3729,7 +4051,8 @@ impl<'input> crate::x11_utils::VoidRequest for SetClientInfoARBRequest<'input> {
 
 /// Opcode for the CreateContextAttribsARB request
 pub const CREATE_CONTEXT_ATTRIBS_ARB_REQUEST: u8 = 34;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextAttribsARBRequest<'input> {
     pub context: Context,
@@ -3738,6 +4061,12 @@ pub struct CreateContextAttribsARBRequest<'input> {
     pub share_list: Context,
     pub is_direct: bool,
     pub attribs: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateContextAttribsARBRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateContextAttribsARBRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateContextAttribsARBRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3841,7 +4170,8 @@ impl<'input> crate::x11_utils::VoidRequest for CreateContextAttribsARBRequest<'i
 
 /// Opcode for the SetClientInfo2ARB request
 pub const SET_CLIENT_INFO2_ARB_REQUEST: u8 = 35;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetClientInfo2ARBRequest<'input> {
     pub major_version: u32,
@@ -3849,6 +4179,12 @@ pub struct SetClientInfo2ARBRequest<'input> {
     pub gl_versions: Cow<'input, [u32]>,
     pub gl_extension_string: Cow<'input, [u8]>,
     pub glx_extension_string: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetClientInfo2ARBRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetClientInfo2ARBRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetClientInfo2ARBRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3955,12 +4291,19 @@ impl<'input> crate::x11_utils::VoidRequest for SetClientInfo2ARBRequest<'input> 
 
 /// Opcode for the NewList request
 pub const NEW_LIST_REQUEST: u8 = 101;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NewListRequest {
     pub context_tag: ContextTag,
     pub list: u32,
     pub mode: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for NewListRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NewListRequest").finish_non_exhaustive()
+    }
 }
 impl NewListRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4024,10 +4367,17 @@ impl crate::x11_utils::VoidRequest for NewListRequest {
 
 /// Opcode for the EndList request
 pub const END_LIST_REQUEST: u8 = 102;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EndListRequest {
     pub context_tag: ContextTag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EndListRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EndListRequest").finish_non_exhaustive()
+    }
 }
 impl EndListRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4077,12 +4427,19 @@ impl crate::x11_utils::VoidRequest for EndListRequest {
 
 /// Opcode for the DeleteLists request
 pub const DELETE_LISTS_REQUEST: u8 = 103;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteListsRequest {
     pub context_tag: ContextTag,
     pub list: u32,
     pub range: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeleteListsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeleteListsRequest").finish_non_exhaustive()
+    }
 }
 impl DeleteListsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4146,11 +4503,18 @@ impl crate::x11_utils::VoidRequest for DeleteListsRequest {
 
 /// Opcode for the GenLists request
 pub const GEN_LISTS_REQUEST: u8 = 104;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenListsRequest {
     pub context_tag: ContextTag,
     pub range: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GenListsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GenListsRequest").finish_non_exhaustive()
+    }
 }
 impl GenListsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4206,12 +4570,19 @@ impl crate::x11_utils::ReplyRequest for GenListsRequest {
     type Reply = GenListsReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenListsReply {
     pub sequence: u16,
     pub length: u32,
     pub ret_val: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GenListsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GenListsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GenListsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4266,12 +4637,19 @@ impl Serialize for GenListsReply {
 
 /// Opcode for the FeedbackBuffer request
 pub const FEEDBACK_BUFFER_REQUEST: u8 = 105;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackBufferRequest {
     pub context_tag: ContextTag,
     pub size: i32,
     pub type_: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackBufferRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackBufferRequest").finish_non_exhaustive()
+    }
 }
 impl FeedbackBufferRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4335,11 +4713,18 @@ impl crate::x11_utils::VoidRequest for FeedbackBufferRequest {
 
 /// Opcode for the SelectBuffer request
 pub const SELECT_BUFFER_REQUEST: u8 = 106;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectBufferRequest {
     pub context_tag: ContextTag,
     pub size: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectBufferRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectBufferRequest").finish_non_exhaustive()
+    }
 }
 impl SelectBufferRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4396,11 +4781,18 @@ impl crate::x11_utils::VoidRequest for SelectBufferRequest {
 
 /// Opcode for the RenderMode request
 pub const RENDER_MODE_REQUEST: u8 = 107;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RenderModeRequest {
     pub context_tag: ContextTag,
     pub mode: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RenderModeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RenderModeRequest").finish_non_exhaustive()
+    }
 }
 impl RenderModeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4456,7 +4848,8 @@ impl crate::x11_utils::ReplyRequest for RenderModeRequest {
     type Reply = RenderModeReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RenderModeReply {
     pub sequence: u16,
@@ -4464,6 +4857,12 @@ pub struct RenderModeReply {
     pub ret_val: u32,
     pub new_mode: u32,
     pub data: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RenderModeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RenderModeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for RenderModeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4582,10 +4981,17 @@ impl core::fmt::Debug for RM  {
 
 /// Opcode for the Finish request
 pub const FINISH_REQUEST: u8 = 108;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FinishRequest {
     pub context_tag: ContextTag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FinishRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FinishRequest").finish_non_exhaustive()
+    }
 }
 impl FinishRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4634,11 +5040,18 @@ impl crate::x11_utils::ReplyRequest for FinishRequest {
     type Reply = FinishReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FinishReply {
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FinishReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FinishReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for FinishReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4686,12 +5099,19 @@ impl Serialize for FinishReply {
 
 /// Opcode for the PixelStoref request
 pub const PIXEL_STOREF_REQUEST: u8 = 109;
-#[derive(Debug, Clone, Copy, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PixelStorefRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
     pub datum: Float32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PixelStorefRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PixelStorefRequest").finish_non_exhaustive()
+    }
 }
 impl PixelStorefRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4755,12 +5175,19 @@ impl crate::x11_utils::VoidRequest for PixelStorefRequest {
 
 /// Opcode for the PixelStorei request
 pub const PIXEL_STOREI_REQUEST: u8 = 110;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PixelStoreiRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
     pub datum: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PixelStoreiRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PixelStoreiRequest").finish_non_exhaustive()
+    }
 }
 impl PixelStoreiRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4824,7 +5251,8 @@ impl crate::x11_utils::VoidRequest for PixelStoreiRequest {
 
 /// Opcode for the ReadPixels request
 pub const READ_PIXELS_REQUEST: u8 = 111;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReadPixelsRequest {
     pub context_tag: ContextTag,
@@ -4836,6 +5264,12 @@ pub struct ReadPixelsRequest {
     pub type_: u32,
     pub swap_bytes: bool,
     pub lsb_first: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ReadPixelsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ReadPixelsRequest").finish_non_exhaustive()
+    }
 }
 impl ReadPixelsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4936,11 +5370,18 @@ impl crate::x11_utils::ReplyRequest for ReadPixelsRequest {
     type Reply = ReadPixelsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReadPixelsReply {
     pub sequence: u16,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ReadPixelsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ReadPixelsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ReadPixelsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5001,11 +5442,18 @@ impl ReadPixelsReply {
 
 /// Opcode for the GetBooleanv request
 pub const GET_BOOLEANV_REQUEST: u8 = 112;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBooleanvRequest {
     pub context_tag: ContextTag,
     pub pname: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetBooleanvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetBooleanvRequest").finish_non_exhaustive()
+    }
 }
 impl GetBooleanvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5061,13 +5509,20 @@ impl crate::x11_utils::ReplyRequest for GetBooleanvRequest {
     type Reply = GetBooleanvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetBooleanvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: bool,
     pub data: Vec<bool>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetBooleanvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetBooleanvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetBooleanvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5131,11 +5586,18 @@ impl GetBooleanvReply {
 
 /// Opcode for the GetClipPlane request
 pub const GET_CLIP_PLANE_REQUEST: u8 = 113;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClipPlaneRequest {
     pub context_tag: ContextTag,
     pub plane: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetClipPlaneRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetClipPlaneRequest").finish_non_exhaustive()
+    }
 }
 impl GetClipPlaneRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5191,11 +5653,18 @@ impl crate::x11_utils::ReplyRequest for GetClipPlaneRequest {
     type Reply = GetClipPlaneReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClipPlaneReply {
     pub sequence: u16,
     pub data: Vec<Float64>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetClipPlaneReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetClipPlaneReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetClipPlaneReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5254,11 +5723,18 @@ impl GetClipPlaneReply {
 
 /// Opcode for the GetDoublev request
 pub const GET_DOUBLEV_REQUEST: u8 = 114;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDoublevRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDoublevRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDoublevRequest").finish_non_exhaustive()
+    }
 }
 impl GetDoublevRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5314,13 +5790,20 @@ impl crate::x11_utils::ReplyRequest for GetDoublevRequest {
     type Reply = GetDoublevReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDoublevReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float64,
     pub data: Vec<Float64>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDoublevReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDoublevReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDoublevReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5384,10 +5867,17 @@ impl GetDoublevReply {
 
 /// Opcode for the GetError request
 pub const GET_ERROR_REQUEST: u8 = 115;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetErrorRequest {
     pub context_tag: ContextTag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetErrorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetErrorRequest").finish_non_exhaustive()
+    }
 }
 impl GetErrorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5436,12 +5926,19 @@ impl crate::x11_utils::ReplyRequest for GetErrorRequest {
     type Reply = GetErrorReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetErrorReply {
     pub sequence: u16,
     pub length: u32,
     pub error: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetErrorReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetErrorReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetErrorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5496,11 +5993,18 @@ impl Serialize for GetErrorReply {
 
 /// Opcode for the GetFloatv request
 pub const GET_FLOATV_REQUEST: u8 = 116;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFloatvRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetFloatvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetFloatvRequest").finish_non_exhaustive()
+    }
 }
 impl GetFloatvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5556,13 +6060,20 @@ impl crate::x11_utils::ReplyRequest for GetFloatvRequest {
     type Reply = GetFloatvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFloatvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetFloatvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetFloatvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetFloatvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5626,11 +6137,18 @@ impl GetFloatvReply {
 
 /// Opcode for the GetIntegerv request
 pub const GET_INTEGERV_REQUEST: u8 = 117;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetIntegervRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetIntegervRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetIntegervRequest").finish_non_exhaustive()
+    }
 }
 impl GetIntegervRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5686,13 +6204,20 @@ impl crate::x11_utils::ReplyRequest for GetIntegervRequest {
     type Reply = GetIntegervReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetIntegervReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetIntegervReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetIntegervReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetIntegervReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5756,12 +6281,19 @@ impl GetIntegervReply {
 
 /// Opcode for the GetLightfv request
 pub const GET_LIGHTFV_REQUEST: u8 = 118;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetLightfvRequest {
     pub context_tag: ContextTag,
     pub light: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetLightfvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetLightfvRequest").finish_non_exhaustive()
+    }
 }
 impl GetLightfvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5824,13 +6356,20 @@ impl crate::x11_utils::ReplyRequest for GetLightfvRequest {
     type Reply = GetLightfvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetLightfvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetLightfvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetLightfvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetLightfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5894,12 +6433,19 @@ impl GetLightfvReply {
 
 /// Opcode for the GetLightiv request
 pub const GET_LIGHTIV_REQUEST: u8 = 119;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetLightivRequest {
     pub context_tag: ContextTag,
     pub light: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetLightivRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetLightivRequest").finish_non_exhaustive()
+    }
 }
 impl GetLightivRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5962,13 +6508,20 @@ impl crate::x11_utils::ReplyRequest for GetLightivRequest {
     type Reply = GetLightivReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetLightivReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetLightivReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetLightivReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetLightivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6032,12 +6585,19 @@ impl GetLightivReply {
 
 /// Opcode for the GetMapdv request
 pub const GET_MAPDV_REQUEST: u8 = 120;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapdvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub query: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMapdvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMapdvRequest").finish_non_exhaustive()
+    }
 }
 impl GetMapdvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6100,13 +6660,20 @@ impl crate::x11_utils::ReplyRequest for GetMapdvRequest {
     type Reply = GetMapdvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapdvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float64,
     pub data: Vec<Float64>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMapdvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMapdvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMapdvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6170,12 +6737,19 @@ impl GetMapdvReply {
 
 /// Opcode for the GetMapfv request
 pub const GET_MAPFV_REQUEST: u8 = 121;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub query: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMapfvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMapfvRequest").finish_non_exhaustive()
+    }
 }
 impl GetMapfvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6238,13 +6812,20 @@ impl crate::x11_utils::ReplyRequest for GetMapfvRequest {
     type Reply = GetMapfvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapfvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMapfvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMapfvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMapfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6308,12 +6889,19 @@ impl GetMapfvReply {
 
 /// Opcode for the GetMapiv request
 pub const GET_MAPIV_REQUEST: u8 = 122;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub query: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMapivRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMapivRequest").finish_non_exhaustive()
+    }
 }
 impl GetMapivRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6376,13 +6964,20 @@ impl crate::x11_utils::ReplyRequest for GetMapivRequest {
     type Reply = GetMapivReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapivReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMapivReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMapivReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMapivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6446,12 +7041,19 @@ impl GetMapivReply {
 
 /// Opcode for the GetMaterialfv request
 pub const GET_MATERIALFV_REQUEST: u8 = 123;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMaterialfvRequest {
     pub context_tag: ContextTag,
     pub face: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMaterialfvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMaterialfvRequest").finish_non_exhaustive()
+    }
 }
 impl GetMaterialfvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6514,13 +7116,20 @@ impl crate::x11_utils::ReplyRequest for GetMaterialfvRequest {
     type Reply = GetMaterialfvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMaterialfvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMaterialfvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMaterialfvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMaterialfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6584,12 +7193,19 @@ impl GetMaterialfvReply {
 
 /// Opcode for the GetMaterialiv request
 pub const GET_MATERIALIV_REQUEST: u8 = 124;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMaterialivRequest {
     pub context_tag: ContextTag,
     pub face: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMaterialivRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMaterialivRequest").finish_non_exhaustive()
+    }
 }
 impl GetMaterialivRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6652,13 +7268,20 @@ impl crate::x11_utils::ReplyRequest for GetMaterialivRequest {
     type Reply = GetMaterialivReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMaterialivReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMaterialivReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMaterialivReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMaterialivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6722,11 +7345,18 @@ impl GetMaterialivReply {
 
 /// Opcode for the GetPixelMapfv request
 pub const GET_PIXEL_MAPFV_REQUEST: u8 = 125;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPixelMapfvRequest {
     pub context_tag: ContextTag,
     pub map: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPixelMapfvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPixelMapfvRequest").finish_non_exhaustive()
+    }
 }
 impl GetPixelMapfvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6782,13 +7412,20 @@ impl crate::x11_utils::ReplyRequest for GetPixelMapfvRequest {
     type Reply = GetPixelMapfvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPixelMapfvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPixelMapfvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPixelMapfvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPixelMapfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6852,11 +7489,18 @@ impl GetPixelMapfvReply {
 
 /// Opcode for the GetPixelMapuiv request
 pub const GET_PIXEL_MAPUIV_REQUEST: u8 = 126;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPixelMapuivRequest {
     pub context_tag: ContextTag,
     pub map: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPixelMapuivRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPixelMapuivRequest").finish_non_exhaustive()
+    }
 }
 impl GetPixelMapuivRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6912,13 +7556,20 @@ impl crate::x11_utils::ReplyRequest for GetPixelMapuivRequest {
     type Reply = GetPixelMapuivReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPixelMapuivReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: u32,
     pub data: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPixelMapuivReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPixelMapuivReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPixelMapuivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6982,11 +7633,18 @@ impl GetPixelMapuivReply {
 
 /// Opcode for the GetPixelMapusv request
 pub const GET_PIXEL_MAPUSV_REQUEST: u8 = 127;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPixelMapusvRequest {
     pub context_tag: ContextTag,
     pub map: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPixelMapusvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPixelMapusvRequest").finish_non_exhaustive()
+    }
 }
 impl GetPixelMapusvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7042,13 +7700,20 @@ impl crate::x11_utils::ReplyRequest for GetPixelMapusvRequest {
     type Reply = GetPixelMapusvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPixelMapusvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: u16,
     pub data: Vec<u16>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPixelMapusvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPixelMapusvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPixelMapusvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7112,11 +7777,18 @@ impl GetPixelMapusvReply {
 
 /// Opcode for the GetPolygonStipple request
 pub const GET_POLYGON_STIPPLE_REQUEST: u8 = 128;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPolygonStippleRequest {
     pub context_tag: ContextTag,
     pub lsb_first: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPolygonStippleRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPolygonStippleRequest").finish_non_exhaustive()
+    }
 }
 impl GetPolygonStippleRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7172,11 +7844,18 @@ impl crate::x11_utils::ReplyRequest for GetPolygonStippleRequest {
     type Reply = GetPolygonStippleReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPolygonStippleReply {
     pub sequence: u16,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPolygonStippleReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPolygonStippleReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPolygonStippleReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7237,11 +7916,18 @@ impl GetPolygonStippleReply {
 
 /// Opcode for the GetString request
 pub const GET_STRING_REQUEST: u8 = 129;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStringRequest {
     pub context_tag: ContextTag,
     pub name: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetStringRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetStringRequest").finish_non_exhaustive()
+    }
 }
 impl GetStringRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7297,12 +7983,19 @@ impl crate::x11_utils::ReplyRequest for GetStringRequest {
     type Reply = GetStringReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStringReply {
     pub sequence: u16,
     pub length: u32,
     pub string: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetStringReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetStringReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetStringReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7365,12 +8058,19 @@ impl GetStringReply {
 
 /// Opcode for the GetTexEnvfv request
 pub const GET_TEX_ENVFV_REQUEST: u8 = 130;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexEnvfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexEnvfvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexEnvfvRequest").finish_non_exhaustive()
+    }
 }
 impl GetTexEnvfvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7433,13 +8133,20 @@ impl crate::x11_utils::ReplyRequest for GetTexEnvfvRequest {
     type Reply = GetTexEnvfvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexEnvfvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexEnvfvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexEnvfvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetTexEnvfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7503,12 +8210,19 @@ impl GetTexEnvfvReply {
 
 /// Opcode for the GetTexEnviv request
 pub const GET_TEX_ENVIV_REQUEST: u8 = 131;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexEnvivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexEnvivRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexEnvivRequest").finish_non_exhaustive()
+    }
 }
 impl GetTexEnvivRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7571,13 +8285,20 @@ impl crate::x11_utils::ReplyRequest for GetTexEnvivRequest {
     type Reply = GetTexEnvivReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexEnvivReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexEnvivReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexEnvivReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetTexEnvivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7641,12 +8362,19 @@ impl GetTexEnvivReply {
 
 /// Opcode for the GetTexGendv request
 pub const GET_TEX_GENDV_REQUEST: u8 = 132;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexGendvRequest {
     pub context_tag: ContextTag,
     pub coord: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexGendvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexGendvRequest").finish_non_exhaustive()
+    }
 }
 impl GetTexGendvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7709,13 +8437,20 @@ impl crate::x11_utils::ReplyRequest for GetTexGendvRequest {
     type Reply = GetTexGendvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexGendvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float64,
     pub data: Vec<Float64>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexGendvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexGendvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetTexGendvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7779,12 +8514,19 @@ impl GetTexGendvReply {
 
 /// Opcode for the GetTexGenfv request
 pub const GET_TEX_GENFV_REQUEST: u8 = 133;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexGenfvRequest {
     pub context_tag: ContextTag,
     pub coord: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexGenfvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexGenfvRequest").finish_non_exhaustive()
+    }
 }
 impl GetTexGenfvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7847,13 +8589,20 @@ impl crate::x11_utils::ReplyRequest for GetTexGenfvRequest {
     type Reply = GetTexGenfvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexGenfvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexGenfvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexGenfvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetTexGenfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7917,12 +8666,19 @@ impl GetTexGenfvReply {
 
 /// Opcode for the GetTexGeniv request
 pub const GET_TEX_GENIV_REQUEST: u8 = 134;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexGenivRequest {
     pub context_tag: ContextTag,
     pub coord: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexGenivRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexGenivRequest").finish_non_exhaustive()
+    }
 }
 impl GetTexGenivRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7985,13 +8741,20 @@ impl crate::x11_utils::ReplyRequest for GetTexGenivRequest {
     type Reply = GetTexGenivReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexGenivReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexGenivReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexGenivReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetTexGenivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8055,7 +8818,8 @@ impl GetTexGenivReply {
 
 /// Opcode for the GetTexImage request
 pub const GET_TEX_IMAGE_REQUEST: u8 = 135;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexImageRequest {
     pub context_tag: ContextTag,
@@ -8064,6 +8828,12 @@ pub struct GetTexImageRequest {
     pub format: u32,
     pub type_: u32,
     pub swap_bytes: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexImageRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexImageRequest").finish_non_exhaustive()
+    }
 }
 impl GetTexImageRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8147,7 +8917,8 @@ impl crate::x11_utils::ReplyRequest for GetTexImageRequest {
     type Reply = GetTexImageReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexImageReply {
     pub sequence: u16,
@@ -8155,6 +8926,12 @@ pub struct GetTexImageReply {
     pub height: i32,
     pub depth: i32,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexImageReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexImageReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetTexImageReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8223,12 +9000,19 @@ impl GetTexImageReply {
 
 /// Opcode for the GetTexParameterfv request
 pub const GET_TEX_PARAMETERFV_REQUEST: u8 = 136;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexParameterfvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexParameterfvRequest").finish_non_exhaustive()
+    }
 }
 impl GetTexParameterfvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8291,13 +9075,20 @@ impl crate::x11_utils::ReplyRequest for GetTexParameterfvRequest {
     type Reply = GetTexParameterfvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexParameterfvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexParameterfvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexParameterfvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetTexParameterfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8361,12 +9152,19 @@ impl GetTexParameterfvReply {
 
 /// Opcode for the GetTexParameteriv request
 pub const GET_TEX_PARAMETERIV_REQUEST: u8 = 137;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexParameterivRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexParameterivRequest").finish_non_exhaustive()
+    }
 }
 impl GetTexParameterivRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8429,13 +9227,20 @@ impl crate::x11_utils::ReplyRequest for GetTexParameterivRequest {
     type Reply = GetTexParameterivReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexParameterivReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexParameterivReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexParameterivReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetTexParameterivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8499,13 +9304,20 @@ impl GetTexParameterivReply {
 
 /// Opcode for the GetTexLevelParameterfv request
 pub const GET_TEX_LEVEL_PARAMETERFV_REQUEST: u8 = 138;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexLevelParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub level: i32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexLevelParameterfvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexLevelParameterfvRequest").finish_non_exhaustive()
+    }
 }
 impl GetTexLevelParameterfvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8575,13 +9387,20 @@ impl crate::x11_utils::ReplyRequest for GetTexLevelParameterfvRequest {
     type Reply = GetTexLevelParameterfvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexLevelParameterfvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexLevelParameterfvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexLevelParameterfvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetTexLevelParameterfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8645,13 +9464,20 @@ impl GetTexLevelParameterfvReply {
 
 /// Opcode for the GetTexLevelParameteriv request
 pub const GET_TEX_LEVEL_PARAMETERIV_REQUEST: u8 = 139;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexLevelParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub level: i32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexLevelParameterivRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexLevelParameterivRequest").finish_non_exhaustive()
+    }
 }
 impl GetTexLevelParameterivRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8721,13 +9547,20 @@ impl crate::x11_utils::ReplyRequest for GetTexLevelParameterivRequest {
     type Reply = GetTexLevelParameterivReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTexLevelParameterivReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetTexLevelParameterivReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetTexLevelParameterivReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetTexLevelParameterivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8791,11 +9624,18 @@ impl GetTexLevelParameterivReply {
 
 /// Opcode for the IsEnabled request
 pub const IS_ENABLED_REQUEST: u8 = 140;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsEnabledRequest {
     pub context_tag: ContextTag,
     pub capability: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IsEnabledRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IsEnabledRequest").finish_non_exhaustive()
+    }
 }
 impl IsEnabledRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8851,12 +9691,19 @@ impl crate::x11_utils::ReplyRequest for IsEnabledRequest {
     type Reply = IsEnabledReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsEnabledReply {
     pub sequence: u16,
     pub length: u32,
     pub ret_val: Bool32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IsEnabledReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IsEnabledReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for IsEnabledReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8911,11 +9758,18 @@ impl Serialize for IsEnabledReply {
 
 /// Opcode for the IsList request
 pub const IS_LIST_REQUEST: u8 = 141;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsListRequest {
     pub context_tag: ContextTag,
     pub list: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IsListRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IsListRequest").finish_non_exhaustive()
+    }
 }
 impl IsListRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8971,12 +9825,19 @@ impl crate::x11_utils::ReplyRequest for IsListRequest {
     type Reply = IsListReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsListReply {
     pub sequence: u16,
     pub length: u32,
     pub ret_val: Bool32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IsListReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IsListReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for IsListReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9031,10 +9892,17 @@ impl Serialize for IsListReply {
 
 /// Opcode for the Flush request
 pub const FLUSH_REQUEST: u8 = 142;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FlushRequest {
     pub context_tag: ContextTag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FlushRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FlushRequest").finish_non_exhaustive()
+    }
 }
 impl FlushRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9084,11 +9952,18 @@ impl crate::x11_utils::VoidRequest for FlushRequest {
 
 /// Opcode for the AreTexturesResident request
 pub const ARE_TEXTURES_RESIDENT_REQUEST: u8 = 143;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AreTexturesResidentRequest<'input> {
     pub context_tag: ContextTag,
     pub textures: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for AreTexturesResidentRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AreTexturesResidentRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> AreTexturesResidentRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -9157,12 +10032,19 @@ impl<'input> crate::x11_utils::ReplyRequest for AreTexturesResidentRequest<'inpu
     type Reply = AreTexturesResidentReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AreTexturesResidentReply {
     pub sequence: u16,
     pub ret_val: Bool32,
     pub data: Vec<bool>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AreTexturesResidentReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AreTexturesResidentReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for AreTexturesResidentReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9224,11 +10106,18 @@ impl AreTexturesResidentReply {
 
 /// Opcode for the DeleteTextures request
 pub const DELETE_TEXTURES_REQUEST: u8 = 144;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteTexturesRequest<'input> {
     pub context_tag: ContextTag,
     pub textures: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for DeleteTexturesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeleteTexturesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> DeleteTexturesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -9298,11 +10187,18 @@ impl<'input> crate::x11_utils::VoidRequest for DeleteTexturesRequest<'input> {
 
 /// Opcode for the GenTextures request
 pub const GEN_TEXTURES_REQUEST: u8 = 145;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenTexturesRequest {
     pub context_tag: ContextTag,
     pub n: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GenTexturesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GenTexturesRequest").finish_non_exhaustive()
+    }
 }
 impl GenTexturesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9358,11 +10254,18 @@ impl crate::x11_utils::ReplyRequest for GenTexturesRequest {
     type Reply = GenTexturesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenTexturesReply {
     pub sequence: u16,
     pub data: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GenTexturesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GenTexturesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GenTexturesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9420,11 +10323,18 @@ impl GenTexturesReply {
 
 /// Opcode for the IsTexture request
 pub const IS_TEXTURE_REQUEST: u8 = 146;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsTextureRequest {
     pub context_tag: ContextTag,
     pub texture: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IsTextureRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IsTextureRequest").finish_non_exhaustive()
+    }
 }
 impl IsTextureRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9480,12 +10390,19 @@ impl crate::x11_utils::ReplyRequest for IsTextureRequest {
     type Reply = IsTextureReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsTextureReply {
     pub sequence: u16,
     pub length: u32,
     pub ret_val: Bool32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IsTextureReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IsTextureReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for IsTextureReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9540,7 +10457,8 @@ impl Serialize for IsTextureReply {
 
 /// Opcode for the GetColorTable request
 pub const GET_COLOR_TABLE_REQUEST: u8 = 147;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetColorTableRequest {
     pub context_tag: ContextTag,
@@ -9548,6 +10466,12 @@ pub struct GetColorTableRequest {
     pub format: u32,
     pub type_: u32,
     pub swap_bytes: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetColorTableRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetColorTableRequest").finish_non_exhaustive()
+    }
 }
 impl GetColorTableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9624,12 +10548,19 @@ impl crate::x11_utils::ReplyRequest for GetColorTableRequest {
     type Reply = GetColorTableReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetColorTableReply {
     pub sequence: u16,
     pub width: i32,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetColorTableReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetColorTableReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetColorTableReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9694,12 +10625,19 @@ impl GetColorTableReply {
 
 /// Opcode for the GetColorTableParameterfv request
 pub const GET_COLOR_TABLE_PARAMETERFV_REQUEST: u8 = 148;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetColorTableParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetColorTableParameterfvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetColorTableParameterfvRequest").finish_non_exhaustive()
+    }
 }
 impl GetColorTableParameterfvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9762,13 +10700,20 @@ impl crate::x11_utils::ReplyRequest for GetColorTableParameterfvRequest {
     type Reply = GetColorTableParameterfvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetColorTableParameterfvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetColorTableParameterfvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetColorTableParameterfvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetColorTableParameterfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9832,12 +10777,19 @@ impl GetColorTableParameterfvReply {
 
 /// Opcode for the GetColorTableParameteriv request
 pub const GET_COLOR_TABLE_PARAMETERIV_REQUEST: u8 = 149;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetColorTableParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetColorTableParameterivRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetColorTableParameterivRequest").finish_non_exhaustive()
+    }
 }
 impl GetColorTableParameterivRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9900,13 +10852,20 @@ impl crate::x11_utils::ReplyRequest for GetColorTableParameterivRequest {
     type Reply = GetColorTableParameterivReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetColorTableParameterivReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetColorTableParameterivReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetColorTableParameterivReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetColorTableParameterivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9970,7 +10929,8 @@ impl GetColorTableParameterivReply {
 
 /// Opcode for the GetConvolutionFilter request
 pub const GET_CONVOLUTION_FILTER_REQUEST: u8 = 150;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetConvolutionFilterRequest {
     pub context_tag: ContextTag,
@@ -9978,6 +10938,12 @@ pub struct GetConvolutionFilterRequest {
     pub format: u32,
     pub type_: u32,
     pub swap_bytes: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetConvolutionFilterRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetConvolutionFilterRequest").finish_non_exhaustive()
+    }
 }
 impl GetConvolutionFilterRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10054,13 +11020,20 @@ impl crate::x11_utils::ReplyRequest for GetConvolutionFilterRequest {
     type Reply = GetConvolutionFilterReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetConvolutionFilterReply {
     pub sequence: u16,
     pub width: i32,
     pub height: i32,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetConvolutionFilterReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetConvolutionFilterReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetConvolutionFilterReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10127,12 +11100,19 @@ impl GetConvolutionFilterReply {
 
 /// Opcode for the GetConvolutionParameterfv request
 pub const GET_CONVOLUTION_PARAMETERFV_REQUEST: u8 = 151;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetConvolutionParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetConvolutionParameterfvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetConvolutionParameterfvRequest").finish_non_exhaustive()
+    }
 }
 impl GetConvolutionParameterfvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10195,13 +11175,20 @@ impl crate::x11_utils::ReplyRequest for GetConvolutionParameterfvRequest {
     type Reply = GetConvolutionParameterfvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetConvolutionParameterfvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetConvolutionParameterfvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetConvolutionParameterfvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetConvolutionParameterfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10265,12 +11252,19 @@ impl GetConvolutionParameterfvReply {
 
 /// Opcode for the GetConvolutionParameteriv request
 pub const GET_CONVOLUTION_PARAMETERIV_REQUEST: u8 = 152;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetConvolutionParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetConvolutionParameterivRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetConvolutionParameterivRequest").finish_non_exhaustive()
+    }
 }
 impl GetConvolutionParameterivRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10333,13 +11327,20 @@ impl crate::x11_utils::ReplyRequest for GetConvolutionParameterivRequest {
     type Reply = GetConvolutionParameterivReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetConvolutionParameterivReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetConvolutionParameterivReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetConvolutionParameterivReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetConvolutionParameterivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10403,7 +11404,8 @@ impl GetConvolutionParameterivReply {
 
 /// Opcode for the GetSeparableFilter request
 pub const GET_SEPARABLE_FILTER_REQUEST: u8 = 153;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSeparableFilterRequest {
     pub context_tag: ContextTag,
@@ -10411,6 +11413,12 @@ pub struct GetSeparableFilterRequest {
     pub format: u32,
     pub type_: u32,
     pub swap_bytes: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSeparableFilterRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSeparableFilterRequest").finish_non_exhaustive()
+    }
 }
 impl GetSeparableFilterRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10487,13 +11495,20 @@ impl crate::x11_utils::ReplyRequest for GetSeparableFilterRequest {
     type Reply = GetSeparableFilterReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSeparableFilterReply {
     pub sequence: u16,
     pub row_w: i32,
     pub col_h: i32,
     pub rows_and_cols: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSeparableFilterReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSeparableFilterReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetSeparableFilterReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10560,7 +11575,8 @@ impl GetSeparableFilterReply {
 
 /// Opcode for the GetHistogram request
 pub const GET_HISTOGRAM_REQUEST: u8 = 154;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetHistogramRequest {
     pub context_tag: ContextTag,
@@ -10569,6 +11585,12 @@ pub struct GetHistogramRequest {
     pub type_: u32,
     pub swap_bytes: bool,
     pub reset: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetHistogramRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetHistogramRequest").finish_non_exhaustive()
+    }
 }
 impl GetHistogramRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10648,12 +11670,19 @@ impl crate::x11_utils::ReplyRequest for GetHistogramRequest {
     type Reply = GetHistogramReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetHistogramReply {
     pub sequence: u16,
     pub width: i32,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetHistogramReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetHistogramReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetHistogramReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10718,12 +11747,19 @@ impl GetHistogramReply {
 
 /// Opcode for the GetHistogramParameterfv request
 pub const GET_HISTOGRAM_PARAMETERFV_REQUEST: u8 = 155;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetHistogramParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetHistogramParameterfvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetHistogramParameterfvRequest").finish_non_exhaustive()
+    }
 }
 impl GetHistogramParameterfvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10786,13 +11822,20 @@ impl crate::x11_utils::ReplyRequest for GetHistogramParameterfvRequest {
     type Reply = GetHistogramParameterfvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetHistogramParameterfvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetHistogramParameterfvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetHistogramParameterfvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetHistogramParameterfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10856,12 +11899,19 @@ impl GetHistogramParameterfvReply {
 
 /// Opcode for the GetHistogramParameteriv request
 pub const GET_HISTOGRAM_PARAMETERIV_REQUEST: u8 = 156;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetHistogramParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetHistogramParameterivRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetHistogramParameterivRequest").finish_non_exhaustive()
+    }
 }
 impl GetHistogramParameterivRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10924,13 +11974,20 @@ impl crate::x11_utils::ReplyRequest for GetHistogramParameterivRequest {
     type Reply = GetHistogramParameterivReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetHistogramParameterivReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetHistogramParameterivReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetHistogramParameterivReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetHistogramParameterivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10994,7 +12051,8 @@ impl GetHistogramParameterivReply {
 
 /// Opcode for the GetMinmax request
 pub const GET_MINMAX_REQUEST: u8 = 157;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMinmaxRequest {
     pub context_tag: ContextTag,
@@ -11003,6 +12061,12 @@ pub struct GetMinmaxRequest {
     pub type_: u32,
     pub swap_bytes: bool,
     pub reset: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMinmaxRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMinmaxRequest").finish_non_exhaustive()
+    }
 }
 impl GetMinmaxRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11082,11 +12146,18 @@ impl crate::x11_utils::ReplyRequest for GetMinmaxRequest {
     type Reply = GetMinmaxReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMinmaxReply {
     pub sequence: u16,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMinmaxReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMinmaxReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMinmaxReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11147,12 +12218,19 @@ impl GetMinmaxReply {
 
 /// Opcode for the GetMinmaxParameterfv request
 pub const GET_MINMAX_PARAMETERFV_REQUEST: u8 = 158;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMinmaxParameterfvRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMinmaxParameterfvRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMinmaxParameterfvRequest").finish_non_exhaustive()
+    }
 }
 impl GetMinmaxParameterfvRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11215,13 +12293,20 @@ impl crate::x11_utils::ReplyRequest for GetMinmaxParameterfvRequest {
     type Reply = GetMinmaxParameterfvReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, PartialOrd)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, PartialOrd))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMinmaxParameterfvReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: Float32,
     pub data: Vec<Float32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMinmaxParameterfvReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMinmaxParameterfvReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMinmaxParameterfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11285,12 +12370,19 @@ impl GetMinmaxParameterfvReply {
 
 /// Opcode for the GetMinmaxParameteriv request
 pub const GET_MINMAX_PARAMETERIV_REQUEST: u8 = 159;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMinmaxParameterivRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMinmaxParameterivRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMinmaxParameterivRequest").finish_non_exhaustive()
+    }
 }
 impl GetMinmaxParameterivRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11353,13 +12445,20 @@ impl crate::x11_utils::ReplyRequest for GetMinmaxParameterivRequest {
     type Reply = GetMinmaxParameterivReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMinmaxParameterivReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMinmaxParameterivReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMinmaxParameterivReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMinmaxParameterivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11423,12 +12522,19 @@ impl GetMinmaxParameterivReply {
 
 /// Opcode for the GetCompressedTexImageARB request
 pub const GET_COMPRESSED_TEX_IMAGE_ARB_REQUEST: u8 = 160;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCompressedTexImageARBRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub level: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCompressedTexImageARBRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCompressedTexImageARBRequest").finish_non_exhaustive()
+    }
 }
 impl GetCompressedTexImageARBRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11491,12 +12597,19 @@ impl crate::x11_utils::ReplyRequest for GetCompressedTexImageARBRequest {
     type Reply = GetCompressedTexImageARBReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCompressedTexImageARBReply {
     pub sequence: u16,
     pub size: i32,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCompressedTexImageARBReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCompressedTexImageARBReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetCompressedTexImageARBReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11561,11 +12674,18 @@ impl GetCompressedTexImageARBReply {
 
 /// Opcode for the DeleteQueriesARB request
 pub const DELETE_QUERIES_ARB_REQUEST: u8 = 161;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteQueriesARBRequest<'input> {
     pub context_tag: ContextTag,
     pub ids: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for DeleteQueriesARBRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeleteQueriesARBRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> DeleteQueriesARBRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -11635,11 +12755,18 @@ impl<'input> crate::x11_utils::VoidRequest for DeleteQueriesARBRequest<'input> {
 
 /// Opcode for the GenQueriesARB request
 pub const GEN_QUERIES_ARB_REQUEST: u8 = 162;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenQueriesARBRequest {
     pub context_tag: ContextTag,
     pub n: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GenQueriesARBRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GenQueriesARBRequest").finish_non_exhaustive()
+    }
 }
 impl GenQueriesARBRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11695,11 +12822,18 @@ impl crate::x11_utils::ReplyRequest for GenQueriesARBRequest {
     type Reply = GenQueriesARBReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenQueriesARBReply {
     pub sequence: u16,
     pub data: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GenQueriesARBReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GenQueriesARBReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GenQueriesARBReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11757,11 +12891,18 @@ impl GenQueriesARBReply {
 
 /// Opcode for the IsQueryARB request
 pub const IS_QUERY_ARB_REQUEST: u8 = 163;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsQueryARBRequest {
     pub context_tag: ContextTag,
     pub id: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IsQueryARBRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IsQueryARBRequest").finish_non_exhaustive()
+    }
 }
 impl IsQueryARBRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11817,12 +12958,19 @@ impl crate::x11_utils::ReplyRequest for IsQueryARBRequest {
     type Reply = IsQueryARBReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsQueryARBReply {
     pub sequence: u16,
     pub length: u32,
     pub ret_val: Bool32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IsQueryARBReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IsQueryARBReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for IsQueryARBReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11877,12 +13025,19 @@ impl Serialize for IsQueryARBReply {
 
 /// Opcode for the GetQueryivARB request
 pub const GET_QUERYIV_ARB_REQUEST: u8 = 164;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetQueryivARBRequest {
     pub context_tag: ContextTag,
     pub target: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetQueryivARBRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetQueryivARBRequest").finish_non_exhaustive()
+    }
 }
 impl GetQueryivARBRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11945,13 +13100,20 @@ impl crate::x11_utils::ReplyRequest for GetQueryivARBRequest {
     type Reply = GetQueryivARBReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetQueryivARBReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetQueryivARBReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetQueryivARBReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetQueryivARBReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12015,12 +13177,19 @@ impl GetQueryivARBReply {
 
 /// Opcode for the GetQueryObjectivARB request
 pub const GET_QUERY_OBJECTIV_ARB_REQUEST: u8 = 165;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetQueryObjectivARBRequest {
     pub context_tag: ContextTag,
     pub id: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetQueryObjectivARBRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetQueryObjectivARBRequest").finish_non_exhaustive()
+    }
 }
 impl GetQueryObjectivARBRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12083,13 +13252,20 @@ impl crate::x11_utils::ReplyRequest for GetQueryObjectivARBRequest {
     type Reply = GetQueryObjectivARBReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetQueryObjectivARBReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: i32,
     pub data: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetQueryObjectivARBReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetQueryObjectivARBReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetQueryObjectivARBReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12153,12 +13329,19 @@ impl GetQueryObjectivARBReply {
 
 /// Opcode for the GetQueryObjectuivARB request
 pub const GET_QUERY_OBJECTUIV_ARB_REQUEST: u8 = 166;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetQueryObjectuivARBRequest {
     pub context_tag: ContextTag,
     pub id: u32,
     pub pname: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetQueryObjectuivARBRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetQueryObjectuivARBRequest").finish_non_exhaustive()
+    }
 }
 impl GetQueryObjectuivARBRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12221,13 +13404,20 @@ impl crate::x11_utils::ReplyRequest for GetQueryObjectuivARBRequest {
     type Reply = GetQueryObjectuivARBReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetQueryObjectuivARBReply {
     pub sequence: u16,
     pub length: u32,
     pub datum: u32,
     pub data: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetQueryObjectuivARBReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetQueryObjectuivARBReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetQueryObjectuivARBReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/glx.rs
+++ b/x11rb-protocol/src/protocol/glx.rs
@@ -576,6 +576,7 @@ impl<'input> RenderRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != RENDER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -663,6 +664,7 @@ impl<'input> RenderLargeRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != RENDER_LARGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -763,6 +765,7 @@ impl CreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -832,6 +835,7 @@ impl DestroyContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -904,6 +908,7 @@ impl MakeCurrentRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != MAKE_CURRENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1056,6 +1061,7 @@ impl IsDirectRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != IS_DIRECT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1210,6 +1216,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1364,6 +1371,7 @@ impl WaitGLRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != WAIT_GL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1424,6 +1432,7 @@ impl WaitXRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != WAIT_X_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1502,6 +1511,7 @@ impl CopyContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COPY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1659,6 +1669,7 @@ impl SwapBuffersRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SWAP_BUFFERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1745,6 +1756,7 @@ impl UseXFontRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != USE_X_FONT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1831,6 +1843,7 @@ impl CreateGLXPixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_GLX_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1897,6 +1910,7 @@ impl GetVisualConfigsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VISUAL_CONFIGS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2031,6 +2045,7 @@ impl DestroyGLXPixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_GLX_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2101,6 +2116,7 @@ impl<'input> VendorPrivateRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != VENDOR_PRIVATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2183,6 +2199,7 @@ impl<'input> VendorPrivateWithReplyRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != VENDOR_PRIVATE_WITH_REPLY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2330,6 +2347,7 @@ impl QueryExtensionsStringRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_EXTENSIONS_STRING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2486,6 +2504,7 @@ impl QueryServerStringRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_SERVER_STRING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2638,6 +2657,7 @@ impl<'input> ClientInfoRequest<'input> {
         ([request0.into(), self.string, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CLIENT_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2711,6 +2731,7 @@ impl GetFBConfigsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_FB_CONFIGS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2875,6 +2896,7 @@ impl<'input> CreatePixmapRequest<'input> {
         ([request0.into(), attribs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2954,6 +2976,7 @@ impl DestroyPixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3044,6 +3067,7 @@ impl CreateNewContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_NEW_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3115,6 +3139,7 @@ impl QueryContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3266,6 +3291,7 @@ impl MakeContextCurrentRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != MAKE_CONTEXT_CURRENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3444,6 +3470,7 @@ impl<'input> CreatePbufferRequest<'input> {
         ([request0.into(), attribs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_PBUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3520,6 +3547,7 @@ impl DestroyPbufferRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_PBUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3580,6 +3608,7 @@ impl GetDrawableAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DRAWABLE_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3725,6 +3754,7 @@ impl<'input> ChangeDrawableAttributesRequest<'input> {
         ([request0.into(), attribs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_DRAWABLE_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3825,6 +3855,7 @@ impl<'input> CreateWindowRequest<'input> {
         ([request0.into(), attribs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3904,6 +3935,7 @@ impl DeleteWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4000,6 +4032,7 @@ impl<'input> SetClientInfoARBRequest<'input> {
         ([request0.into(), gl_versions_bytes.into(), self.gl_extension_string, padding0.into(), self.glx_extension_string, padding1.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CLIENT_INFO_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4121,6 +4154,7 @@ impl<'input> CreateContextAttribsARBRequest<'input> {
         ([request0.into(), attribs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONTEXT_ATTRIBS_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4240,6 +4274,7 @@ impl<'input> SetClientInfo2ARBRequest<'input> {
         ([request0.into(), gl_versions_bytes.into(), self.gl_extension_string, padding0.into(), self.glx_extension_string, padding1.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CLIENT_INFO2_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4337,6 +4372,7 @@ impl NewListRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != NEW_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4401,6 +4437,7 @@ impl EndListRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != END_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4473,6 +4510,7 @@ impl DeleteListsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_LISTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4543,6 +4581,7 @@ impl GenListsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GEN_LISTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4683,6 +4722,7 @@ impl FeedbackBufferRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FEEDBACK_BUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4753,6 +4793,7 @@ impl SelectBufferRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_BUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4821,6 +4862,7 @@ impl RenderModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != RENDER_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5015,6 +5057,7 @@ impl FinishRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FINISH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5145,6 +5188,7 @@ impl PixelStorefRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PIXEL_STOREF_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5221,6 +5265,7 @@ impl PixelStoreiRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PIXEL_STOREI_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5329,6 +5374,7 @@ impl ReadPixelsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != READ_PIXELS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5482,6 +5528,7 @@ impl GetBooleanvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_BOOLEANV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5626,6 +5673,7 @@ impl GetClipPlaneRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CLIP_PLANE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5763,6 +5811,7 @@ impl GetDoublevRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DOUBLEV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5901,6 +5950,7 @@ impl GetErrorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_ERROR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6033,6 +6083,7 @@ impl GetFloatvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_FLOATV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6177,6 +6228,7 @@ impl GetIntegervRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_INTEGERV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6327,6 +6379,7 @@ impl GetLightfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_LIGHTFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6479,6 +6532,7 @@ impl GetLightivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_LIGHTIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6631,6 +6685,7 @@ impl GetMapdvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MAPDV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6783,6 +6838,7 @@ impl GetMapfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MAPFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6935,6 +6991,7 @@ impl GetMapivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MAPIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7087,6 +7144,7 @@ impl GetMaterialfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MATERIALFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7239,6 +7297,7 @@ impl GetMaterialivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MATERIALIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7385,6 +7444,7 @@ impl GetPixelMapfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PIXEL_MAPFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7529,6 +7589,7 @@ impl GetPixelMapuivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PIXEL_MAPUIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7673,6 +7734,7 @@ impl GetPixelMapusvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PIXEL_MAPUSV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7817,6 +7879,7 @@ impl GetPolygonStippleRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_POLYGON_STIPPLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7956,6 +8019,7 @@ impl GetStringRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_STRING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8104,6 +8168,7 @@ impl GetTexEnvfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_ENVFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8256,6 +8321,7 @@ impl GetTexEnvivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_ENVIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8408,6 +8474,7 @@ impl GetTexGendvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_GENDV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8560,6 +8627,7 @@ impl GetTexGenfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_GENFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8712,6 +8780,7 @@ impl GetTexGenivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_GENIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8882,6 +8951,7 @@ impl GetTexImageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9046,6 +9116,7 @@ impl GetTexParameterfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_PARAMETERFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9198,6 +9269,7 @@ impl GetTexParameterivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_PARAMETERIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9356,6 +9428,7 @@ impl GetTexLevelParameterfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_LEVEL_PARAMETERFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9516,6 +9589,7 @@ impl GetTexLevelParameterivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_LEVEL_PARAMETERIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9664,6 +9738,7 @@ impl IsEnabledRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != IS_ENABLED_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9798,6 +9873,7 @@ impl IsListRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != IS_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9926,6 +10002,7 @@ impl FlushRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FLUSH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9997,6 +10074,7 @@ impl<'input> AreTexturesResidentRequest<'input> {
         ([request0.into(), textures_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ARE_TEXTURES_RESIDENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10151,6 +10229,7 @@ impl<'input> DeleteTexturesRequest<'input> {
         ([request0.into(), textures_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_TEXTURES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10227,6 +10306,7 @@ impl GenTexturesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GEN_TEXTURES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10363,6 +10443,7 @@ impl IsTextureRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != IS_TEXTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10515,6 +10596,7 @@ impl GetColorTableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_COLOR_TABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10671,6 +10753,7 @@ impl GetColorTableParameterfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_COLOR_TABLE_PARAMETERFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10823,6 +10906,7 @@ impl GetColorTableParameterivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_COLOR_TABLE_PARAMETERIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10987,6 +11071,7 @@ impl GetConvolutionFilterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CONVOLUTION_FILTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11146,6 +11231,7 @@ impl GetConvolutionParameterfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CONVOLUTION_PARAMETERFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11298,6 +11384,7 @@ impl GetConvolutionParameterivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CONVOLUTION_PARAMETERIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11462,6 +11549,7 @@ impl GetSeparableFilterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SEPARABLE_FILTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11635,6 +11723,7 @@ impl GetHistogramRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_HISTOGRAM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11793,6 +11882,7 @@ impl GetHistogramParameterfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_HISTOGRAM_PARAMETERFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11945,6 +12035,7 @@ impl GetHistogramParameterivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_HISTOGRAM_PARAMETERIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12111,6 +12202,7 @@ impl GetMinmaxRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MINMAX_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12264,6 +12356,7 @@ impl GetMinmaxParameterfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MINMAX_PARAMETERFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12416,6 +12509,7 @@ impl GetMinmaxParameterivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MINMAX_PARAMETERIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12568,6 +12662,7 @@ impl GetCompressedTexImageARBRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_COMPRESSED_TEX_IMAGE_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12719,6 +12814,7 @@ impl<'input> DeleteQueriesARBRequest<'input> {
         ([request0.into(), ids_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_QUERIES_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12795,6 +12891,7 @@ impl GenQueriesARBRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GEN_QUERIES_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12931,6 +13028,7 @@ impl IsQueryARBRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != IS_QUERY_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13071,6 +13169,7 @@ impl GetQueryivARBRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_QUERYIV_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13223,6 +13322,7 @@ impl GetQueryObjectivARBRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_QUERY_OBJECTIV_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13375,6 +13475,7 @@ impl GetQueryObjectuivARBRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_QUERY_OBJECTUIV_ARB_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/glx.rs
+++ b/x11rb-protocol/src/protocol/glx.rs
@@ -576,7 +576,7 @@ impl<'input> RenderRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != RENDER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -664,7 +664,7 @@ impl<'input> RenderLargeRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != RENDER_LARGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -765,7 +765,7 @@ impl CreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -835,7 +835,7 @@ impl DestroyContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -908,7 +908,7 @@ impl MakeCurrentRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != MAKE_CURRENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1061,7 +1061,7 @@ impl IsDirectRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != IS_DIRECT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1216,7 +1216,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1371,7 +1371,7 @@ impl WaitGLRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != WAIT_GL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1432,7 +1432,7 @@ impl WaitXRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != WAIT_X_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1511,7 +1511,7 @@ impl CopyContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COPY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1669,7 +1669,7 @@ impl SwapBuffersRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SWAP_BUFFERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1756,7 +1756,7 @@ impl UseXFontRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != USE_X_FONT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1843,7 +1843,7 @@ impl CreateGLXPixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_GLX_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1910,7 +1910,7 @@ impl GetVisualConfigsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VISUAL_CONFIGS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2045,7 +2045,7 @@ impl DestroyGLXPixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_GLX_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2116,7 +2116,7 @@ impl<'input> VendorPrivateRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != VENDOR_PRIVATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2199,7 +2199,7 @@ impl<'input> VendorPrivateWithReplyRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != VENDOR_PRIVATE_WITH_REPLY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2347,7 +2347,7 @@ impl QueryExtensionsStringRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_EXTENSIONS_STRING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2504,7 +2504,7 @@ impl QueryServerStringRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_SERVER_STRING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2657,7 +2657,7 @@ impl<'input> ClientInfoRequest<'input> {
         ([request0.into(), self.string, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CLIENT_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2731,7 +2731,7 @@ impl GetFBConfigsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_FB_CONFIGS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2896,7 +2896,7 @@ impl<'input> CreatePixmapRequest<'input> {
         ([request0.into(), attribs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2976,7 +2976,7 @@ impl DestroyPixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3067,7 +3067,7 @@ impl CreateNewContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_NEW_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3139,7 +3139,7 @@ impl QueryContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3291,7 +3291,7 @@ impl MakeContextCurrentRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != MAKE_CONTEXT_CURRENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3470,7 +3470,7 @@ impl<'input> CreatePbufferRequest<'input> {
         ([request0.into(), attribs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_PBUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3547,7 +3547,7 @@ impl DestroyPbufferRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_PBUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3608,7 +3608,7 @@ impl GetDrawableAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DRAWABLE_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3754,7 +3754,7 @@ impl<'input> ChangeDrawableAttributesRequest<'input> {
         ([request0.into(), attribs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_DRAWABLE_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3855,7 +3855,7 @@ impl<'input> CreateWindowRequest<'input> {
         ([request0.into(), attribs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3935,7 +3935,7 @@ impl DeleteWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4032,7 +4032,7 @@ impl<'input> SetClientInfoARBRequest<'input> {
         ([request0.into(), gl_versions_bytes.into(), self.gl_extension_string, padding0.into(), self.glx_extension_string, padding1.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CLIENT_INFO_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4154,7 +4154,7 @@ impl<'input> CreateContextAttribsARBRequest<'input> {
         ([request0.into(), attribs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONTEXT_ATTRIBS_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4274,7 +4274,7 @@ impl<'input> SetClientInfo2ARBRequest<'input> {
         ([request0.into(), gl_versions_bytes.into(), self.gl_extension_string, padding0.into(), self.glx_extension_string, padding1.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CLIENT_INFO2_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4372,7 +4372,7 @@ impl NewListRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != NEW_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4437,7 +4437,7 @@ impl EndListRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != END_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4510,7 +4510,7 @@ impl DeleteListsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_LISTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4581,7 +4581,7 @@ impl GenListsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GEN_LISTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4722,7 +4722,7 @@ impl FeedbackBufferRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FEEDBACK_BUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4793,7 +4793,7 @@ impl SelectBufferRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_BUFFER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4862,7 +4862,7 @@ impl RenderModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != RENDER_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5057,7 +5057,7 @@ impl FinishRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FINISH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5188,7 +5188,7 @@ impl PixelStorefRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PIXEL_STOREF_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5265,7 +5265,7 @@ impl PixelStoreiRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PIXEL_STOREI_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5374,7 +5374,7 @@ impl ReadPixelsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != READ_PIXELS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5528,7 +5528,7 @@ impl GetBooleanvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_BOOLEANV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5673,7 +5673,7 @@ impl GetClipPlaneRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CLIP_PLANE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5811,7 +5811,7 @@ impl GetDoublevRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DOUBLEV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5950,7 +5950,7 @@ impl GetErrorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_ERROR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6083,7 +6083,7 @@ impl GetFloatvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_FLOATV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6228,7 +6228,7 @@ impl GetIntegervRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_INTEGERV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6379,7 +6379,7 @@ impl GetLightfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_LIGHTFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6532,7 +6532,7 @@ impl GetLightivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_LIGHTIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6685,7 +6685,7 @@ impl GetMapdvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MAPDV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6838,7 +6838,7 @@ impl GetMapfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MAPFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6991,7 +6991,7 @@ impl GetMapivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MAPIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7144,7 +7144,7 @@ impl GetMaterialfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MATERIALFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7297,7 +7297,7 @@ impl GetMaterialivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MATERIALIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7444,7 +7444,7 @@ impl GetPixelMapfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PIXEL_MAPFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7589,7 +7589,7 @@ impl GetPixelMapuivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PIXEL_MAPUIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7734,7 +7734,7 @@ impl GetPixelMapusvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PIXEL_MAPUSV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7879,7 +7879,7 @@ impl GetPolygonStippleRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_POLYGON_STIPPLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8019,7 +8019,7 @@ impl GetStringRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_STRING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8168,7 +8168,7 @@ impl GetTexEnvfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_ENVFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8321,7 +8321,7 @@ impl GetTexEnvivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_ENVIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8474,7 +8474,7 @@ impl GetTexGendvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_GENDV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8627,7 +8627,7 @@ impl GetTexGenfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_GENFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8780,7 +8780,7 @@ impl GetTexGenivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_GENIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8951,7 +8951,7 @@ impl GetTexImageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9116,7 +9116,7 @@ impl GetTexParameterfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_PARAMETERFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9269,7 +9269,7 @@ impl GetTexParameterivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_PARAMETERIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9428,7 +9428,7 @@ impl GetTexLevelParameterfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_LEVEL_PARAMETERFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9589,7 +9589,7 @@ impl GetTexLevelParameterivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_TEX_LEVEL_PARAMETERIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9738,7 +9738,7 @@ impl IsEnabledRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != IS_ENABLED_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9873,7 +9873,7 @@ impl IsListRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != IS_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10002,7 +10002,7 @@ impl FlushRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FLUSH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10074,7 +10074,7 @@ impl<'input> AreTexturesResidentRequest<'input> {
         ([request0.into(), textures_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ARE_TEXTURES_RESIDENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10229,7 +10229,7 @@ impl<'input> DeleteTexturesRequest<'input> {
         ([request0.into(), textures_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_TEXTURES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10306,7 +10306,7 @@ impl GenTexturesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GEN_TEXTURES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10443,7 +10443,7 @@ impl IsTextureRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != IS_TEXTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10596,7 +10596,7 @@ impl GetColorTableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_COLOR_TABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10753,7 +10753,7 @@ impl GetColorTableParameterfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_COLOR_TABLE_PARAMETERFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10906,7 +10906,7 @@ impl GetColorTableParameterivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_COLOR_TABLE_PARAMETERIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11071,7 +11071,7 @@ impl GetConvolutionFilterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CONVOLUTION_FILTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11231,7 +11231,7 @@ impl GetConvolutionParameterfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CONVOLUTION_PARAMETERFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11384,7 +11384,7 @@ impl GetConvolutionParameterivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CONVOLUTION_PARAMETERIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11549,7 +11549,7 @@ impl GetSeparableFilterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SEPARABLE_FILTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11723,7 +11723,7 @@ impl GetHistogramRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_HISTOGRAM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11882,7 +11882,7 @@ impl GetHistogramParameterfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_HISTOGRAM_PARAMETERFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12035,7 +12035,7 @@ impl GetHistogramParameterivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_HISTOGRAM_PARAMETERIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12202,7 +12202,7 @@ impl GetMinmaxRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MINMAX_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12356,7 +12356,7 @@ impl GetMinmaxParameterfvRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MINMAX_PARAMETERFV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12509,7 +12509,7 @@ impl GetMinmaxParameterivRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MINMAX_PARAMETERIV_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12662,7 +12662,7 @@ impl GetCompressedTexImageARBRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_COMPRESSED_TEX_IMAGE_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12814,7 +12814,7 @@ impl<'input> DeleteQueriesARBRequest<'input> {
         ([request0.into(), ids_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_QUERIES_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12891,7 +12891,7 @@ impl GenQueriesARBRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GEN_QUERIES_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13028,7 +13028,7 @@ impl IsQueryARBRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != IS_QUERY_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13169,7 +13169,7 @@ impl GetQueryivARBRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_QUERYIV_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13322,7 +13322,7 @@ impl GetQueryObjectivARBRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_QUERY_OBJECTIV_ARB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13475,7 +13475,7 @@ impl GetQueryObjectuivARBRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_QUERY_OBJECTUIV_ARB_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/mod.rs
+++ b/x11rb-protocol/src/protocol/mod.rs
@@ -2217,7 +2217,7 @@ pub enum Request<'input> {
 impl<'input> Request<'input> {
     // Parse a X11 request into a concrete type
     #[allow(clippy::cognitive_complexity, clippy::single_match)]
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn parse(
         header: RequestHeader,
         body: &'input [u8],

--- a/x11rb-protocol/src/protocol/mod.rs
+++ b/x11rb-protocol/src/protocol/mod.rs
@@ -2217,6 +2217,7 @@ pub enum Request<'input> {
 impl<'input> Request<'input> {
     // Parse a X11 request into a concrete type
     #[allow(clippy::cognitive_complexity, clippy::single_match)]
+    #[cfg(feature = "extra-traits")]
     pub fn parse(
         header: RequestHeader,
         body: &'input [u8],

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -501,6 +501,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -732,6 +733,7 @@ impl<'input> PixmapRequest<'input> {
         ([request0.into(), notifies_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -888,6 +890,7 @@ impl NotifyMSCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != NOTIFY_MSC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -971,6 +974,7 @@ impl SelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1036,6 +1040,7 @@ impl QueryCapabilitiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_CAPABILITIES_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -415,11 +415,18 @@ impl core::fmt::Debug for CompleteMode  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Notify {
     pub window: xproto::Window,
     pub serial: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Notify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Notify").finish_non_exhaustive()
+    }
 }
 impl TryParse for Notify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -454,11 +461,18 @@ impl Serialize for Notify {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -514,13 +528,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -582,7 +603,8 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the Pixmap request
 pub const PIXMAP_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PixmapRequest<'input> {
     pub window: xproto::Window,
@@ -600,6 +622,12 @@ pub struct PixmapRequest<'input> {
     pub divisor: u64,
     pub remainder: u64,
     pub notifies: Cow<'input, [Notify]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PixmapRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PixmapRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PixmapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -786,7 +814,8 @@ impl<'input> crate::x11_utils::VoidRequest for PixmapRequest<'input> {
 
 /// Opcode for the NotifyMSC request
 pub const NOTIFY_MSC_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyMSCRequest {
     pub window: xproto::Window,
@@ -794,6 +823,12 @@ pub struct NotifyMSCRequest {
     pub target_msc: u64,
     pub divisor: u64,
     pub remainder: u64,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for NotifyMSCRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NotifyMSCRequest").finish_non_exhaustive()
+    }
 }
 impl NotifyMSCRequest {
     /// Serialize this request into bytes for the provided connection
@@ -890,12 +925,19 @@ pub type Event = u32;
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputRequest {
     pub eid: Event,
     pub window: xproto::Window,
     pub event_mask: EventMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectInputRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectInputRequest").finish_non_exhaustive()
+    }
 }
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
@@ -960,10 +1002,17 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 
 /// Opcode for the QueryCapabilities request
 pub const QUERY_CAPABILITIES_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryCapabilitiesRequest {
     pub target: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryCapabilitiesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryCapabilitiesRequest").finish_non_exhaustive()
+    }
 }
 impl QueryCapabilitiesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1012,12 +1061,19 @@ impl crate::x11_utils::ReplyRequest for QueryCapabilitiesRequest {
     type Reply = QueryCapabilitiesReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryCapabilitiesReply {
     pub sequence: u16,
     pub length: u32,
     pub capabilities: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryCapabilitiesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryCapabilitiesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryCapabilitiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1072,7 +1128,8 @@ impl Serialize for QueryCapabilitiesReply {
 
 /// Opcode for the Generic event
 pub const GENERIC_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GenericEvent {
     pub response_type: u8,
@@ -1081,6 +1138,12 @@ pub struct GenericEvent {
     pub length: u32,
     pub evtype: u16,
     pub event: Event,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GenericEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GenericEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for GenericEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1191,7 +1254,8 @@ impl From<GenericEvent> for [u8; 32] {
 
 /// Opcode for the ConfigureNotify event
 pub const CONFIGURE_NOTIFY_EVENT: u16 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureNotifyEvent {
     pub response_type: u8,
@@ -1210,6 +1274,12 @@ pub struct ConfigureNotifyEvent {
     pub pixmap_width: u16,
     pub pixmap_height: u16,
     pub pixmap_flags: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ConfigureNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ConfigureNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ConfigureNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1324,7 +1394,8 @@ impl Serialize for ConfigureNotifyEvent {
 
 /// Opcode for the CompleteNotify event
 pub const COMPLETE_NOTIFY_EVENT: u16 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompleteNotifyEvent {
     pub response_type: u8,
@@ -1339,6 +1410,12 @@ pub struct CompleteNotifyEvent {
     pub serial: u32,
     pub ust: u64,
     pub msc: u64,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CompleteNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CompleteNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for CompleteNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1441,7 +1518,8 @@ impl Serialize for CompleteNotifyEvent {
 
 /// Opcode for the IdleNotify event
 pub const IDLE_NOTIFY_EVENT: u16 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IdleNotifyEvent {
     pub response_type: u8,
@@ -1454,6 +1532,12 @@ pub struct IdleNotifyEvent {
     pub serial: u32,
     pub pixmap: xproto::Pixmap,
     pub idle_fence: sync::Fence,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IdleNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IdleNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for IdleNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1542,7 +1626,8 @@ impl Serialize for IdleNotifyEvent {
 
 /// Opcode for the RedirectNotify event
 pub const REDIRECT_NOTIFY_EVENT: u16 = 3;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RedirectNotifyEvent {
     pub response_type: u8,
@@ -1570,6 +1655,12 @@ pub struct RedirectNotifyEvent {
     pub divisor: u64,
     pub remainder: u64,
     pub notifies: Vec<Notify>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RedirectNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RedirectNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for RedirectNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -501,7 +501,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -733,7 +733,7 @@ impl<'input> PixmapRequest<'input> {
         ([request0.into(), notifies_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -890,7 +890,7 @@ impl NotifyMSCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != NOTIFY_MSC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -974,7 +974,7 @@ impl SelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1040,7 +1040,7 @@ impl QueryCapabilitiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_CAPABILITIES_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -122,13 +122,20 @@ impl core::fmt::Debug for Rotation  {
 }
 bitmask_binop!(Rotation, u16);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScreenSize {
     pub width: u16,
     pub height: u16,
     pub mwidth: u16,
     pub mheight: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ScreenSize {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ScreenSize").finish_non_exhaustive()
+    }
 }
 impl TryParse for ScreenSize {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -167,10 +174,17 @@ impl Serialize for ScreenSize {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RefreshRates {
     pub rates: Vec<u16>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RefreshRates {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RefreshRates").finish_non_exhaustive()
+    }
 }
 impl TryParse for RefreshRates {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -211,11 +225,18 @@ impl RefreshRates {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -271,13 +292,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -420,7 +448,8 @@ impl core::fmt::Debug for SetConfig  {
 
 /// Opcode for the SetScreenConfig request
 pub const SET_SCREEN_CONFIG_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetScreenConfigRequest {
     pub window: xproto::Window,
@@ -429,6 +458,12 @@ pub struct SetScreenConfigRequest {
     pub size_id: u16,
     pub rotation: Rotation,
     pub rate: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetScreenConfigRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetScreenConfigRequest").finish_non_exhaustive()
+    }
 }
 impl SetScreenConfigRequest {
     /// Serialize this request into bytes for the provided connection
@@ -510,7 +545,8 @@ impl crate::x11_utils::ReplyRequest for SetScreenConfigRequest {
     type Reply = SetScreenConfigReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetScreenConfigReply {
     pub status: SetConfig,
@@ -520,6 +556,12 @@ pub struct SetScreenConfigReply {
     pub config_timestamp: xproto::Timestamp,
     pub root: xproto::Window,
     pub subpixel_order: render::SubPixel,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetScreenConfigReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetScreenConfigReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetScreenConfigReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -674,11 +716,18 @@ bitmask_binop!(NotifyMask, u16);
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputRequest {
     pub window: xproto::Window,
     pub enable: NotifyMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectInputRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectInputRequest").finish_non_exhaustive()
+    }
 }
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
@@ -737,10 +786,17 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 
 /// Opcode for the GetScreenInfo request
 pub const GET_SCREEN_INFO_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenInfoRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenInfoRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenInfoRequest").finish_non_exhaustive()
+    }
 }
 impl GetScreenInfoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -789,7 +845,8 @@ impl crate::x11_utils::ReplyRequest for GetScreenInfoRequest {
     type Reply = GetScreenInfoReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenInfoReply {
     pub rotations: Rotation,
@@ -804,6 +861,12 @@ pub struct GetScreenInfoReply {
     pub n_info: u16,
     pub sizes: Vec<ScreenSize>,
     pub rates: Vec<RefreshRates>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenInfoReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenInfoReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetScreenInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -882,10 +945,17 @@ impl GetScreenInfoReply {
 
 /// Opcode for the GetScreenSizeRange request
 pub const GET_SCREEN_SIZE_RANGE_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSizeRangeRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenSizeRangeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenSizeRangeRequest").finish_non_exhaustive()
+    }
 }
 impl GetScreenSizeRangeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -934,7 +1004,8 @@ impl crate::x11_utils::ReplyRequest for GetScreenSizeRangeRequest {
     type Reply = GetScreenSizeRangeReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSizeRangeReply {
     pub sequence: u16,
@@ -943,6 +1014,12 @@ pub struct GetScreenSizeRangeReply {
     pub min_height: u16,
     pub max_width: u16,
     pub max_height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenSizeRangeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenSizeRangeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetScreenSizeRangeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1028,7 +1105,8 @@ impl Serialize for GetScreenSizeRangeReply {
 
 /// Opcode for the SetScreenSize request
 pub const SET_SCREEN_SIZE_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetScreenSizeRequest {
     pub window: xproto::Window,
@@ -1036,6 +1114,12 @@ pub struct SetScreenSizeRequest {
     pub height: u16,
     pub mm_width: u32,
     pub mm_height: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetScreenSizeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetScreenSizeRequest").finish_non_exhaustive()
+    }
 }
 impl SetScreenSizeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1179,7 +1263,8 @@ impl core::fmt::Debug for ModeFlag  {
 }
 bitmask_binop!(ModeFlag, u32);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModeInfo {
     pub id: u32,
@@ -1195,6 +1280,12 @@ pub struct ModeInfo {
     pub vtotal: u16,
     pub name_len: u16,
     pub mode_flags: ModeFlag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ModeInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ModeInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for ModeInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1287,10 +1378,17 @@ impl Serialize for ModeInfo {
 
 /// Opcode for the GetScreenResources request
 pub const GET_SCREEN_RESOURCES_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenResourcesRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenResourcesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenResourcesRequest").finish_non_exhaustive()
+    }
 }
 impl GetScreenResourcesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1339,7 +1437,8 @@ impl crate::x11_utils::ReplyRequest for GetScreenResourcesRequest {
     type Reply = GetScreenResourcesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenResourcesReply {
     pub sequence: u16,
@@ -1350,6 +1449,12 @@ pub struct GetScreenResourcesReply {
     pub outputs: Vec<Output>,
     pub modes: Vec<ModeInfo>,
     pub names: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenResourcesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenResourcesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetScreenResourcesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1529,11 +1634,18 @@ impl core::fmt::Debug for Connection  {
 
 /// Opcode for the GetOutputInfo request
 pub const GET_OUTPUT_INFO_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOutputInfoRequest {
     pub output: Output,
     pub config_timestamp: xproto::Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetOutputInfoRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetOutputInfoRequest").finish_non_exhaustive()
+    }
 }
 impl GetOutputInfoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1589,7 +1701,8 @@ impl crate::x11_utils::ReplyRequest for GetOutputInfoRequest {
     type Reply = GetOutputInfoReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOutputInfoReply {
     pub status: SetConfig,
@@ -1606,6 +1719,12 @@ pub struct GetOutputInfoReply {
     pub modes: Vec<Mode>,
     pub clones: Vec<Output>,
     pub name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetOutputInfoReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetOutputInfoReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetOutputInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1735,10 +1854,17 @@ impl GetOutputInfoReply {
 
 /// Opcode for the ListOutputProperties request
 pub const LIST_OUTPUT_PROPERTIES_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListOutputPropertiesRequest {
     pub output: Output,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListOutputPropertiesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListOutputPropertiesRequest").finish_non_exhaustive()
+    }
 }
 impl ListOutputPropertiesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1787,12 +1913,19 @@ impl crate::x11_utils::ReplyRequest for ListOutputPropertiesRequest {
     type Reply = ListOutputPropertiesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListOutputPropertiesReply {
     pub sequence: u16,
     pub length: u32,
     pub atoms: Vec<xproto::Atom>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListOutputPropertiesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListOutputPropertiesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListOutputPropertiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1852,11 +1985,18 @@ impl ListOutputPropertiesReply {
 
 /// Opcode for the QueryOutputProperty request
 pub const QUERY_OUTPUT_PROPERTY_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryOutputPropertyRequest {
     pub output: Output,
     pub property: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryOutputPropertyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryOutputPropertyRequest").finish_non_exhaustive()
+    }
 }
 impl QueryOutputPropertyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1912,7 +2052,8 @@ impl crate::x11_utils::ReplyRequest for QueryOutputPropertyRequest {
     type Reply = QueryOutputPropertyReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryOutputPropertyReply {
     pub sequence: u16,
@@ -1920,6 +2061,12 @@ pub struct QueryOutputPropertyReply {
     pub range: bool,
     pub immutable: bool,
     pub valid_values: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryOutputPropertyReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryOutputPropertyReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryOutputPropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1983,7 +2130,8 @@ impl QueryOutputPropertyReply {
 
 /// Opcode for the ConfigureOutputProperty request
 pub const CONFIGURE_OUTPUT_PROPERTY_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureOutputPropertyRequest<'input> {
     pub output: Output,
@@ -1991,6 +2139,12 @@ pub struct ConfigureOutputPropertyRequest<'input> {
     pub pending: bool,
     pub range: bool,
     pub values: Cow<'input, [i32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ConfigureOutputPropertyRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ConfigureOutputPropertyRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ConfigureOutputPropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2081,7 +2235,8 @@ impl<'input> crate::x11_utils::VoidRequest for ConfigureOutputPropertyRequest<'i
 
 /// Opcode for the ChangeOutputProperty request
 pub const CHANGE_OUTPUT_PROPERTY_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeOutputPropertyRequest<'input> {
     pub output: Output,
@@ -2091,6 +2246,12 @@ pub struct ChangeOutputPropertyRequest<'input> {
     pub mode: xproto::PropMode,
     pub num_units: u32,
     pub data: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeOutputPropertyRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeOutputPropertyRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeOutputPropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2191,11 +2352,18 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeOutputPropertyRequest<'inpu
 
 /// Opcode for the DeleteOutputProperty request
 pub const DELETE_OUTPUT_PROPERTY_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteOutputPropertyRequest {
     pub output: Output,
     pub property: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeleteOutputPropertyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeleteOutputPropertyRequest").finish_non_exhaustive()
+    }
 }
 impl DeleteOutputPropertyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2252,7 +2420,8 @@ impl crate::x11_utils::VoidRequest for DeleteOutputPropertyRequest {
 
 /// Opcode for the GetOutputProperty request
 pub const GET_OUTPUT_PROPERTY_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOutputPropertyRequest {
     pub output: Output,
@@ -2262,6 +2431,12 @@ pub struct GetOutputPropertyRequest {
     pub long_length: u32,
     pub delete: bool,
     pub pending: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetOutputPropertyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetOutputPropertyRequest").finish_non_exhaustive()
+    }
 }
 impl GetOutputPropertyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2349,7 +2524,8 @@ impl crate::x11_utils::ReplyRequest for GetOutputPropertyRequest {
     type Reply = GetOutputPropertyReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOutputPropertyReply {
     pub format: u8,
@@ -2359,6 +2535,12 @@ pub struct GetOutputPropertyReply {
     pub bytes_after: u32,
     pub num_items: u32,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetOutputPropertyReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetOutputPropertyReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetOutputPropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2408,12 +2590,19 @@ impl Serialize for GetOutputPropertyReply {
 
 /// Opcode for the CreateMode request
 pub const CREATE_MODE_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateModeRequest<'input> {
     pub window: xproto::Window,
     pub mode_info: ModeInfo,
     pub name: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateModeRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateModeRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateModeRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2510,12 +2699,19 @@ impl<'input> crate::x11_utils::ReplyRequest for CreateModeRequest<'input> {
     type Reply = CreateModeReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateModeReply {
     pub sequence: u16,
     pub length: u32,
     pub mode: Mode,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateModeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateModeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for CreateModeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2592,10 +2788,17 @@ impl Serialize for CreateModeReply {
 
 /// Opcode for the DestroyMode request
 pub const DESTROY_MODE_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyModeRequest {
     pub mode: Mode,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyModeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyModeRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyModeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2645,11 +2848,18 @@ impl crate::x11_utils::VoidRequest for DestroyModeRequest {
 
 /// Opcode for the AddOutputMode request
 pub const ADD_OUTPUT_MODE_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddOutputModeRequest {
     pub output: Output,
     pub mode: Mode,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AddOutputModeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AddOutputModeRequest").finish_non_exhaustive()
+    }
 }
 impl AddOutputModeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2706,11 +2916,18 @@ impl crate::x11_utils::VoidRequest for AddOutputModeRequest {
 
 /// Opcode for the DeleteOutputMode request
 pub const DELETE_OUTPUT_MODE_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteOutputModeRequest {
     pub output: Output,
     pub mode: Mode,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeleteOutputModeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeleteOutputModeRequest").finish_non_exhaustive()
+    }
 }
 impl DeleteOutputModeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2767,11 +2984,18 @@ impl crate::x11_utils::VoidRequest for DeleteOutputModeRequest {
 
 /// Opcode for the GetCrtcInfo request
 pub const GET_CRTC_INFO_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcInfoRequest {
     pub crtc: Crtc,
     pub config_timestamp: xproto::Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCrtcInfoRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCrtcInfoRequest").finish_non_exhaustive()
+    }
 }
 impl GetCrtcInfoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2827,7 +3051,8 @@ impl crate::x11_utils::ReplyRequest for GetCrtcInfoRequest {
     type Reply = GetCrtcInfoReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcInfoReply {
     pub status: SetConfig,
@@ -2843,6 +3068,12 @@ pub struct GetCrtcInfoReply {
     pub rotations: Rotation,
     pub outputs: Vec<Output>,
     pub possible: Vec<Output>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCrtcInfoReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCrtcInfoReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetCrtcInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2937,7 +3168,8 @@ impl GetCrtcInfoReply {
 
 /// Opcode for the SetCrtcConfig request
 pub const SET_CRTC_CONFIG_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCrtcConfigRequest<'input> {
     pub crtc: Crtc,
@@ -2948,6 +3180,12 @@ pub struct SetCrtcConfigRequest<'input> {
     pub mode: Mode,
     pub rotation: Rotation,
     pub outputs: Cow<'input, [Output]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetCrtcConfigRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetCrtcConfigRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetCrtcConfigRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3062,13 +3300,20 @@ impl<'input> crate::x11_utils::ReplyRequest for SetCrtcConfigRequest<'input> {
     type Reply = SetCrtcConfigReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCrtcConfigReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
     pub timestamp: xproto::Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetCrtcConfigReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetCrtcConfigReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetCrtcConfigReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3147,10 +3392,17 @@ impl Serialize for SetCrtcConfigReply {
 
 /// Opcode for the GetCrtcGammaSize request
 pub const GET_CRTC_GAMMA_SIZE_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcGammaSizeRequest {
     pub crtc: Crtc,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCrtcGammaSizeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCrtcGammaSizeRequest").finish_non_exhaustive()
+    }
 }
 impl GetCrtcGammaSizeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3199,12 +3451,19 @@ impl crate::x11_utils::ReplyRequest for GetCrtcGammaSizeRequest {
     type Reply = GetCrtcGammaSizeReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcGammaSizeReply {
     pub sequence: u16,
     pub length: u32,
     pub size: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCrtcGammaSizeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCrtcGammaSizeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetCrtcGammaSizeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3281,10 +3540,17 @@ impl Serialize for GetCrtcGammaSizeReply {
 
 /// Opcode for the GetCrtcGamma request
 pub const GET_CRTC_GAMMA_REQUEST: u8 = 23;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcGammaRequest {
     pub crtc: Crtc,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCrtcGammaRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCrtcGammaRequest").finish_non_exhaustive()
+    }
 }
 impl GetCrtcGammaRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3333,7 +3599,8 @@ impl crate::x11_utils::ReplyRequest for GetCrtcGammaRequest {
     type Reply = GetCrtcGammaReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcGammaReply {
     pub sequence: u16,
@@ -3341,6 +3608,12 @@ pub struct GetCrtcGammaReply {
     pub red: Vec<u16>,
     pub green: Vec<u16>,
     pub blue: Vec<u16>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCrtcGammaReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCrtcGammaReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetCrtcGammaReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3406,13 +3679,20 @@ impl GetCrtcGammaReply {
 
 /// Opcode for the SetCrtcGamma request
 pub const SET_CRTC_GAMMA_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCrtcGammaRequest<'input> {
     pub crtc: Crtc,
     pub red: Cow<'input, [u16]>,
     pub green: Cow<'input, [u16]>,
     pub blue: Cow<'input, [u16]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetCrtcGammaRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetCrtcGammaRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetCrtcGammaRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3495,10 +3775,17 @@ impl<'input> crate::x11_utils::VoidRequest for SetCrtcGammaRequest<'input> {
 
 /// Opcode for the GetScreenResourcesCurrent request
 pub const GET_SCREEN_RESOURCES_CURRENT_REQUEST: u8 = 25;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenResourcesCurrentRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenResourcesCurrentRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenResourcesCurrentRequest").finish_non_exhaustive()
+    }
 }
 impl GetScreenResourcesCurrentRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3547,7 +3834,8 @@ impl crate::x11_utils::ReplyRequest for GetScreenResourcesCurrentRequest {
     type Reply = GetScreenResourcesCurrentReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenResourcesCurrentReply {
     pub sequence: u16,
@@ -3558,6 +3846,12 @@ pub struct GetScreenResourcesCurrentReply {
     pub outputs: Vec<Output>,
     pub modes: Vec<ModeInfo>,
     pub names: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenResourcesCurrentReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenResourcesCurrentReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetScreenResourcesCurrentReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3740,13 +4034,20 @@ bitmask_binop!(Transform, u8);
 
 /// Opcode for the SetCrtcTransform request
 pub const SET_CRTC_TRANSFORM_REQUEST: u8 = 26;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCrtcTransformRequest<'input> {
     pub crtc: Crtc,
     pub transform: render::Transform,
     pub filter_name: Cow<'input, [u8]>,
     pub filter_params: Cow<'input, [render::Fixed]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetCrtcTransformRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetCrtcTransformRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetCrtcTransformRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3874,10 +4175,17 @@ impl<'input> crate::x11_utils::VoidRequest for SetCrtcTransformRequest<'input> {
 
 /// Opcode for the GetCrtcTransform request
 pub const GET_CRTC_TRANSFORM_REQUEST: u8 = 27;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcTransformRequest {
     pub crtc: Crtc,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCrtcTransformRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCrtcTransformRequest").finish_non_exhaustive()
+    }
 }
 impl GetCrtcTransformRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3926,7 +4234,8 @@ impl crate::x11_utils::ReplyRequest for GetCrtcTransformRequest {
     type Reply = GetCrtcTransformReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCrtcTransformReply {
     pub sequence: u16,
@@ -3938,6 +4247,12 @@ pub struct GetCrtcTransformReply {
     pub pending_params: Vec<render::Fixed>,
     pub current_filter_name: Vec<u8>,
     pub current_params: Vec<render::Fixed>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCrtcTransformReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCrtcTransformReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetCrtcTransformReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4072,10 +4387,17 @@ impl GetCrtcTransformReply {
 
 /// Opcode for the GetPanning request
 pub const GET_PANNING_REQUEST: u8 = 28;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPanningRequest {
     pub crtc: Crtc,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPanningRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPanningRequest").finish_non_exhaustive()
+    }
 }
 impl GetPanningRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4124,7 +4446,8 @@ impl crate::x11_utils::ReplyRequest for GetPanningRequest {
     type Reply = GetPanningReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPanningReply {
     pub status: SetConfig,
@@ -4143,6 +4466,12 @@ pub struct GetPanningReply {
     pub border_top: i16,
     pub border_right: i16,
     pub border_bottom: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPanningReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPanningReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPanningReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4259,7 +4588,8 @@ impl Serialize for GetPanningReply {
 
 /// Opcode for the SetPanning request
 pub const SET_PANNING_REQUEST: u8 = 29;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPanningRequest {
     pub crtc: Crtc,
@@ -4276,6 +4606,12 @@ pub struct SetPanningRequest {
     pub border_top: i16,
     pub border_right: i16,
     pub border_bottom: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetPanningRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetPanningRequest").finish_non_exhaustive()
+    }
 }
 impl SetPanningRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4391,13 +4727,20 @@ impl crate::x11_utils::ReplyRequest for SetPanningRequest {
     type Reply = SetPanningReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPanningReply {
     pub status: SetConfig,
     pub sequence: u16,
     pub length: u32,
     pub timestamp: xproto::Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetPanningReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetPanningReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetPanningReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4454,11 +4797,18 @@ impl Serialize for SetPanningReply {
 
 /// Opcode for the SetOutputPrimary request
 pub const SET_OUTPUT_PRIMARY_REQUEST: u8 = 30;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetOutputPrimaryRequest {
     pub window: xproto::Window,
     pub output: Output,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetOutputPrimaryRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetOutputPrimaryRequest").finish_non_exhaustive()
+    }
 }
 impl SetOutputPrimaryRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4515,10 +4865,17 @@ impl crate::x11_utils::VoidRequest for SetOutputPrimaryRequest {
 
 /// Opcode for the GetOutputPrimary request
 pub const GET_OUTPUT_PRIMARY_REQUEST: u8 = 31;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOutputPrimaryRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetOutputPrimaryRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetOutputPrimaryRequest").finish_non_exhaustive()
+    }
 }
 impl GetOutputPrimaryRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4567,12 +4924,19 @@ impl crate::x11_utils::ReplyRequest for GetOutputPrimaryRequest {
     type Reply = GetOutputPrimaryReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetOutputPrimaryReply {
     pub sequence: u16,
     pub length: u32,
     pub output: Output,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetOutputPrimaryReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetOutputPrimaryReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetOutputPrimaryReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4627,10 +4991,17 @@ impl Serialize for GetOutputPrimaryReply {
 
 /// Opcode for the GetProviders request
 pub const GET_PROVIDERS_REQUEST: u8 = 32;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetProvidersRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetProvidersRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetProvidersRequest").finish_non_exhaustive()
+    }
 }
 impl GetProvidersRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4679,13 +5050,20 @@ impl crate::x11_utils::ReplyRequest for GetProvidersRequest {
     type Reply = GetProvidersReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetProvidersReply {
     pub sequence: u16,
     pub length: u32,
     pub timestamp: xproto::Timestamp,
     pub providers: Vec<Provider>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetProvidersReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetProvidersReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetProvidersReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4799,11 +5177,18 @@ bitmask_binop!(ProviderCapability, u32);
 
 /// Opcode for the GetProviderInfo request
 pub const GET_PROVIDER_INFO_REQUEST: u8 = 33;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetProviderInfoRequest {
     pub provider: Provider,
     pub config_timestamp: xproto::Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetProviderInfoRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetProviderInfoRequest").finish_non_exhaustive()
+    }
 }
 impl GetProviderInfoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4859,7 +5244,8 @@ impl crate::x11_utils::ReplyRequest for GetProviderInfoRequest {
     type Reply = GetProviderInfoReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetProviderInfoReply {
     pub status: u8,
@@ -4872,6 +5258,12 @@ pub struct GetProviderInfoReply {
     pub associated_providers: Vec<Provider>,
     pub associated_capability: Vec<u32>,
     pub name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetProviderInfoReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetProviderInfoReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetProviderInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4994,12 +5386,19 @@ impl GetProviderInfoReply {
 
 /// Opcode for the SetProviderOffloadSink request
 pub const SET_PROVIDER_OFFLOAD_SINK_REQUEST: u8 = 34;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetProviderOffloadSinkRequest {
     pub provider: Provider,
     pub sink_provider: Provider,
     pub config_timestamp: xproto::Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetProviderOffloadSinkRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetProviderOffloadSinkRequest").finish_non_exhaustive()
+    }
 }
 impl SetProviderOffloadSinkRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5063,12 +5462,19 @@ impl crate::x11_utils::VoidRequest for SetProviderOffloadSinkRequest {
 
 /// Opcode for the SetProviderOutputSource request
 pub const SET_PROVIDER_OUTPUT_SOURCE_REQUEST: u8 = 35;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetProviderOutputSourceRequest {
     pub provider: Provider,
     pub source_provider: Provider,
     pub config_timestamp: xproto::Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetProviderOutputSourceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetProviderOutputSourceRequest").finish_non_exhaustive()
+    }
 }
 impl SetProviderOutputSourceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5132,10 +5538,17 @@ impl crate::x11_utils::VoidRequest for SetProviderOutputSourceRequest {
 
 /// Opcode for the ListProviderProperties request
 pub const LIST_PROVIDER_PROPERTIES_REQUEST: u8 = 36;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListProviderPropertiesRequest {
     pub provider: Provider,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListProviderPropertiesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListProviderPropertiesRequest").finish_non_exhaustive()
+    }
 }
 impl ListProviderPropertiesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5184,12 +5597,19 @@ impl crate::x11_utils::ReplyRequest for ListProviderPropertiesRequest {
     type Reply = ListProviderPropertiesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListProviderPropertiesReply {
     pub sequence: u16,
     pub length: u32,
     pub atoms: Vec<xproto::Atom>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListProviderPropertiesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListProviderPropertiesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListProviderPropertiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5249,11 +5669,18 @@ impl ListProviderPropertiesReply {
 
 /// Opcode for the QueryProviderProperty request
 pub const QUERY_PROVIDER_PROPERTY_REQUEST: u8 = 37;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryProviderPropertyRequest {
     pub provider: Provider,
     pub property: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryProviderPropertyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryProviderPropertyRequest").finish_non_exhaustive()
+    }
 }
 impl QueryProviderPropertyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5309,7 +5736,8 @@ impl crate::x11_utils::ReplyRequest for QueryProviderPropertyRequest {
     type Reply = QueryProviderPropertyReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryProviderPropertyReply {
     pub sequence: u16,
@@ -5317,6 +5745,12 @@ pub struct QueryProviderPropertyReply {
     pub range: bool,
     pub immutable: bool,
     pub valid_values: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryProviderPropertyReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryProviderPropertyReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryProviderPropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5380,7 +5814,8 @@ impl QueryProviderPropertyReply {
 
 /// Opcode for the ConfigureProviderProperty request
 pub const CONFIGURE_PROVIDER_PROPERTY_REQUEST: u8 = 38;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureProviderPropertyRequest<'input> {
     pub provider: Provider,
@@ -5388,6 +5823,12 @@ pub struct ConfigureProviderPropertyRequest<'input> {
     pub pending: bool,
     pub range: bool,
     pub values: Cow<'input, [i32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ConfigureProviderPropertyRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ConfigureProviderPropertyRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ConfigureProviderPropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -5478,7 +5919,8 @@ impl<'input> crate::x11_utils::VoidRequest for ConfigureProviderPropertyRequest<
 
 /// Opcode for the ChangeProviderProperty request
 pub const CHANGE_PROVIDER_PROPERTY_REQUEST: u8 = 39;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeProviderPropertyRequest<'input> {
     pub provider: Provider,
@@ -5488,6 +5930,12 @@ pub struct ChangeProviderPropertyRequest<'input> {
     pub mode: u8,
     pub num_items: u32,
     pub data: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeProviderPropertyRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeProviderPropertyRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeProviderPropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -5587,11 +6035,18 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeProviderPropertyRequest<'in
 
 /// Opcode for the DeleteProviderProperty request
 pub const DELETE_PROVIDER_PROPERTY_REQUEST: u8 = 40;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteProviderPropertyRequest {
     pub provider: Provider,
     pub property: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeleteProviderPropertyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeleteProviderPropertyRequest").finish_non_exhaustive()
+    }
 }
 impl DeleteProviderPropertyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5648,7 +6103,8 @@ impl crate::x11_utils::VoidRequest for DeleteProviderPropertyRequest {
 
 /// Opcode for the GetProviderProperty request
 pub const GET_PROVIDER_PROPERTY_REQUEST: u8 = 41;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetProviderPropertyRequest {
     pub provider: Provider,
@@ -5658,6 +6114,12 @@ pub struct GetProviderPropertyRequest {
     pub long_length: u32,
     pub delete: bool,
     pub pending: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetProviderPropertyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetProviderPropertyRequest").finish_non_exhaustive()
+    }
 }
 impl GetProviderPropertyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5745,7 +6207,8 @@ impl crate::x11_utils::ReplyRequest for GetProviderPropertyRequest {
     type Reply = GetProviderPropertyReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetProviderPropertyReply {
     pub format: u8,
@@ -5755,6 +6218,12 @@ pub struct GetProviderPropertyReply {
     pub bytes_after: u32,
     pub num_items: u32,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetProviderPropertyReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetProviderPropertyReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetProviderPropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5804,7 +6273,8 @@ impl Serialize for GetProviderPropertyReply {
 
 /// Opcode for the ScreenChangeNotify event
 pub const SCREEN_CHANGE_NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScreenChangeNotifyEvent {
     pub response_type: u8,
@@ -5820,6 +6290,12 @@ pub struct ScreenChangeNotifyEvent {
     pub height: u16,
     pub mwidth: u16,
     pub mheight: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ScreenChangeNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ScreenChangeNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ScreenChangeNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6040,7 +6516,8 @@ impl core::fmt::Debug for Notify  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CrtcChange {
     pub timestamp: xproto::Timestamp,
@@ -6052,6 +6529,12 @@ pub struct CrtcChange {
     pub y: i16,
     pub width: u16,
     pub height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CrtcChange {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CrtcChange").finish_non_exhaustive()
+    }
 }
 impl TryParse for CrtcChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6128,7 +6611,8 @@ impl Serialize for CrtcChange {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OutputChange {
     pub timestamp: xproto::Timestamp,
@@ -6140,6 +6624,12 @@ pub struct OutputChange {
     pub rotation: Rotation,
     pub connection: Connection,
     pub subpixel_order: render::SubPixel,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for OutputChange {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OutputChange").finish_non_exhaustive()
+    }
 }
 impl TryParse for OutputChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6216,7 +6706,8 @@ impl Serialize for OutputChange {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OutputProperty {
     pub window: xproto::Window,
@@ -6224,6 +6715,12 @@ pub struct OutputProperty {
     pub atom: xproto::Atom,
     pub timestamp: xproto::Timestamp,
     pub status: xproto::Property,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for OutputProperty {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OutputProperty").finish_non_exhaustive()
+    }
 }
 impl TryParse for OutputProperty {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6288,12 +6785,19 @@ impl Serialize for OutputProperty {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProviderChange {
     pub timestamp: xproto::Timestamp,
     pub window: xproto::Window,
     pub provider: Provider,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ProviderChange {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ProviderChange").finish_non_exhaustive()
+    }
 }
 impl TryParse for ProviderChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6351,7 +6855,8 @@ impl Serialize for ProviderChange {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ProviderProperty {
     pub window: xproto::Window,
@@ -6359,6 +6864,12 @@ pub struct ProviderProperty {
     pub atom: xproto::Atom,
     pub timestamp: xproto::Timestamp,
     pub state: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ProviderProperty {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ProviderProperty").finish_non_exhaustive()
+    }
 }
 impl TryParse for ProviderProperty {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6422,11 +6933,18 @@ impl Serialize for ProviderProperty {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResourceChange {
     pub timestamp: xproto::Timestamp,
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ResourceChange {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ResourceChange").finish_non_exhaustive()
+    }
 }
 impl TryParse for ResourceChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6481,7 +6999,8 @@ impl Serialize for ResourceChange {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MonitorInfo {
     pub name: xproto::Atom,
@@ -6494,6 +7013,12 @@ pub struct MonitorInfo {
     pub width_in_millimeters: u32,
     pub height_in_millimeters: u32,
     pub outputs: Vec<Output>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MonitorInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MonitorInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for MonitorInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6553,11 +7078,18 @@ impl MonitorInfo {
 
 /// Opcode for the GetMonitors request
 pub const GET_MONITORS_REQUEST: u8 = 42;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMonitorsRequest {
     pub window: xproto::Window,
     pub get_active: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMonitorsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMonitorsRequest").finish_non_exhaustive()
+    }
 }
 impl GetMonitorsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6613,7 +7145,8 @@ impl crate::x11_utils::ReplyRequest for GetMonitorsRequest {
     type Reply = GetMonitorsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMonitorsReply {
     pub sequence: u16,
@@ -6621,6 +7154,12 @@ pub struct GetMonitorsReply {
     pub timestamp: xproto::Timestamp,
     pub n_outputs: u32,
     pub monitors: Vec<MonitorInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMonitorsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMonitorsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMonitorsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6684,11 +7223,18 @@ impl GetMonitorsReply {
 
 /// Opcode for the SetMonitor request
 pub const SET_MONITOR_REQUEST: u8 = 43;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetMonitorRequest {
     pub window: xproto::Window,
     pub monitorinfo: MonitorInfo,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetMonitorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetMonitorRequest").finish_non_exhaustive()
+    }
 }
 impl SetMonitorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6744,11 +7290,18 @@ impl crate::x11_utils::VoidRequest for SetMonitorRequest {
 
 /// Opcode for the DeleteMonitor request
 pub const DELETE_MONITOR_REQUEST: u8 = 44;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteMonitorRequest {
     pub window: xproto::Window,
     pub name: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeleteMonitorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeleteMonitorRequest").finish_non_exhaustive()
+    }
 }
 impl DeleteMonitorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6805,13 +7358,20 @@ impl crate::x11_utils::VoidRequest for DeleteMonitorRequest {
 
 /// Opcode for the CreateLease request
 pub const CREATE_LEASE_REQUEST: u8 = 45;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateLeaseRequest<'input> {
     pub window: xproto::Window,
     pub lid: Lease,
     pub crtcs: Cow<'input, [Crtc]>,
     pub outputs: Cow<'input, [Output]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateLeaseRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateLeaseRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateLeaseRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -6896,12 +7456,18 @@ impl<'input> crate::x11_utils::ReplyFDsRequest for CreateLeaseRequest<'input> {
     type Reply = CreateLeaseReply;
 }
 
-#[derive(Debug)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 pub struct CreateLeaseReply {
     pub nfd: u8,
     pub sequence: u16,
     pub length: u32,
     pub master_fd: RawFdContainer,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateLeaseReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateLeaseReply").finish_non_exhaustive()
+    }
 }
 impl TryParseFd for CreateLeaseReply {
     fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
@@ -6978,11 +7544,18 @@ impl Serialize for CreateLeaseReply {
 
 /// Opcode for the FreeLease request
 pub const FREE_LEASE_REQUEST: u8 = 46;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeLeaseRequest {
     pub lid: Lease,
     pub terminate: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FreeLeaseRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FreeLeaseRequest").finish_non_exhaustive()
+    }
 }
 impl FreeLeaseRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7037,13 +7610,20 @@ impl Request for FreeLeaseRequest {
 impl crate::x11_utils::VoidRequest for FreeLeaseRequest {
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LeaseNotify {
     pub timestamp: xproto::Timestamp,
     pub window: xproto::Window,
     pub lease: Lease,
     pub created: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for LeaseNotify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LeaseNotify").finish_non_exhaustive()
+    }
 }
 impl TryParse for LeaseNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7229,13 +7809,20 @@ impl From<LeaseNotify> for NotifyData {
 
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyEvent {
     pub response_type: u8,
     pub sub_code: Notify,
     pub sequence: u16,
     pub u: NotifyData,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for NotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for NotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -265,6 +265,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -508,6 +509,7 @@ impl SetScreenConfigRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_SCREEN_CONFIG_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -756,6 +758,7 @@ impl SelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -820,6 +823,7 @@ impl GetScreenInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SCREEN_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -979,6 +983,7 @@ impl GetScreenSizeRangeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SCREEN_SIZE_RANGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1159,6 +1164,7 @@ impl SetScreenSizeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_SCREEN_SIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1412,6 +1418,7 @@ impl GetScreenResourcesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SCREEN_RESOURCES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1674,6 +1681,7 @@ impl GetOutputInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_OUTPUT_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1888,6 +1896,7 @@ impl ListOutputPropertiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_OUTPUT_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2025,6 +2034,7 @@ impl QueryOutputPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_OUTPUT_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2183,6 +2193,7 @@ impl<'input> ConfigureOutputPropertyRequest<'input> {
         ([request0.into(), values_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CONFIGURE_OUTPUT_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2300,6 +2311,7 @@ impl<'input> ChangeOutputPropertyRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_OUTPUT_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2392,6 +2404,7 @@ impl DeleteOutputPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_OUTPUT_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2486,6 +2499,7 @@ impl GetOutputPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_OUTPUT_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2662,6 +2676,7 @@ impl<'input> CreateModeRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2822,6 +2837,7 @@ impl DestroyModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2888,6 +2904,7 @@ impl AddOutputModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ADD_OUTPUT_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2956,6 +2973,7 @@ impl DeleteOutputModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_OUTPUT_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3024,6 +3042,7 @@ impl GetCrtcInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CRTC_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3239,6 +3258,7 @@ impl<'input> SetCrtcConfigRequest<'input> {
         ([request0.into(), outputs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CRTC_CONFIG_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3426,6 +3446,7 @@ impl GetCrtcGammaSizeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CRTC_GAMMA_SIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3574,6 +3595,7 @@ impl GetCrtcGammaRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CRTC_GAMMA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3732,6 +3754,7 @@ impl<'input> SetCrtcGammaRequest<'input> {
         ([request0.into(), red_bytes.into(), green_bytes.into(), blue_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CRTC_GAMMA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3809,6 +3832,7 @@ impl GetScreenResourcesCurrentRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SCREEN_RESOURCES_CURRENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4121,6 +4145,7 @@ impl<'input> SetCrtcTransformRequest<'input> {
         ([request0.into(), self.filter_name, padding0.into(), filter_params_bytes.into(), padding1.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CRTC_TRANSFORM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4209,6 +4234,7 @@ impl GetCrtcTransformRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CRTC_TRANSFORM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4421,6 +4447,7 @@ impl GetPanningRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PANNING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4676,6 +4703,7 @@ impl SetPanningRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PANNING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4837,6 +4865,7 @@ impl SetOutputPrimaryRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_OUTPUT_PRIMARY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4899,6 +4928,7 @@ impl GetOutputPrimaryRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_OUTPUT_PRIMARY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5025,6 +5055,7 @@ impl GetProvidersRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROVIDERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5217,6 +5248,7 @@ impl GetProviderInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROVIDER_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5432,6 +5464,7 @@ impl SetProviderOffloadSinkRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PROVIDER_OFFLOAD_SINK_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5508,6 +5541,7 @@ impl SetProviderOutputSourceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PROVIDER_OUTPUT_SOURCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5572,6 +5606,7 @@ impl ListProviderPropertiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_PROVIDER_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5709,6 +5744,7 @@ impl QueryProviderPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_PROVIDER_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5867,6 +5903,7 @@ impl<'input> ConfigureProviderPropertyRequest<'input> {
         ([request0.into(), values_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CONFIGURE_PROVIDER_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5984,6 +6021,7 @@ impl<'input> ChangeProviderPropertyRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_PROVIDER_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6075,6 +6113,7 @@ impl DeleteProviderPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_PROVIDER_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6169,6 +6208,7 @@ impl GetProviderPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROVIDER_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7118,6 +7158,7 @@ impl GetMonitorsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MONITORS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7262,6 +7303,7 @@ impl SetMonitorRequest {
         ([request0.into(), monitorinfo_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_MONITOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7330,6 +7372,7 @@ impl DeleteMonitorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_MONITOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7414,6 +7457,7 @@ impl<'input> CreateLeaseRequest<'input> {
         ([request0.into(), crtcs_bytes.into(), outputs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_LEASE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7584,6 +7628,7 @@ impl FreeLeaseRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FREE_LEASE_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -265,7 +265,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -509,7 +509,7 @@ impl SetScreenConfigRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_SCREEN_CONFIG_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -758,7 +758,7 @@ impl SelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -823,7 +823,7 @@ impl GetScreenInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SCREEN_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -983,7 +983,7 @@ impl GetScreenSizeRangeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SCREEN_SIZE_RANGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1164,7 +1164,7 @@ impl SetScreenSizeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_SCREEN_SIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1418,7 +1418,7 @@ impl GetScreenResourcesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SCREEN_RESOURCES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1681,7 +1681,7 @@ impl GetOutputInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_OUTPUT_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1896,7 +1896,7 @@ impl ListOutputPropertiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_OUTPUT_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2034,7 +2034,7 @@ impl QueryOutputPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_OUTPUT_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2193,7 +2193,7 @@ impl<'input> ConfigureOutputPropertyRequest<'input> {
         ([request0.into(), values_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CONFIGURE_OUTPUT_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2311,7 +2311,7 @@ impl<'input> ChangeOutputPropertyRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_OUTPUT_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2404,7 +2404,7 @@ impl DeleteOutputPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_OUTPUT_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2499,7 +2499,7 @@ impl GetOutputPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_OUTPUT_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2676,7 +2676,7 @@ impl<'input> CreateModeRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2837,7 +2837,7 @@ impl DestroyModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2904,7 +2904,7 @@ impl AddOutputModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ADD_OUTPUT_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2973,7 +2973,7 @@ impl DeleteOutputModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_OUTPUT_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3042,7 +3042,7 @@ impl GetCrtcInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CRTC_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3258,7 +3258,7 @@ impl<'input> SetCrtcConfigRequest<'input> {
         ([request0.into(), outputs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CRTC_CONFIG_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3446,7 +3446,7 @@ impl GetCrtcGammaSizeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CRTC_GAMMA_SIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3595,7 +3595,7 @@ impl GetCrtcGammaRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CRTC_GAMMA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3754,7 +3754,7 @@ impl<'input> SetCrtcGammaRequest<'input> {
         ([request0.into(), red_bytes.into(), green_bytes.into(), blue_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CRTC_GAMMA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3832,7 +3832,7 @@ impl GetScreenResourcesCurrentRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SCREEN_RESOURCES_CURRENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4145,7 +4145,7 @@ impl<'input> SetCrtcTransformRequest<'input> {
         ([request0.into(), self.filter_name, padding0.into(), filter_params_bytes.into(), padding1.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CRTC_TRANSFORM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4234,7 +4234,7 @@ impl GetCrtcTransformRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CRTC_TRANSFORM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4447,7 +4447,7 @@ impl GetPanningRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PANNING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4703,7 +4703,7 @@ impl SetPanningRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PANNING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4865,7 +4865,7 @@ impl SetOutputPrimaryRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_OUTPUT_PRIMARY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4928,7 +4928,7 @@ impl GetOutputPrimaryRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_OUTPUT_PRIMARY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5055,7 +5055,7 @@ impl GetProvidersRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROVIDERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5248,7 +5248,7 @@ impl GetProviderInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROVIDER_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5464,7 +5464,7 @@ impl SetProviderOffloadSinkRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PROVIDER_OFFLOAD_SINK_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5541,7 +5541,7 @@ impl SetProviderOutputSourceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PROVIDER_OUTPUT_SOURCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5606,7 +5606,7 @@ impl ListProviderPropertiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_PROVIDER_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5744,7 +5744,7 @@ impl QueryProviderPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_PROVIDER_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5903,7 +5903,7 @@ impl<'input> ConfigureProviderPropertyRequest<'input> {
         ([request0.into(), values_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CONFIGURE_PROVIDER_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6021,7 +6021,7 @@ impl<'input> ChangeProviderPropertyRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_PROVIDER_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6113,7 +6113,7 @@ impl DeleteProviderPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_PROVIDER_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6208,7 +6208,7 @@ impl GetProviderPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROVIDER_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7158,7 +7158,7 @@ impl GetMonitorsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MONITORS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7303,7 +7303,7 @@ impl SetMonitorRequest {
         ([request0.into(), monitorinfo_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_MONITOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7372,7 +7372,7 @@ impl DeleteMonitorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_MONITOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7457,7 +7457,7 @@ impl<'input> CreateLeaseRequest<'input> {
         ([request0.into(), crtcs_bytes.into(), outputs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_LEASE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7628,7 +7628,7 @@ impl FreeLeaseRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FREE_LEASE_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/record.rs
+++ b/x11rb-protocol/src/protocol/record.rs
@@ -465,6 +465,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -623,6 +624,7 @@ impl<'input> CreateContextRequest<'input> {
         ([request0.into(), client_specs_bytes.into(), ranges_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -727,6 +729,7 @@ impl<'input> RegisterClientsRequest<'input> {
         ([request0.into(), client_specs_bytes.into(), ranges_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != REGISTER_CLIENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -816,6 +819,7 @@ impl<'input> UnregisterClientsRequest<'input> {
         ([request0.into(), client_specs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNREGISTER_CLIENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -886,6 +890,7 @@ impl GetContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1023,6 +1028,7 @@ impl EnableContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ENABLE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1172,6 +1178,7 @@ impl DisableContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DISABLE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1232,6 +1239,7 @@ impl FreeContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FREE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/record.rs
+++ b/x11rb-protocol/src/protocol/record.rs
@@ -36,11 +36,18 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 13);
 
 pub type Context = u32;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Range8 {
     pub first: u8,
     pub last: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Range8 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Range8").finish_non_exhaustive()
+    }
 }
 impl TryParse for Range8 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -67,11 +74,18 @@ impl Serialize for Range8 {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Range16 {
     pub first: u16,
     pub last: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Range16 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Range16").finish_non_exhaustive()
+    }
 }
 impl TryParse for Range16 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -100,11 +114,18 @@ impl Serialize for Range16 {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtRange {
     pub major: Range8,
     pub minor: Range16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ExtRange {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ExtRange").finish_non_exhaustive()
+    }
 }
 impl TryParse for ExtRange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -135,7 +156,8 @@ impl Serialize for ExtRange {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Range {
     pub core_requests: Range8,
@@ -147,6 +169,12 @@ pub struct Range {
     pub errors: Range8,
     pub client_started: bool,
     pub client_died: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Range {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Range").finish_non_exhaustive()
+    }
 }
 impl TryParse for Range {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -343,11 +371,18 @@ impl core::fmt::Debug for CS  {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientInfo {
     pub client_resource: ClientSpec,
     pub ranges: Vec<Range>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ClientInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ClientInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for ClientInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -394,11 +429,18 @@ pub const BAD_CONTEXT_ERROR: u8 = 0;
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major_version: u16,
     pub minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -450,13 +492,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u16,
     pub minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -514,13 +563,20 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextRequest<'input> {
     pub context: Context,
     pub element_header: ElementHeader,
     pub client_specs: Cow<'input, [ClientSpec]>,
     pub ranges: Cow<'input, [Range]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateContextRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateContextRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -611,13 +667,20 @@ impl<'input> crate::x11_utils::VoidRequest for CreateContextRequest<'input> {
 
 /// Opcode for the RegisterClients request
 pub const REGISTER_CLIENTS_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RegisterClientsRequest<'input> {
     pub context: Context,
     pub element_header: ElementHeader,
     pub client_specs: Cow<'input, [ClientSpec]>,
     pub ranges: Cow<'input, [Range]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for RegisterClientsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RegisterClientsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> RegisterClientsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -708,11 +771,18 @@ impl<'input> crate::x11_utils::VoidRequest for RegisterClientsRequest<'input> {
 
 /// Opcode for the UnregisterClients request
 pub const UNREGISTER_CLIENTS_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnregisterClientsRequest<'input> {
     pub context: Context,
     pub client_specs: Cow<'input, [ClientSpec]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for UnregisterClientsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UnregisterClientsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> UnregisterClientsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -782,10 +852,17 @@ impl<'input> crate::x11_utils::VoidRequest for UnregisterClientsRequest<'input> 
 
 /// Opcode for the GetContext request
 pub const GET_CONTEXT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetContextRequest {
     pub context: Context,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetContextRequest").finish_non_exhaustive()
+    }
 }
 impl GetContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -834,7 +911,8 @@ impl crate::x11_utils::ReplyRequest for GetContextRequest {
     type Reply = GetContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetContextReply {
     pub enabled: bool,
@@ -842,6 +920,12 @@ pub struct GetContextReply {
     pub length: u32,
     pub element_header: ElementHeader,
     pub intercepted_clients: Vec<ClientInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -905,10 +989,17 @@ impl GetContextReply {
 
 /// Opcode for the EnableContext request
 pub const ENABLE_CONTEXT_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnableContextRequest {
     pub context: Context,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EnableContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EnableContextRequest").finish_non_exhaustive()
+    }
 }
 impl EnableContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -957,7 +1048,8 @@ impl crate::x11_utils::ReplyRequest for EnableContextRequest {
     type Reply = EnableContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnableContextReply {
     pub category: u8,
@@ -968,6 +1060,12 @@ pub struct EnableContextReply {
     pub server_time: u32,
     pub rec_sequence_num: u32,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EnableContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EnableContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for EnableContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1040,10 +1138,17 @@ impl EnableContextReply {
 
 /// Opcode for the DisableContext request
 pub const DISABLE_CONTEXT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DisableContextRequest {
     pub context: Context,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DisableContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DisableContextRequest").finish_non_exhaustive()
+    }
 }
 impl DisableContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1093,10 +1198,17 @@ impl crate::x11_utils::VoidRequest for DisableContextRequest {
 
 /// Opcode for the FreeContext request
 pub const FREE_CONTEXT_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeContextRequest {
     pub context: Context,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FreeContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FreeContextRequest").finish_non_exhaustive()
+    }
 }
 impl FreeContextRequest {
     /// Serialize this request into bytes for the provided connection

--- a/x11rb-protocol/src/protocol/record.rs
+++ b/x11rb-protocol/src/protocol/record.rs
@@ -465,7 +465,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -624,7 +624,7 @@ impl<'input> CreateContextRequest<'input> {
         ([request0.into(), client_specs_bytes.into(), ranges_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -729,7 +729,7 @@ impl<'input> RegisterClientsRequest<'input> {
         ([request0.into(), client_specs_bytes.into(), ranges_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != REGISTER_CLIENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -819,7 +819,7 @@ impl<'input> UnregisterClientsRequest<'input> {
         ([request0.into(), client_specs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNREGISTER_CLIENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -890,7 +890,7 @@ impl GetContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1028,7 +1028,7 @@ impl EnableContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ENABLE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1178,7 +1178,7 @@ impl DisableContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DISABLE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1239,7 +1239,7 @@ impl FreeContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FREE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -608,7 +608,8 @@ pub const GLYPH_SET_ERROR: u8 = 3;
 /// Opcode for the Glyph error
 pub const GLYPH_ERROR: u8 = 4;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Directformat {
     pub red_shift: u16,
@@ -619,6 +620,12 @@ pub struct Directformat {
     pub blue_mask: u16,
     pub alpha_shift: u16,
     pub alpha_mask: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Directformat {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Directformat").finish_non_exhaustive()
+    }
 }
 impl TryParse for Directformat {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -677,7 +684,8 @@ impl Serialize for Directformat {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pictforminfo {
     pub id: Pictformat,
@@ -685,6 +693,12 @@ pub struct Pictforminfo {
     pub depth: u8,
     pub direct: Directformat,
     pub colormap: xproto::Colormap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Pictforminfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Pictforminfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for Pictforminfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -749,11 +763,18 @@ impl Serialize for Pictforminfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pictvisual {
     pub visual: xproto::Visualid,
     pub format: Pictformat,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Pictvisual {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Pictvisual").finish_non_exhaustive()
+    }
 }
 impl TryParse for Pictvisual {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -786,11 +807,18 @@ impl Serialize for Pictvisual {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pictdepth {
     pub depth: u8,
     pub visuals: Vec<Pictvisual>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Pictdepth {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Pictdepth").finish_non_exhaustive()
+    }
 }
 impl TryParse for Pictdepth {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -836,11 +864,18 @@ impl Pictdepth {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pictscreen {
     pub fallback: Pictformat,
     pub depths: Vec<Pictdepth>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Pictscreen {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Pictscreen").finish_non_exhaustive()
+    }
 }
 impl TryParse for Pictscreen {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -882,7 +917,8 @@ impl Pictscreen {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Indexvalue {
     pub pixel: u32,
@@ -890,6 +926,12 @@ pub struct Indexvalue {
     pub green: u16,
     pub blue: u16,
     pub alpha: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Indexvalue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Indexvalue").finish_non_exhaustive()
+    }
 }
 impl TryParse for Indexvalue {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -935,13 +977,20 @@ impl Serialize for Indexvalue {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Color {
     pub red: u16,
     pub green: u16,
     pub blue: u16,
     pub alpha: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Color {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Color").finish_non_exhaustive()
+    }
 }
 impl TryParse for Color {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -980,11 +1029,18 @@ impl Serialize for Color {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Pointfix {
     pub x: Fixed,
     pub y: Fixed,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Pointfix {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Pointfix").finish_non_exhaustive()
+    }
 }
 impl TryParse for Pointfix {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1017,11 +1073,18 @@ impl Serialize for Pointfix {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Linefix {
     pub p1: Pointfix,
     pub p2: Pointfix,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Linefix {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Linefix").finish_non_exhaustive()
+    }
 }
 impl TryParse for Linefix {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1062,12 +1125,19 @@ impl Serialize for Linefix {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Triangle {
     pub p1: Pointfix,
     pub p2: Pointfix,
     pub p3: Pointfix,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Triangle {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Triangle").finish_non_exhaustive()
+    }
 }
 impl TryParse for Triangle {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1119,13 +1189,20 @@ impl Serialize for Triangle {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Trapezoid {
     pub top: Fixed,
     pub bottom: Fixed,
     pub left: Linefix,
     pub right: Linefix,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Trapezoid {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Trapezoid").finish_non_exhaustive()
+    }
 }
 impl TryParse for Trapezoid {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1196,7 +1273,8 @@ impl Serialize for Trapezoid {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Glyphinfo {
     pub width: u16,
@@ -1205,6 +1283,12 @@ pub struct Glyphinfo {
     pub y: i16,
     pub x_off: i16,
     pub y_off: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Glyphinfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Glyphinfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for Glyphinfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1255,11 +1339,18 @@ impl Serialize for Glyphinfo {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1315,13 +1406,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1401,9 +1499,16 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the QueryPictFormats request
 pub const QUERY_PICT_FORMATS_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPictFormatsRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryPictFormatsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryPictFormatsRequest").finish_non_exhaustive()
+    }
+}
 impl QueryPictFormatsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1444,7 +1549,8 @@ impl crate::x11_utils::ReplyRequest for QueryPictFormatsRequest {
     type Reply = QueryPictFormatsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPictFormatsReply {
     pub sequence: u16,
@@ -1454,6 +1560,12 @@ pub struct QueryPictFormatsReply {
     pub formats: Vec<Pictforminfo>,
     pub screens: Vec<Pictscreen>,
     pub subpixels: Vec<SubPixel>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryPictFormatsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryPictFormatsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryPictFormatsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1563,10 +1675,17 @@ impl QueryPictFormatsReply {
 
 /// Opcode for the QueryPictIndexValues request
 pub const QUERY_PICT_INDEX_VALUES_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPictIndexValuesRequest {
     pub format: Pictformat,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryPictIndexValuesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryPictIndexValuesRequest").finish_non_exhaustive()
+    }
 }
 impl QueryPictIndexValuesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1615,12 +1734,19 @@ impl crate::x11_utils::ReplyRequest for QueryPictIndexValuesRequest {
     type Reply = QueryPictIndexValuesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPictIndexValuesReply {
     pub sequence: u16,
     pub length: u32,
     pub values: Vec<Indexvalue>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryPictIndexValuesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryPictIndexValuesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryPictIndexValuesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1679,7 +1805,8 @@ impl QueryPictIndexValuesReply {
 }
 
 /// Auxiliary and optional information for the `create_picture` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePictureAux {
     pub repeat: Option<Repeat>,
@@ -1695,6 +1822,12 @@ pub struct CreatePictureAux {
     pub polymode: Option<PolyMode>,
     pub dither: Option<xproto::Atom>,
     pub componentalpha: Option<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreatePictureAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreatePictureAux").finish_non_exhaustive()
+    }
 }
 impl CreatePictureAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -1994,13 +2127,20 @@ impl CreatePictureAux {
 
 /// Opcode for the CreatePicture request
 pub const CREATE_PICTURE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePictureRequest<'input> {
     pub pid: Picture,
     pub drawable: xproto::Drawable,
     pub format: Pictformat,
     pub value_list: Cow<'input, CreatePictureAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreatePictureRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreatePictureRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreatePictureRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2085,7 +2225,8 @@ impl<'input> crate::x11_utils::VoidRequest for CreatePictureRequest<'input> {
 }
 
 /// Auxiliary and optional information for the `change_picture` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangePictureAux {
     pub repeat: Option<Repeat>,
@@ -2101,6 +2242,12 @@ pub struct ChangePictureAux {
     pub polymode: Option<PolyMode>,
     pub dither: Option<xproto::Atom>,
     pub componentalpha: Option<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangePictureAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangePictureAux").finish_non_exhaustive()
+    }
 }
 impl ChangePictureAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -2400,11 +2547,18 @@ impl ChangePictureAux {
 
 /// Opcode for the ChangePicture request
 pub const CHANGE_PICTURE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangePictureRequest<'input> {
     pub picture: Picture,
     pub value_list: Cow<'input, ChangePictureAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangePictureRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangePictureRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangePictureRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2474,13 +2628,20 @@ impl<'input> crate::x11_utils::VoidRequest for ChangePictureRequest<'input> {
 
 /// Opcode for the SetPictureClipRectangles request
 pub const SET_PICTURE_CLIP_RECTANGLES_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPictureClipRectanglesRequest<'input> {
     pub picture: Picture,
     pub clip_x_origin: i16,
     pub clip_y_origin: i16,
     pub rectangles: Cow<'input, [xproto::Rectangle]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetPictureClipRectanglesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetPictureClipRectanglesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetPictureClipRectanglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2562,10 +2723,17 @@ impl<'input> crate::x11_utils::VoidRequest for SetPictureClipRectanglesRequest<'
 
 /// Opcode for the FreePicture request
 pub const FREE_PICTURE_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreePictureRequest {
     pub picture: Picture,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FreePictureRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FreePictureRequest").finish_non_exhaustive()
+    }
 }
 impl FreePictureRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2615,7 +2783,8 @@ impl crate::x11_utils::VoidRequest for FreePictureRequest {
 
 /// Opcode for the Composite request
 pub const COMPOSITE_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompositeRequest {
     pub op: PictOp,
@@ -2630,6 +2799,12 @@ pub struct CompositeRequest {
     pub dst_y: i16,
     pub width: u16,
     pub height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CompositeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CompositeRequest").finish_non_exhaustive()
+    }
 }
 impl CompositeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2742,7 +2917,8 @@ impl crate::x11_utils::VoidRequest for CompositeRequest {
 
 /// Opcode for the Trapezoids request
 pub const TRAPEZOIDS_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TrapezoidsRequest<'input> {
     pub op: PictOp,
@@ -2752,6 +2928,12 @@ pub struct TrapezoidsRequest<'input> {
     pub src_x: i16,
     pub src_y: i16,
     pub traps: Cow<'input, [Trapezoid]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for TrapezoidsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TrapezoidsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> TrapezoidsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2859,7 +3041,8 @@ impl<'input> crate::x11_utils::VoidRequest for TrapezoidsRequest<'input> {
 
 /// Opcode for the Triangles request
 pub const TRIANGLES_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TrianglesRequest<'input> {
     pub op: PictOp,
@@ -2869,6 +3052,12 @@ pub struct TrianglesRequest<'input> {
     pub src_x: i16,
     pub src_y: i16,
     pub triangles: Cow<'input, [Triangle]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for TrianglesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TrianglesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> TrianglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2976,7 +3165,8 @@ impl<'input> crate::x11_utils::VoidRequest for TrianglesRequest<'input> {
 
 /// Opcode for the TriStrip request
 pub const TRI_STRIP_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TriStripRequest<'input> {
     pub op: PictOp,
@@ -2986,6 +3176,12 @@ pub struct TriStripRequest<'input> {
     pub src_x: i16,
     pub src_y: i16,
     pub points: Cow<'input, [Pointfix]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for TriStripRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TriStripRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> TriStripRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3093,7 +3289,8 @@ impl<'input> crate::x11_utils::VoidRequest for TriStripRequest<'input> {
 
 /// Opcode for the TriFan request
 pub const TRI_FAN_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TriFanRequest<'input> {
     pub op: PictOp,
@@ -3103,6 +3300,12 @@ pub struct TriFanRequest<'input> {
     pub src_x: i16,
     pub src_y: i16,
     pub points: Cow<'input, [Pointfix]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for TriFanRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TriFanRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> TriFanRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3210,11 +3413,18 @@ impl<'input> crate::x11_utils::VoidRequest for TriFanRequest<'input> {
 
 /// Opcode for the CreateGlyphSet request
 pub const CREATE_GLYPH_SET_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateGlyphSetRequest {
     pub gsid: Glyphset,
     pub format: Pictformat,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateGlyphSetRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateGlyphSetRequest").finish_non_exhaustive()
+    }
 }
 impl CreateGlyphSetRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3271,11 +3481,18 @@ impl crate::x11_utils::VoidRequest for CreateGlyphSetRequest {
 
 /// Opcode for the ReferenceGlyphSet request
 pub const REFERENCE_GLYPH_SET_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReferenceGlyphSetRequest {
     pub gsid: Glyphset,
     pub existing: Glyphset,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ReferenceGlyphSetRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ReferenceGlyphSetRequest").finish_non_exhaustive()
+    }
 }
 impl ReferenceGlyphSetRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3332,10 +3549,17 @@ impl crate::x11_utils::VoidRequest for ReferenceGlyphSetRequest {
 
 /// Opcode for the FreeGlyphSet request
 pub const FREE_GLYPH_SET_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeGlyphSetRequest {
     pub glyphset: Glyphset,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FreeGlyphSetRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FreeGlyphSetRequest").finish_non_exhaustive()
+    }
 }
 impl FreeGlyphSetRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3385,13 +3609,20 @@ impl crate::x11_utils::VoidRequest for FreeGlyphSetRequest {
 
 /// Opcode for the AddGlyphs request
 pub const ADD_GLYPHS_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddGlyphsRequest<'input> {
     pub glyphset: Glyphset,
     pub glyphids: Cow<'input, [u32]>,
     pub glyphs: Cow<'input, [Glyphinfo]>,
     pub data: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for AddGlyphsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AddGlyphsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> AddGlyphsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3471,11 +3702,18 @@ impl<'input> crate::x11_utils::VoidRequest for AddGlyphsRequest<'input> {
 
 /// Opcode for the FreeGlyphs request
 pub const FREE_GLYPHS_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeGlyphsRequest<'input> {
     pub glyphset: Glyphset,
     pub glyphs: Cow<'input, [Glyph]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for FreeGlyphsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FreeGlyphsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> FreeGlyphsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3545,7 +3783,8 @@ impl<'input> crate::x11_utils::VoidRequest for FreeGlyphsRequest<'input> {
 
 /// Opcode for the CompositeGlyphs8 request
 pub const COMPOSITE_GLYPHS8_REQUEST: u8 = 23;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompositeGlyphs8Request<'input> {
     pub op: PictOp,
@@ -3556,6 +3795,12 @@ pub struct CompositeGlyphs8Request<'input> {
     pub src_x: i16,
     pub src_y: i16,
     pub glyphcmds: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CompositeGlyphs8Request<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CompositeGlyphs8Request").finish_non_exhaustive()
+    }
 }
 impl<'input> CompositeGlyphs8Request<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3663,7 +3908,8 @@ impl<'input> crate::x11_utils::VoidRequest for CompositeGlyphs8Request<'input> {
 
 /// Opcode for the CompositeGlyphs16 request
 pub const COMPOSITE_GLYPHS16_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompositeGlyphs16Request<'input> {
     pub op: PictOp,
@@ -3674,6 +3920,12 @@ pub struct CompositeGlyphs16Request<'input> {
     pub src_x: i16,
     pub src_y: i16,
     pub glyphcmds: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CompositeGlyphs16Request<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CompositeGlyphs16Request").finish_non_exhaustive()
+    }
 }
 impl<'input> CompositeGlyphs16Request<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3781,7 +4033,8 @@ impl<'input> crate::x11_utils::VoidRequest for CompositeGlyphs16Request<'input> 
 
 /// Opcode for the CompositeGlyphs32 request
 pub const COMPOSITE_GLYPHS32_REQUEST: u8 = 25;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompositeGlyphs32Request<'input> {
     pub op: PictOp,
@@ -3792,6 +4045,12 @@ pub struct CompositeGlyphs32Request<'input> {
     pub src_x: i16,
     pub src_y: i16,
     pub glyphcmds: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CompositeGlyphs32Request<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CompositeGlyphs32Request").finish_non_exhaustive()
+    }
 }
 impl<'input> CompositeGlyphs32Request<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3899,13 +4158,20 @@ impl<'input> crate::x11_utils::VoidRequest for CompositeGlyphs32Request<'input> 
 
 /// Opcode for the FillRectangles request
 pub const FILL_RECTANGLES_REQUEST: u8 = 26;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FillRectanglesRequest<'input> {
     pub op: PictOp,
     pub dst: Picture,
     pub color: Color,
     pub rects: Cow<'input, [xproto::Rectangle]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for FillRectanglesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FillRectanglesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> FillRectanglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3997,13 +4263,20 @@ impl<'input> crate::x11_utils::VoidRequest for FillRectanglesRequest<'input> {
 
 /// Opcode for the CreateCursor request
 pub const CREATE_CURSOR_REQUEST: u8 = 27;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateCursorRequest {
     pub cid: xproto::Cursor,
     pub source: Picture,
     pub x: u16,
     pub y: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateCursorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateCursorRequest").finish_non_exhaustive()
+    }
 }
 impl CreateCursorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4068,7 +4341,8 @@ impl Request for CreateCursorRequest {
 impl crate::x11_utils::VoidRequest for CreateCursorRequest {
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Transform {
     pub matrix11: Fixed,
@@ -4080,6 +4354,12 @@ pub struct Transform {
     pub matrix31: Fixed,
     pub matrix32: Fixed,
     pub matrix33: Fixed,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Transform {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Transform").finish_non_exhaustive()
+    }
 }
 impl TryParse for Transform {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4163,11 +4443,18 @@ impl Serialize for Transform {
 
 /// Opcode for the SetPictureTransform request
 pub const SET_PICTURE_TRANSFORM_REQUEST: u8 = 28;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPictureTransformRequest {
     pub picture: Picture,
     pub transform: Transform,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetPictureTransformRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetPictureTransformRequest").finish_non_exhaustive()
+    }
 }
 impl SetPictureTransformRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4256,10 +4543,17 @@ impl crate::x11_utils::VoidRequest for SetPictureTransformRequest {
 
 /// Opcode for the QueryFilters request
 pub const QUERY_FILTERS_REQUEST: u8 = 29;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryFiltersRequest {
     pub drawable: xproto::Drawable,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryFiltersRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryFiltersRequest").finish_non_exhaustive()
+    }
 }
 impl QueryFiltersRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4308,13 +4602,20 @@ impl crate::x11_utils::ReplyRequest for QueryFiltersRequest {
     type Reply = QueryFiltersReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryFiltersReply {
     pub sequence: u16,
     pub length: u32,
     pub aliases: Vec<u16>,
     pub filters: Vec<xproto::Str>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryFiltersReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryFiltersReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryFiltersReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4392,12 +4693,19 @@ impl QueryFiltersReply {
 
 /// Opcode for the SetPictureFilter request
 pub const SET_PICTURE_FILTER_REQUEST: u8 = 30;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPictureFilterRequest<'input> {
     pub picture: Picture,
     pub filter: Cow<'input, [u8]>,
     pub values: Cow<'input, [Fixed]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetPictureFilterRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetPictureFilterRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetPictureFilterRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -4483,11 +4791,18 @@ impl<'input> Request for SetPictureFilterRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for SetPictureFilterRequest<'input> {
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Animcursorelt {
     pub cursor: xproto::Cursor,
     pub delay: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Animcursorelt {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Animcursorelt").finish_non_exhaustive()
+    }
 }
 impl TryParse for Animcursorelt {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4522,11 +4837,18 @@ impl Serialize for Animcursorelt {
 
 /// Opcode for the CreateAnimCursor request
 pub const CREATE_ANIM_CURSOR_REQUEST: u8 = 31;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateAnimCursorRequest<'input> {
     pub cid: xproto::Cursor,
     pub cursors: Cow<'input, [Animcursorelt]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateAnimCursorRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateAnimCursorRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateAnimCursorRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -4594,12 +4916,19 @@ impl<'input> Request for CreateAnimCursorRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for CreateAnimCursorRequest<'input> {
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Spanfix {
     pub l: Fixed,
     pub r: Fixed,
     pub y: Fixed,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Spanfix {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Spanfix").finish_non_exhaustive()
+    }
 }
 impl TryParse for Spanfix {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4639,11 +4968,18 @@ impl Serialize for Spanfix {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Trap {
     pub top: Spanfix,
     pub bot: Spanfix,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Trap {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Trap").finish_non_exhaustive()
+    }
 }
 impl TryParse for Trap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4694,13 +5030,20 @@ impl Serialize for Trap {
 
 /// Opcode for the AddTraps request
 pub const ADD_TRAPS_REQUEST: u8 = 32;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddTrapsRequest<'input> {
     pub picture: Picture,
     pub x_off: i16,
     pub y_off: i16,
     pub traps: Cow<'input, [Trap]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for AddTrapsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AddTrapsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> AddTrapsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -4782,11 +5125,18 @@ impl<'input> crate::x11_utils::VoidRequest for AddTrapsRequest<'input> {
 
 /// Opcode for the CreateSolidFill request
 pub const CREATE_SOLID_FILL_REQUEST: u8 = 33;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateSolidFillRequest {
     pub picture: Picture,
     pub color: Color,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateSolidFillRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateSolidFillRequest").finish_non_exhaustive()
+    }
 }
 impl CreateSolidFillRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4847,7 +5197,8 @@ impl crate::x11_utils::VoidRequest for CreateSolidFillRequest {
 
 /// Opcode for the CreateLinearGradient request
 pub const CREATE_LINEAR_GRADIENT_REQUEST: u8 = 34;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateLinearGradientRequest<'input> {
     pub picture: Picture,
@@ -4855,6 +5206,12 @@ pub struct CreateLinearGradientRequest<'input> {
     pub p2: Pointfix,
     pub stops: Cow<'input, [Fixed]>,
     pub colors: Cow<'input, [Color]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateLinearGradientRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateLinearGradientRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateLinearGradientRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -4954,7 +5311,8 @@ impl<'input> crate::x11_utils::VoidRequest for CreateLinearGradientRequest<'inpu
 
 /// Opcode for the CreateRadialGradient request
 pub const CREATE_RADIAL_GRADIENT_REQUEST: u8 = 35;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRadialGradientRequest<'input> {
     pub picture: Picture,
@@ -4964,6 +5322,12 @@ pub struct CreateRadialGradientRequest<'input> {
     pub outer_radius: Fixed,
     pub stops: Cow<'input, [Fixed]>,
     pub colors: Cow<'input, [Color]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateRadialGradientRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateRadialGradientRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateRadialGradientRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -5079,7 +5443,8 @@ impl<'input> crate::x11_utils::VoidRequest for CreateRadialGradientRequest<'inpu
 
 /// Opcode for the CreateConicalGradient request
 pub const CREATE_CONICAL_GRADIENT_REQUEST: u8 = 36;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateConicalGradientRequest<'input> {
     pub picture: Picture,
@@ -5087,6 +5452,12 @@ pub struct CreateConicalGradientRequest<'input> {
     pub angle: Fixed,
     pub stops: Cow<'input, [Fixed]>,
     pub colors: Cow<'input, [Color]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateConicalGradientRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateConicalGradientRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateConicalGradientRequest<'input> {
     /// Serialize this request into bytes for the provided connection

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -1379,7 +1379,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1527,7 +1527,7 @@ impl QueryPictFormatsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_PICT_FORMATS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1711,7 +1711,7 @@ impl QueryPictIndexValuesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_PICT_INDEX_VALUES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1833,6 +1833,7 @@ impl core::fmt::Debug for CreatePictureAux {
     }
 }
 impl CreatePictureAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
@@ -2187,7 +2188,7 @@ impl<'input> CreatePictureRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_PICTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2254,6 +2255,7 @@ impl core::fmt::Debug for ChangePictureAux {
     }
 }
 impl ChangePictureAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
@@ -2596,7 +2598,7 @@ impl<'input> ChangePictureRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_PICTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2680,7 +2682,7 @@ impl<'input> SetPictureClipRectanglesRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PICTURE_CLIP_RECTANGLES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2763,7 +2765,7 @@ impl FreePictureRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FREE_PICTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2874,7 +2876,7 @@ impl CompositeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COMPOSITE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2990,7 +2992,7 @@ impl<'input> TrapezoidsRequest<'input> {
         ([request0.into(), traps_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != TRAPEZOIDS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3115,7 +3117,7 @@ impl<'input> TrianglesRequest<'input> {
         ([request0.into(), triangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != TRIANGLES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3240,7 +3242,7 @@ impl<'input> TriStripRequest<'input> {
         ([request0.into(), points_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != TRI_STRIP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3365,7 +3367,7 @@ impl<'input> TriFanRequest<'input> {
         ([request0.into(), points_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != TRI_FAN_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3465,7 +3467,7 @@ impl CreateGlyphSetRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_GLYPH_SET_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3534,7 +3536,7 @@ impl ReferenceGlyphSetRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != REFERENCE_GLYPH_SET_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3597,7 +3599,7 @@ impl FreeGlyphSetRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FREE_GLYPH_SET_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3675,7 +3677,7 @@ impl<'input> AddGlyphsRequest<'input> {
         ([request0.into(), glyphids_bytes.into(), glyphs_bytes.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ADD_GLYPHS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3757,7 +3759,7 @@ impl<'input> FreeGlyphsRequest<'input> {
         ([request0.into(), glyphs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FREE_GLYPHS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3870,7 +3872,7 @@ impl<'input> CompositeGlyphs8Request<'input> {
         ([request0.into(), self.glyphcmds, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COMPOSITE_GLYPHS8_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3996,7 +3998,7 @@ impl<'input> CompositeGlyphs16Request<'input> {
         ([request0.into(), self.glyphcmds, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COMPOSITE_GLYPHS16_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4122,7 +4124,7 @@ impl<'input> CompositeGlyphs32Request<'input> {
         ([request0.into(), self.glyphcmds, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COMPOSITE_GLYPHS32_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4233,7 +4235,7 @@ impl<'input> FillRectanglesRequest<'input> {
         ([request0.into(), rects_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FILL_RECTANGLES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4332,7 +4334,7 @@ impl CreateCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4537,7 +4539,7 @@ impl SetPictureTransformRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PICTURE_TRANSFORM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4600,7 +4602,7 @@ impl QueryFiltersRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_FILTERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4766,7 +4768,7 @@ impl<'input> SetPictureFilterRequest<'input> {
         ([request0.into(), self.filter, padding0.into(), values_bytes.into(), padding1.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PICTURE_FILTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4901,7 +4903,7 @@ impl<'input> CreateAnimCursorRequest<'input> {
         ([request0.into(), cursors_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_ANIM_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5103,7 +5105,7 @@ impl<'input> AddTrapsRequest<'input> {
         ([request0.into(), traps_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ADD_TRAPS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5196,7 +5198,7 @@ impl CreateSolidFillRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_SOLID_FILL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5294,7 +5296,7 @@ impl<'input> CreateLinearGradientRequest<'input> {
         ([request0.into(), stops_bytes.into(), colors_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_LINEAR_GRADIENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5421,7 +5423,7 @@ impl<'input> CreateRadialGradientRequest<'input> {
         ([request0.into(), stops_bytes.into(), colors_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_RADIAL_GRADIENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5538,7 +5540,7 @@ impl<'input> CreateConicalGradientRequest<'input> {
         ([request0.into(), stops_bytes.into(), colors_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONICAL_GRADIENT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -1379,6 +1379,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1526,6 +1527,7 @@ impl QueryPictFormatsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_PICT_FORMATS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1709,6 +1711,7 @@ impl QueryPictIndexValuesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_PICT_INDEX_VALUES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2184,6 +2187,7 @@ impl<'input> CreatePictureRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_PICTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2592,6 +2596,7 @@ impl<'input> ChangePictureRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_PICTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2675,6 +2680,7 @@ impl<'input> SetPictureClipRectanglesRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PICTURE_CLIP_RECTANGLES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2757,6 +2763,7 @@ impl FreePictureRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FREE_PICTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2867,6 +2874,7 @@ impl CompositeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COMPOSITE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2982,6 +2990,7 @@ impl<'input> TrapezoidsRequest<'input> {
         ([request0.into(), traps_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != TRAPEZOIDS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3106,6 +3115,7 @@ impl<'input> TrianglesRequest<'input> {
         ([request0.into(), triangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != TRIANGLES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3230,6 +3240,7 @@ impl<'input> TriStripRequest<'input> {
         ([request0.into(), points_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != TRI_STRIP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3354,6 +3365,7 @@ impl<'input> TriFanRequest<'input> {
         ([request0.into(), points_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != TRI_FAN_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3453,6 +3465,7 @@ impl CreateGlyphSetRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_GLYPH_SET_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3521,6 +3534,7 @@ impl ReferenceGlyphSetRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != REFERENCE_GLYPH_SET_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3583,6 +3597,7 @@ impl FreeGlyphSetRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FREE_GLYPH_SET_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3660,6 +3675,7 @@ impl<'input> AddGlyphsRequest<'input> {
         ([request0.into(), glyphids_bytes.into(), glyphs_bytes.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ADD_GLYPHS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3741,6 +3757,7 @@ impl<'input> FreeGlyphsRequest<'input> {
         ([request0.into(), glyphs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FREE_GLYPHS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3853,6 +3870,7 @@ impl<'input> CompositeGlyphs8Request<'input> {
         ([request0.into(), self.glyphcmds, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COMPOSITE_GLYPHS8_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3978,6 +3996,7 @@ impl<'input> CompositeGlyphs16Request<'input> {
         ([request0.into(), self.glyphcmds, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COMPOSITE_GLYPHS16_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4103,6 +4122,7 @@ impl<'input> CompositeGlyphs32Request<'input> {
         ([request0.into(), self.glyphcmds, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COMPOSITE_GLYPHS32_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4213,6 +4233,7 @@ impl<'input> FillRectanglesRequest<'input> {
         ([request0.into(), rects_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FILL_RECTANGLES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4311,6 +4332,7 @@ impl CreateCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4515,6 +4537,7 @@ impl SetPictureTransformRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PICTURE_TRANSFORM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4577,6 +4600,7 @@ impl QueryFiltersRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_FILTERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4742,6 +4766,7 @@ impl<'input> SetPictureFilterRequest<'input> {
         ([request0.into(), self.filter, padding0.into(), values_bytes.into(), padding1.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PICTURE_FILTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4876,6 +4901,7 @@ impl<'input> CreateAnimCursorRequest<'input> {
         ([request0.into(), cursors_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_ANIM_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5077,6 +5103,7 @@ impl<'input> AddTrapsRequest<'input> {
         ([request0.into(), traps_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ADD_TRAPS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5169,6 +5196,7 @@ impl CreateSolidFillRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_SOLID_FILL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5266,6 +5294,7 @@ impl<'input> CreateLinearGradientRequest<'input> {
         ([request0.into(), stops_bytes.into(), colors_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_LINEAR_GRADIENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5392,6 +5421,7 @@ impl<'input> CreateRadialGradientRequest<'input> {
         ([request0.into(), stops_bytes.into(), colors_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_RADIAL_GRADIENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5508,6 +5538,7 @@ impl<'input> CreateConicalGradientRequest<'input> {
         ([request0.into(), stops_bytes.into(), colors_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONICAL_GRADIENT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -470,6 +470,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -595,6 +596,7 @@ impl QueryClientsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_CLIENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -724,6 +726,7 @@ impl QueryClientResourcesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_CLIENT_RESOURCES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -855,6 +858,7 @@ impl QueryClientPixmapBytesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_CLIENT_PIXMAP_BYTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -994,6 +998,7 @@ impl<'input> QueryClientIdsRequest<'input> {
         ([request0.into(), specs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_CLIENT_IDS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1143,6 +1148,7 @@ impl<'input> QueryResourceBytesRequest<'input> {
         ([request0.into(), specs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_RESOURCE_BYTES_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -36,11 +36,18 @@ pub const X11_EXTENSION_NAME: &str = "X-Resource";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 2);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Client {
     pub resource_base: u32,
     pub resource_mask: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Client {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Client").finish_non_exhaustive()
+    }
 }
 impl TryParse for Client {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -73,11 +80,18 @@ impl Serialize for Client {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Type {
     pub resource_type: xproto::Atom,
     pub count: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Type {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Type").finish_non_exhaustive()
+    }
 }
 impl TryParse for Type {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -158,11 +172,18 @@ impl core::fmt::Debug for ClientIdMask  {
 }
 bitmask_binop!(ClientIdMask, u32);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientIdSpec {
     pub client: u32,
     pub mask: ClientIdMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ClientIdSpec {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ClientIdSpec").finish_non_exhaustive()
+    }
 }
 impl TryParse for ClientIdSpec {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -196,11 +217,18 @@ impl Serialize for ClientIdSpec {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientIdValue {
     pub spec: ClientIdSpec,
     pub value: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ClientIdValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ClientIdValue").finish_non_exhaustive()
+    }
 }
 impl TryParse for ClientIdValue {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -243,11 +271,18 @@ impl ClientIdValue {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResourceIdSpec {
     pub resource: u32,
     pub type_: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ResourceIdSpec {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ResourceIdSpec").finish_non_exhaustive()
+    }
 }
 impl TryParse for ResourceIdSpec {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -280,13 +315,20 @@ impl Serialize for ResourceIdSpec {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResourceSizeSpec {
     pub spec: ResourceIdSpec,
     pub bytes: u32,
     pub ref_count: u32,
     pub use_count: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ResourceSizeSpec {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ResourceSizeSpec").finish_non_exhaustive()
+    }
 }
 impl TryParse for ResourceSizeSpec {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -337,11 +379,18 @@ impl Serialize for ResourceSizeSpec {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResourceSizeValue {
     pub size: ResourceSizeSpec,
     pub cross_references: Vec<ResourceSizeSpec>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ResourceSizeValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ResourceSizeValue").finish_non_exhaustive()
+    }
 }
 impl TryParse for ResourceSizeValue {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -385,11 +434,18 @@ impl ResourceSizeValue {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major: u8,
     pub client_minor: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -441,13 +497,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub server_major: u16,
     pub server_minor: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -505,9 +568,16 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the QueryClients request
 pub const QUERY_CLIENTS_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientsRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryClientsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryClientsRequest").finish_non_exhaustive()
+    }
+}
 impl QueryClientsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -548,12 +618,19 @@ impl crate::x11_utils::ReplyRequest for QueryClientsRequest {
     type Reply = QueryClientsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientsReply {
     pub sequence: u16,
     pub length: u32,
     pub clients: Vec<Client>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryClientsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryClientsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryClientsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -613,10 +690,17 @@ impl QueryClientsReply {
 
 /// Opcode for the QueryClientResources request
 pub const QUERY_CLIENT_RESOURCES_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientResourcesRequest {
     pub xid: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryClientResourcesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryClientResourcesRequest").finish_non_exhaustive()
+    }
 }
 impl QueryClientResourcesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -665,12 +749,19 @@ impl crate::x11_utils::ReplyRequest for QueryClientResourcesRequest {
     type Reply = QueryClientResourcesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientResourcesReply {
     pub sequence: u16,
     pub length: u32,
     pub types: Vec<Type>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryClientResourcesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryClientResourcesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryClientResourcesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -730,10 +821,17 @@ impl QueryClientResourcesReply {
 
 /// Opcode for the QueryClientPixmapBytes request
 pub const QUERY_CLIENT_PIXMAP_BYTES_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientPixmapBytesRequest {
     pub xid: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryClientPixmapBytesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryClientPixmapBytesRequest").finish_non_exhaustive()
+    }
 }
 impl QueryClientPixmapBytesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -782,13 +880,20 @@ impl crate::x11_utils::ReplyRequest for QueryClientPixmapBytesRequest {
     type Reply = QueryClientPixmapBytesReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientPixmapBytesReply {
     pub sequence: u16,
     pub length: u32,
     pub bytes: u32,
     pub bytes_overflow: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryClientPixmapBytesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryClientPixmapBytesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryClientPixmapBytesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -850,10 +955,17 @@ impl Serialize for QueryClientPixmapBytesReply {
 
 /// Opcode for the QueryClientIds request
 pub const QUERY_CLIENT_IDS_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientIdsRequest<'input> {
     pub specs: Cow<'input, [ClientIdSpec]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for QueryClientIdsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryClientIdsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> QueryClientIdsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -914,12 +1026,19 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryClientIdsRequest<'input> {
     type Reply = QueryClientIdsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientIdsReply {
     pub sequence: u16,
     pub length: u32,
     pub ids: Vec<ClientIdValue>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryClientIdsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryClientIdsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryClientIdsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -979,11 +1098,18 @@ impl QueryClientIdsReply {
 
 /// Opcode for the QueryResourceBytes request
 pub const QUERY_RESOURCE_BYTES_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryResourceBytesRequest<'input> {
     pub client: u32,
     pub specs: Cow<'input, [ResourceIdSpec]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for QueryResourceBytesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryResourceBytesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> QueryResourceBytesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1052,12 +1178,19 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryResourceBytesRequest<'input
     type Reply = QueryResourceBytesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryResourceBytesReply {
     pub sequence: u16,
     pub length: u32,
     pub sizes: Vec<ResourceSizeValue>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryResourceBytesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryResourceBytesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryResourceBytesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -470,7 +470,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -596,7 +596,7 @@ impl QueryClientsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_CLIENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -726,7 +726,7 @@ impl QueryClientResourcesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_CLIENT_RESOURCES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -858,7 +858,7 @@ impl QueryClientPixmapBytesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_CLIENT_PIXMAP_BYTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -998,7 +998,7 @@ impl<'input> QueryClientIdsRequest<'input> {
         ([request0.into(), specs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_CLIENT_IDS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1148,7 +1148,7 @@ impl<'input> QueryResourceBytesRequest<'input> {
         ([request0.into(), specs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_RESOURCE_BYTES_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -246,7 +246,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -402,7 +402,7 @@ impl QueryInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -576,7 +576,7 @@ impl SelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -632,6 +632,7 @@ impl core::fmt::Debug for SetAttributesAux {
     }
 }
 impl SetAttributesAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
@@ -1047,7 +1048,7 @@ impl<'input> SetAttributesRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1143,7 +1144,7 @@ impl UnsetAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNSET_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1204,7 +1205,7 @@ impl SuspendRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SUSPEND_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -246,6 +246,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -401,6 +402,7 @@ impl QueryInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -574,6 +576,7 @@ impl SelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1044,6 +1047,7 @@ impl<'input> SetAttributesRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1139,6 +1143,7 @@ impl UnsetAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNSET_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1199,6 +1204,7 @@ impl SuspendRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SUSPEND_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -210,11 +210,18 @@ impl core::fmt::Debug for State  {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u8,
     pub client_minor_version: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -267,13 +274,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub server_major_version: u16,
     pub server_minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -353,10 +367,17 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the QueryInfo request
 pub const QUERY_INFO_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryInfoRequest {
     pub drawable: xproto::Drawable,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryInfoRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryInfoRequest").finish_non_exhaustive()
+    }
 }
 impl QueryInfoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -405,7 +426,8 @@ impl crate::x11_utils::ReplyRequest for QueryInfoRequest {
     type Reply = QueryInfoReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryInfoReply {
     pub state: u8,
@@ -416,6 +438,12 @@ pub struct QueryInfoReply {
     pub ms_since_user_input: u32,
     pub event_mask: u32,
     pub kind: Kind,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryInfoReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryInfoReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -506,11 +534,18 @@ impl Serialize for QueryInfoReply {
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputRequest {
     pub drawable: xproto::Drawable,
     pub event_mask: Event,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectInputRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectInputRequest").finish_non_exhaustive()
+    }
 }
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
@@ -567,7 +602,8 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 }
 
 /// Auxiliary and optional information for the `set_attributes` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetAttributesAux {
     pub background_pixmap: Option<xproto::Pixmap>,
@@ -585,6 +621,12 @@ pub struct SetAttributesAux {
     pub do_not_propogate_mask: Option<xproto::EventMask>,
     pub colormap: Option<xproto::Colormap>,
     pub cursor: Option<xproto::Cursor>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetAttributesAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetAttributesAux").finish_non_exhaustive()
+    }
 }
 impl SetAttributesAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -925,7 +967,8 @@ impl SetAttributesAux {
 
 /// Opcode for the SetAttributes request
 pub const SET_ATTRIBUTES_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetAttributesRequest<'input> {
     pub drawable: xproto::Drawable,
@@ -938,6 +981,12 @@ pub struct SetAttributesRequest<'input> {
     pub depth: u8,
     pub visual: xproto::Visualid,
     pub value_list: Cow<'input, SetAttributesAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetAttributesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetAttributesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1056,10 +1105,17 @@ impl<'input> crate::x11_utils::VoidRequest for SetAttributesRequest<'input> {
 
 /// Opcode for the UnsetAttributes request
 pub const UNSET_ATTRIBUTES_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnsetAttributesRequest {
     pub drawable: xproto::Drawable,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UnsetAttributesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UnsetAttributesRequest").finish_non_exhaustive()
+    }
 }
 impl UnsetAttributesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1109,10 +1165,17 @@ impl crate::x11_utils::VoidRequest for UnsetAttributesRequest {
 
 /// Opcode for the Suspend request
 pub const SUSPEND_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SuspendRequest {
     pub suspend: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SuspendRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SuspendRequest").finish_non_exhaustive()
+    }
 }
 impl SuspendRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1162,7 +1225,8 @@ impl crate::x11_utils::VoidRequest for SuspendRequest {
 
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyEvent {
     pub response_type: u8,
@@ -1173,6 +1237,12 @@ pub struct NotifyEvent {
     pub window: xproto::Window,
     pub kind: Kind,
     pub forced: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for NotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for NotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/shape.rs
+++ b/x11rb-protocol/src/protocol/shape.rs
@@ -168,7 +168,8 @@ impl core::fmt::Debug for SK  {
 
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyEvent {
     pub response_type: u8,
@@ -181,6 +182,12 @@ pub struct NotifyEvent {
     pub extents_height: u16,
     pub server_time: xproto::Timestamp,
     pub shaped: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for NotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for NotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -323,9 +330,16 @@ impl From<NotifyEvent> for [u8; 32] {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
+}
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -366,13 +380,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u16,
     pub minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -430,7 +451,8 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the Rectangles request
 pub const RECTANGLES_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RectanglesRequest<'input> {
     pub operation: SO,
@@ -440,6 +462,12 @@ pub struct RectanglesRequest<'input> {
     pub x_offset: i16,
     pub y_offset: i16,
     pub rectangles: Cow<'input, [xproto::Rectangle]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for RectanglesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RectanglesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> RectanglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -541,7 +569,8 @@ impl<'input> crate::x11_utils::VoidRequest for RectanglesRequest<'input> {
 
 /// Opcode for the Mask request
 pub const MASK_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MaskRequest {
     pub operation: SO,
@@ -550,6 +579,12 @@ pub struct MaskRequest {
     pub x_offset: i16,
     pub y_offset: i16,
     pub source_bitmap: xproto::Pixmap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MaskRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MaskRequest").finish_non_exhaustive()
+    }
 }
 impl MaskRequest {
     /// Serialize this request into bytes for the provided connection
@@ -629,7 +664,8 @@ impl crate::x11_utils::VoidRequest for MaskRequest {
 
 /// Opcode for the Combine request
 pub const COMBINE_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CombineRequest {
     pub operation: SO,
@@ -639,6 +675,12 @@ pub struct CombineRequest {
     pub x_offset: i16,
     pub y_offset: i16,
     pub source_window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CombineRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CombineRequest").finish_non_exhaustive()
+    }
 }
 impl CombineRequest {
     /// Serialize this request into bytes for the provided connection
@@ -722,13 +764,20 @@ impl crate::x11_utils::VoidRequest for CombineRequest {
 
 /// Opcode for the Offset request
 pub const OFFSET_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OffsetRequest {
     pub destination_kind: SK,
     pub destination_window: xproto::Window,
     pub x_offset: i16,
     pub y_offset: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for OffsetRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OffsetRequest").finish_non_exhaustive()
+    }
 }
 impl OffsetRequest {
     /// Serialize this request into bytes for the provided connection
@@ -797,10 +846,17 @@ impl crate::x11_utils::VoidRequest for OffsetRequest {
 
 /// Opcode for the QueryExtents request
 pub const QUERY_EXTENTS_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtentsRequest {
     pub destination_window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryExtentsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryExtentsRequest").finish_non_exhaustive()
+    }
 }
 impl QueryExtentsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -849,7 +905,8 @@ impl crate::x11_utils::ReplyRequest for QueryExtentsRequest {
     type Reply = QueryExtentsReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtentsReply {
     pub sequence: u16,
@@ -864,6 +921,12 @@ pub struct QueryExtentsReply {
     pub clip_shape_extents_y: i16,
     pub clip_shape_extents_width: u16,
     pub clip_shape_extents_height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryExtentsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryExtentsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryExtentsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -963,11 +1026,18 @@ impl Serialize for QueryExtentsReply {
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputRequest {
     pub destination_window: xproto::Window,
     pub enable: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectInputRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectInputRequest").finish_non_exhaustive()
+    }
 }
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1025,10 +1095,17 @@ impl crate::x11_utils::VoidRequest for SelectInputRequest {
 
 /// Opcode for the InputSelected request
 pub const INPUT_SELECTED_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputSelectedRequest {
     pub destination_window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputSelectedRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputSelectedRequest").finish_non_exhaustive()
+    }
 }
 impl InputSelectedRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1077,12 +1154,19 @@ impl crate::x11_utils::ReplyRequest for InputSelectedRequest {
     type Reply = InputSelectedReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputSelectedReply {
     pub enabled: bool,
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputSelectedReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputSelectedReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for InputSelectedReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1131,11 +1215,18 @@ impl Serialize for InputSelectedReply {
 
 /// Opcode for the GetRectangles request
 pub const GET_RECTANGLES_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetRectanglesRequest {
     pub window: xproto::Window,
     pub source_kind: SK,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetRectanglesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetRectanglesRequest").finish_non_exhaustive()
+    }
 }
 impl GetRectanglesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1193,13 +1284,20 @@ impl crate::x11_utils::ReplyRequest for GetRectanglesRequest {
     type Reply = GetRectanglesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetRectanglesReply {
     pub ordering: xproto::ClipOrdering,
     pub sequence: u16,
     pub length: u32,
     pub rectangles: Vec<xproto::Rectangle>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetRectanglesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetRectanglesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetRectanglesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/shape.rs
+++ b/x11rb-protocol/src/protocol/shape.rs
@@ -357,6 +357,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -508,6 +509,7 @@ impl<'input> RectanglesRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != RECTANGLES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -625,6 +627,7 @@ impl MaskRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != MASK_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -722,6 +725,7 @@ impl CombineRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COMBINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -812,6 +816,7 @@ impl OffsetRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != OFFSET_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -880,6 +885,7 @@ impl QueryExtentsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_EXTENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1066,6 +1072,7 @@ impl SelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1129,6 +1136,7 @@ impl InputSelectedRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != INPUT_SELECTED_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1255,6 +1263,7 @@ impl GetRectanglesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_RECTANGLES_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/shape.rs
+++ b/x11rb-protocol/src/protocol/shape.rs
@@ -357,7 +357,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -509,7 +509,7 @@ impl<'input> RectanglesRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != RECTANGLES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -627,7 +627,7 @@ impl MaskRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != MASK_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -725,7 +725,7 @@ impl CombineRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COMBINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -816,7 +816,7 @@ impl OffsetRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != OFFSET_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -885,7 +885,7 @@ impl QueryExtentsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_EXTENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1072,7 +1072,7 @@ impl SelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1136,7 +1136,7 @@ impl InputSelectedRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != INPUT_SELECTED_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1263,7 +1263,7 @@ impl GetRectanglesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_RECTANGLES_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/shm.rs
+++ b/x11rb-protocol/src/protocol/shm.rs
@@ -53,7 +53,8 @@ pub const COMPLETION_EVENT: u8 = 0;
 /// extension.
 /// * `shmseg` - The shared memory segment used in the request.
 /// * `offset` - The offset in the shared memory segment used in the request.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompletionEvent {
     pub response_type: u8,
@@ -63,6 +64,12 @@ pub struct CompletionEvent {
     pub major_event: u8,
     pub shmseg: Seg,
     pub offset: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CompletionEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CompletionEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for CompletionEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -191,9 +198,16 @@ pub const QUERY_VERSION_REQUEST: u8 = 0;
 /// This is used to determine the version of the MIT-SHM extension supported by the
 /// X server.  Clients MUST NOT make other requests in this extension until a reply
 /// to this requests indicates the X server supports them.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
+}
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -252,7 +266,8 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
 /// * `minor_version` - The minor version of the extension supported.
 /// * `uid` - The UID of the server.
 /// * `gid` - The GID of the server.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub shared_pixmaps: bool,
@@ -263,6 +278,12 @@ pub struct QueryVersionReply {
     pub uid: u16,
     pub gid: u16,
     pub pixmap_format: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -364,12 +385,19 @@ pub const ATTACH_REQUEST: u8 = 1;
 /// * `shmseg` - A shared memory segment ID created with xcb_generate_id().
 /// * `shmid` - The System V shared memory segment the server should map.
 /// * `read_only` - True if the segment shall be mapped read only by the X11 server, otherwise false.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttachRequest {
     pub shmseg: Seg,
     pub shmid: u32,
     pub read_only: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AttachRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AttachRequest").finish_non_exhaustive()
+    }
 }
 impl AttachRequest {
     /// Serialize this request into bytes for the provided connection
@@ -442,10 +470,17 @@ pub const DETACH_REQUEST: u8 = 2;
 /// # Fields
 ///
 /// * `shmseg` - The segment to be destroyed.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DetachRequest {
     pub shmseg: Seg,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DetachRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DetachRequest").finish_non_exhaustive()
+    }
 }
 impl DetachRequest {
     /// Serialize this request into bytes for the provided connection
@@ -526,7 +561,8 @@ pub const PUT_IMAGE_REQUEST: u8 = 3;
 /// * `send_event` - True if the server should send an XCB_SHM_COMPLETION event when the blit
 /// completes.
 /// * `offset` - The offset that the source image starts at.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PutImageRequest {
     pub drawable: xproto::Drawable,
@@ -544,6 +580,12 @@ pub struct PutImageRequest {
     pub send_event: bool,
     pub shmseg: Seg,
     pub offset: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PutImageRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PutImageRequest").finish_non_exhaustive()
+    }
 }
 impl PutImageRequest {
     /// Serialize this request into bytes for the provided connection
@@ -685,7 +727,8 @@ pub const GET_IMAGE_REQUEST: u8 = 4;
 /// * `format` - The format to use for the copy (???).
 /// * `shmseg` - The destination shared memory segment.
 /// * `offset` - The offset in the shared memory segment to copy data to.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetImageRequest {
     pub drawable: xproto::Drawable,
@@ -697,6 +740,12 @@ pub struct GetImageRequest {
     pub format: u8,
     pub shmseg: Seg,
     pub offset: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetImageRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetImageRequest").finish_non_exhaustive()
+    }
 }
 impl GetImageRequest {
     /// Serialize this request into bytes for the provided connection
@@ -803,7 +852,8 @@ impl crate::x11_utils::ReplyRequest for GetImageRequest {
 /// * `depth` - The depth of the source drawable.
 /// * `visual` - The visual ID of the source drawable.
 /// * `size` - The number of bytes copied.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetImageReply {
     pub depth: u8,
@@ -811,6 +861,12 @@ pub struct GetImageReply {
     pub length: u32,
     pub visual: xproto::Visualid,
     pub size: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetImageReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetImageReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetImageReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -888,7 +944,8 @@ pub const CREATE_PIXMAP_REQUEST: u8 = 5;
 /// * `depth` - The depth of the pixmap to create.  Must be nonzero, or a Value error results.
 /// * `shmseg` - The shared memory segment to use to create the pixmap.
 /// * `offset` - The offset in the segment to create the pixmap at.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePixmapRequest {
     pub pid: xproto::Pixmap,
@@ -898,6 +955,12 @@ pub struct CreatePixmapRequest {
     pub depth: u8,
     pub shmseg: Seg,
     pub offset: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreatePixmapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreatePixmapRequest").finish_non_exhaustive()
+    }
 }
 impl CreatePixmapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -997,11 +1060,17 @@ pub const ATTACH_FD_REQUEST: u8 = 6;
 /// * `shmseg` - A shared memory segment ID created with xcb_generate_id().
 /// * `shm_fd` - The file descriptor the server should mmap().
 /// * `read_only` - True if the segment shall be mapped read only by the X11 server, otherwise false.
-#[derive(Debug)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 pub struct AttachFdRequest {
     pub shmseg: Seg,
     pub shm_fd: RawFdContainer,
     pub read_only: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AttachFdRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AttachFdRequest").finish_non_exhaustive()
+    }
 }
 impl AttachFdRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1072,12 +1141,19 @@ pub const CREATE_SEGMENT_REQUEST: u8 = 7;
 /// * `shmseg` - A shared memory segment ID created with xcb_generate_id().
 /// * `size` - The size of the segment to create.
 /// * `read_only` - True if the server should map the segment read-only; otherwise false.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateSegmentRequest {
     pub shmseg: Seg,
     pub size: u32,
     pub read_only: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateSegmentRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateSegmentRequest").finish_non_exhaustive()
+    }
 }
 impl CreateSegmentRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1149,12 +1225,18 @@ impl crate::x11_utils::ReplyFDsRequest for CreateSegmentRequest {
 /// # Fields
 ///
 /// * `nfd` - The number of file descriptors sent by the server.  Will always be 1.
-#[derive(Debug)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 pub struct CreateSegmentReply {
     pub nfd: u8,
     pub sequence: u16,
     pub length: u32,
     pub shm_fd: RawFdContainer,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateSegmentReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateSegmentReply").finish_non_exhaustive()
+    }
 }
 impl TryParseFd for CreateSegmentReply {
     fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/shm.rs
+++ b/x11rb-protocol/src/protocol/shm.rs
@@ -225,6 +225,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -431,6 +432,7 @@ impl AttachRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ATTACH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -504,6 +506,7 @@ impl DetachRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DETACH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -655,6 +658,7 @@ impl PutImageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PUT_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -801,6 +805,7 @@ impl GetImageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1010,6 +1015,7 @@ impl CreatePixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1099,6 +1105,7 @@ impl AttachFdRequest {
         ([request0.into()], vec![self.shm_fd])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request_fd(header: RequestHeader, value: &[u8], fds: &mut Vec<RawFdContainer>) -> Result<Self, ParseError> {
         if header.minor_opcode != ATTACH_FD_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1187,6 +1194,7 @@ impl CreateSegmentRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_SEGMENT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/shm.rs
+++ b/x11rb-protocol/src/protocol/shm.rs
@@ -225,7 +225,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -432,7 +432,7 @@ impl AttachRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ATTACH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -506,7 +506,7 @@ impl DetachRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DETACH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -658,7 +658,7 @@ impl PutImageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PUT_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -805,7 +805,7 @@ impl GetImageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1015,7 +1015,7 @@ impl CreatePixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1105,7 +1105,7 @@ impl AttachFdRequest {
         ([request0.into()], vec![self.shm_fd])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request_fd(header: RequestHeader, value: &[u8], fds: &mut Vec<RawFdContainer>) -> Result<Self, ParseError> {
         if header.minor_opcode != ATTACH_FD_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1194,7 +1194,7 @@ impl CreateSegmentRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_SEGMENT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -257,11 +257,18 @@ impl core::fmt::Debug for CA  {
 }
 bitmask_binop!(CA, u32);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Int64 {
     pub hi: i32,
     pub lo: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Int64 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Int64").finish_non_exhaustive()
+    }
 }
 impl TryParse for Int64 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -294,12 +301,19 @@ impl Serialize for Int64 {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Systemcounter {
     pub counter: Counter,
     pub resolution: Int64,
     pub name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Systemcounter {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Systemcounter").finish_non_exhaustive()
+    }
 }
 impl TryParse for Systemcounter {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -350,13 +364,20 @@ impl Systemcounter {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Trigger {
     pub counter: Counter,
     pub wait_type: VALUETYPE,
     pub wait_value: Int64,
     pub test_type: TESTTYPE,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Trigger {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Trigger").finish_non_exhaustive()
+    }
 }
 impl TryParse for Trigger {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -409,11 +430,18 @@ impl Serialize for Trigger {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Waitcondition {
     pub trigger: Trigger,
     pub event_threshold: Int64,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Waitcondition {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Waitcondition").finish_non_exhaustive()
+    }
 }
 impl TryParse for Waitcondition {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -474,11 +502,18 @@ pub const ALARM_ERROR: u8 = 1;
 
 /// Opcode for the Initialize request
 pub const INITIALIZE_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InitializeRequest {
     pub desired_major_version: u8,
     pub desired_minor_version: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InitializeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InitializeRequest").finish_non_exhaustive()
+    }
 }
 impl InitializeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -530,13 +565,20 @@ impl crate::x11_utils::ReplyRequest for InitializeRequest {
     type Reply = InitializeReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InitializeReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u8,
     pub minor_version: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InitializeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InitializeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for InitializeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -616,9 +658,16 @@ impl Serialize for InitializeReply {
 
 /// Opcode for the ListSystemCounters request
 pub const LIST_SYSTEM_COUNTERS_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSystemCountersRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListSystemCountersRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListSystemCountersRequest").finish_non_exhaustive()
+    }
+}
 impl ListSystemCountersRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -659,12 +708,19 @@ impl crate::x11_utils::ReplyRequest for ListSystemCountersRequest {
     type Reply = ListSystemCountersReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSystemCountersReply {
     pub sequence: u16,
     pub length: u32,
     pub counters: Vec<Systemcounter>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListSystemCountersReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListSystemCountersReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListSystemCountersReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -724,11 +780,18 @@ impl ListSystemCountersReply {
 
 /// Opcode for the CreateCounter request
 pub const CREATE_COUNTER_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateCounterRequest {
     pub id: Counter,
     pub initial_value: Int64,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateCounterRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateCounterRequest").finish_non_exhaustive()
+    }
 }
 impl CreateCounterRequest {
     /// Serialize this request into bytes for the provided connection
@@ -789,10 +852,17 @@ impl crate::x11_utils::VoidRequest for CreateCounterRequest {
 
 /// Opcode for the DestroyCounter request
 pub const DESTROY_COUNTER_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyCounterRequest {
     pub counter: Counter,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyCounterRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyCounterRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyCounterRequest {
     /// Serialize this request into bytes for the provided connection
@@ -842,10 +912,17 @@ impl crate::x11_utils::VoidRequest for DestroyCounterRequest {
 
 /// Opcode for the QueryCounter request
 pub const QUERY_COUNTER_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryCounterRequest {
     pub counter: Counter,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryCounterRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryCounterRequest").finish_non_exhaustive()
+    }
 }
 impl QueryCounterRequest {
     /// Serialize this request into bytes for the provided connection
@@ -894,12 +971,19 @@ impl crate::x11_utils::ReplyRequest for QueryCounterRequest {
     type Reply = QueryCounterReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryCounterReply {
     pub sequence: u16,
     pub length: u32,
     pub counter_value: Int64,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryCounterReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryCounterReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryCounterReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -958,10 +1042,17 @@ impl Serialize for QueryCounterReply {
 
 /// Opcode for the Await request
 pub const AWAIT_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AwaitRequest<'input> {
     pub wait_list: Cow<'input, [Waitcondition]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for AwaitRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AwaitRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> AwaitRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1023,11 +1114,18 @@ impl<'input> crate::x11_utils::VoidRequest for AwaitRequest<'input> {
 
 /// Opcode for the ChangeCounter request
 pub const CHANGE_COUNTER_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeCounterRequest {
     pub counter: Counter,
     pub amount: Int64,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeCounterRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeCounterRequest").finish_non_exhaustive()
+    }
 }
 impl ChangeCounterRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1088,11 +1186,18 @@ impl crate::x11_utils::VoidRequest for ChangeCounterRequest {
 
 /// Opcode for the SetCounter request
 pub const SET_COUNTER_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCounterRequest {
     pub counter: Counter,
     pub value: Int64,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetCounterRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetCounterRequest").finish_non_exhaustive()
+    }
 }
 impl SetCounterRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1152,7 +1257,8 @@ impl crate::x11_utils::VoidRequest for SetCounterRequest {
 }
 
 /// Auxiliary and optional information for the `create_alarm` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateAlarmAux {
     pub counter: Option<Counter>,
@@ -1161,6 +1267,12 @@ pub struct CreateAlarmAux {
     pub test_type: Option<TESTTYPE>,
     pub delta: Option<Int64>,
     pub events: Option<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateAlarmAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateAlarmAux").finish_non_exhaustive()
+    }
 }
 impl CreateAlarmAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -1318,11 +1430,18 @@ impl CreateAlarmAux {
 
 /// Opcode for the CreateAlarm request
 pub const CREATE_ALARM_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateAlarmRequest<'input> {
     pub id: Alarm,
     pub value_list: Cow<'input, CreateAlarmAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateAlarmRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateAlarmRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateAlarmRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1391,7 +1510,8 @@ impl<'input> crate::x11_utils::VoidRequest for CreateAlarmRequest<'input> {
 }
 
 /// Auxiliary and optional information for the `change_alarm` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeAlarmAux {
     pub counter: Option<Counter>,
@@ -1400,6 +1520,12 @@ pub struct ChangeAlarmAux {
     pub test_type: Option<TESTTYPE>,
     pub delta: Option<Int64>,
     pub events: Option<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeAlarmAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeAlarmAux").finish_non_exhaustive()
+    }
 }
 impl ChangeAlarmAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -1557,11 +1683,18 @@ impl ChangeAlarmAux {
 
 /// Opcode for the ChangeAlarm request
 pub const CHANGE_ALARM_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeAlarmRequest<'input> {
     pub id: Alarm,
     pub value_list: Cow<'input, ChangeAlarmAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeAlarmRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeAlarmRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeAlarmRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1631,10 +1764,17 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeAlarmRequest<'input> {
 
 /// Opcode for the DestroyAlarm request
 pub const DESTROY_ALARM_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyAlarmRequest {
     pub alarm: Alarm,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyAlarmRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyAlarmRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyAlarmRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1684,10 +1824,17 @@ impl crate::x11_utils::VoidRequest for DestroyAlarmRequest {
 
 /// Opcode for the QueryAlarm request
 pub const QUERY_ALARM_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryAlarmRequest {
     pub alarm: Alarm,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryAlarmRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryAlarmRequest").finish_non_exhaustive()
+    }
 }
 impl QueryAlarmRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1736,7 +1883,8 @@ impl crate::x11_utils::ReplyRequest for QueryAlarmRequest {
     type Reply = QueryAlarmReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryAlarmReply {
     pub sequence: u16,
@@ -1745,6 +1893,12 @@ pub struct QueryAlarmReply {
     pub delta: Int64,
     pub events: bool,
     pub state: ALARMSTATE,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryAlarmReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryAlarmReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryAlarmReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1839,11 +1993,18 @@ impl Serialize for QueryAlarmReply {
 
 /// Opcode for the SetPriority request
 pub const SET_PRIORITY_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPriorityRequest {
     pub id: u32,
     pub priority: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetPriorityRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetPriorityRequest").finish_non_exhaustive()
+    }
 }
 impl SetPriorityRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1900,10 +2061,17 @@ impl crate::x11_utils::VoidRequest for SetPriorityRequest {
 
 /// Opcode for the GetPriority request
 pub const GET_PRIORITY_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPriorityRequest {
     pub id: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPriorityRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPriorityRequest").finish_non_exhaustive()
+    }
 }
 impl GetPriorityRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1952,12 +2120,19 @@ impl crate::x11_utils::ReplyRequest for GetPriorityRequest {
     type Reply = GetPriorityReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPriorityReply {
     pub sequence: u16,
     pub length: u32,
     pub priority: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPriorityReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPriorityReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPriorityReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2012,12 +2187,19 @@ impl Serialize for GetPriorityReply {
 
 /// Opcode for the CreateFence request
 pub const CREATE_FENCE_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateFenceRequest {
     pub drawable: xproto::Drawable,
     pub fence: Fence,
     pub initially_triggered: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateFenceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateFenceRequest").finish_non_exhaustive()
+    }
 }
 impl CreateFenceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2081,10 +2263,17 @@ impl crate::x11_utils::VoidRequest for CreateFenceRequest {
 
 /// Opcode for the TriggerFence request
 pub const TRIGGER_FENCE_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TriggerFenceRequest {
     pub fence: Fence,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for TriggerFenceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TriggerFenceRequest").finish_non_exhaustive()
+    }
 }
 impl TriggerFenceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2134,10 +2323,17 @@ impl crate::x11_utils::VoidRequest for TriggerFenceRequest {
 
 /// Opcode for the ResetFence request
 pub const RESET_FENCE_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResetFenceRequest {
     pub fence: Fence,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ResetFenceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ResetFenceRequest").finish_non_exhaustive()
+    }
 }
 impl ResetFenceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2187,10 +2383,17 @@ impl crate::x11_utils::VoidRequest for ResetFenceRequest {
 
 /// Opcode for the DestroyFence request
 pub const DESTROY_FENCE_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyFenceRequest {
     pub fence: Fence,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyFenceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyFenceRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyFenceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2240,10 +2443,17 @@ impl crate::x11_utils::VoidRequest for DestroyFenceRequest {
 
 /// Opcode for the QueryFence request
 pub const QUERY_FENCE_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryFenceRequest {
     pub fence: Fence,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryFenceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryFenceRequest").finish_non_exhaustive()
+    }
 }
 impl QueryFenceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2292,12 +2502,19 @@ impl crate::x11_utils::ReplyRequest for QueryFenceRequest {
     type Reply = QueryFenceReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryFenceReply {
     pub sequence: u16,
     pub length: u32,
     pub triggered: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryFenceReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryFenceReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryFenceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2374,10 +2591,17 @@ impl Serialize for QueryFenceReply {
 
 /// Opcode for the AwaitFence request
 pub const AWAIT_FENCE_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AwaitFenceRequest<'input> {
     pub fence_list: Cow<'input, [Fence]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for AwaitFenceRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AwaitFenceRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> AwaitFenceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2439,7 +2663,8 @@ impl<'input> crate::x11_utils::VoidRequest for AwaitFenceRequest<'input> {
 
 /// Opcode for the CounterNotify event
 pub const COUNTER_NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CounterNotifyEvent {
     pub response_type: u8,
@@ -2451,6 +2676,12 @@ pub struct CounterNotifyEvent {
     pub timestamp: xproto::Timestamp,
     pub count: u16,
     pub destroyed: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CounterNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CounterNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for CounterNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2588,7 +2819,8 @@ impl From<CounterNotifyEvent> for [u8; 32] {
 
 /// Opcode for the AlarmNotify event
 pub const ALARM_NOTIFY_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AlarmNotifyEvent {
     pub response_type: u8,
@@ -2599,6 +2831,12 @@ pub struct AlarmNotifyEvent {
     pub alarm_value: Int64,
     pub timestamp: xproto::Timestamp,
     pub state: ALARMSTATE,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AlarmNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AlarmNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for AlarmNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -538,7 +538,7 @@ impl InitializeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != INITIALIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -686,7 +686,7 @@ impl ListSystemCountersRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_SYSTEM_COUNTERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -826,7 +826,7 @@ impl CreateCounterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_COUNTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -889,7 +889,7 @@ impl DestroyCounterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_COUNTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -950,7 +950,7 @@ impl QueryCounterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_COUNTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1080,7 +1080,7 @@ impl<'input> AwaitRequest<'input> {
         ([request0.into(), wait_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != AWAIT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1164,7 +1164,7 @@ impl ChangeCounterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_COUNTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1237,7 +1237,7 @@ impl SetCounterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_COUNTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1283,6 +1283,7 @@ impl core::fmt::Debug for CreateAlarmAux {
     }
 }
 impl CreateAlarmAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
@@ -1483,7 +1484,7 @@ impl<'input> CreateAlarmRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_ALARM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1537,6 +1538,7 @@ impl core::fmt::Debug for ChangeAlarmAux {
     }
 }
 impl ChangeAlarmAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
@@ -1737,7 +1739,7 @@ impl<'input> ChangeAlarmRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_ALARM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1808,7 +1810,7 @@ impl DestroyAlarmRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_ALARM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1869,7 +1871,7 @@ impl QueryAlarmRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_ALARM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2045,7 +2047,7 @@ impl SetPriorityRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PRIORITY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2108,7 +2110,7 @@ impl GetPriorityRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PRIORITY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2247,7 +2249,7 @@ impl CreateFenceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2312,7 +2314,7 @@ impl TriggerFenceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != TRIGGER_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2373,7 +2375,7 @@ impl ResetFenceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != RESET_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2434,7 +2436,7 @@ impl DestroyFenceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2495,7 +2497,7 @@ impl QueryFenceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2643,7 +2645,7 @@ impl<'input> AwaitFenceRequest<'input> {
         ([request0.into(), fence_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != AWAIT_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -538,6 +538,7 @@ impl InitializeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != INITIALIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -685,6 +686,7 @@ impl ListSystemCountersRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_SYSTEM_COUNTERS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -824,6 +826,7 @@ impl CreateCounterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_COUNTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -886,6 +889,7 @@ impl DestroyCounterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_COUNTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -946,6 +950,7 @@ impl QueryCounterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_COUNTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1075,6 +1080,7 @@ impl<'input> AwaitRequest<'input> {
         ([request0.into(), wait_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != AWAIT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1158,6 +1164,7 @@ impl ChangeCounterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_COUNTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1230,6 +1237,7 @@ impl SetCounterRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_COUNTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1475,6 +1483,7 @@ impl<'input> CreateAlarmRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_ALARM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1728,6 +1737,7 @@ impl<'input> ChangeAlarmRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_ALARM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1798,6 +1808,7 @@ impl DestroyAlarmRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_ALARM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1858,6 +1869,7 @@ impl QueryAlarmRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_ALARM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2033,6 +2045,7 @@ impl SetPriorityRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PRIORITY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2095,6 +2108,7 @@ impl GetPriorityRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PRIORITY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2233,6 +2247,7 @@ impl CreateFenceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2297,6 +2312,7 @@ impl TriggerFenceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != TRIGGER_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2357,6 +2373,7 @@ impl ResetFenceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != RESET_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2417,6 +2434,7 @@ impl DestroyFenceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2477,6 +2495,7 @@ impl QueryFenceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2624,6 +2643,7 @@ impl<'input> AwaitFenceRequest<'input> {
         ([request0.into(), fence_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != AWAIT_FENCE_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xc_misc.rs
+++ b/x11rb-protocol/src/protocol/xc_misc.rs
@@ -72,6 +72,7 @@ impl GetVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -197,6 +198,7 @@ impl GetXIDRangeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_XID_RANGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -329,6 +331,7 @@ impl GetXIDListRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_XID_LIST_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xc_misc.rs
+++ b/x11rb-protocol/src/protocol/xc_misc.rs
@@ -36,11 +36,18 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
 /// Opcode for the GetVersion request
 pub const GET_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetVersionRequest").finish_non_exhaustive()
+    }
 }
 impl GetVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -92,13 +99,20 @@ impl crate::x11_utils::ReplyRequest for GetVersionRequest {
     type Reply = GetVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub server_major_version: u16,
     pub server_minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -156,9 +170,16 @@ impl Serialize for GetVersionReply {
 
 /// Opcode for the GetXIDRange request
 pub const GET_XID_RANGE_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetXIDRangeRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetXIDRangeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetXIDRangeRequest").finish_non_exhaustive()
+    }
+}
 impl GetXIDRangeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -199,13 +220,20 @@ impl crate::x11_utils::ReplyRequest for GetXIDRangeRequest {
     type Reply = GetXIDRangeReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetXIDRangeReply {
     pub sequence: u16,
     pub length: u32,
     pub start_id: u32,
     pub count: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetXIDRangeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetXIDRangeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetXIDRangeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -267,10 +295,17 @@ impl Serialize for GetXIDRangeReply {
 
 /// Opcode for the GetXIDList request
 pub const GET_XID_LIST_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetXIDListRequest {
     pub count: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetXIDListRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetXIDListRequest").finish_non_exhaustive()
+    }
 }
 impl GetXIDListRequest {
     /// Serialize this request into bytes for the provided connection
@@ -319,12 +354,19 @@ impl crate::x11_utils::ReplyRequest for GetXIDListRequest {
     type Reply = GetXIDListReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetXIDListReply {
     pub sequence: u16,
     pub length: u32,
     pub ids: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetXIDListReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetXIDListReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetXIDListReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/xc_misc.rs
+++ b/x11rb-protocol/src/protocol/xc_misc.rs
@@ -72,7 +72,7 @@ impl GetVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -198,7 +198,7 @@ impl GetXIDRangeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_XID_RANGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -331,7 +331,7 @@ impl GetXIDListRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_XID_LIST_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xevie.rs
+++ b/x11rb-protocol/src/protocol/xevie.rs
@@ -36,11 +36,18 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -92,13 +99,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub server_major_version: u16,
     pub server_minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -178,10 +192,17 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the Start request
 pub const START_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StartRequest {
     pub screen: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for StartRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StartRequest").finish_non_exhaustive()
+    }
 }
 impl StartRequest {
     /// Serialize this request into bytes for the provided connection
@@ -230,11 +251,18 @@ impl crate::x11_utils::ReplyRequest for StartRequest {
     type Reply = StartReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StartReply {
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for StartReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StartReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for StartReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -308,10 +336,17 @@ impl Serialize for StartReply {
 
 /// Opcode for the End request
 pub const END_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EndRequest {
     pub cmap: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EndRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EndRequest").finish_non_exhaustive()
+    }
 }
 impl EndRequest {
     /// Serialize this request into bytes for the provided connection
@@ -360,11 +395,18 @@ impl crate::x11_utils::ReplyRequest for EndRequest {
     type Reply = EndReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EndReply {
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EndReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EndReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for EndReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -507,9 +549,16 @@ impl core::fmt::Debug for Datatype  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Event {
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Event {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Event").finish_non_exhaustive()
+    }
 }
 impl TryParse for Event {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -564,11 +613,18 @@ impl Serialize for Event {
 
 /// Opcode for the Send request
 pub const SEND_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SendRequest {
     pub event: Event,
     pub data_type: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SendRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SendRequest").finish_non_exhaustive()
+    }
 }
 impl SendRequest {
     /// Serialize this request into bytes for the provided connection
@@ -717,11 +773,18 @@ impl crate::x11_utils::ReplyRequest for SendRequest {
     type Reply = SendReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SendReply {
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SendReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SendReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SendReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -795,10 +858,17 @@ impl Serialize for SendReply {
 
 /// Opcode for the SelectInput request
 pub const SELECT_INPUT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputRequest {
     pub event_mask: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectInputRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectInputRequest").finish_non_exhaustive()
+    }
 }
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
@@ -847,11 +917,18 @@ impl crate::x11_utils::ReplyRequest for SelectInputRequest {
     type Reply = SelectInputReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectInputReply {
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectInputReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectInputReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectInputReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/xevie.rs
+++ b/x11rb-protocol/src/protocol/xevie.rs
@@ -72,7 +72,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -227,7 +227,7 @@ impl StartRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != START_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -372,7 +372,7 @@ impl EndRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != END_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -748,7 +748,7 @@ impl SendRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SEND_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -896,7 +896,7 @@ impl SelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xevie.rs
+++ b/x11rb-protocol/src/protocol/xevie.rs
@@ -72,6 +72,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -226,6 +227,7 @@ impl StartRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != START_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -370,6 +372,7 @@ impl EndRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != END_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -745,6 +748,7 @@ impl SendRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SEND_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -892,6 +896,7 @@ impl SelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xf86dri.rs
+++ b/x11rb-protocol/src/protocol/xf86dri.rs
@@ -115,7 +115,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -252,7 +252,7 @@ impl QueryDirectRenderingCapableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_DIRECT_RENDERING_CAPABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -376,7 +376,7 @@ impl OpenConnectionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != OPEN_CONNECTION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -515,7 +515,7 @@ impl CloseConnectionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CLOSE_CONNECTION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -576,7 +576,7 @@ impl GetClientDriverNameRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CLIENT_DRIVER_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -730,7 +730,7 @@ impl CreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -867,7 +867,7 @@ impl DestroyContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -936,7 +936,7 @@ impl CreateDrawableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_DRAWABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1071,7 +1071,7 @@ impl DestroyDrawableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_DRAWABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1140,7 +1140,7 @@ impl GetDrawableInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DRAWABLE_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1315,7 +1315,7 @@ impl GetDeviceInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1466,7 +1466,7 @@ impl AuthConnectionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != AUTH_CONNECTION_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xf86dri.rs
+++ b/x11rb-protocol/src/protocol/xf86dri.rs
@@ -115,6 +115,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -251,6 +252,7 @@ impl QueryDirectRenderingCapableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_DIRECT_RENDERING_CAPABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -374,6 +376,7 @@ impl OpenConnectionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != OPEN_CONNECTION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -512,6 +515,7 @@ impl CloseConnectionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CLOSE_CONNECTION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -572,6 +576,7 @@ impl GetClientDriverNameRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CLIENT_DRIVER_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -725,6 +730,7 @@ impl CreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -861,6 +867,7 @@ impl DestroyContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -929,6 +936,7 @@ impl CreateDrawableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_DRAWABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1063,6 +1071,7 @@ impl DestroyDrawableRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_DRAWABLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1131,6 +1140,7 @@ impl GetDrawableInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DRAWABLE_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1305,6 +1315,7 @@ impl GetDeviceInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1455,6 +1466,7 @@ impl AuthConnectionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != AUTH_CONNECTION_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xf86dri.rs
+++ b/x11rb-protocol/src/protocol/xf86dri.rs
@@ -34,13 +34,20 @@ pub const X11_EXTENSION_NAME: &str = "XFree86-DRI";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (4, 1);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DrmClipRect {
     pub x1: i16,
     pub y1: i16,
     pub x2: i16,
     pub x3: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DrmClipRect {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DrmClipRect").finish_non_exhaustive()
+    }
 }
 impl TryParse for DrmClipRect {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -81,9 +88,16 @@ impl Serialize for DrmClipRect {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
+}
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -124,7 +138,8 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
@@ -132,6 +147,12 @@ pub struct QueryVersionReply {
     pub dri_major_version: u16,
     pub dri_minor_version: u16,
     pub dri_minor_patch: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -196,10 +217,17 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the QueryDirectRenderingCapable request
 pub const QUERY_DIRECT_RENDERING_CAPABLE_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryDirectRenderingCapableRequest {
     pub screen: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryDirectRenderingCapableRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryDirectRenderingCapableRequest").finish_non_exhaustive()
+    }
 }
 impl QueryDirectRenderingCapableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -248,12 +276,19 @@ impl crate::x11_utils::ReplyRequest for QueryDirectRenderingCapableRequest {
     type Reply = QueryDirectRenderingCapableReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryDirectRenderingCapableReply {
     pub sequence: u16,
     pub length: u32,
     pub is_capable: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryDirectRenderingCapableReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryDirectRenderingCapableReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryDirectRenderingCapableReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -305,10 +340,17 @@ impl Serialize for QueryDirectRenderingCapableReply {
 
 /// Opcode for the OpenConnection request
 pub const OPEN_CONNECTION_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenConnectionRequest {
     pub screen: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for OpenConnectionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OpenConnectionRequest").finish_non_exhaustive()
+    }
 }
 impl OpenConnectionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -357,7 +399,8 @@ impl crate::x11_utils::ReplyRequest for OpenConnectionRequest {
     type Reply = OpenConnectionReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenConnectionReply {
     pub sequence: u16,
@@ -365,6 +408,12 @@ pub struct OpenConnectionReply {
     pub sarea_handle_low: u32,
     pub sarea_handle_high: u32,
     pub bus_id: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for OpenConnectionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OpenConnectionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for OpenConnectionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -429,10 +478,17 @@ impl OpenConnectionReply {
 
 /// Opcode for the CloseConnection request
 pub const CLOSE_CONNECTION_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CloseConnectionRequest {
     pub screen: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CloseConnectionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CloseConnectionRequest").finish_non_exhaustive()
+    }
 }
 impl CloseConnectionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -482,10 +538,17 @@ impl crate::x11_utils::VoidRequest for CloseConnectionRequest {
 
 /// Opcode for the GetClientDriverName request
 pub const GET_CLIENT_DRIVER_NAME_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClientDriverNameRequest {
     pub screen: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetClientDriverNameRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetClientDriverNameRequest").finish_non_exhaustive()
+    }
 }
 impl GetClientDriverNameRequest {
     /// Serialize this request into bytes for the provided connection
@@ -534,7 +597,8 @@ impl crate::x11_utils::ReplyRequest for GetClientDriverNameRequest {
     type Reply = GetClientDriverNameReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClientDriverNameReply {
     pub sequence: u16,
@@ -543,6 +607,12 @@ pub struct GetClientDriverNameReply {
     pub client_driver_minor_version: u32,
     pub client_driver_patch_version: u32,
     pub client_driver_name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetClientDriverNameReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetClientDriverNameReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetClientDriverNameReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -609,12 +679,19 @@ impl GetClientDriverNameReply {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextRequest {
     pub screen: u32,
     pub visual: u32,
     pub context: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateContextRequest").finish_non_exhaustive()
+    }
 }
 impl CreateContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -677,12 +754,19 @@ impl crate::x11_utils::ReplyRequest for CreateContextRequest {
     type Reply = CreateContextReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextReply {
     pub sequence: u16,
     pub length: u32,
     pub hw_context: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for CreateContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -737,11 +821,18 @@ impl Serialize for CreateContextReply {
 
 /// Opcode for the DestroyContext request
 pub const DESTROY_CONTEXT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyContextRequest {
     pub screen: u32,
     pub context: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyContextRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -798,11 +889,18 @@ impl crate::x11_utils::VoidRequest for DestroyContextRequest {
 
 /// Opcode for the CreateDrawable request
 pub const CREATE_DRAWABLE_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateDrawableRequest {
     pub screen: u32,
     pub drawable: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateDrawableRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateDrawableRequest").finish_non_exhaustive()
+    }
 }
 impl CreateDrawableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -858,12 +956,19 @@ impl crate::x11_utils::ReplyRequest for CreateDrawableRequest {
     type Reply = CreateDrawableReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateDrawableReply {
     pub sequence: u16,
     pub length: u32,
     pub hw_drawable_handle: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateDrawableReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateDrawableReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for CreateDrawableReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -918,11 +1023,18 @@ impl Serialize for CreateDrawableReply {
 
 /// Opcode for the DestroyDrawable request
 pub const DESTROY_DRAWABLE_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyDrawableRequest {
     pub screen: u32,
     pub drawable: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyDrawableRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyDrawableRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyDrawableRequest {
     /// Serialize this request into bytes for the provided connection
@@ -979,11 +1091,18 @@ impl crate::x11_utils::VoidRequest for DestroyDrawableRequest {
 
 /// Opcode for the GetDrawableInfo request
 pub const GET_DRAWABLE_INFO_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDrawableInfoRequest {
     pub screen: u32,
     pub drawable: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDrawableInfoRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDrawableInfoRequest").finish_non_exhaustive()
+    }
 }
 impl GetDrawableInfoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1039,7 +1158,8 @@ impl crate::x11_utils::ReplyRequest for GetDrawableInfoRequest {
     type Reply = GetDrawableInfoReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDrawableInfoReply {
     pub sequence: u16,
@@ -1054,6 +1174,12 @@ pub struct GetDrawableInfoReply {
     pub back_y: i16,
     pub clip_rects: Vec<DrmClipRect>,
     pub back_clip_rects: Vec<DrmClipRect>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDrawableInfoReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDrawableInfoReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDrawableInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1145,10 +1271,17 @@ impl GetDrawableInfoReply {
 
 /// Opcode for the GetDeviceInfo request
 pub const GET_DEVICE_INFO_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceInfoRequest {
     pub screen: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceInfoRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceInfoRequest").finish_non_exhaustive()
+    }
 }
 impl GetDeviceInfoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1197,7 +1330,8 @@ impl crate::x11_utils::ReplyRequest for GetDeviceInfoRequest {
     type Reply = GetDeviceInfoReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceInfoReply {
     pub sequence: u16,
@@ -1208,6 +1342,12 @@ pub struct GetDeviceInfoReply {
     pub framebuffer_size: u32,
     pub framebuffer_stride: u32,
     pub device_private: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceInfoReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceInfoReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDeviceInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1275,11 +1415,18 @@ impl GetDeviceInfoReply {
 
 /// Opcode for the AuthConnection request
 pub const AUTH_CONNECTION_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AuthConnectionRequest {
     pub screen: u32,
     pub magic: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AuthConnectionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AuthConnectionRequest").finish_non_exhaustive()
+    }
 }
 impl AuthConnectionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1335,12 +1482,19 @@ impl crate::x11_utils::ReplyRequest for AuthConnectionRequest {
     type Reply = AuthConnectionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AuthConnectionReply {
     pub sequence: u16,
     pub length: u32,
     pub authenticated: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AuthConnectionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AuthConnectionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for AuthConnectionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -360,6 +360,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -488,6 +489,7 @@ impl GetModeLineRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MODE_LINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -723,6 +725,7 @@ impl<'input> ModModeLineRequest<'input> {
         ([request0.into(), self.private, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != MOD_MODE_LINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -828,6 +831,7 @@ impl SwitchModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SWITCH_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -890,6 +894,7 @@ impl GetMonitorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MONITOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1088,6 +1093,7 @@ impl LockModeSwitchRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LOCK_MODE_SWITCH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1150,6 +1156,7 @@ impl GetAllModeLinesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_ALL_MODE_LINES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1416,6 +1423,7 @@ impl<'input> AddModeLineRequest<'input> {
         ([request0.into(), self.private, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ADD_MODE_LINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1630,6 +1638,7 @@ impl<'input> DeleteModeLineRequest<'input> {
         ([request0.into(), self.private, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_MODE_LINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1808,6 +1817,7 @@ impl<'input> ValidateModeLineRequest<'input> {
         ([request0.into(), self.private, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != VALIDATE_MODE_LINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2074,6 +2084,7 @@ impl<'input> SwitchToModeRequest<'input> {
         ([request0.into(), self.private, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SWITCH_TO_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2180,6 +2191,7 @@ impl GetViewPortRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VIEW_PORT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2345,6 +2357,7 @@ impl SetViewPortRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_VIEW_PORT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2410,6 +2423,7 @@ impl GetDotClocksRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DOT_CLOCKS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2537,6 +2551,7 @@ impl SetClientVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CLIENT_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2629,6 +2644,7 @@ impl SetGammaRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_GAMMA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2721,6 +2737,7 @@ impl GetGammaRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_GAMMA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2880,6 +2897,7 @@ impl GetGammaRampRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_GAMMA_RAMP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3023,6 +3041,7 @@ impl<'input> SetGammaRampRequest<'input> {
         ([request0.into(), red_bytes.into(), green_bytes.into(), blue_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_GAMMA_RAMP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3101,6 +3120,7 @@ impl GetGammaRampSizeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_GAMMA_RAMP_SIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3250,6 +3270,7 @@ impl GetPermissionsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PERMISSIONS_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -202,7 +202,8 @@ impl core::fmt::Debug for Permission  {
 }
 bitmask_binop!(Permission, u32);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModeInfo {
     pub dotclock: Dotclock,
@@ -217,6 +218,12 @@ pub struct ModeInfo {
     pub vtotal: u16,
     pub flags: ModeFlag,
     pub privsize: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ModeInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ModeInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for ModeInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -326,9 +333,16 @@ impl Serialize for ModeInfo {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
+}
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -369,13 +383,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u16,
     pub minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -433,10 +454,17 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the GetModeLine request
 pub const GET_MODE_LINE_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetModeLineRequest {
     pub screen: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetModeLineRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetModeLineRequest").finish_non_exhaustive()
+    }
 }
 impl GetModeLineRequest {
     /// Serialize this request into bytes for the provided connection
@@ -486,7 +514,8 @@ impl crate::x11_utils::ReplyRequest for GetModeLineRequest {
     type Reply = GetModeLineReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetModeLineReply {
     pub sequence: u16,
@@ -503,6 +532,12 @@ pub struct GetModeLineReply {
     pub vtotal: u16,
     pub flags: ModeFlag,
     pub private: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetModeLineReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetModeLineReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetModeLineReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -588,7 +623,8 @@ impl GetModeLineReply {
 
 /// Opcode for the ModModeLine request
 pub const MOD_MODE_LINE_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModModeLineRequest<'input> {
     pub screen: u32,
@@ -603,6 +639,12 @@ pub struct ModModeLineRequest<'input> {
     pub vtotal: u16,
     pub flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ModModeLineRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ModModeLineRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ModModeLineRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -750,11 +792,18 @@ impl<'input> crate::x11_utils::VoidRequest for ModModeLineRequest<'input> {
 
 /// Opcode for the SwitchMode request
 pub const SWITCH_MODE_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwitchModeRequest {
     pub screen: u16,
     pub zoom: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SwitchModeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SwitchModeRequest").finish_non_exhaustive()
+    }
 }
 impl SwitchModeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -807,10 +856,17 @@ impl crate::x11_utils::VoidRequest for SwitchModeRequest {
 
 /// Opcode for the GetMonitor request
 pub const GET_MONITOR_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMonitorRequest {
     pub screen: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMonitorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMonitorRequest").finish_non_exhaustive()
+    }
 }
 impl GetMonitorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -860,7 +916,8 @@ impl crate::x11_utils::ReplyRequest for GetMonitorRequest {
     type Reply = GetMonitorReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMonitorReply {
     pub sequence: u16,
@@ -870,6 +927,12 @@ pub struct GetMonitorReply {
     pub vendor: Vec<u8>,
     pub alignment_pad: Vec<u8>,
     pub model: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMonitorReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMonitorReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMonitorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -989,11 +1052,18 @@ impl GetMonitorReply {
 
 /// Opcode for the LockModeSwitch request
 pub const LOCK_MODE_SWITCH_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LockModeSwitchRequest {
     pub screen: u16,
     pub lock: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for LockModeSwitchRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LockModeSwitchRequest").finish_non_exhaustive()
+    }
 }
 impl LockModeSwitchRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1046,10 +1116,17 @@ impl crate::x11_utils::VoidRequest for LockModeSwitchRequest {
 
 /// Opcode for the GetAllModeLines request
 pub const GET_ALL_MODE_LINES_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetAllModeLinesRequest {
     pub screen: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetAllModeLinesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetAllModeLinesRequest").finish_non_exhaustive()
+    }
 }
 impl GetAllModeLinesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1099,12 +1176,19 @@ impl crate::x11_utils::ReplyRequest for GetAllModeLinesRequest {
     type Reply = GetAllModeLinesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetAllModeLinesReply {
     pub sequence: u16,
     pub length: u32,
     pub modeinfo: Vec<ModeInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetAllModeLinesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetAllModeLinesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetAllModeLinesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1164,7 +1248,8 @@ impl GetAllModeLinesReply {
 
 /// Opcode for the AddModeLine request
 pub const ADD_MODE_LINE_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddModeLineRequest<'input> {
     pub screen: u32,
@@ -1191,6 +1276,12 @@ pub struct AddModeLineRequest<'input> {
     pub after_vtotal: u16,
     pub after_flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for AddModeLineRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AddModeLineRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> AddModeLineRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1433,7 +1524,8 @@ impl<'input> crate::x11_utils::VoidRequest for AddModeLineRequest<'input> {
 
 /// Opcode for the DeleteModeLine request
 pub const DELETE_MODE_LINE_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteModeLineRequest<'input> {
     pub screen: u32,
@@ -1449,6 +1541,12 @@ pub struct DeleteModeLineRequest<'input> {
     pub vtotal: u16,
     pub flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for DeleteModeLineRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeleteModeLineRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> DeleteModeLineRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1604,7 +1702,8 @@ impl<'input> crate::x11_utils::VoidRequest for DeleteModeLineRequest<'input> {
 
 /// Opcode for the ValidateModeLine request
 pub const VALIDATE_MODE_LINE_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValidateModeLineRequest<'input> {
     pub screen: u32,
@@ -1620,6 +1719,12 @@ pub struct ValidateModeLineRequest<'input> {
     pub vtotal: u16,
     pub flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ValidateModeLineRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ValidateModeLineRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ValidateModeLineRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1774,12 +1879,19 @@ impl<'input> crate::x11_utils::ReplyRequest for ValidateModeLineRequest<'input> 
     type Reply = ValidateModeLineReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValidateModeLineReply {
     pub sequence: u16,
     pub length: u32,
     pub status: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ValidateModeLineReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ValidateModeLineReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ValidateModeLineReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1856,7 +1968,8 @@ impl Serialize for ValidateModeLineReply {
 
 /// Opcode for the SwitchToMode request
 pub const SWITCH_TO_MODE_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SwitchToModeRequest<'input> {
     pub screen: u32,
@@ -1872,6 +1985,12 @@ pub struct SwitchToModeRequest<'input> {
     pub vtotal: u16,
     pub flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SwitchToModeRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SwitchToModeRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SwitchToModeRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2027,10 +2146,17 @@ impl<'input> crate::x11_utils::VoidRequest for SwitchToModeRequest<'input> {
 
 /// Opcode for the GetViewPort request
 pub const GET_VIEW_PORT_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetViewPortRequest {
     pub screen: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetViewPortRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetViewPortRequest").finish_non_exhaustive()
+    }
 }
 impl GetViewPortRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2080,13 +2206,20 @@ impl crate::x11_utils::ReplyRequest for GetViewPortRequest {
     type Reply = GetViewPortReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetViewPortReply {
     pub sequence: u16,
     pub length: u32,
     pub x: u32,
     pub y: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetViewPortReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetViewPortReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetViewPortReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2166,12 +2299,19 @@ impl Serialize for GetViewPortReply {
 
 /// Opcode for the SetViewPort request
 pub const SET_VIEW_PORT_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetViewPortRequest {
     pub screen: u16,
     pub x: u32,
     pub y: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetViewPortRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetViewPortRequest").finish_non_exhaustive()
+    }
 }
 impl SetViewPortRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2236,10 +2376,17 @@ impl crate::x11_utils::VoidRequest for SetViewPortRequest {
 
 /// Opcode for the GetDotClocks request
 pub const GET_DOT_CLOCKS_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDotClocksRequest {
     pub screen: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDotClocksRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDotClocksRequest").finish_non_exhaustive()
+    }
 }
 impl GetDotClocksRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2289,7 +2436,8 @@ impl crate::x11_utils::ReplyRequest for GetDotClocksRequest {
     type Reply = GetDotClocksReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDotClocksReply {
     pub sequence: u16,
@@ -2298,6 +2446,12 @@ pub struct GetDotClocksReply {
     pub clocks: u32,
     pub maxclocks: u32,
     pub clock: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDotClocksReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDotClocksReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDotClocksReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2347,11 +2501,18 @@ impl Serialize for GetDotClocksReply {
 
 /// Opcode for the SetClientVersion request
 pub const SET_CLIENT_VERSION_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetClientVersionRequest {
     pub major: u16,
     pub minor: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetClientVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetClientVersionRequest").finish_non_exhaustive()
+    }
 }
 impl SetClientVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2404,13 +2565,20 @@ impl crate::x11_utils::VoidRequest for SetClientVersionRequest {
 
 /// Opcode for the SetGamma request
 pub const SET_GAMMA_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetGammaRequest {
     pub screen: u16,
     pub red: u32,
     pub green: u32,
     pub blue: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetGammaRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetGammaRequest").finish_non_exhaustive()
+    }
 }
 impl SetGammaRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2495,10 +2663,17 @@ impl crate::x11_utils::VoidRequest for SetGammaRequest {
 
 /// Opcode for the GetGamma request
 pub const GET_GAMMA_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGammaRequest {
     pub screen: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetGammaRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetGammaRequest").finish_non_exhaustive()
+    }
 }
 impl GetGammaRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2572,7 +2747,8 @@ impl crate::x11_utils::ReplyRequest for GetGammaRequest {
     type Reply = GetGammaReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGammaReply {
     pub sequence: u16,
@@ -2580,6 +2756,12 @@ pub struct GetGammaReply {
     pub red: u32,
     pub green: u32,
     pub blue: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetGammaReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetGammaReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetGammaReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2662,11 +2844,18 @@ impl Serialize for GetGammaReply {
 
 /// Opcode for the GetGammaRamp request
 pub const GET_GAMMA_RAMP_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGammaRampRequest {
     pub screen: u16,
     pub size: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetGammaRampRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetGammaRampRequest").finish_non_exhaustive()
+    }
 }
 impl GetGammaRampRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2718,7 +2907,8 @@ impl crate::x11_utils::ReplyRequest for GetGammaRampRequest {
     type Reply = GetGammaRampReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGammaRampReply {
     pub sequence: u16,
@@ -2727,6 +2917,12 @@ pub struct GetGammaRampReply {
     pub red: Vec<u16>,
     pub green: Vec<u16>,
     pub blue: Vec<u16>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetGammaRampReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetGammaRampReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetGammaRampReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2777,7 +2973,8 @@ impl Serialize for GetGammaRampReply {
 
 /// Opcode for the SetGammaRamp request
 pub const SET_GAMMA_RAMP_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetGammaRampRequest<'input> {
     pub screen: u16,
@@ -2785,6 +2982,12 @@ pub struct SetGammaRampRequest<'input> {
     pub red: Cow<'input, [u16]>,
     pub green: Cow<'input, [u16]>,
     pub blue: Cow<'input, [u16]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetGammaRampRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetGammaRampRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetGammaRampRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2864,10 +3067,17 @@ impl<'input> crate::x11_utils::VoidRequest for SetGammaRampRequest<'input> {
 
 /// Opcode for the GetGammaRampSize request
 pub const GET_GAMMA_RAMP_SIZE_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGammaRampSizeRequest {
     pub screen: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetGammaRampSizeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetGammaRampSizeRequest").finish_non_exhaustive()
+    }
 }
 impl GetGammaRampSizeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2917,12 +3127,19 @@ impl crate::x11_utils::ReplyRequest for GetGammaRampSizeRequest {
     type Reply = GetGammaRampSizeReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGammaRampSizeReply {
     pub sequence: u16,
     pub length: u32,
     pub size: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetGammaRampSizeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetGammaRampSizeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetGammaRampSizeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2999,10 +3216,17 @@ impl Serialize for GetGammaRampSizeReply {
 
 /// Opcode for the GetPermissions request
 pub const GET_PERMISSIONS_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPermissionsRequest {
     pub screen: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPermissionsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPermissionsRequest").finish_non_exhaustive()
+    }
 }
 impl GetPermissionsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3052,12 +3276,19 @@ impl crate::x11_utils::ReplyRequest for GetPermissionsRequest {
     type Reply = GetPermissionsReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPermissionsReply {
     pub sequence: u16,
     pub length: u32,
     pub permissions: Permission,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPermissionsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPermissionsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPermissionsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -360,7 +360,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -489,7 +489,7 @@ impl GetModeLineRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MODE_LINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -725,7 +725,7 @@ impl<'input> ModModeLineRequest<'input> {
         ([request0.into(), self.private, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != MOD_MODE_LINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -831,7 +831,7 @@ impl SwitchModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SWITCH_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -894,7 +894,7 @@ impl GetMonitorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MONITOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1093,7 +1093,7 @@ impl LockModeSwitchRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LOCK_MODE_SWITCH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1156,7 +1156,7 @@ impl GetAllModeLinesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_ALL_MODE_LINES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1423,7 +1423,7 @@ impl<'input> AddModeLineRequest<'input> {
         ([request0.into(), self.private, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ADD_MODE_LINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1638,7 +1638,7 @@ impl<'input> DeleteModeLineRequest<'input> {
         ([request0.into(), self.private, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_MODE_LINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1817,7 +1817,7 @@ impl<'input> ValidateModeLineRequest<'input> {
         ([request0.into(), self.private, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != VALIDATE_MODE_LINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2084,7 +2084,7 @@ impl<'input> SwitchToModeRequest<'input> {
         ([request0.into(), self.private, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SWITCH_TO_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2191,7 +2191,7 @@ impl GetViewPortRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VIEW_PORT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2357,7 +2357,7 @@ impl SetViewPortRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_VIEW_PORT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2423,7 +2423,7 @@ impl GetDotClocksRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DOT_CLOCKS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2551,7 +2551,7 @@ impl SetClientVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CLIENT_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2644,7 +2644,7 @@ impl SetGammaRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_GAMMA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2737,7 +2737,7 @@ impl GetGammaRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_GAMMA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2897,7 +2897,7 @@ impl GetGammaRampRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_GAMMA_RAMP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3041,7 +3041,7 @@ impl<'input> SetGammaRampRequest<'input> {
         ([request0.into(), red_bytes.into(), green_bytes.into(), blue_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_GAMMA_RAMP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3120,7 +3120,7 @@ impl GetGammaRampSizeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_GAMMA_RAMP_SIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3270,7 +3270,7 @@ impl GetPermissionsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PERMISSIONS_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -42,11 +42,18 @@ pub const X11_XML_VERSION: (u32, u32) = (6, 0);
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -102,13 +109,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u32,
     pub minor_version: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -365,13 +379,20 @@ impl core::fmt::Debug for SaveSetMapping  {
 
 /// Opcode for the ChangeSaveSet request
 pub const CHANGE_SAVE_SET_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeSaveSetRequest {
     pub mode: SaveSetMode,
     pub target: SaveSetTarget,
     pub map: SaveSetMapping,
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeSaveSetRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeSaveSetRequest").finish_non_exhaustive()
+    }
 }
 impl ChangeSaveSetRequest {
     /// Serialize this request into bytes for the provided connection
@@ -549,7 +570,8 @@ bitmask_binop!(SelectionEventMask, u32);
 
 /// Opcode for the SelectionNotify event
 pub const SELECTION_NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectionNotifyEvent {
     pub response_type: u8,
@@ -560,6 +582,12 @@ pub struct SelectionNotifyEvent {
     pub selection: xproto::Atom,
     pub timestamp: xproto::Timestamp,
     pub selection_timestamp: xproto::Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectionNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectionNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectionNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -694,12 +722,19 @@ impl From<SelectionNotifyEvent> for [u8; 32] {
 
 /// Opcode for the SelectSelectionInput request
 pub const SELECT_SELECTION_INPUT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectSelectionInputRequest {
     pub window: xproto::Window,
     pub selection: xproto::Atom,
     pub event_mask: SelectionEventMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectSelectionInputRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectSelectionInputRequest").finish_non_exhaustive()
+    }
 }
 impl SelectSelectionInputRequest {
     /// Serialize this request into bytes for the provided connection
@@ -867,7 +902,8 @@ bitmask_binop!(CursorNotifyMask, u32);
 
 /// Opcode for the CursorNotify event
 pub const CURSOR_NOTIFY_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursorNotifyEvent {
     pub response_type: u8,
@@ -877,6 +913,12 @@ pub struct CursorNotifyEvent {
     pub cursor_serial: u32,
     pub timestamp: xproto::Timestamp,
     pub name: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CursorNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CursorNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for CursorNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1007,11 +1049,18 @@ impl From<CursorNotifyEvent> for [u8; 32] {
 
 /// Opcode for the SelectCursorInput request
 pub const SELECT_CURSOR_INPUT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectCursorInputRequest {
     pub window: xproto::Window,
     pub event_mask: CursorNotifyMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectCursorInputRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectCursorInputRequest").finish_non_exhaustive()
+    }
 }
 impl SelectCursorInputRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1069,9 +1118,16 @@ impl crate::x11_utils::VoidRequest for SelectCursorInputRequest {
 
 /// Opcode for the GetCursorImage request
 pub const GET_CURSOR_IMAGE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorImageRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCursorImageRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCursorImageRequest").finish_non_exhaustive()
+    }
+}
 impl GetCursorImageRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1112,7 +1168,8 @@ impl crate::x11_utils::ReplyRequest for GetCursorImageRequest {
     type Reply = GetCursorImageReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorImageReply {
     pub sequence: u16,
@@ -1125,6 +1182,12 @@ pub struct GetCursorImageReply {
     pub yhot: u16,
     pub cursor_serial: u32,
     pub cursor_image: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCursorImageReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCursorImageReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetCursorImageReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1243,11 +1306,18 @@ impl core::fmt::Debug for RegionEnum  {
 
 /// Opcode for the CreateRegion request
 pub const CREATE_REGION_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRegionRequest<'input> {
     pub region: Region,
     pub rectangles: Cow<'input, [xproto::Rectangle]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateRegionRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateRegionRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateRegionRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1317,11 +1387,18 @@ impl<'input> crate::x11_utils::VoidRequest for CreateRegionRequest<'input> {
 
 /// Opcode for the CreateRegionFromBitmap request
 pub const CREATE_REGION_FROM_BITMAP_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRegionFromBitmapRequest {
     pub region: Region,
     pub bitmap: xproto::Pixmap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateRegionFromBitmapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateRegionFromBitmapRequest").finish_non_exhaustive()
+    }
 }
 impl CreateRegionFromBitmapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1378,12 +1455,19 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromBitmapRequest {
 
 /// Opcode for the CreateRegionFromWindow request
 pub const CREATE_REGION_FROM_WINDOW_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRegionFromWindowRequest {
     pub region: Region,
     pub window: xproto::Window,
     pub kind: shape::SK,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateRegionFromWindowRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateRegionFromWindowRequest").finish_non_exhaustive()
+    }
 }
 impl CreateRegionFromWindowRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1449,11 +1533,18 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromWindowRequest {
 
 /// Opcode for the CreateRegionFromGC request
 pub const CREATE_REGION_FROM_GC_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRegionFromGCRequest {
     pub region: Region,
     pub gc: xproto::Gcontext,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateRegionFromGCRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateRegionFromGCRequest").finish_non_exhaustive()
+    }
 }
 impl CreateRegionFromGCRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1510,11 +1601,18 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromGCRequest {
 
 /// Opcode for the CreateRegionFromPicture request
 pub const CREATE_REGION_FROM_PICTURE_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateRegionFromPictureRequest {
     pub region: Region,
     pub picture: render::Picture,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateRegionFromPictureRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateRegionFromPictureRequest").finish_non_exhaustive()
+    }
 }
 impl CreateRegionFromPictureRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1571,10 +1669,17 @@ impl crate::x11_utils::VoidRequest for CreateRegionFromPictureRequest {
 
 /// Opcode for the DestroyRegion request
 pub const DESTROY_REGION_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyRegionRequest {
     pub region: Region,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyRegionRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1624,11 +1729,18 @@ impl crate::x11_utils::VoidRequest for DestroyRegionRequest {
 
 /// Opcode for the SetRegion request
 pub const SET_REGION_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetRegionRequest<'input> {
     pub region: Region,
     pub rectangles: Cow<'input, [xproto::Rectangle]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetRegionRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetRegionRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetRegionRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1698,11 +1810,18 @@ impl<'input> crate::x11_utils::VoidRequest for SetRegionRequest<'input> {
 
 /// Opcode for the CopyRegion request
 pub const COPY_REGION_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyRegionRequest {
     pub source: Region,
     pub destination: Region,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CopyRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CopyRegionRequest").finish_non_exhaustive()
+    }
 }
 impl CopyRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1759,12 +1878,19 @@ impl crate::x11_utils::VoidRequest for CopyRegionRequest {
 
 /// Opcode for the UnionRegion request
 pub const UNION_REGION_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnionRegionRequest {
     pub source1: Region,
     pub source2: Region,
     pub destination: Region,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UnionRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UnionRegionRequest").finish_non_exhaustive()
+    }
 }
 impl UnionRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1828,12 +1954,19 @@ impl crate::x11_utils::VoidRequest for UnionRegionRequest {
 
 /// Opcode for the IntersectRegion request
 pub const INTERSECT_REGION_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IntersectRegionRequest {
     pub source1: Region,
     pub source2: Region,
     pub destination: Region,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IntersectRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IntersectRegionRequest").finish_non_exhaustive()
+    }
 }
 impl IntersectRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1897,12 +2030,19 @@ impl crate::x11_utils::VoidRequest for IntersectRegionRequest {
 
 /// Opcode for the SubtractRegion request
 pub const SUBTRACT_REGION_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SubtractRegionRequest {
     pub source1: Region,
     pub source2: Region,
     pub destination: Region,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SubtractRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SubtractRegionRequest").finish_non_exhaustive()
+    }
 }
 impl SubtractRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1966,12 +2106,19 @@ impl crate::x11_utils::VoidRequest for SubtractRegionRequest {
 
 /// Opcode for the InvertRegion request
 pub const INVERT_REGION_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InvertRegionRequest {
     pub source: Region,
     pub bounds: xproto::Rectangle,
     pub destination: Region,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InvertRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InvertRegionRequest").finish_non_exhaustive()
+    }
 }
 impl InvertRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2039,12 +2186,19 @@ impl crate::x11_utils::VoidRequest for InvertRegionRequest {
 
 /// Opcode for the TranslateRegion request
 pub const TRANSLATE_REGION_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TranslateRegionRequest {
     pub region: Region,
     pub dx: i16,
     pub dy: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for TranslateRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TranslateRegionRequest").finish_non_exhaustive()
+    }
 }
 impl TranslateRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2104,11 +2258,18 @@ impl crate::x11_utils::VoidRequest for TranslateRegionRequest {
 
 /// Opcode for the RegionExtents request
 pub const REGION_EXTENTS_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RegionExtentsRequest {
     pub source: Region,
     pub destination: Region,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RegionExtentsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RegionExtentsRequest").finish_non_exhaustive()
+    }
 }
 impl RegionExtentsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2165,10 +2326,17 @@ impl crate::x11_utils::VoidRequest for RegionExtentsRequest {
 
 /// Opcode for the FetchRegion request
 pub const FETCH_REGION_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FetchRegionRequest {
     pub region: Region,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FetchRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FetchRegionRequest").finish_non_exhaustive()
+    }
 }
 impl FetchRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2217,12 +2385,19 @@ impl crate::x11_utils::ReplyRequest for FetchRegionRequest {
     type Reply = FetchRegionReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FetchRegionReply {
     pub sequence: u16,
     pub extents: xproto::Rectangle,
     pub rectangles: Vec<xproto::Rectangle>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FetchRegionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FetchRegionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for FetchRegionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2283,13 +2458,20 @@ impl FetchRegionReply {
 
 /// Opcode for the SetGCClipRegion request
 pub const SET_GC_CLIP_REGION_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetGCClipRegionRequest {
     pub gc: xproto::Gcontext,
     pub region: Region,
     pub x_origin: i16,
     pub y_origin: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetGCClipRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetGCClipRegionRequest").finish_non_exhaustive()
+    }
 }
 impl SetGCClipRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2356,7 +2538,8 @@ impl crate::x11_utils::VoidRequest for SetGCClipRegionRequest {
 
 /// Opcode for the SetWindowShapeRegion request
 pub const SET_WINDOW_SHAPE_REGION_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetWindowShapeRegionRequest {
     pub dest: xproto::Window,
@@ -2364,6 +2547,12 @@ pub struct SetWindowShapeRegionRequest {
     pub x_offset: i16,
     pub y_offset: i16,
     pub region: Region,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetWindowShapeRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetWindowShapeRegionRequest").finish_non_exhaustive()
+    }
 }
 impl SetWindowShapeRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2439,13 +2628,20 @@ impl crate::x11_utils::VoidRequest for SetWindowShapeRegionRequest {
 
 /// Opcode for the SetPictureClipRegion request
 pub const SET_PICTURE_CLIP_REGION_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPictureClipRegionRequest {
     pub picture: render::Picture,
     pub region: Region,
     pub x_origin: i16,
     pub y_origin: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetPictureClipRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetPictureClipRegionRequest").finish_non_exhaustive()
+    }
 }
 impl SetPictureClipRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2512,11 +2708,18 @@ impl crate::x11_utils::VoidRequest for SetPictureClipRegionRequest {
 
 /// Opcode for the SetCursorName request
 pub const SET_CURSOR_NAME_REQUEST: u8 = 23;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCursorNameRequest<'input> {
     pub cursor: xproto::Cursor,
     pub name: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetCursorNameRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetCursorNameRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetCursorNameRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2586,10 +2789,17 @@ impl<'input> crate::x11_utils::VoidRequest for SetCursorNameRequest<'input> {
 
 /// Opcode for the GetCursorName request
 pub const GET_CURSOR_NAME_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorNameRequest {
     pub cursor: xproto::Cursor,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCursorNameRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCursorNameRequest").finish_non_exhaustive()
+    }
 }
 impl GetCursorNameRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2638,13 +2848,20 @@ impl crate::x11_utils::ReplyRequest for GetCursorNameRequest {
     type Reply = GetCursorNameReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorNameReply {
     pub sequence: u16,
     pub length: u32,
     pub atom: xproto::Atom,
     pub name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCursorNameReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCursorNameReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetCursorNameReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2707,9 +2924,16 @@ impl GetCursorNameReply {
 
 /// Opcode for the GetCursorImageAndName request
 pub const GET_CURSOR_IMAGE_AND_NAME_REQUEST: u8 = 25;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorImageAndNameRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCursorImageAndNameRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCursorImageAndNameRequest").finish_non_exhaustive()
+    }
+}
 impl GetCursorImageAndNameRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2750,7 +2974,8 @@ impl crate::x11_utils::ReplyRequest for GetCursorImageAndNameRequest {
     type Reply = GetCursorImageAndNameReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorImageAndNameReply {
     pub sequence: u16,
@@ -2765,6 +2990,12 @@ pub struct GetCursorImageAndNameReply {
     pub cursor_atom: xproto::Atom,
     pub cursor_image: Vec<u32>,
     pub name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCursorImageAndNameReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCursorImageAndNameReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetCursorImageAndNameReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2844,11 +3075,18 @@ impl GetCursorImageAndNameReply {
 
 /// Opcode for the ChangeCursor request
 pub const CHANGE_CURSOR_REQUEST: u8 = 26;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeCursorRequest {
     pub source: xproto::Cursor,
     pub destination: xproto::Cursor,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeCursorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeCursorRequest").finish_non_exhaustive()
+    }
 }
 impl ChangeCursorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2905,11 +3143,18 @@ impl crate::x11_utils::VoidRequest for ChangeCursorRequest {
 
 /// Opcode for the ChangeCursorByName request
 pub const CHANGE_CURSOR_BY_NAME_REQUEST: u8 = 27;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeCursorByNameRequest<'input> {
     pub src: xproto::Cursor,
     pub name: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeCursorByNameRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeCursorByNameRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeCursorByNameRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2979,7 +3224,8 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeCursorByNameRequest<'input>
 
 /// Opcode for the ExpandRegion request
 pub const EXPAND_REGION_REQUEST: u8 = 28;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExpandRegionRequest {
     pub source: Region,
@@ -2988,6 +3234,12 @@ pub struct ExpandRegionRequest {
     pub right: u16,
     pub top: u16,
     pub bottom: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ExpandRegionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ExpandRegionRequest").finish_non_exhaustive()
+    }
 }
 impl ExpandRegionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3064,10 +3316,17 @@ impl crate::x11_utils::VoidRequest for ExpandRegionRequest {
 
 /// Opcode for the HideCursor request
 pub const HIDE_CURSOR_REQUEST: u8 = 29;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HideCursorRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for HideCursorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HideCursorRequest").finish_non_exhaustive()
+    }
 }
 impl HideCursorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3117,10 +3376,17 @@ impl crate::x11_utils::VoidRequest for HideCursorRequest {
 
 /// Opcode for the ShowCursor request
 pub const SHOW_CURSOR_REQUEST: u8 = 30;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ShowCursorRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ShowCursorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ShowCursorRequest").finish_non_exhaustive()
+    }
 }
 impl ShowCursorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3224,7 +3490,8 @@ bitmask_binop!(BarrierDirections, u32);
 
 /// Opcode for the CreatePointerBarrier request
 pub const CREATE_POINTER_BARRIER_REQUEST: u8 = 31;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePointerBarrierRequest<'input> {
     pub barrier: Barrier,
@@ -3235,6 +3502,12 @@ pub struct CreatePointerBarrierRequest<'input> {
     pub y2: u16,
     pub directions: BarrierDirections,
     pub devices: Cow<'input, [u16]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreatePointerBarrierRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreatePointerBarrierRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreatePointerBarrierRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3346,10 +3619,17 @@ impl<'input> crate::x11_utils::VoidRequest for CreatePointerBarrierRequest<'inpu
 
 /// Opcode for the DeletePointerBarrier request
 pub const DELETE_POINTER_BARRIER_REQUEST: u8 = 32;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeletePointerBarrierRequest {
     pub barrier: Barrier,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeletePointerBarrierRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeletePointerBarrierRequest").finish_non_exhaustive()
+    }
 }
 impl DeletePointerBarrierRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3460,10 +3740,17 @@ pub const SET_CLIENT_DISCONNECT_MODE_REQUEST: u8 = 33;
 /// # Fields
 ///
 /// * `disconnect_mode` - The new disconnect mode.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetClientDisconnectModeRequest {
     pub disconnect_mode: ClientDisconnectFlags,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetClientDisconnectModeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetClientDisconnectModeRequest").finish_non_exhaustive()
+    }
 }
 impl SetClientDisconnectModeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3514,9 +3801,16 @@ impl crate::x11_utils::VoidRequest for SetClientDisconnectModeRequest {
 
 /// Opcode for the GetClientDisconnectMode request
 pub const GET_CLIENT_DISCONNECT_MODE_REQUEST: u8 = 34;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClientDisconnectModeRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetClientDisconnectModeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetClientDisconnectModeRequest").finish_non_exhaustive()
+    }
+}
 impl GetClientDisconnectModeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3562,12 +3856,19 @@ impl crate::x11_utils::ReplyRequest for GetClientDisconnectModeRequest {
 /// # Fields
 ///
 /// * `disconnect_mode` - The current disconnect mode.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClientDisconnectModeReply {
     pub sequence: u16,
     pub length: u32,
     pub disconnect_mode: ClientDisconnectFlags,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetClientDisconnectModeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetClientDisconnectModeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetClientDisconnectModeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -82,6 +82,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -423,6 +424,7 @@ impl ChangeSaveSetRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_SAVE_SET_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -768,6 +770,7 @@ impl SelectSelectionInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_SELECTION_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1089,6 +1092,7 @@ impl SelectCursorInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_CURSOR_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1145,6 +1149,7 @@ impl GetCursorImageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CURSOR_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1345,6 +1350,7 @@ impl<'input> CreateRegionRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1427,6 +1433,7 @@ impl CreateRegionFromBitmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REGION_FROM_BITMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1501,6 +1508,7 @@ impl CreateRegionFromWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REGION_FROM_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1573,6 +1581,7 @@ impl CreateRegionFromGCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REGION_FROM_GC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1641,6 +1650,7 @@ impl CreateRegionFromPictureRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REGION_FROM_PICTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1703,6 +1713,7 @@ impl DestroyRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1768,6 +1779,7 @@ impl<'input> SetRegionRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1850,6 +1862,7 @@ impl CopyRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COPY_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1924,6 +1937,7 @@ impl UnionRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNION_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2000,6 +2014,7 @@ impl IntersectRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != INTERSECT_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2076,6 +2091,7 @@ impl SubtractRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SUBTRACT_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2156,6 +2172,7 @@ impl InvertRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != INVERT_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2228,6 +2245,7 @@ impl TranslateRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != TRANSLATE_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2298,6 +2316,7 @@ impl RegionExtentsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != REGION_EXTENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2360,6 +2379,7 @@ impl FetchRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FETCH_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2506,6 +2526,7 @@ impl SetGCClipRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_GC_CLIP_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2592,6 +2613,7 @@ impl SetWindowShapeRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_WINDOW_SHAPE_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2676,6 +2698,7 @@ impl SetPictureClipRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PICTURE_CLIP_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2752,6 +2775,7 @@ impl<'input> SetCursorNameRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CURSOR_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2823,6 +2847,7 @@ impl GetCursorNameRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CURSOR_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2951,6 +2976,7 @@ impl GetCursorImageAndNameRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CURSOR_IMAGE_AND_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3115,6 +3141,7 @@ impl ChangeCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3187,6 +3214,7 @@ impl<'input> ChangeCursorByNameRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_CURSOR_BY_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3280,6 +3308,7 @@ impl ExpandRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != EXPAND_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3350,6 +3379,7 @@ impl HideCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != HIDE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3410,6 +3440,7 @@ impl ShowCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SHOW_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3563,6 +3594,7 @@ impl<'input> CreatePointerBarrierRequest<'input> {
         ([request0.into(), devices_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_POINTER_BARRIER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3653,6 +3685,7 @@ impl DeletePointerBarrierRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_POINTER_BARRIER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3774,6 +3807,7 @@ impl SetClientDisconnectModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CLIENT_DISCONNECT_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3828,6 +3862,7 @@ impl GetClientDisconnectModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CLIENT_DISCONNECT_MODE_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -82,7 +82,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -424,7 +424,7 @@ impl ChangeSaveSetRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_SAVE_SET_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -770,7 +770,7 @@ impl SelectSelectionInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_SELECTION_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1092,7 +1092,7 @@ impl SelectCursorInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_CURSOR_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1149,7 +1149,7 @@ impl GetCursorImageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CURSOR_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1350,7 +1350,7 @@ impl<'input> CreateRegionRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1433,7 +1433,7 @@ impl CreateRegionFromBitmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REGION_FROM_BITMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1508,7 +1508,7 @@ impl CreateRegionFromWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REGION_FROM_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1581,7 +1581,7 @@ impl CreateRegionFromGCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REGION_FROM_GC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1650,7 +1650,7 @@ impl CreateRegionFromPictureRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_REGION_FROM_PICTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1713,7 +1713,7 @@ impl DestroyRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1779,7 +1779,7 @@ impl<'input> SetRegionRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1862,7 +1862,7 @@ impl CopyRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COPY_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1937,7 +1937,7 @@ impl UnionRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNION_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2014,7 +2014,7 @@ impl IntersectRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != INTERSECT_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2091,7 +2091,7 @@ impl SubtractRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SUBTRACT_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2172,7 +2172,7 @@ impl InvertRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != INVERT_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2245,7 +2245,7 @@ impl TranslateRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != TRANSLATE_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2316,7 +2316,7 @@ impl RegionExtentsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != REGION_EXTENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2379,7 +2379,7 @@ impl FetchRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FETCH_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2526,7 +2526,7 @@ impl SetGCClipRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_GC_CLIP_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2613,7 +2613,7 @@ impl SetWindowShapeRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_WINDOW_SHAPE_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2698,7 +2698,7 @@ impl SetPictureClipRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PICTURE_CLIP_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2775,7 +2775,7 @@ impl<'input> SetCursorNameRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CURSOR_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2847,7 +2847,7 @@ impl GetCursorNameRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CURSOR_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2976,7 +2976,7 @@ impl GetCursorImageAndNameRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CURSOR_IMAGE_AND_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3141,7 +3141,7 @@ impl ChangeCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3214,7 +3214,7 @@ impl<'input> ChangeCursorByNameRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_CURSOR_BY_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3308,7 +3308,7 @@ impl ExpandRegionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != EXPAND_REGION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3379,7 +3379,7 @@ impl HideCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != HIDE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3440,7 +3440,7 @@ impl ShowCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SHOW_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3594,7 +3594,7 @@ impl<'input> CreatePointerBarrierRequest<'input> {
         ([request0.into(), devices_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_POINTER_BARRIER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3685,7 +3685,7 @@ impl DeletePointerBarrierRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_POINTER_BARRIER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3807,7 +3807,7 @@ impl SetClientDisconnectModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CLIENT_DISCONNECT_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3862,7 +3862,7 @@ impl GetClientDisconnectModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CLIENT_DISCONNECT_MODE_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xinerama.rs
+++ b/x11rb-protocol/src/protocol/xinerama.rs
@@ -126,6 +126,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -258,6 +259,7 @@ impl GetStateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_STATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -386,6 +388,7 @@ impl GetScreenCountRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SCREEN_COUNT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -520,6 +523,7 @@ impl GetScreenSizeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SCREEN_SIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -665,6 +669,7 @@ impl IsActiveRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != IS_ACTIVE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -782,6 +787,7 @@ impl QueryScreensRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_SCREENS_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xinerama.rs
+++ b/x11rb-protocol/src/protocol/xinerama.rs
@@ -36,13 +36,20 @@ pub const X11_EXTENSION_NAME: &str = "XINERAMA";
 /// send the maximum version of the extension that you need.
 pub const X11_XML_VERSION: (u32, u32) = (1, 1);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScreenInfo {
     pub x_org: i16,
     pub y_org: i16,
     pub width: u16,
     pub height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ScreenInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ScreenInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for ScreenInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -83,11 +90,18 @@ impl Serialize for ScreenInfo {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub major: u8,
     pub minor: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -139,13 +153,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major: u16,
     pub minor: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -203,10 +224,17 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the GetState request
 pub const GET_STATE_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStateRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetStateRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetStateRequest").finish_non_exhaustive()
+    }
 }
 impl GetStateRequest {
     /// Serialize this request into bytes for the provided connection
@@ -255,13 +283,20 @@ impl crate::x11_utils::ReplyRequest for GetStateRequest {
     type Reply = GetStateReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStateReply {
     pub state: u8,
     pub sequence: u16,
     pub length: u32,
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetStateReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetStateReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetStateReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -317,10 +352,17 @@ impl Serialize for GetStateReply {
 
 /// Opcode for the GetScreenCount request
 pub const GET_SCREEN_COUNT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenCountRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenCountRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenCountRequest").finish_non_exhaustive()
+    }
 }
 impl GetScreenCountRequest {
     /// Serialize this request into bytes for the provided connection
@@ -369,13 +411,20 @@ impl crate::x11_utils::ReplyRequest for GetScreenCountRequest {
     type Reply = GetScreenCountReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenCountReply {
     pub screen_count: u8,
     pub sequence: u16,
     pub length: u32,
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenCountReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenCountReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetScreenCountReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -431,11 +480,18 @@ impl Serialize for GetScreenCountReply {
 
 /// Opcode for the GetScreenSize request
 pub const GET_SCREEN_SIZE_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSizeRequest {
     pub window: xproto::Window,
     pub screen: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenSizeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenSizeRequest").finish_non_exhaustive()
+    }
 }
 impl GetScreenSizeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -491,7 +547,8 @@ impl crate::x11_utils::ReplyRequest for GetScreenSizeRequest {
     type Reply = GetScreenSizeReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSizeReply {
     pub sequence: u16,
@@ -500,6 +557,12 @@ pub struct GetScreenSizeReply {
     pub height: u32,
     pub window: xproto::Window,
     pub screen: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenSizeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenSizeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetScreenSizeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -575,9 +638,16 @@ impl Serialize for GetScreenSizeReply {
 
 /// Opcode for the IsActive request
 pub const IS_ACTIVE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsActiveRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IsActiveRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IsActiveRequest").finish_non_exhaustive()
+    }
+}
 impl IsActiveRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -618,12 +688,19 @@ impl crate::x11_utils::ReplyRequest for IsActiveRequest {
     type Reply = IsActiveReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsActiveReply {
     pub sequence: u16,
     pub length: u32,
     pub state: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IsActiveReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IsActiveReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for IsActiveReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -678,9 +755,16 @@ impl Serialize for IsActiveReply {
 
 /// Opcode for the QueryScreens request
 pub const QUERY_SCREENS_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryScreensRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryScreensRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryScreensRequest").finish_non_exhaustive()
+    }
+}
 impl QueryScreensRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -721,12 +805,19 @@ impl crate::x11_utils::ReplyRequest for QueryScreensRequest {
     type Reply = QueryScreensReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryScreensReply {
     pub sequence: u16,
     pub length: u32,
     pub screen_info: Vec<ScreenInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryScreensReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryScreensReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryScreensReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/xinerama.rs
+++ b/x11rb-protocol/src/protocol/xinerama.rs
@@ -126,7 +126,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -259,7 +259,7 @@ impl GetStateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_STATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -388,7 +388,7 @@ impl GetScreenCountRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SCREEN_COUNT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -523,7 +523,7 @@ impl GetScreenSizeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SCREEN_SIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -669,7 +669,7 @@ impl IsActiveRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != IS_ACTIVE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -787,7 +787,7 @@ impl QueryScreensRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_SCREENS_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -46,11 +46,18 @@ pub type DeviceId = u16;
 
 pub type Fp1616 = i32;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Fp3232 {
     pub integral: i32,
     pub frac: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Fp3232 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Fp3232").finish_non_exhaustive()
+    }
 }
 impl TryParse for Fp3232 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -85,10 +92,17 @@ impl Serialize for Fp3232 {
 
 /// Opcode for the GetExtensionVersion request
 pub const GET_EXTENSION_VERSION_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetExtensionVersionRequest<'input> {
     pub name: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for GetExtensionVersionRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetExtensionVersionRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> GetExtensionVersionRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -149,7 +163,8 @@ impl<'input> crate::x11_utils::ReplyRequest for GetExtensionVersionRequest<'inpu
     type Reply = GetExtensionVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetExtensionVersionReply {
     pub xi_reply_type: u8,
@@ -158,6 +173,12 @@ pub struct GetExtensionVersionReply {
     pub server_major: u16,
     pub server_minor: u16,
     pub present: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetExtensionVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetExtensionVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetExtensionVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -432,13 +453,20 @@ impl core::fmt::Debug for ValuatorMode  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceInfo {
     pub device_type: xproto::Atom,
     pub device_id: u8,
     pub num_class_info: u8,
     pub device_use: DeviceUse,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -480,7 +508,8 @@ impl Serialize for DeviceInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyInfo {
     pub class_id: InputClass,
@@ -488,6 +517,12 @@ pub struct KeyInfo {
     pub min_keycode: KeyCode,
     pub max_keycode: KeyCode,
     pub num_keys: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KeyInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeyInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for KeyInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -532,12 +567,19 @@ impl Serialize for KeyInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ButtonInfo {
     pub class_id: InputClass,
     pub len: u8,
     pub num_buttons: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ButtonInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ButtonInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for ButtonInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -570,12 +612,19 @@ impl Serialize for ButtonInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AxisInfo {
     pub resolution: u32,
     pub minimum: i32,
     pub maximum: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AxisInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AxisInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for AxisInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -615,7 +664,8 @@ impl Serialize for AxisInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValuatorInfo {
     pub class_id: InputClass,
@@ -623,6 +673,12 @@ pub struct ValuatorInfo {
     pub mode: ValuatorMode,
     pub motion_size: u32,
     pub axes: Vec<AxisInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ValuatorInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ValuatorInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for ValuatorInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -672,12 +728,19 @@ impl ValuatorInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputInfoInfoKey {
     pub min_keycode: KeyCode,
     pub max_keycode: KeyCode,
     pub num_keys: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputInfoInfoKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputInfoInfoKey").finish_non_exhaustive()
+    }
 }
 impl TryParse for InputInfoInfoKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -712,10 +775,17 @@ impl Serialize for InputInfoInfoKey {
         bytes.extend_from_slice(&[0; 2]);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputInfoInfoButton {
     pub num_buttons: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputInfoInfoButton {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputInfoInfoButton").finish_non_exhaustive()
+    }
 }
 impl TryParse for InputInfoInfoButton {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -738,12 +808,19 @@ impl Serialize for InputInfoInfoButton {
         self.num_buttons.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputInfoInfoValuator {
     pub mode: ValuatorMode,
     pub motion_size: u32,
     pub axes: Vec<AxisInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputInfoInfoValuator {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputInfoInfoValuator").finish_non_exhaustive()
+    }
 }
 impl TryParse for InputInfoInfoValuator {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -787,7 +864,8 @@ impl InputInfoInfoValuator {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum InputInfoInfo {
     Key(InputInfoInfoKey),
@@ -802,6 +880,12 @@ pub enum InputInfoInfo {
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
     InvalidValue(u8),
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputInfoInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputInfoInfo").finish_non_exhaustive()
+    }
 }
 impl InputInfoInfo {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -880,11 +964,18 @@ impl InputInfoInfo {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputInfo {
     pub len: u8,
     pub info: InputInfoInfo,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for InputInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -911,10 +1002,17 @@ impl Serialize for InputInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceName {
     pub string: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceName {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceName").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceName {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -957,9 +1055,16 @@ impl DeviceName {
 
 /// Opcode for the ListInputDevices request
 pub const LIST_INPUT_DEVICES_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListInputDevicesRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListInputDevicesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListInputDevicesRequest").finish_non_exhaustive()
+    }
+}
 impl ListInputDevicesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1000,7 +1105,8 @@ impl crate::x11_utils::ReplyRequest for ListInputDevicesRequest {
     type Reply = ListInputDevicesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListInputDevicesReply {
     pub xi_reply_type: u8,
@@ -1009,6 +1115,12 @@ pub struct ListInputDevicesReply {
     pub devices: Vec<DeviceInfo>,
     pub infos: Vec<InputInfo>,
     pub names: Vec<xproto::Str>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListInputDevicesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListInputDevicesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListInputDevicesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1080,11 +1192,18 @@ impl ListInputDevicesReply {
 
 pub type EventTypeBase = u8;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputClassInfo {
     pub class_id: InputClass,
     pub event_type_base: EventTypeBase,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputClassInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputClassInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for InputClassInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1114,10 +1233,17 @@ impl Serialize for InputClassInfo {
 
 /// Opcode for the OpenDevice request
 pub const OPEN_DEVICE_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenDeviceRequest {
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for OpenDeviceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OpenDeviceRequest").finish_non_exhaustive()
+    }
 }
 impl OpenDeviceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1167,13 +1293,20 @@ impl crate::x11_utils::ReplyRequest for OpenDeviceRequest {
     type Reply = OpenDeviceReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenDeviceReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub class_info: Vec<InputClassInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for OpenDeviceReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OpenDeviceReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for OpenDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1239,10 +1372,17 @@ impl OpenDeviceReply {
 
 /// Opcode for the CloseDevice request
 pub const CLOSE_DEVICE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CloseDeviceRequest {
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CloseDeviceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CloseDeviceRequest").finish_non_exhaustive()
+    }
 }
 impl CloseDeviceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1293,11 +1433,18 @@ impl crate::x11_utils::VoidRequest for CloseDeviceRequest {
 
 /// Opcode for the SetDeviceMode request
 pub const SET_DEVICE_MODE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceModeRequest {
     pub device_id: u8,
     pub mode: ValuatorMode,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetDeviceModeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDeviceModeRequest").finish_non_exhaustive()
+    }
 }
 impl SetDeviceModeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1351,13 +1498,20 @@ impl crate::x11_utils::ReplyRequest for SetDeviceModeRequest {
     type Reply = SetDeviceModeReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceModeReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub status: xproto::GrabStatus,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetDeviceModeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDeviceModeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetDeviceModeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1436,11 +1590,18 @@ impl Serialize for SetDeviceModeReply {
 
 /// Opcode for the SelectExtensionEvent request
 pub const SELECT_EXTENSION_EVENT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectExtensionEventRequest<'input> {
     pub window: xproto::Window,
     pub classes: Cow<'input, [EventClass]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SelectExtensionEventRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectExtensionEventRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SelectExtensionEventRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1511,10 +1672,17 @@ impl<'input> crate::x11_utils::VoidRequest for SelectExtensionEventRequest<'inpu
 
 /// Opcode for the GetSelectedExtensionEvents request
 pub const GET_SELECTED_EXTENSION_EVENTS_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectedExtensionEventsRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSelectedExtensionEventsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSelectedExtensionEventsRequest").finish_non_exhaustive()
+    }
 }
 impl GetSelectedExtensionEventsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1563,7 +1731,8 @@ impl crate::x11_utils::ReplyRequest for GetSelectedExtensionEventsRequest {
     type Reply = GetSelectedExtensionEventsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectedExtensionEventsReply {
     pub xi_reply_type: u8,
@@ -1571,6 +1740,12 @@ pub struct GetSelectedExtensionEventsReply {
     pub length: u32,
     pub this_classes: Vec<EventClass>,
     pub all_classes: Vec<EventClass>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSelectedExtensionEventsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSelectedExtensionEventsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetSelectedExtensionEventsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1707,12 +1882,19 @@ impl core::fmt::Debug for PropagateMode  {
 
 /// Opcode for the ChangeDeviceDontPropagateList request
 pub const CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDeviceDontPropagateListRequest<'input> {
     pub window: xproto::Window,
     pub mode: PropagateMode,
     pub classes: Cow<'input, [EventClass]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeDeviceDontPropagateListRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeDeviceDontPropagateListRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1788,10 +1970,17 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeDeviceDontPropagateListRequ
 
 /// Opcode for the GetDeviceDontPropagateList request
 pub const GET_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceDontPropagateListRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceDontPropagateListRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceDontPropagateListRequest").finish_non_exhaustive()
+    }
 }
 impl GetDeviceDontPropagateListRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1840,13 +2029,20 @@ impl crate::x11_utils::ReplyRequest for GetDeviceDontPropagateListRequest {
     type Reply = GetDeviceDontPropagateListReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceDontPropagateListReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub classes: Vec<EventClass>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceDontPropagateListReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceDontPropagateListReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDeviceDontPropagateListReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1904,11 +2100,18 @@ impl GetDeviceDontPropagateListReply {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceTimeCoord {
     pub time: xproto::Timestamp,
     pub axisvalues: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceTimeCoord {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceTimeCoord").finish_non_exhaustive()
+    }
 }
 impl DeviceTimeCoord {
     pub fn try_parse(remaining: &[u8], num_axes: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -1934,12 +2137,19 @@ impl DeviceTimeCoord {
 
 /// Opcode for the GetDeviceMotionEvents request
 pub const GET_DEVICE_MOTION_EVENTS_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceMotionEventsRequest {
     pub start: xproto::Timestamp,
     pub stop: xproto::Timestamp,
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceMotionEventsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceMotionEventsRequest").finish_non_exhaustive()
+    }
 }
 impl GetDeviceMotionEventsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2003,7 +2213,8 @@ impl crate::x11_utils::ReplyRequest for GetDeviceMotionEventsRequest {
     type Reply = GetDeviceMotionEventsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceMotionEventsReply {
     pub xi_reply_type: u8,
@@ -2012,6 +2223,12 @@ pub struct GetDeviceMotionEventsReply {
     pub num_axes: u8,
     pub device_mode: ValuatorMode,
     pub events: Vec<DeviceTimeCoord>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceMotionEventsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceMotionEventsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDeviceMotionEventsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2085,10 +2302,17 @@ impl GetDeviceMotionEventsReply {
 
 /// Opcode for the ChangeKeyboardDevice request
 pub const CHANGE_KEYBOARD_DEVICE_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeKeyboardDeviceRequest {
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeKeyboardDeviceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeKeyboardDeviceRequest").finish_non_exhaustive()
+    }
 }
 impl ChangeKeyboardDeviceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2138,13 +2362,20 @@ impl crate::x11_utils::ReplyRequest for ChangeKeyboardDeviceRequest {
     type Reply = ChangeKeyboardDeviceReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeKeyboardDeviceReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub status: xproto::GrabStatus,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeKeyboardDeviceReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeKeyboardDeviceReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ChangeKeyboardDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2223,12 +2454,19 @@ impl Serialize for ChangeKeyboardDeviceReply {
 
 /// Opcode for the ChangePointerDevice request
 pub const CHANGE_POINTER_DEVICE_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangePointerDeviceRequest {
     pub x_axis: u8,
     pub y_axis: u8,
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangePointerDeviceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangePointerDeviceRequest").finish_non_exhaustive()
+    }
 }
 impl ChangePointerDeviceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2284,13 +2522,20 @@ impl crate::x11_utils::ReplyRequest for ChangePointerDeviceRequest {
     type Reply = ChangePointerDeviceReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangePointerDeviceReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub status: xproto::GrabStatus,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangePointerDeviceReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangePointerDeviceReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ChangePointerDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2369,7 +2614,8 @@ impl Serialize for ChangePointerDeviceReply {
 
 /// Opcode for the GrabDevice request
 pub const GRAB_DEVICE_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabDeviceRequest<'input> {
     pub grab_window: xproto::Window,
@@ -2379,6 +2625,12 @@ pub struct GrabDeviceRequest<'input> {
     pub owner_events: bool,
     pub device_id: u8,
     pub classes: Cow<'input, [EventClass]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for GrabDeviceRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabDeviceRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> GrabDeviceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2478,13 +2730,20 @@ impl<'input> crate::x11_utils::ReplyRequest for GrabDeviceRequest<'input> {
     type Reply = GrabDeviceReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabDeviceReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub status: xproto::GrabStatus,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GrabDeviceReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabDeviceReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GrabDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2563,11 +2822,18 @@ impl Serialize for GrabDeviceReply {
 
 /// Opcode for the UngrabDevice request
 pub const UNGRAB_DEVICE_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabDeviceRequest {
     pub time: xproto::Timestamp,
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UngrabDeviceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UngrabDeviceRequest").finish_non_exhaustive()
+    }
 }
 impl UngrabDeviceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2682,7 +2948,8 @@ impl core::fmt::Debug for ModifierDevice  {
 
 /// Opcode for the GrabDeviceKey request
 pub const GRAB_DEVICE_KEY_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabDeviceKeyRequest<'input> {
     pub grab_window: xproto::Window,
@@ -2694,6 +2961,12 @@ pub struct GrabDeviceKeyRequest<'input> {
     pub other_device_mode: xproto::GrabMode,
     pub owner_events: bool,
     pub classes: Cow<'input, [EventClass]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for GrabDeviceKeyRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabDeviceKeyRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> GrabDeviceKeyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2803,7 +3076,8 @@ impl<'input> crate::x11_utils::VoidRequest for GrabDeviceKeyRequest<'input> {
 
 /// Opcode for the UngrabDeviceKey request
 pub const UNGRAB_DEVICE_KEY_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabDeviceKeyRequest {
     pub grab_window: xproto::Window,
@@ -2811,6 +3085,12 @@ pub struct UngrabDeviceKeyRequest {
     pub modifier_device: u8,
     pub key: u8,
     pub grabbed_device: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UngrabDeviceKeyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UngrabDeviceKeyRequest").finish_non_exhaustive()
+    }
 }
 impl UngrabDeviceKeyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2881,7 +3161,8 @@ impl crate::x11_utils::VoidRequest for UngrabDeviceKeyRequest {
 
 /// Opcode for the GrabDeviceButton request
 pub const GRAB_DEVICE_BUTTON_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabDeviceButtonRequest<'input> {
     pub grab_window: xproto::Window,
@@ -2893,6 +3174,12 @@ pub struct GrabDeviceButtonRequest<'input> {
     pub button: u8,
     pub owner_events: bool,
     pub classes: Cow<'input, [EventClass]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for GrabDeviceButtonRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabDeviceButtonRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> GrabDeviceButtonRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3002,7 +3289,8 @@ impl<'input> crate::x11_utils::VoidRequest for GrabDeviceButtonRequest<'input> {
 
 /// Opcode for the UngrabDeviceButton request
 pub const UNGRAB_DEVICE_BUTTON_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabDeviceButtonRequest {
     pub grab_window: xproto::Window,
@@ -3010,6 +3298,12 @@ pub struct UngrabDeviceButtonRequest {
     pub modifier_device: u8,
     pub button: u8,
     pub grabbed_device: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UngrabDeviceButtonRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UngrabDeviceButtonRequest").finish_non_exhaustive()
+    }
 }
 impl UngrabDeviceButtonRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3148,12 +3442,19 @@ impl core::fmt::Debug for DeviceInputMode  {
 
 /// Opcode for the AllowDeviceEvents request
 pub const ALLOW_DEVICE_EVENTS_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllowDeviceEventsRequest {
     pub time: xproto::Timestamp,
     pub mode: DeviceInputMode,
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AllowDeviceEventsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllowDeviceEventsRequest").finish_non_exhaustive()
+    }
 }
 impl AllowDeviceEventsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3215,10 +3516,17 @@ impl crate::x11_utils::VoidRequest for AllowDeviceEventsRequest {
 
 /// Opcode for the GetDeviceFocus request
 pub const GET_DEVICE_FOCUS_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceFocusRequest {
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceFocusRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceFocusRequest").finish_non_exhaustive()
+    }
 }
 impl GetDeviceFocusRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3268,7 +3576,8 @@ impl crate::x11_utils::ReplyRequest for GetDeviceFocusRequest {
     type Reply = GetDeviceFocusReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceFocusReply {
     pub xi_reply_type: u8,
@@ -3277,6 +3586,12 @@ pub struct GetDeviceFocusReply {
     pub focus: xproto::Window,
     pub time: xproto::Timestamp,
     pub revert_to: xproto::InputFocus,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceFocusReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceFocusReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDeviceFocusReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3361,13 +3676,20 @@ impl Serialize for GetDeviceFocusReply {
 
 /// Opcode for the SetDeviceFocus request
 pub const SET_DEVICE_FOCUS_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceFocusRequest {
     pub focus: xproto::Window,
     pub time: xproto::Timestamp,
     pub revert_to: xproto::InputFocus,
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetDeviceFocusRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDeviceFocusRequest").finish_non_exhaustive()
+    }
 }
 impl SetDeviceFocusRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3501,7 +3823,8 @@ impl core::fmt::Debug for FeedbackClass  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KbdFeedbackState {
     pub class_id: FeedbackClass,
@@ -3515,6 +3838,12 @@ pub struct KbdFeedbackState {
     pub click: u8,
     pub percent: u8,
     pub auto_repeats: [u8; 32],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KbdFeedbackState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KbdFeedbackState").finish_non_exhaustive()
+    }
 }
 impl TryParse for KbdFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3620,7 +3949,8 @@ impl Serialize for KbdFeedbackState {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PtrFeedbackState {
     pub class_id: FeedbackClass,
@@ -3629,6 +3959,12 @@ pub struct PtrFeedbackState {
     pub accel_num: u16,
     pub accel_denom: u16,
     pub threshold: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PtrFeedbackState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PtrFeedbackState").finish_non_exhaustive()
+    }
 }
 impl TryParse for PtrFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3680,7 +4016,8 @@ impl Serialize for PtrFeedbackState {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IntegerFeedbackState {
     pub class_id: FeedbackClass,
@@ -3689,6 +4026,12 @@ pub struct IntegerFeedbackState {
     pub resolution: u32,
     pub min_value: i32,
     pub max_value: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IntegerFeedbackState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IntegerFeedbackState").finish_non_exhaustive()
+    }
 }
 impl TryParse for IntegerFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3742,7 +4085,8 @@ impl Serialize for IntegerFeedbackState {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StringFeedbackState {
     pub class_id: FeedbackClass,
@@ -3750,6 +4094,12 @@ pub struct StringFeedbackState {
     pub len: u16,
     pub max_symbols: u16,
     pub keysyms: Vec<xproto::Keysym>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for StringFeedbackState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StringFeedbackState").finish_non_exhaustive()
+    }
 }
 impl TryParse for StringFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3798,7 +4148,8 @@ impl StringFeedbackState {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BellFeedbackState {
     pub class_id: FeedbackClass,
@@ -3807,6 +4158,12 @@ pub struct BellFeedbackState {
     pub percent: u8,
     pub pitch: u16,
     pub duration: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BellFeedbackState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BellFeedbackState").finish_non_exhaustive()
+    }
 }
 impl TryParse for BellFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3858,7 +4215,8 @@ impl Serialize for BellFeedbackState {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LedFeedbackState {
     pub class_id: FeedbackClass,
@@ -3866,6 +4224,12 @@ pub struct LedFeedbackState {
     pub len: u16,
     pub led_mask: u32,
     pub led_values: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for LedFeedbackState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LedFeedbackState").finish_non_exhaustive()
+    }
 }
 impl TryParse for LedFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3912,7 +4276,8 @@ impl Serialize for LedFeedbackState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackStateDataKeyboard {
     pub pitch: u16,
@@ -3923,6 +4288,12 @@ pub struct FeedbackStateDataKeyboard {
     pub click: u8,
     pub percent: u8,
     pub auto_repeats: [u8; 32],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackStateDataKeyboard {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackStateDataKeyboard").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackStateDataKeyboard {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4013,12 +4384,19 @@ impl Serialize for FeedbackStateDataKeyboard {
         bytes.extend_from_slice(&self.auto_repeats);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackStateDataPointer {
     pub accel_num: u16,
     pub accel_denom: u16,
     pub threshold: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackStateDataPointer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackStateDataPointer").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackStateDataPointer {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4055,11 +4433,18 @@ impl Serialize for FeedbackStateDataPointer {
         self.threshold.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackStateDataString {
     pub max_symbols: u16,
     pub keysyms: Vec<xproto::Keysym>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackStateDataString {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackStateDataString").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackStateDataString {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4100,12 +4485,19 @@ impl FeedbackStateDataString {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackStateDataInteger {
     pub resolution: u32,
     pub min_value: i32,
     pub max_value: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackStateDataInteger {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackStateDataInteger").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackStateDataInteger {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4144,11 +4536,18 @@ impl Serialize for FeedbackStateDataInteger {
         self.max_value.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackStateDataLed {
     pub led_mask: u32,
     pub led_values: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackStateDataLed {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackStateDataLed").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackStateDataLed {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4180,12 +4579,19 @@ impl Serialize for FeedbackStateDataLed {
         self.led_values.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackStateDataBell {
     pub percent: u8,
     pub pitch: u16,
     pub duration: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackStateDataBell {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackStateDataBell").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackStateDataBell {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4222,7 +4628,8 @@ impl Serialize for FeedbackStateDataBell {
         self.duration.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FeedbackStateData {
     Keyboard(FeedbackStateDataKeyboard),
@@ -4240,6 +4647,12 @@ pub enum FeedbackStateData {
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
     InvalidValue(u8),
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackStateData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackStateData").finish_non_exhaustive()
+    }
 }
 impl FeedbackStateData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -4360,12 +4773,19 @@ impl FeedbackStateData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackState {
     pub feedback_id: u8,
     pub len: u16,
     pub data: FeedbackStateData,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackState").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4396,10 +4816,17 @@ impl Serialize for FeedbackState {
 
 /// Opcode for the GetFeedbackControl request
 pub const GET_FEEDBACK_CONTROL_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFeedbackControlRequest {
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetFeedbackControlRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetFeedbackControlRequest").finish_non_exhaustive()
+    }
 }
 impl GetFeedbackControlRequest {
     /// Serialize this request into bytes for the provided connection
@@ -4449,13 +4876,20 @@ impl crate::x11_utils::ReplyRequest for GetFeedbackControlRequest {
     type Reply = GetFeedbackControlReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFeedbackControlReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub feedbacks: Vec<FeedbackState>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetFeedbackControlReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetFeedbackControlReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetFeedbackControlReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4513,7 +4947,8 @@ impl GetFeedbackControlReply {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KbdFeedbackCtl {
     pub class_id: FeedbackClass,
@@ -4527,6 +4962,12 @@ pub struct KbdFeedbackCtl {
     pub bell_duration: i16,
     pub led_mask: u32,
     pub led_values: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KbdFeedbackCtl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KbdFeedbackCtl").finish_non_exhaustive()
+    }
 }
 impl TryParse for KbdFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4599,7 +5040,8 @@ impl Serialize for KbdFeedbackCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PtrFeedbackCtl {
     pub class_id: FeedbackClass,
@@ -4608,6 +5050,12 @@ pub struct PtrFeedbackCtl {
     pub num: i16,
     pub denom: i16,
     pub threshold: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PtrFeedbackCtl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PtrFeedbackCtl").finish_non_exhaustive()
+    }
 }
 impl TryParse for PtrFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4659,13 +5107,20 @@ impl Serialize for PtrFeedbackCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IntegerFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
     pub len: u16,
     pub int_to_display: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IntegerFeedbackCtl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IntegerFeedbackCtl").finish_non_exhaustive()
+    }
 }
 impl TryParse for IntegerFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4705,13 +5160,20 @@ impl Serialize for IntegerFeedbackCtl {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StringFeedbackCtl {
     pub class_id: FeedbackClass,
     pub feedback_id: u8,
     pub len: u16,
     pub keysyms: Vec<xproto::Keysym>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for StringFeedbackCtl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StringFeedbackCtl").finish_non_exhaustive()
+    }
 }
 impl TryParse for StringFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4760,7 +5222,8 @@ impl StringFeedbackCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BellFeedbackCtl {
     pub class_id: FeedbackClass,
@@ -4769,6 +5232,12 @@ pub struct BellFeedbackCtl {
     pub percent: i8,
     pub pitch: i16,
     pub duration: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BellFeedbackCtl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BellFeedbackCtl").finish_non_exhaustive()
+    }
 }
 impl TryParse for BellFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4820,7 +5289,8 @@ impl Serialize for BellFeedbackCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LedFeedbackCtl {
     pub class_id: FeedbackClass,
@@ -4828,6 +5298,12 @@ pub struct LedFeedbackCtl {
     pub len: u16,
     pub led_mask: u32,
     pub led_values: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for LedFeedbackCtl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LedFeedbackCtl").finish_non_exhaustive()
+    }
 }
 impl TryParse for LedFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4874,7 +5350,8 @@ impl Serialize for LedFeedbackCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtlDataKeyboard {
     pub key: KeyCode,
@@ -4885,6 +5362,12 @@ pub struct FeedbackCtlDataKeyboard {
     pub bell_duration: i16,
     pub led_mask: u32,
     pub led_values: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackCtlDataKeyboard {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackCtlDataKeyboard").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackCtlDataKeyboard {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4942,12 +5425,19 @@ impl Serialize for FeedbackCtlDataKeyboard {
         self.led_values.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtlDataPointer {
     pub num: i16,
     pub denom: i16,
     pub threshold: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackCtlDataPointer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackCtlDataPointer").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackCtlDataPointer {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4984,10 +5474,17 @@ impl Serialize for FeedbackCtlDataPointer {
         self.threshold.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtlDataString {
     pub keysyms: Vec<xproto::Keysym>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackCtlDataString {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackCtlDataString").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackCtlDataString {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5028,10 +5525,17 @@ impl FeedbackCtlDataString {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtlDataInteger {
     pub int_to_display: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackCtlDataInteger {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackCtlDataInteger").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackCtlDataInteger {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5056,11 +5560,18 @@ impl Serialize for FeedbackCtlDataInteger {
         self.int_to_display.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtlDataLed {
     pub led_mask: u32,
     pub led_values: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackCtlDataLed {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackCtlDataLed").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackCtlDataLed {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5092,12 +5603,19 @@ impl Serialize for FeedbackCtlDataLed {
         self.led_values.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtlDataBell {
     pub percent: i8,
     pub pitch: i16,
     pub duration: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackCtlDataBell {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackCtlDataBell").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackCtlDataBell {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5134,7 +5652,8 @@ impl Serialize for FeedbackCtlDataBell {
         self.duration.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FeedbackCtlData {
     Keyboard(FeedbackCtlDataKeyboard),
@@ -5152,6 +5671,12 @@ pub enum FeedbackCtlData {
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
     InvalidValue(u8),
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackCtlData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackCtlData").finish_non_exhaustive()
+    }
 }
 impl FeedbackCtlData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -5272,12 +5797,19 @@ impl FeedbackCtlData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeedbackCtl {
     pub feedback_id: u8,
     pub len: u16,
     pub data: FeedbackCtlData,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FeedbackCtl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FeedbackCtl").finish_non_exhaustive()
+    }
 }
 impl TryParse for FeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5378,13 +5910,20 @@ bitmask_binop!(ChangeFeedbackControlMask, u32);
 
 /// Opcode for the ChangeFeedbackControl request
 pub const CHANGE_FEEDBACK_CONTROL_REQUEST: u8 = 23;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeFeedbackControlRequest {
     pub mask: ChangeFeedbackControlMask,
     pub device_id: u8,
     pub feedback_id: u8,
     pub feedback: FeedbackCtl,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeFeedbackControlRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeFeedbackControlRequest").finish_non_exhaustive()
+    }
 }
 impl ChangeFeedbackControlRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5452,12 +5991,19 @@ impl crate::x11_utils::VoidRequest for ChangeFeedbackControlRequest {
 
 /// Opcode for the GetDeviceKeyMapping request
 pub const GET_DEVICE_KEY_MAPPING_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceKeyMappingRequest {
     pub device_id: u8,
     pub first_keycode: KeyCode,
     pub count: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceKeyMappingRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceKeyMappingRequest").finish_non_exhaustive()
+    }
 }
 impl GetDeviceKeyMappingRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5513,13 +6059,20 @@ impl crate::x11_utils::ReplyRequest for GetDeviceKeyMappingRequest {
     type Reply = GetDeviceKeyMappingReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceKeyMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub keysyms_per_keycode: u8,
     pub keysyms: Vec<xproto::Keysym>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceKeyMappingReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceKeyMappingReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDeviceKeyMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5579,7 +6132,8 @@ impl GetDeviceKeyMappingReply {
 
 /// Opcode for the ChangeDeviceKeyMapping request
 pub const CHANGE_DEVICE_KEY_MAPPING_REQUEST: u8 = 25;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDeviceKeyMappingRequest<'input> {
     pub device_id: u8,
@@ -5587,6 +6141,12 @@ pub struct ChangeDeviceKeyMappingRequest<'input> {
     pub keysyms_per_keycode: u8,
     pub keycode_count: u8,
     pub keysyms: Cow<'input, [xproto::Keysym]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeDeviceKeyMappingRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeDeviceKeyMappingRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeDeviceKeyMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -5662,10 +6222,17 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeDeviceKeyMappingRequest<'in
 
 /// Opcode for the GetDeviceModifierMapping request
 pub const GET_DEVICE_MODIFIER_MAPPING_REQUEST: u8 = 26;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceModifierMappingRequest {
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceModifierMappingRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceModifierMappingRequest").finish_non_exhaustive()
+    }
 }
 impl GetDeviceModifierMappingRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5715,13 +6282,20 @@ impl crate::x11_utils::ReplyRequest for GetDeviceModifierMappingRequest {
     type Reply = GetDeviceModifierMappingReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceModifierMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub keymaps: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceModifierMappingReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceModifierMappingReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDeviceModifierMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5784,11 +6358,18 @@ impl GetDeviceModifierMappingReply {
 
 /// Opcode for the SetDeviceModifierMapping request
 pub const SET_DEVICE_MODIFIER_MAPPING_REQUEST: u8 = 27;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceModifierMappingRequest<'input> {
     pub device_id: u8,
     pub keymaps: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetDeviceModifierMappingRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDeviceModifierMappingRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetDeviceModifierMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -5854,13 +6435,20 @@ impl<'input> crate::x11_utils::ReplyRequest for SetDeviceModifierMappingRequest<
     type Reply = SetDeviceModifierMappingReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceModifierMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub status: xproto::MappingStatus,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetDeviceModifierMappingReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDeviceModifierMappingReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetDeviceModifierMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5939,10 +6527,17 @@ impl Serialize for SetDeviceModifierMappingReply {
 
 /// Opcode for the GetDeviceButtonMapping request
 pub const GET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 28;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceButtonMappingRequest {
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceButtonMappingRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceButtonMappingRequest").finish_non_exhaustive()
+    }
 }
 impl GetDeviceButtonMappingRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5992,13 +6587,20 @@ impl crate::x11_utils::ReplyRequest for GetDeviceButtonMappingRequest {
     type Reply = GetDeviceButtonMappingReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceButtonMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub map: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceButtonMappingReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceButtonMappingReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDeviceButtonMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6065,11 +6667,18 @@ impl GetDeviceButtonMappingReply {
 
 /// Opcode for the SetDeviceButtonMapping request
 pub const SET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 29;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceButtonMappingRequest<'input> {
     pub device_id: u8,
     pub map: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetDeviceButtonMappingRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDeviceButtonMappingRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetDeviceButtonMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -6134,13 +6743,20 @@ impl<'input> crate::x11_utils::ReplyRequest for SetDeviceButtonMappingRequest<'i
     type Reply = SetDeviceButtonMappingReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceButtonMappingReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub status: xproto::MappingStatus,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetDeviceButtonMappingReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDeviceButtonMappingReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetDeviceButtonMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6217,13 +6833,20 @@ impl Serialize for SetDeviceButtonMappingReply {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyState {
     pub class_id: InputClass,
     pub len: u8,
     pub num_keys: u8,
     pub keys: [u8; 32],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KeyState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeyState").finish_non_exhaustive()
+    }
 }
 impl TryParse for KeyState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6292,13 +6915,20 @@ impl Serialize for KeyState {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ButtonState {
     pub class_id: InputClass,
     pub len: u8,
     pub num_buttons: u8,
     pub buttons: [u8; 32],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ButtonState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ButtonState").finish_non_exhaustive()
+    }
 }
 impl TryParse for ButtonState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6427,13 +7057,20 @@ impl core::fmt::Debug for ValuatorStateModeMask  {
 }
 bitmask_binop!(ValuatorStateModeMask, u8);
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValuatorState {
     pub class_id: InputClass,
     pub len: u8,
     pub mode: ValuatorStateModeMask,
     pub valuators: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ValuatorState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ValuatorState").finish_non_exhaustive()
+    }
 }
 impl TryParse for ValuatorState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6481,11 +7118,18 @@ impl ValuatorState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputStateDataKey {
     pub num_keys: u8,
     pub keys: [u8; 32],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputStateDataKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputStateDataKey").finish_non_exhaustive()
+    }
 }
 impl TryParse for InputStateDataKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6544,11 +7188,18 @@ impl Serialize for InputStateDataKey {
         bytes.extend_from_slice(&self.keys);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputStateDataButton {
     pub num_buttons: u8,
     pub buttons: [u8; 32],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputStateDataButton {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputStateDataButton").finish_non_exhaustive()
+    }
 }
 impl TryParse for InputStateDataButton {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6607,11 +7258,18 @@ impl Serialize for InputStateDataButton {
         bytes.extend_from_slice(&self.buttons);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputStateDataValuator {
     pub mode: ValuatorStateModeMask,
     pub valuators: Vec<i32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputStateDataValuator {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputStateDataValuator").finish_non_exhaustive()
+    }
 }
 impl TryParse for InputStateDataValuator {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6653,7 +7311,8 @@ impl InputStateDataValuator {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum InputStateData {
     Key(InputStateDataKey),
@@ -6668,6 +7327,12 @@ pub enum InputStateData {
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
     InvalidValue(u8),
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputStateData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputStateData").finish_non_exhaustive()
+    }
 }
 impl InputStateData {
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -6746,11 +7411,18 @@ impl InputStateData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InputState {
     pub len: u8,
     pub data: InputStateData,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InputState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputState").finish_non_exhaustive()
+    }
 }
 impl TryParse for InputState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6779,10 +7451,17 @@ impl Serialize for InputState {
 
 /// Opcode for the QueryDeviceState request
 pub const QUERY_DEVICE_STATE_REQUEST: u8 = 30;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryDeviceStateRequest {
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryDeviceStateRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryDeviceStateRequest").finish_non_exhaustive()
+    }
 }
 impl QueryDeviceStateRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6832,13 +7511,20 @@ impl crate::x11_utils::ReplyRequest for QueryDeviceStateRequest {
     type Reply = QueryDeviceStateReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryDeviceStateReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub classes: Vec<InputState>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryDeviceStateReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryDeviceStateReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryDeviceStateReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6898,13 +7584,20 @@ impl QueryDeviceStateReply {
 
 /// Opcode for the DeviceBell request
 pub const DEVICE_BELL_REQUEST: u8 = 32;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceBellRequest {
     pub device_id: u8,
     pub feedback_id: u8,
     pub feedback_class: u8,
     pub percent: i8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceBellRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceBellRequest").finish_non_exhaustive()
+    }
 }
 impl DeviceBellRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6963,12 +7656,19 @@ impl crate::x11_utils::VoidRequest for DeviceBellRequest {
 
 /// Opcode for the SetDeviceValuators request
 pub const SET_DEVICE_VALUATORS_REQUEST: u8 = 33;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceValuatorsRequest<'input> {
     pub device_id: u8,
     pub first_valuator: u8,
     pub valuators: Cow<'input, [i32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetDeviceValuatorsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDeviceValuatorsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetDeviceValuatorsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -7038,13 +7738,20 @@ impl<'input> crate::x11_utils::ReplyRequest for SetDeviceValuatorsRequest<'input
     type Reply = SetDeviceValuatorsReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceValuatorsReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub status: xproto::GrabStatus,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetDeviceValuatorsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDeviceValuatorsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetDeviceValuatorsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7180,7 +7887,8 @@ impl core::fmt::Debug for DeviceControl  {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceResolutionState {
     pub control_id: DeviceControl,
@@ -7188,6 +7896,12 @@ pub struct DeviceResolutionState {
     pub resolution_values: Vec<u32>,
     pub resolution_min: Vec<u32>,
     pub resolution_max: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceResolutionState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceResolutionState").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceResolutionState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7238,7 +7952,8 @@ impl DeviceResolutionState {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceAbsCalibState {
     pub control_id: DeviceControl,
@@ -7251,6 +7966,12 @@ pub struct DeviceAbsCalibState {
     pub flip_y: u32,
     pub rotation: u32,
     pub button_threshold: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceAbsCalibState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceAbsCalibState").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceAbsCalibState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7336,7 +8057,8 @@ impl Serialize for DeviceAbsCalibState {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceAbsAreaState {
     pub control_id: DeviceControl,
@@ -7347,6 +8069,12 @@ pub struct DeviceAbsAreaState {
     pub height: u32,
     pub screen: u32,
     pub following: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceAbsAreaState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceAbsAreaState").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceAbsAreaState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7418,13 +8146,20 @@ impl Serialize for DeviceAbsAreaState {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCoreState {
     pub control_id: DeviceControl,
     pub len: u16,
     pub status: u8,
     pub iscore: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceCoreState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceCoreState").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceCoreState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7466,12 +8201,19 @@ impl Serialize for DeviceCoreState {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceEnableState {
     pub control_id: DeviceControl,
     pub len: u16,
     pub enable: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceEnableState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceEnableState").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceEnableState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7510,12 +8252,19 @@ impl Serialize for DeviceEnableState {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceStateDataResolution {
     pub resolution_values: Vec<u32>,
     pub resolution_min: Vec<u32>,
     pub resolution_max: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceStateDataResolution {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceStateDataResolution").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceStateDataResolution {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7559,7 +8308,8 @@ impl DeviceStateDataResolution {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceStateDataAbsCalib {
     pub min_x: i32,
@@ -7570,6 +8320,12 @@ pub struct DeviceStateDataAbsCalib {
     pub flip_y: u32,
     pub rotation: u32,
     pub button_threshold: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceStateDataAbsCalib {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceStateDataAbsCalib").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceStateDataAbsCalib {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7643,11 +8399,18 @@ impl Serialize for DeviceStateDataAbsCalib {
         self.button_threshold.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceStateDataCore {
     pub status: u8,
     pub iscore: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceStateDataCore {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceStateDataCore").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceStateDataCore {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7677,7 +8440,8 @@ impl Serialize for DeviceStateDataCore {
         bytes.extend_from_slice(&[0; 2]);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceStateDataAbsArea {
     pub offset_x: u32,
@@ -7686,6 +8450,12 @@ pub struct DeviceStateDataAbsArea {
     pub height: u32,
     pub screen: u32,
     pub following: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceStateDataAbsArea {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceStateDataAbsArea").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceStateDataAbsArea {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7745,7 +8515,8 @@ impl Serialize for DeviceStateDataAbsArea {
         self.following.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceStateData {
     Resolution(DeviceStateDataResolution),
@@ -7762,6 +8533,12 @@ pub enum DeviceStateData {
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
     InvalidValue(u16),
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceStateData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceStateData").finish_non_exhaustive()
+    }
 }
 impl DeviceStateData {
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -7874,11 +8651,18 @@ impl DeviceStateData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceState {
     pub len: u16,
     pub data: DeviceStateData,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceState").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7907,11 +8691,18 @@ impl Serialize for DeviceState {
 
 /// Opcode for the GetDeviceControl request
 pub const GET_DEVICE_CONTROL_REQUEST: u8 = 34;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceControlRequest {
     pub control_id: DeviceControl,
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceControlRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceControlRequest").finish_non_exhaustive()
+    }
 }
 impl GetDeviceControlRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7965,7 +8756,8 @@ impl crate::x11_utils::ReplyRequest for GetDeviceControlRequest {
     type Reply = GetDeviceControlReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceControlReply {
     pub xi_reply_type: u8,
@@ -7973,6 +8765,12 @@ pub struct GetDeviceControlReply {
     pub length: u32,
     pub status: u8,
     pub control: DeviceState,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceControlReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceControlReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDeviceControlReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8014,13 +8812,20 @@ impl Serialize for GetDeviceControlReply {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceResolutionCtl {
     pub control_id: DeviceControl,
     pub len: u16,
     pub first_valuator: u8,
     pub resolution_values: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceResolutionCtl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceResolutionCtl").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceResolutionCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8069,7 +8874,8 @@ impl DeviceResolutionCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceAbsCalibCtl {
     pub control_id: DeviceControl,
@@ -8082,6 +8888,12 @@ pub struct DeviceAbsCalibCtl {
     pub flip_y: u32,
     pub rotation: u32,
     pub button_threshold: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceAbsCalibCtl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceAbsCalibCtl").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceAbsCalibCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8167,7 +8979,8 @@ impl Serialize for DeviceAbsCalibCtl {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceAbsAreaCtrl {
     pub control_id: DeviceControl,
@@ -8178,6 +8991,12 @@ pub struct DeviceAbsAreaCtrl {
     pub height: i32,
     pub screen: i32,
     pub following: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceAbsAreaCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceAbsAreaCtrl").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceAbsAreaCtrl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8249,12 +9068,19 @@ impl Serialize for DeviceAbsAreaCtrl {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCoreCtrl {
     pub control_id: DeviceControl,
     pub len: u16,
     pub status: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceCoreCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceCoreCtrl").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceCoreCtrl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8293,12 +9119,19 @@ impl Serialize for DeviceCoreCtrl {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceEnableCtrl {
     pub control_id: DeviceControl,
     pub len: u16,
     pub enable: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceEnableCtrl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceEnableCtrl").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceEnableCtrl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8337,11 +9170,18 @@ impl Serialize for DeviceEnableCtrl {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCtlDataResolution {
     pub first_valuator: u8,
     pub resolution_values: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceCtlDataResolution {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceCtlDataResolution").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceCtlDataResolution {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8384,7 +9224,8 @@ impl DeviceCtlDataResolution {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCtlDataAbsCalib {
     pub min_x: i32,
@@ -8395,6 +9236,12 @@ pub struct DeviceCtlDataAbsCalib {
     pub flip_y: u32,
     pub rotation: u32,
     pub button_threshold: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceCtlDataAbsCalib {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceCtlDataAbsCalib").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceCtlDataAbsCalib {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8468,10 +9315,17 @@ impl Serialize for DeviceCtlDataAbsCalib {
         self.button_threshold.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCtlDataCore {
     pub status: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceCtlDataCore {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceCtlDataCore").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceCtlDataCore {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8498,7 +9352,8 @@ impl Serialize for DeviceCtlDataCore {
         bytes.extend_from_slice(&[0; 3]);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCtlDataAbsArea {
     pub offset_x: u32,
@@ -8507,6 +9362,12 @@ pub struct DeviceCtlDataAbsArea {
     pub height: i32,
     pub screen: i32,
     pub following: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceCtlDataAbsArea {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceCtlDataAbsArea").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceCtlDataAbsArea {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8566,7 +9427,8 @@ impl Serialize for DeviceCtlDataAbsArea {
         self.following.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceCtlData {
     Resolution(DeviceCtlDataResolution),
@@ -8583,6 +9445,12 @@ pub enum DeviceCtlData {
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
     InvalidValue(u16),
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceCtlData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceCtlData").finish_non_exhaustive()
+    }
 }
 impl DeviceCtlData {
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -8695,11 +9563,18 @@ impl DeviceCtlData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceCtl {
     pub len: u16,
     pub data: DeviceCtlData,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceCtl {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceCtl").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8728,12 +9603,19 @@ impl Serialize for DeviceCtl {
 
 /// Opcode for the ChangeDeviceControl request
 pub const CHANGE_DEVICE_CONTROL_REQUEST: u8 = 35;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDeviceControlRequest {
     pub control_id: DeviceControl,
     pub device_id: u8,
     pub control: DeviceCtl,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeDeviceControlRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeDeviceControlRequest").finish_non_exhaustive()
+    }
 }
 impl ChangeDeviceControlRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8793,13 +9675,20 @@ impl crate::x11_utils::ReplyRequest for ChangeDeviceControlRequest {
     type Reply = ChangeDeviceControlReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDeviceControlReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub status: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeDeviceControlReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeDeviceControlReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ChangeDeviceControlReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8877,10 +9766,17 @@ impl Serialize for ChangeDeviceControlReply {
 
 /// Opcode for the ListDeviceProperties request
 pub const LIST_DEVICE_PROPERTIES_REQUEST: u8 = 36;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListDevicePropertiesRequest {
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListDevicePropertiesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListDevicePropertiesRequest").finish_non_exhaustive()
+    }
 }
 impl ListDevicePropertiesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8930,13 +9826,20 @@ impl crate::x11_utils::ReplyRequest for ListDevicePropertiesRequest {
     type Reply = ListDevicePropertiesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListDevicePropertiesReply {
     pub xi_reply_type: u8,
     pub sequence: u16,
     pub length: u32,
     pub atoms: Vec<xproto::Atom>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListDevicePropertiesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListDevicePropertiesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListDevicePropertiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9055,7 +9958,8 @@ impl core::fmt::Debug for PropertyFormat  {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ChangeDevicePropertyAux {
     Data8(Vec<u8>),
@@ -9070,6 +9974,12 @@ pub enum ChangeDevicePropertyAux {
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
     InvalidValue(u8),
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeDevicePropertyAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeDevicePropertyAux").finish_non_exhaustive()
+    }
 }
 impl ChangeDevicePropertyAux {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -9175,7 +10085,8 @@ impl ChangeDevicePropertyAux {
 
 /// Opcode for the ChangeDeviceProperty request
 pub const CHANGE_DEVICE_PROPERTY_REQUEST: u8 = 37;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDevicePropertyRequest<'input> {
     pub property: xproto::Atom,
@@ -9184,6 +10095,12 @@ pub struct ChangeDevicePropertyRequest<'input> {
     pub mode: xproto::PropMode,
     pub num_items: u32,
     pub items: Cow<'input, ChangeDevicePropertyAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeDevicePropertyRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeDevicePropertyRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeDevicePropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -9279,11 +10196,18 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeDevicePropertyRequest<'inpu
 
 /// Opcode for the DeleteDeviceProperty request
 pub const DELETE_DEVICE_PROPERTY_REQUEST: u8 = 38;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeleteDevicePropertyRequest {
     pub property: xproto::Atom,
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeleteDevicePropertyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeleteDevicePropertyRequest").finish_non_exhaustive()
+    }
 }
 impl DeleteDevicePropertyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9341,7 +10265,8 @@ impl crate::x11_utils::VoidRequest for DeleteDevicePropertyRequest {
 
 /// Opcode for the GetDeviceProperty request
 pub const GET_DEVICE_PROPERTY_REQUEST: u8 = 39;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDevicePropertyRequest {
     pub property: xproto::Atom,
@@ -9350,6 +10275,12 @@ pub struct GetDevicePropertyRequest {
     pub len: u32,
     pub device_id: u8,
     pub delete: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDevicePropertyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDevicePropertyRequest").finish_non_exhaustive()
+    }
 }
 impl GetDevicePropertyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9430,7 +10361,8 @@ impl crate::x11_utils::ReplyRequest for GetDevicePropertyRequest {
     type Reply = GetDevicePropertyReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum GetDevicePropertyItems {
     Data8(Vec<u8>),
@@ -9445,6 +10377,12 @@ pub enum GetDevicePropertyItems {
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
     InvalidValue(u8),
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDevicePropertyItems {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDevicePropertyItems").finish_non_exhaustive()
+    }
 }
 impl GetDevicePropertyItems {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -9548,7 +10486,8 @@ impl GetDevicePropertyItems {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDevicePropertyReply {
     pub xi_reply_type: u8,
@@ -9559,6 +10498,12 @@ pub struct GetDevicePropertyReply {
     pub num_items: u32,
     pub device_id: u8,
     pub items: GetDevicePropertyItems,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDevicePropertyReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDevicePropertyReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDevicePropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9680,13 +10625,20 @@ impl core::fmt::Debug for Device  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GroupInfo {
     pub base: u8,
     pub latched: u8,
     pub locked: u8,
     pub effective: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GroupInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GroupInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for GroupInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9721,13 +10673,20 @@ impl Serialize for GroupInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModifierInfo {
     pub base: u32,
     pub latched: u32,
     pub locked: u32,
     pub effective: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ModifierInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ModifierInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for ModifierInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9776,11 +10735,18 @@ impl Serialize for ModifierInfo {
 
 /// Opcode for the XIQueryPointer request
 pub const XI_QUERY_POINTER_REQUEST: u8 = 40;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIQueryPointerRequest {
     pub window: xproto::Window,
     pub deviceid: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIQueryPointerRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIQueryPointerRequest").finish_non_exhaustive()
+    }
 }
 impl XIQueryPointerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9837,7 +10803,8 @@ impl crate::x11_utils::ReplyRequest for XIQueryPointerRequest {
     type Reply = XIQueryPointerReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIQueryPointerReply {
     pub sequence: u16,
@@ -9852,6 +10819,12 @@ pub struct XIQueryPointerReply {
     pub mods: ModifierInfo,
     pub group: GroupInfo,
     pub buttons: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIQueryPointerReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIQueryPointerReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for XIQueryPointerReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9929,7 +10902,8 @@ impl XIQueryPointerReply {
 
 /// Opcode for the XIWarpPointer request
 pub const XI_WARP_POINTER_REQUEST: u8 = 41;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIWarpPointerRequest {
     pub src_win: xproto::Window,
@@ -9941,6 +10915,12 @@ pub struct XIWarpPointerRequest {
     pub dst_x: Fp1616,
     pub dst_y: Fp1616,
     pub deviceid: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIWarpPointerRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIWarpPointerRequest").finish_non_exhaustive()
+    }
 }
 impl XIWarpPointerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10043,12 +11023,19 @@ impl crate::x11_utils::VoidRequest for XIWarpPointerRequest {
 
 /// Opcode for the XIChangeCursor request
 pub const XI_CHANGE_CURSOR_REQUEST: u8 = 42;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIChangeCursorRequest {
     pub window: xproto::Window,
     pub cursor: xproto::Cursor,
     pub deviceid: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIChangeCursorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIChangeCursorRequest").finish_non_exhaustive()
+    }
 }
 impl XIChangeCursorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10227,7 +11214,8 @@ impl core::fmt::Debug for ChangeMode  {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AddMaster {
     pub type_: HierarchyChangeType,
@@ -10235,6 +11223,12 @@ pub struct AddMaster {
     pub send_core: bool,
     pub enable: bool,
     pub name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AddMaster {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AddMaster").finish_non_exhaustive()
+    }
 }
 impl TryParse for AddMaster {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10290,7 +11284,8 @@ impl AddMaster {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RemoveMaster {
     pub type_: HierarchyChangeType,
@@ -10299,6 +11294,12 @@ pub struct RemoveMaster {
     pub return_mode: ChangeMode,
     pub return_pointer: DeviceId,
     pub return_keyboard: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RemoveMaster {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RemoveMaster").finish_non_exhaustive()
+    }
 }
 impl TryParse for RemoveMaster {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10351,13 +11352,20 @@ impl Serialize for RemoveMaster {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttachSlave {
     pub type_: HierarchyChangeType,
     pub len: u16,
     pub deviceid: DeviceId,
     pub master: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AttachSlave {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AttachSlave").finish_non_exhaustive()
+    }
 }
 impl TryParse for AttachSlave {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10397,12 +11405,19 @@ impl Serialize for AttachSlave {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DetachSlave {
     pub type_: HierarchyChangeType,
     pub len: u16,
     pub deviceid: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DetachSlave {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DetachSlave").finish_non_exhaustive()
+    }
 }
 impl TryParse for DetachSlave {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10441,12 +11456,19 @@ impl Serialize for DetachSlave {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyChangeDataAddMaster {
     pub send_core: bool,
     pub enable: bool,
     pub name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for HierarchyChangeDataAddMaster {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HierarchyChangeDataAddMaster").finish_non_exhaustive()
+    }
 }
 impl TryParse for HierarchyChangeDataAddMaster {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10496,13 +11518,20 @@ impl HierarchyChangeDataAddMaster {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyChangeDataRemoveMaster {
     pub deviceid: DeviceId,
     pub return_mode: ChangeMode,
     pub return_pointer: DeviceId,
     pub return_keyboard: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for HierarchyChangeDataRemoveMaster {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HierarchyChangeDataRemoveMaster").finish_non_exhaustive()
+    }
 }
 impl TryParse for HierarchyChangeDataRemoveMaster {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10543,11 +11572,18 @@ impl Serialize for HierarchyChangeDataRemoveMaster {
         self.return_keyboard.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyChangeDataAttachSlave {
     pub deviceid: DeviceId,
     pub master: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for HierarchyChangeDataAttachSlave {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HierarchyChangeDataAttachSlave").finish_non_exhaustive()
+    }
 }
 impl TryParse for HierarchyChangeDataAttachSlave {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10575,10 +11611,17 @@ impl Serialize for HierarchyChangeDataAttachSlave {
         self.master.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyChangeDataDetachSlave {
     pub deviceid: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for HierarchyChangeDataDetachSlave {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HierarchyChangeDataDetachSlave").finish_non_exhaustive()
+    }
 }
 impl TryParse for HierarchyChangeDataDetachSlave {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10605,7 +11648,8 @@ impl Serialize for HierarchyChangeDataDetachSlave {
         bytes.extend_from_slice(&[0; 2]);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum HierarchyChangeData {
     AddMaster(HierarchyChangeDataAddMaster),
@@ -10621,6 +11665,12 @@ pub enum HierarchyChangeData {
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
     InvalidValue(u16),
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for HierarchyChangeData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HierarchyChangeData").finish_non_exhaustive()
+    }
 }
 impl HierarchyChangeData {
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -10713,11 +11763,18 @@ impl HierarchyChangeData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyChange {
     pub len: u16,
     pub data: HierarchyChangeData,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for HierarchyChange {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HierarchyChange").finish_non_exhaustive()
+    }
 }
 impl TryParse for HierarchyChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10746,10 +11803,17 @@ impl Serialize for HierarchyChange {
 
 /// Opcode for the XIChangeHierarchy request
 pub const XI_CHANGE_HIERARCHY_REQUEST: u8 = 43;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIChangeHierarchyRequest<'input> {
     pub changes: Cow<'input, [HierarchyChange]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for XIChangeHierarchyRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIChangeHierarchyRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> XIChangeHierarchyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -10812,11 +11876,18 @@ impl<'input> crate::x11_utils::VoidRequest for XIChangeHierarchyRequest<'input> 
 
 /// Opcode for the XISetClientPointer request
 pub const XI_SET_CLIENT_POINTER_REQUEST: u8 = 44;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XISetClientPointerRequest {
     pub window: xproto::Window,
     pub deviceid: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XISetClientPointerRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XISetClientPointerRequest").finish_non_exhaustive()
+    }
 }
 impl XISetClientPointerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10874,10 +11945,17 @@ impl crate::x11_utils::VoidRequest for XISetClientPointerRequest {
 
 /// Opcode for the XIGetClientPointer request
 pub const XI_GET_CLIENT_POINTER_REQUEST: u8 = 45;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetClientPointerRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIGetClientPointerRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIGetClientPointerRequest").finish_non_exhaustive()
+    }
 }
 impl XIGetClientPointerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10926,13 +12004,20 @@ impl crate::x11_utils::ReplyRequest for XIGetClientPointerRequest {
     type Reply = XIGetClientPointerReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetClientPointerReply {
     pub sequence: u16,
     pub length: u32,
     pub set: bool,
     pub deviceid: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIGetClientPointerReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIGetClientPointerReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for XIGetClientPointerReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11108,11 +12193,18 @@ impl core::fmt::Debug for XIEventMask  {
 }
 bitmask_binop!(XIEventMask, u32);
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EventMask {
     pub deviceid: DeviceId,
     pub mask: Vec<XIEventMask>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EventMask {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EventMask").finish_non_exhaustive()
+    }
 }
 impl TryParse for EventMask {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11166,11 +12258,18 @@ impl EventMask {
 
 /// Opcode for the XISelectEvents request
 pub const XI_SELECT_EVENTS_REQUEST: u8 = 46;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XISelectEventsRequest<'input> {
     pub window: xproto::Window,
     pub masks: Cow<'input, [EventMask]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for XISelectEventsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XISelectEventsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> XISelectEventsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -11241,11 +12340,18 @@ impl<'input> crate::x11_utils::VoidRequest for XISelectEventsRequest<'input> {
 
 /// Opcode for the XIQueryVersion request
 pub const XI_QUERY_VERSION_REQUEST: u8 = 47;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIQueryVersionRequest {
     pub major_version: u16,
     pub minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIQueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIQueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl XIQueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11297,13 +12403,20 @@ impl crate::x11_utils::ReplyRequest for XIQueryVersionRequest {
     type Reply = XIQueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIQueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u16,
     pub minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIQueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIQueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for XIQueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11661,7 +12774,8 @@ impl core::fmt::Debug for TouchMode  {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ButtonClass {
     pub type_: DeviceClassType,
@@ -11669,6 +12783,12 @@ pub struct ButtonClass {
     pub sourceid: DeviceId,
     pub state: Vec<u32>,
     pub labels: Vec<xproto::Atom>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ButtonClass {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ButtonClass").finish_non_exhaustive()
+    }
 }
 impl TryParse for ButtonClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11718,13 +12838,20 @@ impl ButtonClass {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyClass {
     pub type_: DeviceClassType,
     pub len: u16,
     pub sourceid: DeviceId,
     pub keys: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KeyClass {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeyClass").finish_non_exhaustive()
+    }
 }
 impl TryParse for KeyClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11771,7 +12898,8 @@ impl KeyClass {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScrollClass {
     pub type_: DeviceClassType,
@@ -11781,6 +12909,12 @@ pub struct ScrollClass {
     pub scroll_type: ScrollType,
     pub flags: ScrollFlags,
     pub increment: Fp3232,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ScrollClass {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ScrollClass").finish_non_exhaustive()
+    }
 }
 impl TryParse for ScrollClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11849,7 +12983,8 @@ impl Serialize for ScrollClass {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TouchClass {
     pub type_: DeviceClassType,
@@ -11857,6 +12992,12 @@ pub struct TouchClass {
     pub sourceid: DeviceId,
     pub mode: TouchMode,
     pub num_touches: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for TouchClass {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TouchClass").finish_non_exhaustive()
+    }
 }
 impl TryParse for TouchClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11900,13 +13041,20 @@ impl Serialize for TouchClass {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GestureClass {
     pub type_: DeviceClassType,
     pub len: u16,
     pub sourceid: DeviceId,
     pub num_touches: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GestureClass {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GestureClass").finish_non_exhaustive()
+    }
 }
 impl TryParse for GestureClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11948,7 +13096,8 @@ impl Serialize for GestureClass {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ValuatorClass {
     pub type_: DeviceClassType,
@@ -11961,6 +13110,12 @@ pub struct ValuatorClass {
     pub value: Fp3232,
     pub resolution: u32,
     pub mode: ValuatorMode,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ValuatorClass {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ValuatorClass").finish_non_exhaustive()
+    }
 }
 impl TryParse for ValuatorClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12057,10 +13212,17 @@ impl Serialize for ValuatorClass {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClassDataKey {
     pub keys: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceClassDataKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceClassDataKey").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceClassDataKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12098,11 +13260,18 @@ impl DeviceClassDataKey {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClassDataButton {
     pub state: Vec<u32>,
     pub labels: Vec<xproto::Atom>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceClassDataButton {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceClassDataButton").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceClassDataButton {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12143,7 +13312,8 @@ impl DeviceClassDataButton {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClassDataValuator {
     pub number: u16,
@@ -12153,6 +13323,12 @@ pub struct DeviceClassDataValuator {
     pub value: Fp3232,
     pub resolution: u32,
     pub mode: ValuatorMode,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceClassDataValuator {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceClassDataValuator").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceClassDataValuator {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12232,13 +13408,20 @@ impl Serialize for DeviceClassDataValuator {
         bytes.extend_from_slice(&[0; 3]);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClassDataScroll {
     pub number: u16,
     pub scroll_type: ScrollType,
     pub flags: ScrollFlags,
     pub increment: Fp3232,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceClassDataScroll {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceClassDataScroll").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceClassDataScroll {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12290,11 +13473,18 @@ impl Serialize for DeviceClassDataScroll {
         self.increment.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClassDataTouch {
     pub mode: TouchMode,
     pub num_touches: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceClassDataTouch {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceClassDataTouch").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceClassDataTouch {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12321,10 +13511,17 @@ impl Serialize for DeviceClassDataTouch {
         self.num_touches.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClassDataGesture {
     pub num_touches: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceClassDataGesture {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceClassDataGesture").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceClassDataGesture {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12349,7 +13546,8 @@ impl Serialize for DeviceClassDataGesture {
         bytes.extend_from_slice(&[0; 1]);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceClassData {
     Key(DeviceClassDataKey),
@@ -12367,6 +13565,12 @@ pub enum DeviceClassData {
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
     InvalidValue(u16),
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceClassData {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceClassData").finish_non_exhaustive()
+    }
 }
 impl DeviceClassData {
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -12487,12 +13691,19 @@ impl DeviceClassData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceClass {
     pub len: u16,
     pub sourceid: DeviceId,
     pub data: DeviceClassData,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceClass {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceClass").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceClass {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12526,7 +13737,8 @@ impl Serialize for DeviceClass {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIDeviceInfo {
     pub deviceid: DeviceId,
@@ -12535,6 +13747,12 @@ pub struct XIDeviceInfo {
     pub enabled: bool,
     pub name: Vec<u8>,
     pub classes: Vec<DeviceClass>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIDeviceInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIDeviceInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for XIDeviceInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12612,10 +13830,17 @@ impl XIDeviceInfo {
 
 /// Opcode for the XIQueryDevice request
 pub const XI_QUERY_DEVICE_REQUEST: u8 = 48;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIQueryDeviceRequest {
     pub deviceid: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIQueryDeviceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIQueryDeviceRequest").finish_non_exhaustive()
+    }
 }
 impl XIQueryDeviceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12665,12 +13890,19 @@ impl crate::x11_utils::ReplyRequest for XIQueryDeviceRequest {
     type Reply = XIQueryDeviceReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIQueryDeviceReply {
     pub sequence: u16,
     pub length: u32,
     pub infos: Vec<XIDeviceInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIQueryDeviceReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIQueryDeviceReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for XIQueryDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12730,12 +13962,19 @@ impl XIQueryDeviceReply {
 
 /// Opcode for the XISetFocus request
 pub const XI_SET_FOCUS_REQUEST: u8 = 49;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XISetFocusRequest {
     pub window: xproto::Window,
     pub time: xproto::Timestamp,
     pub deviceid: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XISetFocusRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XISetFocusRequest").finish_non_exhaustive()
+    }
 }
 impl XISetFocusRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12800,10 +14039,17 @@ impl crate::x11_utils::VoidRequest for XISetFocusRequest {
 
 /// Opcode for the XIGetFocus request
 pub const XI_GET_FOCUS_REQUEST: u8 = 50;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetFocusRequest {
     pub deviceid: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIGetFocusRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIGetFocusRequest").finish_non_exhaustive()
+    }
 }
 impl XIGetFocusRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12853,12 +14099,19 @@ impl crate::x11_utils::ReplyRequest for XIGetFocusRequest {
     type Reply = XIGetFocusReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetFocusReply {
     pub sequence: u16,
     pub length: u32,
     pub focus: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIGetFocusReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIGetFocusReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for XIGetFocusReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13006,7 +14259,8 @@ impl core::fmt::Debug for GrabOwner  {
 
 /// Opcode for the XIGrabDevice request
 pub const XI_GRAB_DEVICE_REQUEST: u8 = 51;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGrabDeviceRequest<'input> {
     pub window: xproto::Window,
@@ -13017,6 +14271,12 @@ pub struct XIGrabDeviceRequest<'input> {
     pub paired_device_mode: xproto::GrabMode,
     pub owner_events: GrabOwner,
     pub mask: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for XIGrabDeviceRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIGrabDeviceRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> XIGrabDeviceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -13125,12 +14385,19 @@ impl<'input> crate::x11_utils::ReplyRequest for XIGrabDeviceRequest<'input> {
     type Reply = XIGrabDeviceReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGrabDeviceReply {
     pub sequence: u16,
     pub length: u32,
     pub status: xproto::GrabStatus,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIGrabDeviceReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIGrabDeviceReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for XIGrabDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13208,11 +14475,18 @@ impl Serialize for XIGrabDeviceReply {
 
 /// Opcode for the XIUngrabDevice request
 pub const XI_UNGRAB_DEVICE_REQUEST: u8 = 52;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIUngrabDeviceRequest {
     pub time: xproto::Timestamp,
     pub deviceid: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIUngrabDeviceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIUngrabDeviceRequest").finish_non_exhaustive()
+    }
 }
 impl XIUngrabDeviceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -13341,7 +14615,8 @@ impl core::fmt::Debug for EventMode  {
 
 /// Opcode for the XIAllowEvents request
 pub const XI_ALLOW_EVENTS_REQUEST: u8 = 53;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIAllowEventsRequest {
     pub time: xproto::Timestamp,
@@ -13349,6 +14624,12 @@ pub struct XIAllowEventsRequest {
     pub event_mode: EventMode,
     pub touchid: u32,
     pub grab_window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIAllowEventsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIAllowEventsRequest").finish_non_exhaustive()
+    }
 }
 impl XIAllowEventsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -13598,11 +14879,18 @@ impl core::fmt::Debug for ModifierMask  {
 }
 bitmask_binop!(ModifierMask, u32);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabModifierInfo {
     pub modifiers: u32,
     pub status: xproto::GrabStatus,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GrabModifierInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabModifierInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for GrabModifierInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13640,7 +14928,8 @@ impl Serialize for GrabModifierInfo {
 
 /// Opcode for the XIPassiveGrabDevice request
 pub const XI_PASSIVE_GRAB_DEVICE_REQUEST: u8 = 54;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIPassiveGrabDeviceRequest<'input> {
     pub time: xproto::Timestamp,
@@ -13654,6 +14943,12 @@ pub struct XIPassiveGrabDeviceRequest<'input> {
     pub owner_events: GrabOwner,
     pub mask: Cow<'input, [u32]>,
     pub modifiers: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for XIPassiveGrabDeviceRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIPassiveGrabDeviceRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> XIPassiveGrabDeviceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -13787,12 +15082,19 @@ impl<'input> crate::x11_utils::ReplyRequest for XIPassiveGrabDeviceRequest<'inpu
     type Reply = XIPassiveGrabDeviceReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIPassiveGrabDeviceReply {
     pub sequence: u16,
     pub length: u32,
     pub modifiers: Vec<GrabModifierInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIPassiveGrabDeviceReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIPassiveGrabDeviceReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for XIPassiveGrabDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13852,7 +15154,8 @@ impl XIPassiveGrabDeviceReply {
 
 /// Opcode for the XIPassiveUngrabDevice request
 pub const XI_PASSIVE_UNGRAB_DEVICE_REQUEST: u8 = 55;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIPassiveUngrabDeviceRequest<'input> {
     pub grab_window: xproto::Window,
@@ -13860,6 +15163,12 @@ pub struct XIPassiveUngrabDeviceRequest<'input> {
     pub deviceid: DeviceId,
     pub grab_type: GrabType,
     pub modifiers: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for XIPassiveUngrabDeviceRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIPassiveUngrabDeviceRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> XIPassiveUngrabDeviceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -13951,10 +15260,17 @@ impl<'input> crate::x11_utils::VoidRequest for XIPassiveUngrabDeviceRequest<'inp
 
 /// Opcode for the XIListProperties request
 pub const XI_LIST_PROPERTIES_REQUEST: u8 = 56;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIListPropertiesRequest {
     pub deviceid: DeviceId,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIListPropertiesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIListPropertiesRequest").finish_non_exhaustive()
+    }
 }
 impl XIListPropertiesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -14004,12 +15320,19 @@ impl crate::x11_utils::ReplyRequest for XIListPropertiesRequest {
     type Reply = XIListPropertiesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIListPropertiesReply {
     pub sequence: u16,
     pub length: u32,
     pub properties: Vec<xproto::Atom>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIListPropertiesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIListPropertiesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for XIListPropertiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14067,7 +15390,8 @@ impl XIListPropertiesReply {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum XIChangePropertyAux {
     Data8(Vec<u8>),
@@ -14082,6 +15406,12 @@ pub enum XIChangePropertyAux {
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
     InvalidValue(u8),
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIChangePropertyAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIChangePropertyAux").finish_non_exhaustive()
+    }
 }
 impl XIChangePropertyAux {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -14187,7 +15517,8 @@ impl XIChangePropertyAux {
 
 /// Opcode for the XIChangeProperty request
 pub const XI_CHANGE_PROPERTY_REQUEST: u8 = 57;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIChangePropertyRequest<'input> {
     pub deviceid: DeviceId,
@@ -14196,6 +15527,12 @@ pub struct XIChangePropertyRequest<'input> {
     pub type_: xproto::Atom,
     pub num_items: u32,
     pub items: Cow<'input, XIChangePropertyAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for XIChangePropertyRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIChangePropertyRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> XIChangePropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -14290,11 +15627,18 @@ impl<'input> crate::x11_utils::VoidRequest for XIChangePropertyRequest<'input> {
 
 /// Opcode for the XIDeleteProperty request
 pub const XI_DELETE_PROPERTY_REQUEST: u8 = 58;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIDeletePropertyRequest {
     pub deviceid: DeviceId,
     pub property: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIDeletePropertyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIDeletePropertyRequest").finish_non_exhaustive()
+    }
 }
 impl XIDeletePropertyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -14352,7 +15696,8 @@ impl crate::x11_utils::VoidRequest for XIDeletePropertyRequest {
 
 /// Opcode for the XIGetProperty request
 pub const XI_GET_PROPERTY_REQUEST: u8 = 59;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetPropertyRequest {
     pub deviceid: DeviceId,
@@ -14361,6 +15706,12 @@ pub struct XIGetPropertyRequest {
     pub type_: xproto::Atom,
     pub offset: u32,
     pub len: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIGetPropertyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIGetPropertyRequest").finish_non_exhaustive()
+    }
 }
 impl XIGetPropertyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -14441,7 +15792,8 @@ impl crate::x11_utils::ReplyRequest for XIGetPropertyRequest {
     type Reply = XIGetPropertyReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum XIGetPropertyItems {
     Data8(Vec<u8>),
@@ -14456,6 +15808,12 @@ pub enum XIGetPropertyItems {
     /// Trying to use `serialize` or `serialize_into` with this variant
     /// will raise a panic.
     InvalidValue(u8),
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIGetPropertyItems {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIGetPropertyItems").finish_non_exhaustive()
+    }
 }
 impl XIGetPropertyItems {
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -14559,7 +15917,8 @@ impl XIGetPropertyItems {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetPropertyReply {
     pub sequence: u16,
@@ -14568,6 +15927,12 @@ pub struct XIGetPropertyReply {
     pub bytes_after: u32,
     pub num_items: u32,
     pub items: XIGetPropertyItems,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIGetPropertyReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIGetPropertyReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for XIGetPropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14618,10 +15983,17 @@ impl Serialize for XIGetPropertyReply {
 
 /// Opcode for the XIGetSelectedEvents request
 pub const XI_GET_SELECTED_EVENTS_REQUEST: u8 = 60;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetSelectedEventsRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIGetSelectedEventsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIGetSelectedEventsRequest").finish_non_exhaustive()
+    }
 }
 impl XIGetSelectedEventsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -14670,12 +16042,19 @@ impl crate::x11_utils::ReplyRequest for XIGetSelectedEventsRequest {
     type Reply = XIGetSelectedEventsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIGetSelectedEventsReply {
     pub sequence: u16,
     pub length: u32,
     pub masks: Vec<EventMask>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for XIGetSelectedEventsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIGetSelectedEventsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for XIGetSelectedEventsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14733,12 +16112,19 @@ impl XIGetSelectedEventsReply {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BarrierReleasePointerInfo {
     pub deviceid: DeviceId,
     pub barrier: xfixes::Barrier,
     pub eventid: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BarrierReleasePointerInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BarrierReleasePointerInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for BarrierReleasePointerInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14782,10 +16168,17 @@ impl Serialize for BarrierReleasePointerInfo {
 
 /// Opcode for the XIBarrierReleasePointer request
 pub const XI_BARRIER_RELEASE_POINTER_REQUEST: u8 = 61;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct XIBarrierReleasePointerRequest<'input> {
     pub barriers: Cow<'input, [BarrierReleasePointerInfo]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for XIBarrierReleasePointerRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XIBarrierReleasePointerRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> XIBarrierReleasePointerRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -14847,7 +16240,8 @@ impl<'input> crate::x11_utils::VoidRequest for XIBarrierReleasePointerRequest<'i
 
 /// Opcode for the DeviceValuator event
 pub const DEVICE_VALUATOR_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceValuatorEvent {
     pub response_type: u8,
@@ -14857,6 +16251,12 @@ pub struct DeviceValuatorEvent {
     pub num_valuators: u8,
     pub first_valuator: u8,
     pub valuators: [i32; 6],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceValuatorEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceValuatorEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceValuatorEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -15065,7 +16465,8 @@ bitmask_binop!(MoreEventsMask, u8);
 
 /// Opcode for the DeviceKeyPress event
 pub const DEVICE_KEY_PRESS_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceKeyPressEvent {
     pub response_type: u8,
@@ -15082,6 +16483,12 @@ pub struct DeviceKeyPressEvent {
     pub state: xproto::KeyButMask,
     pub same_screen: bool,
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceKeyPressEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceKeyPressEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceKeyPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -15254,7 +16661,8 @@ pub type DeviceMotionNotifyEvent = DeviceKeyPressEvent;
 
 /// Opcode for the DeviceFocusIn event
 pub const DEVICE_FOCUS_IN_EVENT: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceFocusInEvent {
     pub response_type: u8,
@@ -15264,6 +16672,12 @@ pub struct DeviceFocusInEvent {
     pub window: xproto::Window,
     pub mode: xproto::NotifyMode,
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceFocusInEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceFocusInEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceFocusInEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -15473,7 +16887,8 @@ bitmask_binop!(ClassesReportedMask, u8);
 
 /// Opcode for the DeviceStateNotify event
 pub const DEVICE_STATE_NOTIFY_EVENT: u8 = 10;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceStateNotifyEvent {
     pub response_type: u8,
@@ -15487,6 +16902,12 @@ pub struct DeviceStateNotifyEvent {
     pub buttons: [u8; 4],
     pub keys: [u8; 4],
     pub valuators: [u32; 3],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceStateNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceStateNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceStateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -15638,7 +17059,8 @@ impl From<DeviceStateNotifyEvent> for [u8; 32] {
 
 /// Opcode for the DeviceMappingNotify event
 pub const DEVICE_MAPPING_NOTIFY_EVENT: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceMappingNotifyEvent {
     pub response_type: u8,
@@ -15648,6 +17070,12 @@ pub struct DeviceMappingNotifyEvent {
     pub first_keycode: KeyCode,
     pub count: u8,
     pub time: xproto::Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceMappingNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceMappingNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceMappingNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -15839,7 +17267,8 @@ impl core::fmt::Debug for ChangeDevice  {
 
 /// Opcode for the ChangeDeviceNotify event
 pub const CHANGE_DEVICE_NOTIFY_EVENT: u8 = 12;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeDeviceNotifyEvent {
     pub response_type: u8,
@@ -15847,6 +17276,12 @@ pub struct ChangeDeviceNotifyEvent {
     pub sequence: u16,
     pub time: xproto::Timestamp,
     pub request: ChangeDevice,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeDeviceNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeDeviceNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ChangeDeviceNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -15969,13 +17404,20 @@ impl From<ChangeDeviceNotifyEvent> for [u8; 32] {
 
 /// Opcode for the DeviceKeyStateNotify event
 pub const DEVICE_KEY_STATE_NOTIFY_EVENT: u8 = 13;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceKeyStateNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
     pub sequence: u16,
     pub keys: [u8; 28],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceKeyStateNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceKeyStateNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceKeyStateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -16089,13 +17531,20 @@ impl From<DeviceKeyStateNotifyEvent> for [u8; 32] {
 
 /// Opcode for the DeviceButtonStateNotify event
 pub const DEVICE_BUTTON_STATE_NOTIFY_EVENT: u8 = 14;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceButtonStateNotifyEvent {
     pub response_type: u8,
     pub device_id: u8,
     pub sequence: u16,
     pub buttons: [u8; 28],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceButtonStateNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceButtonStateNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceButtonStateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -16276,7 +17725,8 @@ impl core::fmt::Debug for DeviceChange  {
 
 /// Opcode for the DevicePresenceNotify event
 pub const DEVICE_PRESENCE_NOTIFY_EVENT: u8 = 15;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DevicePresenceNotifyEvent {
     pub response_type: u8,
@@ -16285,6 +17735,12 @@ pub struct DevicePresenceNotifyEvent {
     pub devchange: DeviceChange,
     pub device_id: u8,
     pub control: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DevicePresenceNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DevicePresenceNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for DevicePresenceNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -16413,7 +17869,8 @@ impl From<DevicePresenceNotifyEvent> for [u8; 32] {
 
 /// Opcode for the DevicePropertyNotify event
 pub const DEVICE_PROPERTY_NOTIFY_EVENT: u8 = 16;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DevicePropertyNotifyEvent {
     pub response_type: u8,
@@ -16422,6 +17879,12 @@ pub struct DevicePropertyNotifyEvent {
     pub time: xproto::Timestamp,
     pub property: xproto::Atom,
     pub device_id: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DevicePropertyNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DevicePropertyNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for DevicePropertyNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -16607,7 +18070,8 @@ impl core::fmt::Debug for ChangeReason  {
 
 /// Opcode for the DeviceChanged event
 pub const DEVICE_CHANGED_EVENT: u16 = 1;
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceChangedEvent {
     pub response_type: u8,
@@ -16620,6 +18084,12 @@ pub struct DeviceChangedEvent {
     pub sourceid: DeviceId,
     pub reason: ChangeReason,
     pub classes: Vec<DeviceClass>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceChangedEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceChangedEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceChangedEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -16732,7 +18202,8 @@ bitmask_binop!(KeyEventFlags, u32);
 
 /// Opcode for the KeyPress event
 pub const KEY_PRESS_EVENT: u16 = 2;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyPressEvent {
     pub response_type: u8,
@@ -16757,6 +18228,12 @@ pub struct KeyPressEvent {
     pub button_mask: Vec<u32>,
     pub valuator_mask: Vec<u32>,
     pub axisvalues: Vec<Fp3232>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KeyPressEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeyPressEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for KeyPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -16914,7 +18391,8 @@ bitmask_binop!(PointerEventFlags, u32);
 
 /// Opcode for the ButtonPress event
 pub const BUTTON_PRESS_EVENT: u16 = 4;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ButtonPressEvent {
     pub response_type: u8,
@@ -16939,6 +18417,12 @@ pub struct ButtonPressEvent {
     pub button_mask: Vec<u32>,
     pub valuator_mask: Vec<u32>,
     pub axisvalues: Vec<Fp3232>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ButtonPressEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ButtonPressEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ButtonPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -17192,7 +18676,8 @@ impl core::fmt::Debug for NotifyDetail  {
 
 /// Opcode for the Enter event
 pub const ENTER_EVENT: u16 = 7;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnterEvent {
     pub response_type: u8,
@@ -17217,6 +18702,12 @@ pub struct EnterEvent {
     pub mods: ModifierInfo,
     pub group: GroupInfo,
     pub buttons: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EnterEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EnterEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for EnterEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -17376,7 +18867,8 @@ impl core::fmt::Debug for HierarchyMask  {
 }
 bitmask_binop!(HierarchyMask, u32);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyInfo {
     pub deviceid: DeviceId,
@@ -17384,6 +18876,12 @@ pub struct HierarchyInfo {
     pub type_: DeviceType,
     pub enabled: bool,
     pub flags: HierarchyMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for HierarchyInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HierarchyInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for HierarchyInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -17435,7 +18933,8 @@ impl Serialize for HierarchyInfo {
 
 /// Opcode for the Hierarchy event
 pub const HIERARCHY_EVENT: u16 = 11;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HierarchyEvent {
     pub response_type: u8,
@@ -17447,6 +18946,12 @@ pub struct HierarchyEvent {
     pub time: xproto::Timestamp,
     pub flags: HierarchyMask,
     pub infos: Vec<HierarchyInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for HierarchyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HierarchyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for HierarchyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -17572,7 +19077,8 @@ impl core::fmt::Debug for PropertyFlag  {
 
 /// Opcode for the Property event
 pub const PROPERTY_EVENT: u16 = 12;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PropertyEvent {
     pub response_type: u8,
@@ -17584,6 +19090,12 @@ pub struct PropertyEvent {
     pub time: xproto::Timestamp,
     pub property: xproto::Atom,
     pub what: PropertyFlag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PropertyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PropertyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for PropertyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -17670,7 +19182,8 @@ impl Serialize for PropertyEvent {
 
 /// Opcode for the RawKeyPress event
 pub const RAW_KEY_PRESS_EVENT: u16 = 13;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RawKeyPressEvent {
     pub response_type: u8,
@@ -17686,6 +19199,12 @@ pub struct RawKeyPressEvent {
     pub valuator_mask: Vec<u32>,
     pub axisvalues: Vec<Fp3232>,
     pub axisvalues_raw: Vec<Fp3232>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RawKeyPressEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RawKeyPressEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for RawKeyPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -17764,7 +19283,8 @@ pub type RawKeyReleaseEvent = RawKeyPressEvent;
 
 /// Opcode for the RawButtonPress event
 pub const RAW_BUTTON_PRESS_EVENT: u16 = 15;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RawButtonPressEvent {
     pub response_type: u8,
@@ -17780,6 +19300,12 @@ pub struct RawButtonPressEvent {
     pub valuator_mask: Vec<u32>,
     pub axisvalues: Vec<Fp3232>,
     pub axisvalues_raw: Vec<Fp3232>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RawButtonPressEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RawButtonPressEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for RawButtonPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -17910,7 +19436,8 @@ bitmask_binop!(TouchEventFlags, u32);
 
 /// Opcode for the TouchBegin event
 pub const TOUCH_BEGIN_EVENT: u16 = 18;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TouchBeginEvent {
     pub response_type: u8,
@@ -17935,6 +19462,12 @@ pub struct TouchBeginEvent {
     pub button_mask: Vec<u32>,
     pub valuator_mask: Vec<u32>,
     pub axisvalues: Vec<Fp3232>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for TouchBeginEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TouchBeginEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for TouchBeginEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -18095,7 +19628,8 @@ impl core::fmt::Debug for TouchOwnershipFlags  {
 
 /// Opcode for the TouchOwnership event
 pub const TOUCH_OWNERSHIP_EVENT: u16 = 21;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TouchOwnershipEvent {
     pub response_type: u8,
@@ -18111,6 +19645,12 @@ pub struct TouchOwnershipEvent {
     pub child: xproto::Window,
     pub sourceid: DeviceId,
     pub flags: TouchOwnershipFlags,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for TouchOwnershipEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TouchOwnershipEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for TouchOwnershipEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -18227,7 +19767,8 @@ impl Serialize for TouchOwnershipEvent {
 
 /// Opcode for the RawTouchBegin event
 pub const RAW_TOUCH_BEGIN_EVENT: u16 = 22;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RawTouchBeginEvent {
     pub response_type: u8,
@@ -18243,6 +19784,12 @@ pub struct RawTouchBeginEvent {
     pub valuator_mask: Vec<u32>,
     pub axisvalues: Vec<Fp3232>,
     pub axisvalues_raw: Vec<Fp3232>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RawTouchBeginEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RawTouchBeginEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for RawTouchBeginEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -18373,7 +19920,8 @@ bitmask_binop!(BarrierFlags, u32);
 
 /// Opcode for the BarrierHit event
 pub const BARRIER_HIT_EVENT: u16 = 25;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BarrierHitEvent {
     pub response_type: u8,
@@ -18394,6 +19942,12 @@ pub struct BarrierHitEvent {
     pub root_y: Fp1616,
     pub dx: Fp3232,
     pub dy: Fp3232,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BarrierHitEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BarrierHitEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for BarrierHitEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -18593,7 +20147,8 @@ bitmask_binop!(GesturePinchEventFlags, u32);
 
 /// Opcode for the GesturePinchBegin event
 pub const GESTURE_PINCH_BEGIN_EVENT: u16 = 27;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GesturePinchBeginEvent {
     pub response_type: u8,
@@ -18621,6 +20176,12 @@ pub struct GesturePinchBeginEvent {
     pub mods: ModifierInfo,
     pub group: GroupInfo,
     pub flags: GesturePinchEventFlags,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GesturePinchBeginEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GesturePinchBeginEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for GesturePinchBeginEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -18877,7 +20438,8 @@ bitmask_binop!(GestureSwipeEventFlags, u32);
 
 /// Opcode for the GestureSwipeBegin event
 pub const GESTURE_SWIPE_BEGIN_EVENT: u16 = 30;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GestureSwipeBeginEvent {
     pub response_type: u8,
@@ -18903,6 +20465,12 @@ pub struct GestureSwipeBeginEvent {
     pub mods: ModifierInfo,
     pub group: GroupInfo,
     pub flags: GestureSwipeEventFlags,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GestureSwipeBeginEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GestureSwipeBeginEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for GestureSwipeBeginEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -19292,7 +20860,8 @@ impl From<&DevicePropertyNotifyEvent> for EventForSend {
 
 /// Opcode for the SendExtensionEvent request
 pub const SEND_EXTENSION_EVENT_REQUEST: u8 = 31;
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SendExtensionEventRequest<'input> {
     pub destination: xproto::Window,
@@ -19300,6 +20869,12 @@ pub struct SendExtensionEventRequest<'input> {
     pub propagate: bool,
     pub events: Cow<'input, [EventForSend]>,
     pub classes: Cow<'input, [EventClass]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SendExtensionEventRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SendExtensionEventRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SendExtensionEventRequest<'input> {
     /// Serialize this request into bytes for the provided connection

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -130,7 +130,7 @@ impl<'input> GetExtensionVersionRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_EXTENSION_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -889,6 +889,7 @@ impl core::fmt::Debug for InputInfoInfo {
     }
 }
 impl InputInfoInfo {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u8::from(class_id);
         let mut outer_remaining = value;
@@ -1083,7 +1084,7 @@ impl ListInputDevicesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_INPUT_DEVICES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1269,7 +1270,7 @@ impl OpenDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != OPEN_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1409,7 +1410,7 @@ impl CloseDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CLOSE_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1473,7 +1474,7 @@ impl SetDeviceModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1640,7 +1641,7 @@ impl<'input> SelectExtensionEventRequest<'input> {
         ([request0.into(), classes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_EXTENSION_EVENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1712,7 +1713,7 @@ impl GetSelectedExtensionEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SELECTED_EXTENSION_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1936,7 +1937,7 @@ impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
         ([request0.into(), classes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2012,7 +2013,7 @@ impl GetDeviceDontPropagateListRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_DONT_PROPAGATE_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2192,7 +2193,7 @@ impl GetDeviceMotionEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_MOTION_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2346,7 +2347,7 @@ impl ChangeKeyboardDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_KEYBOARD_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2503,7 +2504,7 @@ impl ChangePointerDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_POINTER_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2689,7 +2690,7 @@ impl<'input> GrabDeviceRequest<'input> {
         ([request0.into(), classes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GRAB_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2875,7 +2876,7 @@ impl UngrabDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNGRAB_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3029,7 +3030,7 @@ impl<'input> GrabDeviceKeyRequest<'input> {
         ([request0.into(), classes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GRAB_DEVICE_KEY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3141,7 +3142,7 @@ impl UngrabDeviceKeyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNGRAB_DEVICE_KEY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3244,7 +3245,7 @@ impl<'input> GrabDeviceButtonRequest<'input> {
         ([request0.into(), classes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GRAB_DEVICE_BUTTON_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3356,7 +3357,7 @@ impl UngrabDeviceButtonRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNGRAB_DEVICE_BUTTON_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3502,7 +3503,7 @@ impl AllowDeviceEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ALLOW_DEVICE_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3569,7 +3570,7 @@ impl GetDeviceFocusRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_FOCUS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3744,7 +3745,7 @@ impl SetDeviceFocusRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_FOCUS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4676,6 +4677,7 @@ impl core::fmt::Debug for FeedbackStateData {
     }
 }
 impl FeedbackStateData {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u8::from(class_id);
         let mut outer_remaining = value;
@@ -4871,7 +4873,7 @@ impl GetFeedbackControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_FEEDBACK_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5701,6 +5703,7 @@ impl core::fmt::Debug for FeedbackCtlData {
     }
 }
 impl FeedbackCtlData {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u8::from(class_id);
         let mut outer_remaining = value;
@@ -5979,7 +5982,7 @@ impl ChangeFeedbackControlRequest {
         ([request0.into(), feedback_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_FEEDBACK_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6052,7 +6055,7 @@ impl GetDeviceKeyMappingRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_KEY_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6202,7 +6205,7 @@ impl<'input> ChangeDeviceKeyMappingRequest<'input> {
         ([request0.into(), keysyms_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_DEVICE_KEY_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6281,7 +6284,7 @@ impl GetDeviceModifierMappingRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_MODIFIER_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6425,7 +6428,7 @@ impl<'input> SetDeviceModifierMappingRequest<'input> {
         ([request0.into(), self.keymaps, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_MODIFIER_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6588,7 +6591,7 @@ impl GetDeviceButtonMappingRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_BUTTON_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6735,7 +6738,7 @@ impl<'input> SetDeviceButtonMappingRequest<'input> {
         ([request0.into(), self.map, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_BUTTON_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7364,6 +7367,7 @@ impl core::fmt::Debug for InputStateData {
     }
 }
 impl InputStateData {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u8::from(class_id);
         let mut outer_remaining = value;
@@ -7514,7 +7518,7 @@ impl QueryDeviceStateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_DEVICE_STATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7654,7 +7658,7 @@ impl DeviceBellRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DEVICE_BELL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7730,7 +7734,7 @@ impl<'input> SetDeviceValuatorsRequest<'input> {
         ([request0.into(), valuators_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_VALUATORS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8573,6 +8577,7 @@ impl core::fmt::Debug for DeviceStateData {
     }
 }
 impl DeviceStateData {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u16::from(control_id);
         let mut outer_remaining = value;
@@ -8759,7 +8764,7 @@ impl GetDeviceControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9486,6 +9491,7 @@ impl core::fmt::Debug for DeviceCtlData {
     }
 }
 impl DeviceCtlData {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u16::from(control_id);
         let mut outer_remaining = value;
@@ -9677,7 +9683,7 @@ impl ChangeDeviceControlRequest {
         ([request0.into(), control_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_DEVICE_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9834,7 +9840,7 @@ impl ListDevicePropertiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_DEVICE_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10017,6 +10023,7 @@ impl core::fmt::Debug for ChangeDevicePropertyAux {
     }
 }
 impl ChangeDevicePropertyAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u8::from(format);
         let mut outer_remaining = value;
@@ -10181,7 +10188,7 @@ impl<'input> ChangeDevicePropertyRequest<'input> {
         ([request0.into(), items_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_DEVICE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10272,7 +10279,7 @@ impl DeleteDevicePropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_DEVICE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10362,7 +10369,7 @@ impl GetDevicePropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10423,6 +10430,7 @@ impl core::fmt::Debug for GetDevicePropertyItems {
     }
 }
 impl GetDevicePropertyItems {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u8::from(format);
         let mut outer_remaining = value;
@@ -10813,7 +10821,7 @@ impl XIQueryPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_QUERY_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11019,7 +11027,7 @@ impl XIWarpPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_WARP_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11109,7 +11117,7 @@ impl XIChangeCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_CHANGE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11714,6 +11722,7 @@ impl core::fmt::Debug for HierarchyChangeData {
     }
 }
 impl HierarchyChangeData {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u16::from(type_);
         let mut outer_remaining = value;
@@ -11883,7 +11892,7 @@ impl<'input> XIChangeHierarchyRequest<'input> {
         ([request0.into(), changes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_CHANGE_HIERARCHY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11958,7 +11967,7 @@ impl XISetClientPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_SET_CLIENT_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12022,7 +12031,7 @@ impl XIGetClientPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_GET_CLIENT_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12347,7 +12356,7 @@ impl<'input> XISelectEventsRequest<'input> {
         ([request0.into(), masks_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_SELECT_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12421,7 +12430,7 @@ impl XIQueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13619,6 +13628,7 @@ impl core::fmt::Debug for DeviceClassData {
     }
 }
 impl DeviceClassData {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u16::from(type_);
         let mut outer_remaining = value;
@@ -13910,7 +13920,7 @@ impl XIQueryDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_QUERY_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14055,7 +14065,7 @@ impl XISetFocusRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_SET_FOCUS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14121,7 +14131,7 @@ impl XIGetFocusRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_GET_FOCUS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14377,7 +14387,7 @@ impl<'input> XIGrabDeviceRequest<'input> {
         ([request0.into(), mask_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_GRAB_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14565,7 +14575,7 @@ impl XIUngrabDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_UNGRAB_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14720,7 +14730,7 @@ impl XIAllowEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_ALLOW_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15066,7 +15076,7 @@ impl<'input> XIPassiveGrabDeviceRequest<'input> {
         ([request0.into(), mask_bytes.into(), modifiers_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_PASSIVE_GRAB_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15266,7 +15276,7 @@ impl<'input> XIPassiveUngrabDeviceRequest<'input> {
         ([request0.into(), modifiers_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_PASSIVE_UNGRAB_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15348,7 +15358,7 @@ impl XIListPropertiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_LIST_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15469,6 +15479,7 @@ impl core::fmt::Debug for XIChangePropertyAux {
     }
 }
 impl XIChangePropertyAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u8::from(format);
         let mut outer_remaining = value;
@@ -15633,7 +15644,7 @@ impl<'input> XIChangePropertyRequest<'input> {
         ([request0.into(), items_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_CHANGE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15723,7 +15734,7 @@ impl XIDeletePropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_DELETE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15813,7 +15824,7 @@ impl XIGetPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_GET_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15874,6 +15885,7 @@ impl core::fmt::Debug for XIGetPropertyItems {
     }
 }
 impl XIGetPropertyItems {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u8::from(format);
         let mut outer_remaining = value;
@@ -16075,7 +16087,7 @@ impl XIGetSelectedEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_GET_SELECTED_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -16266,7 +16278,7 @@ impl<'input> XIBarrierReleasePointerRequest<'input> {
         ([request0.into(), barriers_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_BARRIER_RELEASE_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20978,7 +20990,7 @@ impl<'input> SendExtensionEventRequest<'input> {
         ([request0.into(), events_bytes.into(), classes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SEND_EXTENSION_EVENT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -130,6 +130,7 @@ impl<'input> GetExtensionVersionRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_EXTENSION_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1082,6 +1083,7 @@ impl ListInputDevicesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_INPUT_DEVICES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1267,6 +1269,7 @@ impl OpenDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != OPEN_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1406,6 +1409,7 @@ impl CloseDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CLOSE_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1469,6 +1473,7 @@ impl SetDeviceModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1635,6 +1640,7 @@ impl<'input> SelectExtensionEventRequest<'input> {
         ([request0.into(), classes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_EXTENSION_EVENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1706,6 +1712,7 @@ impl GetSelectedExtensionEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SELECTED_EXTENSION_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1929,6 +1936,7 @@ impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
         ([request0.into(), classes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_DEVICE_DONT_PROPAGATE_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2004,6 +2012,7 @@ impl GetDeviceDontPropagateListRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_DONT_PROPAGATE_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2183,6 +2192,7 @@ impl GetDeviceMotionEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_MOTION_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2336,6 +2346,7 @@ impl ChangeKeyboardDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_KEYBOARD_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2492,6 +2503,7 @@ impl ChangePointerDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_POINTER_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2677,6 +2689,7 @@ impl<'input> GrabDeviceRequest<'input> {
         ([request0.into(), classes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GRAB_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2862,6 +2875,7 @@ impl UngrabDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNGRAB_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3015,6 +3029,7 @@ impl<'input> GrabDeviceKeyRequest<'input> {
         ([request0.into(), classes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GRAB_DEVICE_KEY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3126,6 +3141,7 @@ impl UngrabDeviceKeyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNGRAB_DEVICE_KEY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3228,6 +3244,7 @@ impl<'input> GrabDeviceButtonRequest<'input> {
         ([request0.into(), classes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GRAB_DEVICE_BUTTON_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3339,6 +3356,7 @@ impl UngrabDeviceButtonRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNGRAB_DEVICE_BUTTON_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3484,6 +3502,7 @@ impl AllowDeviceEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != ALLOW_DEVICE_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3550,6 +3569,7 @@ impl GetDeviceFocusRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_FOCUS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3724,6 +3744,7 @@ impl SetDeviceFocusRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_FOCUS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -4850,6 +4871,7 @@ impl GetFeedbackControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_FEEDBACK_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -5957,6 +5979,7 @@ impl ChangeFeedbackControlRequest {
         ([request0.into(), feedback_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_FEEDBACK_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6029,6 +6052,7 @@ impl GetDeviceKeyMappingRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_KEY_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6178,6 +6202,7 @@ impl<'input> ChangeDeviceKeyMappingRequest<'input> {
         ([request0.into(), keysyms_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_DEVICE_KEY_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6256,6 +6281,7 @@ impl GetDeviceModifierMappingRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_MODIFIER_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6399,6 +6425,7 @@ impl<'input> SetDeviceModifierMappingRequest<'input> {
         ([request0.into(), self.keymaps, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_MODIFIER_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6561,6 +6588,7 @@ impl GetDeviceButtonMappingRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_BUTTON_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6707,6 +6735,7 @@ impl<'input> SetDeviceButtonMappingRequest<'input> {
         ([request0.into(), self.map, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_BUTTON_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7485,6 +7514,7 @@ impl QueryDeviceStateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_DEVICE_STATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7624,6 +7654,7 @@ impl DeviceBellRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DEVICE_BELL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7699,6 +7730,7 @@ impl<'input> SetDeviceValuatorsRequest<'input> {
         ([request0.into(), valuators_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_VALUATORS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8727,6 +8759,7 @@ impl GetDeviceControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9644,6 +9677,7 @@ impl ChangeDeviceControlRequest {
         ([request0.into(), control_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_DEVICE_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9800,6 +9834,7 @@ impl ListDevicePropertiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_DEVICE_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10146,6 +10181,7 @@ impl<'input> ChangeDevicePropertyRequest<'input> {
         ([request0.into(), items_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CHANGE_DEVICE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10236,6 +10272,7 @@ impl DeleteDevicePropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DELETE_DEVICE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10325,6 +10362,7 @@ impl GetDevicePropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10775,6 +10813,7 @@ impl XIQueryPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_QUERY_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10980,6 +11019,7 @@ impl XIWarpPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_WARP_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11069,6 +11109,7 @@ impl XIChangeCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_CHANGE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11842,6 +11883,7 @@ impl<'input> XIChangeHierarchyRequest<'input> {
         ([request0.into(), changes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_CHANGE_HIERARCHY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11916,6 +11958,7 @@ impl XISetClientPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_SET_CLIENT_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11979,6 +12022,7 @@ impl XIGetClientPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_GET_CLIENT_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12303,6 +12347,7 @@ impl<'input> XISelectEventsRequest<'input> {
         ([request0.into(), masks_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_SELECT_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12376,6 +12421,7 @@ impl XIQueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13864,6 +13910,7 @@ impl XIQueryDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_QUERY_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14008,6 +14055,7 @@ impl XISetFocusRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_SET_FOCUS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14073,6 +14121,7 @@ impl XIGetFocusRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_GET_FOCUS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14328,6 +14377,7 @@ impl<'input> XIGrabDeviceRequest<'input> {
         ([request0.into(), mask_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_GRAB_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14515,6 +14565,7 @@ impl XIUngrabDeviceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_UNGRAB_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14669,6 +14720,7 @@ impl XIAllowEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_ALLOW_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15014,6 +15066,7 @@ impl<'input> XIPassiveGrabDeviceRequest<'input> {
         ([request0.into(), mask_bytes.into(), modifiers_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_PASSIVE_GRAB_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15213,6 +15266,7 @@ impl<'input> XIPassiveUngrabDeviceRequest<'input> {
         ([request0.into(), modifiers_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_PASSIVE_UNGRAB_DEVICE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15294,6 +15348,7 @@ impl XIListPropertiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_LIST_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15578,6 +15633,7 @@ impl<'input> XIChangePropertyRequest<'input> {
         ([request0.into(), items_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_CHANGE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15667,6 +15723,7 @@ impl XIDeletePropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_DELETE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15756,6 +15813,7 @@ impl XIGetPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_GET_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -16017,6 +16075,7 @@ impl XIGetSelectedEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_GET_SELECTED_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -16207,6 +16266,7 @@ impl<'input> XIBarrierReleasePointerRequest<'input> {
         ([request0.into(), barriers_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != XI_BARRIER_RELEASE_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20918,6 +20978,7 @@ impl<'input> SendExtensionEventRequest<'input> {
         ([request0.into(), events_bytes.into(), classes_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SEND_EXTENSION_EVENT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -6161,6 +6161,7 @@ impl UseExtensionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != USE_EXTENSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7053,6 +7054,7 @@ impl<'input> SelectEventsRequest<'input> {
         ([request0.into(), details_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7177,6 +7179,7 @@ impl BellRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != BELL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7257,6 +7260,7 @@ impl GetStateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_STATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7496,6 +7500,7 @@ impl LatchLockStateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LATCH_LOCK_STATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7576,6 +7581,7 @@ impl GetControlsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CONTROLS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8018,6 +8024,7 @@ impl<'input> SetControlsRequest<'input> {
         ([request0.into(), Cow::Owned(self.per_key_repeat.to_vec())], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CONTROLS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8242,6 +8249,7 @@ impl GetMapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9055,6 +9063,7 @@ impl<'input> SetMapRequest<'input> {
         ([request0.into(), values_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_MAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9211,6 +9220,7 @@ impl GetCompatMapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_COMPAT_MAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9395,6 +9405,7 @@ impl<'input> SetCompatMapRequest<'input> {
         ([request0.into(), si_bytes.into(), group_maps_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_COMPAT_MAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9483,6 +9494,7 @@ impl GetIndicatorStateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_INDICATOR_STATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9640,6 +9652,7 @@ impl GetIndicatorMapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_INDICATOR_MAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9779,6 +9792,7 @@ impl<'input> SetIndicatorMapRequest<'input> {
         ([request0.into(), maps_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_INDICATOR_MAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9866,6 +9880,7 @@ impl GetNamedIndicatorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_NAMED_INDICATOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10136,6 +10151,7 @@ impl SetNamedIndicatorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_NAMED_INDICATOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10240,6 +10256,7 @@ impl GetNamesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_NAMES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11128,6 +11145,7 @@ impl<'input> SetNamesRequest<'input> {
         ([request0.into(), values_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_NAMES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11267,6 +11285,7 @@ impl PerClientFlagsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PER_CLIENT_FLAGS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11451,6 +11470,7 @@ impl ListComponentsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_COMPONENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11693,6 +11713,7 @@ impl GetKbdByNameRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_KBD_BY_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12905,6 +12926,7 @@ impl GetDeviceInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13153,6 +13175,7 @@ impl<'input> SetDeviceInfoRequest<'input> {
         ([request0.into(), btn_actions_bytes.into(), leds_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13262,6 +13285,7 @@ impl<'input> SetDebuggingFlagsRequest<'input> {
         ([request0.into(), self.message, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEBUGGING_FLAGS_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -6161,7 +6161,7 @@ impl UseExtensionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != USE_EXTENSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -6755,6 +6755,7 @@ impl core::fmt::Debug for SelectEventsAux {
     }
 }
 impl SelectEventsAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], affect_which: u16, clear: u16, select_all: u16) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u16::from(affect_which) & ((!u16::from(clear)) & (!u16::from(select_all)));
         let mut outer_remaining = value;
@@ -7054,7 +7055,7 @@ impl<'input> SelectEventsRequest<'input> {
         ([request0.into(), details_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7179,7 +7180,7 @@ impl BellRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != BELL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7260,7 +7261,7 @@ impl GetStateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_STATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7500,7 +7501,7 @@ impl LatchLockStateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LATCH_LOCK_STATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7581,7 +7582,7 @@ impl GetControlsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CONTROLS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8024,7 +8025,7 @@ impl<'input> SetControlsRequest<'input> {
         ([request0.into(), Cow::Owned(self.per_key_repeat.to_vec())], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_CONTROLS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8249,7 +8250,7 @@ impl GetMapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_MAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8375,6 +8376,7 @@ impl core::fmt::Debug for GetMapMap {
     }
 }
 impl GetMapMap {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u16::from(present);
         let mut outer_remaining = value;
@@ -8740,6 +8742,7 @@ impl core::fmt::Debug for SetMapAux {
     }
 }
 impl SetMapAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u16::from(present);
         let mut outer_remaining = value;
@@ -9063,7 +9066,7 @@ impl<'input> SetMapRequest<'input> {
         ([request0.into(), values_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_MAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9220,7 +9223,7 @@ impl GetCompatMapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_COMPAT_MAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9405,7 +9408,7 @@ impl<'input> SetCompatMapRequest<'input> {
         ([request0.into(), si_bytes.into(), group_maps_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_COMPAT_MAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9494,7 +9497,7 @@ impl GetIndicatorStateRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_INDICATOR_STATE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9652,7 +9655,7 @@ impl GetIndicatorMapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_INDICATOR_MAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9792,7 +9795,7 @@ impl<'input> SetIndicatorMapRequest<'input> {
         ([request0.into(), maps_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_INDICATOR_MAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9880,7 +9883,7 @@ impl GetNamedIndicatorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_NAMED_INDICATOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10151,7 +10154,7 @@ impl SetNamedIndicatorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_NAMED_INDICATOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10256,7 +10259,7 @@ impl GetNamesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_NAMES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10354,6 +10357,7 @@ impl core::fmt::Debug for GetNamesValueList {
     }
 }
 impl GetNamesValueList {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(which);
         let mut outer_remaining = value;
@@ -10741,6 +10745,7 @@ impl core::fmt::Debug for SetNamesAux {
     }
 }
 impl SetNamesAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(which);
         let mut outer_remaining = value;
@@ -11145,7 +11150,7 @@ impl<'input> SetNamesRequest<'input> {
         ([request0.into(), values_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_NAMES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11285,7 +11290,7 @@ impl PerClientFlagsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PER_CLIENT_FLAGS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11470,7 +11475,7 @@ impl ListComponentsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_COMPONENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11713,7 +11718,7 @@ impl GetKbdByNameRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_KBD_BY_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11810,6 +11815,7 @@ impl core::fmt::Debug for GetKbdByNameRepliesTypesMap {
     }
 }
 impl GetKbdByNameRepliesTypesMap {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u16::from(present);
         let mut outer_remaining = value;
@@ -12320,6 +12326,7 @@ impl core::fmt::Debug for GetKbdByNameRepliesKeyNamesValueList {
     }
 }
 impl GetKbdByNameRepliesKeyNamesValueList {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(which);
         let mut outer_remaining = value;
@@ -12728,6 +12735,7 @@ impl core::fmt::Debug for GetKbdByNameReplies {
     }
 }
 impl GetKbdByNameReplies {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], reported: u16) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u16::from(reported);
         let mut outer_remaining = value;
@@ -12926,7 +12934,7 @@ impl GetDeviceInfoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13175,7 +13183,7 @@ impl<'input> SetDeviceInfoRequest<'input> {
         ([request0.into(), btn_actions_bytes.into(), leds_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13285,7 +13293,7 @@ impl<'input> SetDebuggingFlagsRequest<'input> {
         ([request0.into(), self.message, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEBUGGING_FLAGS_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -1904,7 +1904,8 @@ impl core::fmt::Debug for IMGroupsWhich  {
 }
 bitmask_binop!(IMGroupsWhich, u8);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndicatorMap {
     pub flags: IMFlag,
@@ -1915,6 +1916,12 @@ pub struct IndicatorMap {
     pub real_mods: xproto::ModMask,
     pub vmods: VMod,
     pub ctrls: BoolCtrl,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IndicatorMap {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IndicatorMap").finish_non_exhaustive()
+    }
 }
 impl TryParse for IndicatorMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2289,12 +2296,19 @@ impl core::fmt::Debug for PerClientFlag  {
 }
 bitmask_binop!(PerClientFlag, u32);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ModDef {
     pub mask: xproto::ModMask,
     pub real_mods: xproto::ModMask,
     pub vmods: VMod,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ModDef {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ModDef").finish_non_exhaustive()
+    }
 }
 impl TryParse for ModDef {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2329,10 +2343,17 @@ impl Serialize for ModDef {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyName {
     pub name: [u8; 4],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KeyName {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeyName").finish_non_exhaustive()
+    }
 }
 impl TryParse for KeyName {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2357,11 +2378,18 @@ impl Serialize for KeyName {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyAlias {
     pub real: [u8; 4],
     pub alias: [u8; 4],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KeyAlias {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeyAlias").finish_non_exhaustive()
+    }
 }
 impl TryParse for KeyAlias {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2392,11 +2420,18 @@ impl Serialize for KeyAlias {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CountedString16 {
     pub string: Vec<u8>,
     pub alignment_pad: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CountedString16 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CountedString16").finish_non_exhaustive()
+    }
 }
 impl TryParse for CountedString16 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2440,7 +2475,8 @@ impl CountedString16 {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KTMapEntry {
     pub active: bool,
@@ -2448,6 +2484,12 @@ pub struct KTMapEntry {
     pub level: u8,
     pub mods_mods: xproto::ModMask,
     pub mods_vmods: VMod,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KTMapEntry {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KTMapEntry").finish_non_exhaustive()
+    }
 }
 impl TryParse for KTMapEntry {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2494,7 +2536,8 @@ impl Serialize for KTMapEntry {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyType {
     pub mods_mask: xproto::ModMask,
@@ -2504,6 +2547,12 @@ pub struct KeyType {
     pub has_preserve: bool,
     pub map: Vec<KTMapEntry>,
     pub preserve: Vec<ModDef>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KeyType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeyType").finish_non_exhaustive()
+    }
 }
 impl TryParse for KeyType {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2561,13 +2610,20 @@ impl KeyType {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeySymMap {
     pub kt_index: [u8; 4],
     pub group_info: u8,
     pub width: u8,
     pub syms: Vec<xproto::Keysym>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KeySymMap {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeySymMap").finish_non_exhaustive()
+    }
 }
 impl TryParse for KeySymMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2613,11 +2669,18 @@ impl KeySymMap {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CommonBehavior {
     pub type_: u8,
     pub data: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CommonBehavior {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CommonBehavior").finish_non_exhaustive()
+    }
 }
 impl TryParse for CommonBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2644,10 +2707,17 @@ impl Serialize for CommonBehavior {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DefaultBehavior {
     pub type_: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DefaultBehavior {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DefaultBehavior").finish_non_exhaustive()
+    }
 }
 impl TryParse for DefaultBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2675,11 +2745,18 @@ impl Serialize for DefaultBehavior {
 
 pub type LockBehavior = DefaultBehavior;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RadioGroupBehavior {
     pub type_: u8,
     pub group: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RadioGroupBehavior {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RadioGroupBehavior").finish_non_exhaustive()
+    }
 }
 impl TryParse for RadioGroupBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2706,11 +2783,18 @@ impl Serialize for RadioGroupBehavior {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OverlayBehavior {
     pub type_: u8,
     pub key: xproto::Keycode,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for OverlayBehavior {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OverlayBehavior").finish_non_exhaustive()
+    }
 }
 impl TryParse for OverlayBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2963,11 +3047,18 @@ impl core::fmt::Debug for BehaviorType  {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetBehavior {
     pub keycode: xproto::Keycode,
     pub behavior: Behavior,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetBehavior {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetBehavior").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2998,11 +3089,18 @@ impl Serialize for SetBehavior {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetExplicit {
     pub keycode: xproto::Keycode,
     pub explicit: Explicit,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetExplicit {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetExplicit").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetExplicit {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3030,11 +3128,18 @@ impl Serialize for SetExplicit {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyModMap {
     pub keycode: xproto::Keycode,
     pub mods: xproto::ModMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KeyModMap {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeyModMap").finish_non_exhaustive()
+    }
 }
 impl TryParse for KeyModMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3062,11 +3167,18 @@ impl Serialize for KeyModMap {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyVModMap {
     pub keycode: xproto::Keycode,
     pub vmods: VMod,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KeyVModMap {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeyVModMap").finish_non_exhaustive()
+    }
 }
 impl TryParse for KeyVModMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3098,12 +3210,19 @@ impl Serialize for KeyVModMap {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KTSetMapEntry {
     pub level: u8,
     pub real_mods: xproto::ModMask,
     pub virtual_mods: VMod,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KTSetMapEntry {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KTSetMapEntry").finish_non_exhaustive()
+    }
 }
 impl TryParse for KTSetMapEntry {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3137,7 +3256,8 @@ impl Serialize for KTSetMapEntry {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetKeyType {
     pub mask: xproto::ModMask,
@@ -3147,6 +3267,12 @@ pub struct SetKeyType {
     pub preserve: bool,
     pub entries: Vec<KTSetMapEntry>,
     pub preserve_entries: Vec<KTSetMapEntry>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetKeyType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetKeyType").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetKeyType {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3206,11 +3332,18 @@ impl SetKeyType {
 
 pub type String8 = u8;
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Outline {
     pub corner_radius: u8,
     pub points: Vec<xproto::Point>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Outline {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Outline").finish_non_exhaustive()
+    }
 }
 impl TryParse for Outline {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3254,13 +3387,20 @@ impl Outline {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Shape {
     pub name: xproto::Atom,
     pub primary_ndx: u8,
     pub approx_ndx: u8,
     pub outlines: Vec<Outline>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Shape {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Shape").finish_non_exhaustive()
+    }
 }
 impl TryParse for Shape {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3308,13 +3448,20 @@ impl Shape {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Key {
     pub name: [String8; 4],
     pub gap: i16,
     pub shape_ndx: u8,
     pub color_ndx: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Key {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Key").finish_non_exhaustive()
+    }
 }
 impl TryParse for Key {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3352,11 +3499,18 @@ impl Serialize for Key {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OverlayKey {
     pub over: [String8; 4],
     pub under: [String8; 4],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for OverlayKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OverlayKey").finish_non_exhaustive()
+    }
 }
 impl TryParse for OverlayKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3387,11 +3541,18 @@ impl Serialize for OverlayKey {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OverlayRow {
     pub row_under: u8,
     pub keys: Vec<OverlayKey>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for OverlayRow {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OverlayRow").finish_non_exhaustive()
+    }
 }
 impl TryParse for OverlayRow {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3435,11 +3596,18 @@ impl OverlayRow {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Overlay {
     pub name: xproto::Atom,
     pub rows: Vec<OverlayRow>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Overlay {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Overlay").finish_non_exhaustive()
+    }
 }
 impl TryParse for Overlay {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3483,13 +3651,20 @@ impl Overlay {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Row {
     pub top: i16,
     pub left: i16,
     pub vertical: bool,
     pub keys: Vec<Key>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Row {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Row").finish_non_exhaustive()
+    }
 }
 impl TryParse for Row {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3602,11 +3777,18 @@ impl core::fmt::Debug for DoodadType  {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Listing {
     pub flags: u16,
     pub string: Vec<String8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Listing {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Listing").finish_non_exhaustive()
+    }
 }
 impl TryParse for Listing {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3655,7 +3837,8 @@ impl Listing {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceLedInfo {
     pub led_class: LedClass,
@@ -3666,6 +3849,12 @@ pub struct DeviceLedInfo {
     pub state: u32,
     pub names: Vec<xproto::Atom>,
     pub maps: Vec<IndicatorMap>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeviceLedInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeviceLedInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for DeviceLedInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3929,10 +4118,17 @@ impl core::fmt::Debug for SAType  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SANoAction {
     pub type_: SAType,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SANoAction {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SANoAction").finish_non_exhaustive()
+    }
 }
 impl TryParse for SANoAction {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3965,7 +4161,8 @@ impl Serialize for SANoAction {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetMods {
     pub type_: SAType,
@@ -3974,6 +4171,12 @@ pub struct SASetMods {
     pub real_mods: xproto::ModMask,
     pub vmods_high: VModsHigh,
     pub vmods_low: VModsLow,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SASetMods {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SASetMods").finish_non_exhaustive()
+    }
 }
 impl TryParse for SASetMods {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4030,12 +4233,19 @@ pub type SALatchMods = SASetMods;
 
 pub type SALockMods = SASetMods;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetGroup {
     pub type_: SAType,
     pub flags: SA,
     pub group: i8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SASetGroup {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SASetGroup").finish_non_exhaustive()
+    }
 }
 impl TryParse for SASetGroup {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4141,7 +4351,8 @@ impl core::fmt::Debug for SAMovePtrFlag  {
 }
 bitmask_binop!(SAMovePtrFlag, u8);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAMovePtr {
     pub type_: SAType,
@@ -4150,6 +4361,12 @@ pub struct SAMovePtr {
     pub x_low: u8,
     pub y_high: i8,
     pub y_low: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SAMovePtr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SAMovePtr").finish_non_exhaustive()
+    }
 }
 impl TryParse for SAMovePtr {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4198,13 +4415,20 @@ impl Serialize for SAMovePtr {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAPtrBtn {
     pub type_: SAType,
     pub flags: u8,
     pub count: u8,
     pub button: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SAPtrBtn {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SAPtrBtn").finish_non_exhaustive()
+    }
 }
 impl TryParse for SAPtrBtn {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4246,12 +4470,19 @@ impl Serialize for SAPtrBtn {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SALockPtrBtn {
     pub type_: SAType,
     pub flags: u8,
     pub button: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SALockPtrBtn {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SALockPtrBtn").finish_non_exhaustive()
+    }
 }
 impl TryParse for SALockPtrBtn {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4352,13 +4583,20 @@ impl core::fmt::Debug for SASetPtrDfltFlag  {
 }
 bitmask_binop!(SASetPtrDfltFlag, u8);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetPtrDflt {
     pub type_: SAType,
     pub flags: SASetPtrDfltFlag,
     pub affect: SASetPtrDfltFlag,
     pub value: i8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SASetPtrDflt {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SASetPtrDflt").finish_non_exhaustive()
+    }
 }
 impl TryParse for SASetPtrDflt {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4532,7 +4770,8 @@ impl core::fmt::Debug for SAIsoLockNoAffect  {
 }
 bitmask_binop!(SAIsoLockNoAffect, u8);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAIsoLock {
     pub type_: SAType,
@@ -4543,6 +4782,12 @@ pub struct SAIsoLock {
     pub affect: SAIsoLockNoAffect,
     pub vmods_high: VModsHigh,
     pub vmods_low: VModsLow,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SAIsoLock {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SAIsoLock").finish_non_exhaustive()
+    }
 }
 impl TryParse for SAIsoLock {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4600,10 +4845,17 @@ impl Serialize for SAIsoLock {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SATerminate {
     pub type_: SAType,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SATerminate {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SATerminate").finish_non_exhaustive()
+    }
 }
 impl TryParse for SATerminate {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4696,12 +4948,19 @@ impl core::fmt::Debug for SwitchScreenFlag  {
 }
 bitmask_binop!(SwitchScreenFlag, u8);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASwitchScreen {
     pub type_: SAType,
     pub flags: u8,
     pub new_screen: i8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SASwitchScreen {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SASwitchScreen").finish_non_exhaustive()
+    }
 }
 impl TryParse for SASwitchScreen {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4878,12 +5137,19 @@ impl core::fmt::Debug for BoolCtrlsLow  {
 }
 bitmask_binop!(BoolCtrlsLow, u8);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SASetControls {
     pub type_: SAType,
     pub bool_ctrls_high: BoolCtrlsHigh,
     pub bool_ctrls_low: BoolCtrlsLow,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SASetControls {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SASetControls").finish_non_exhaustive()
+    }
 }
 impl TryParse for SASetControls {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4990,12 +5256,19 @@ impl core::fmt::Debug for ActionMessageFlag  {
 }
 bitmask_binop!(ActionMessageFlag, u8);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SAActionMessage {
     pub type_: SAType,
     pub flags: ActionMessageFlag,
     pub message: [u8; 6],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SAActionMessage {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SAActionMessage").finish_non_exhaustive()
+    }
 }
 impl TryParse for SAActionMessage {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5032,7 +5305,8 @@ impl Serialize for SAActionMessage {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SARedirectKey {
     pub type_: SAType,
@@ -5043,6 +5317,12 @@ pub struct SARedirectKey {
     pub vmods_mask_low: VModsLow,
     pub vmods_high: VModsHigh,
     pub vmods_low: VModsLow,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SARedirectKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SARedirectKey").finish_non_exhaustive()
+    }
 }
 impl TryParse for SARedirectKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5100,7 +5380,8 @@ impl Serialize for SARedirectKey {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SADeviceBtn {
     pub type_: SAType,
@@ -5108,6 +5389,12 @@ pub struct SADeviceBtn {
     pub count: u8,
     pub button: u8,
     pub device: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SADeviceBtn {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SADeviceBtn").finish_non_exhaustive()
+    }
 }
 impl TryParse for SADeviceBtn {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5212,13 +5499,20 @@ impl core::fmt::Debug for LockDeviceFlags  {
 }
 bitmask_binop!(LockDeviceFlags, u8);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SALockDeviceBtn {
     pub type_: SAType,
     pub flags: LockDeviceFlags,
     pub button: u8,
     pub device: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SALockDeviceBtn {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SALockDeviceBtn").finish_non_exhaustive()
+    }
 }
 impl TryParse for SALockDeviceBtn {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5330,7 +5624,8 @@ impl core::fmt::Debug for SAValWhat  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SADeviceValuator {
     pub type_: SAType,
@@ -5341,6 +5636,12 @@ pub struct SADeviceValuator {
     pub val2what: SAValWhat,
     pub val2index: u8,
     pub val2value: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SADeviceValuator {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SADeviceValuator").finish_non_exhaustive()
+    }
 }
 impl TryParse for SADeviceValuator {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5394,11 +5695,18 @@ impl Serialize for SADeviceValuator {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SIAction {
     pub type_: SAType,
     pub data: [u8; 7],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SIAction {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SIAction").finish_non_exhaustive()
+    }
 }
 impl TryParse for SIAction {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5431,7 +5739,8 @@ impl Serialize for SIAction {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SymInterpret {
     pub sym: xproto::Keysym,
@@ -5440,6 +5749,12 @@ pub struct SymInterpret {
     pub virtual_mod: VModsLow,
     pub flags: u8,
     pub action: SIAction,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SymInterpret {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SymInterpret").finish_non_exhaustive()
+    }
 }
 impl TryParse for SymInterpret {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5810,11 +6125,18 @@ impl From<SAType> for Action {
 
 /// Opcode for the UseExtension request
 pub const USE_EXTENSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UseExtensionRequest {
     pub wanted_major: u16,
     pub wanted_minor: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UseExtensionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UseExtensionRequest").finish_non_exhaustive()
+    }
 }
 impl UseExtensionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -5866,7 +6188,8 @@ impl crate::x11_utils::ReplyRequest for UseExtensionRequest {
     type Reply = UseExtensionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UseExtensionReply {
     pub supported: bool,
@@ -5874,6 +6197,12 @@ pub struct UseExtensionReply {
     pub length: u32,
     pub server_major: u16,
     pub server_minor: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UseExtensionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UseExtensionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for UseExtensionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5952,11 +6281,18 @@ impl Serialize for UseExtensionReply {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxNewKeyboardNotify {
     pub affect_new_keyboard: NKNDetail,
     pub new_keyboard_details: NKNDetail,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectEventsAuxNewKeyboardNotify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsAuxNewKeyboardNotify").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectEventsAuxNewKeyboardNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5986,11 +6322,18 @@ impl Serialize for SelectEventsAuxNewKeyboardNotify {
         u16::from(self.new_keyboard_details).serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxStateNotify {
     pub affect_state: StatePart,
     pub state_details: StatePart,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectEventsAuxStateNotify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsAuxStateNotify").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectEventsAuxStateNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6020,11 +6363,18 @@ impl Serialize for SelectEventsAuxStateNotify {
         u16::from(self.state_details).serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxControlsNotify {
     pub affect_ctrls: Control,
     pub ctrl_details: Control,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectEventsAuxControlsNotify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsAuxControlsNotify").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectEventsAuxControlsNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6058,11 +6408,18 @@ impl Serialize for SelectEventsAuxControlsNotify {
         u32::from(self.ctrl_details).serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxIndicatorStateNotify {
     pub affect_indicator_state: u32,
     pub indicator_state_details: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectEventsAuxIndicatorStateNotify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsAuxIndicatorStateNotify").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectEventsAuxIndicatorStateNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6094,11 +6451,18 @@ impl Serialize for SelectEventsAuxIndicatorStateNotify {
         self.indicator_state_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxIndicatorMapNotify {
     pub affect_indicator_map: u32,
     pub indicator_map_details: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectEventsAuxIndicatorMapNotify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsAuxIndicatorMapNotify").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectEventsAuxIndicatorMapNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6130,11 +6494,18 @@ impl Serialize for SelectEventsAuxIndicatorMapNotify {
         self.indicator_map_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxNamesNotify {
     pub affect_names: NameDetail,
     pub names_details: NameDetail,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectEventsAuxNamesNotify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsAuxNamesNotify").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectEventsAuxNamesNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6164,11 +6535,18 @@ impl Serialize for SelectEventsAuxNamesNotify {
         (u32::from(self.names_details) as u16).serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxCompatMapNotify {
     pub affect_compat: CMDetail,
     pub compat_details: CMDetail,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectEventsAuxCompatMapNotify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsAuxCompatMapNotify").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectEventsAuxCompatMapNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6196,11 +6574,18 @@ impl Serialize for SelectEventsAuxCompatMapNotify {
         u8::from(self.compat_details).serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxBellNotify {
     pub affect_bell: u8,
     pub bell_details: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectEventsAuxBellNotify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsAuxBellNotify").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectEventsAuxBellNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6226,11 +6611,18 @@ impl Serialize for SelectEventsAuxBellNotify {
         self.bell_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxActionMessage {
     pub affect_msg_details: u8,
     pub msg_details: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectEventsAuxActionMessage {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsAuxActionMessage").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectEventsAuxActionMessage {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6256,11 +6648,18 @@ impl Serialize for SelectEventsAuxActionMessage {
         self.msg_details.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxAccessXNotify {
     pub affect_access_x: AXNDetail,
     pub access_x_details: AXNDetail,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectEventsAuxAccessXNotify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsAuxAccessXNotify").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectEventsAuxAccessXNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6290,11 +6689,18 @@ impl Serialize for SelectEventsAuxAccessXNotify {
         u16::from(self.access_x_details).serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAuxExtensionDeviceNotify {
     pub affect_ext_dev: XIFeature,
     pub extdev_details: XIFeature,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectEventsAuxExtensionDeviceNotify {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsAuxExtensionDeviceNotify").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectEventsAuxExtensionDeviceNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6325,7 +6731,8 @@ impl Serialize for SelectEventsAuxExtensionDeviceNotify {
     }
 }
 /// Auxiliary and optional information for the `select_events` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsAux {
     pub new_keyboard_notify: Option<SelectEventsAuxNewKeyboardNotify>,
@@ -6339,6 +6746,12 @@ pub struct SelectEventsAux {
     pub action_message: Option<SelectEventsAuxActionMessage>,
     pub access_x_notify: Option<SelectEventsAuxAccessXNotify>,
     pub extension_device_notify: Option<SelectEventsAuxExtensionDeviceNotify>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectEventsAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsAux").finish_non_exhaustive()
+    }
 }
 impl SelectEventsAux {
     fn try_parse(value: &[u8], affect_which: u16, clear: u16, select_all: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -6583,7 +6996,8 @@ impl SelectEventsAux {
 
 /// Opcode for the SelectEvents request
 pub const SELECT_EVENTS_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectEventsRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -6592,6 +7006,12 @@ pub struct SelectEventsRequest<'input> {
     pub affect_map: MapPart,
     pub map: MapPart,
     pub details: Cow<'input, SelectEventsAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SelectEventsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectEventsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SelectEventsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -6685,7 +7105,8 @@ impl<'input> crate::x11_utils::VoidRequest for SelectEventsRequest<'input> {
 
 /// Opcode for the Bell request
 pub const BELL_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BellRequest {
     pub device_spec: DeviceSpec,
@@ -6698,6 +7119,12 @@ pub struct BellRequest {
     pub duration: i16,
     pub name: xproto::Atom,
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BellRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BellRequest").finish_non_exhaustive()
+    }
 }
 impl BellRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6796,10 +7223,17 @@ impl crate::x11_utils::VoidRequest for BellRequest {
 
 /// Opcode for the GetState request
 pub const GET_STATE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStateRequest {
     pub device_spec: DeviceSpec,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetStateRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetStateRequest").finish_non_exhaustive()
+    }
 }
 impl GetStateRequest {
     /// Serialize this request into bytes for the provided connection
@@ -6849,7 +7283,8 @@ impl crate::x11_utils::ReplyRequest for GetStateRequest {
     type Reply = GetStateReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStateReply {
     pub device_id: u8,
@@ -6869,6 +7304,12 @@ pub struct GetStateReply {
     pub lookup_mods: xproto::ModMask,
     pub compat_lookup_mods: xproto::ModMask,
     pub ptr_btn_state: xproto::KeyButMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetStateReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetStateReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetStateReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6999,7 +7440,8 @@ impl Serialize for GetStateReply {
 
 /// Opcode for the LatchLockState request
 pub const LATCH_LOCK_STATE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LatchLockStateRequest {
     pub device_spec: DeviceSpec,
@@ -7010,6 +7452,12 @@ pub struct LatchLockStateRequest {
     pub affect_mod_latches: xproto::ModMask,
     pub latch_group: bool,
     pub group_latch: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for LatchLockStateRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LatchLockStateRequest").finish_non_exhaustive()
+    }
 }
 impl LatchLockStateRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7094,10 +7542,17 @@ impl crate::x11_utils::VoidRequest for LatchLockStateRequest {
 
 /// Opcode for the GetControls request
 pub const GET_CONTROLS_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetControlsRequest {
     pub device_spec: DeviceSpec,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetControlsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetControlsRequest").finish_non_exhaustive()
+    }
 }
 impl GetControlsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7147,7 +7602,8 @@ impl crate::x11_utils::ReplyRequest for GetControlsRequest {
     type Reply = GetControlsReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetControlsReply {
     pub device_id: u8,
@@ -7179,6 +7635,12 @@ pub struct GetControlsReply {
     pub access_x_timeout_values: BoolCtrl,
     pub enabled_controls: BoolCtrl,
     pub per_key_repeat: [u8; 32],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetControlsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetControlsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetControlsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -7404,7 +7866,8 @@ impl Serialize for GetControlsReply {
 
 /// Opcode for the SetControls request
 pub const SET_CONTROLS_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetControlsRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -7437,6 +7900,12 @@ pub struct SetControlsRequest<'input> {
     pub access_x_timeout_options_mask: AXOption,
     pub access_x_timeout_options_values: AXOption,
     pub per_key_repeat: Cow<'input, [u8; 32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetControlsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetControlsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetControlsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -7685,7 +8154,8 @@ impl<'input> crate::x11_utils::VoidRequest for SetControlsRequest<'input> {
 
 /// Opcode for the GetMap request
 pub const GET_MAP_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapRequest {
     pub device_spec: DeviceSpec,
@@ -7706,6 +8176,12 @@ pub struct GetMapRequest {
     pub n_mod_map_keys: u8,
     pub first_v_mod_map_key: xproto::Keycode,
     pub n_v_mod_map_keys: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMapRequest").finish_non_exhaustive()
+    }
 }
 impl GetMapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7829,11 +8305,18 @@ impl crate::x11_utils::ReplyRequest for GetMapRequest {
     type Reply = GetMapReply;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapMapKeyActions {
     pub acts_rtrn_count: Vec<u8>,
     pub acts_rtrn_acts: Vec<Action>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMapMapKeyActions {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMapMapKeyActions").finish_non_exhaustive()
+    }
 }
 impl GetMapMapKeyActions {
     pub fn try_parse(remaining: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -7864,7 +8347,8 @@ impl GetMapMapKeyActions {
         self.acts_rtrn_acts.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapMap {
     pub types_rtrn: Option<Vec<KeyType>>,
@@ -7875,6 +8359,12 @@ pub struct GetMapMap {
     pub explicit_rtrn: Option<Vec<SetExplicit>>,
     pub modmap_rtrn: Option<Vec<KeyModMap>>,
     pub vmodmap_rtrn: Option<Vec<KeyVModMap>>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMapMap {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMapMap").finish_non_exhaustive()
+    }
 }
 impl GetMapMap {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -8048,7 +8538,8 @@ impl GetMapMap {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMapReply {
     pub device_id: u8,
@@ -8079,6 +8570,12 @@ pub struct GetMapReply {
     pub total_v_mod_map_keys: u8,
     pub virtual_mods: VMod,
     pub map: GetMapMap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMapReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMapReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMapReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8172,11 +8669,18 @@ impl Serialize for GetMapReply {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetMapAuxKeyActions {
     pub actions_count: Vec<u8>,
     pub actions: Vec<Action>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetMapAuxKeyActions {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetMapAuxKeyActions").finish_non_exhaustive()
+    }
 }
 impl SetMapAuxKeyActions {
     pub fn try_parse(remaining: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -8208,7 +8712,8 @@ impl SetMapAuxKeyActions {
     }
 }
 /// Auxiliary and optional information for the `set_map` function
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetMapAux {
     pub types: Option<Vec<SetKeyType>>,
@@ -8219,6 +8724,12 @@ pub struct SetMapAux {
     pub explicit: Option<Vec<SetExplicit>>,
     pub modmap: Option<Vec<KeyModMap>>,
     pub vmodmap: Option<Vec<KeyVModMap>>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetMapAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetMapAux").finish_non_exhaustive()
+    }
 }
 impl SetMapAux {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -8427,7 +8938,8 @@ impl SetMapAux {
 
 /// Opcode for the SetMap request
 pub const SET_MAP_REQUEST: u8 = 9;
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetMapRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -8456,6 +8968,12 @@ pub struct SetMapRequest<'input> {
     pub total_v_mod_map_keys: u8,
     pub virtual_mods: VMod,
     pub values: Cow<'input, SetMapAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetMapRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetMapRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetMapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -8647,7 +9165,8 @@ impl<'input> crate::x11_utils::VoidRequest for SetMapRequest<'input> {
 
 /// Opcode for the GetCompatMap request
 pub const GET_COMPAT_MAP_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCompatMapRequest {
     pub device_spec: DeviceSpec,
@@ -8655,6 +9174,12 @@ pub struct GetCompatMapRequest {
     pub get_all_si: bool,
     pub first_si: u16,
     pub n_si: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCompatMapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCompatMapRequest").finish_non_exhaustive()
+    }
 }
 impl GetCompatMapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8720,7 +9245,8 @@ impl crate::x11_utils::ReplyRequest for GetCompatMapRequest {
     type Reply = GetCompatMapReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCompatMapReply {
     pub device_id: u8,
@@ -8731,6 +9257,12 @@ pub struct GetCompatMapReply {
     pub n_total_si: u16,
     pub si_rtrn: Vec<SymInterpret>,
     pub group_rtrn: Vec<ModDef>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetCompatMapReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetCompatMapReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetCompatMapReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8802,7 +9334,8 @@ impl GetCompatMapReply {
 
 /// Opcode for the SetCompatMap request
 pub const SET_COMPAT_MAP_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCompatMapRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -8812,6 +9345,12 @@ pub struct SetCompatMapRequest<'input> {
     pub first_si: u16,
     pub si: Cow<'input, [SymInterpret]>,
     pub group_maps: Cow<'input, [ModDef]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetCompatMapRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetCompatMapRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetCompatMapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -8910,10 +9449,17 @@ impl<'input> crate::x11_utils::VoidRequest for SetCompatMapRequest<'input> {
 
 /// Opcode for the GetIndicatorState request
 pub const GET_INDICATOR_STATE_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetIndicatorStateRequest {
     pub device_spec: DeviceSpec,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetIndicatorStateRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetIndicatorStateRequest").finish_non_exhaustive()
+    }
 }
 impl GetIndicatorStateRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8963,13 +9509,20 @@ impl crate::x11_utils::ReplyRequest for GetIndicatorStateRequest {
     type Reply = GetIndicatorStateReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetIndicatorStateReply {
     pub device_id: u8,
     pub sequence: u16,
     pub length: u32,
     pub state: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetIndicatorStateReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetIndicatorStateReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetIndicatorStateReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9047,11 +9600,18 @@ impl Serialize for GetIndicatorStateReply {
 
 /// Opcode for the GetIndicatorMap request
 pub const GET_INDICATOR_MAP_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetIndicatorMapRequest {
     pub device_spec: DeviceSpec,
     pub which: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetIndicatorMapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetIndicatorMapRequest").finish_non_exhaustive()
+    }
 }
 impl GetIndicatorMapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9108,7 +9668,8 @@ impl crate::x11_utils::ReplyRequest for GetIndicatorMapRequest {
     type Reply = GetIndicatorMapReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetIndicatorMapReply {
     pub device_id: u8,
@@ -9118,6 +9679,12 @@ pub struct GetIndicatorMapReply {
     pub real_indicators: u32,
     pub n_indicators: u8,
     pub maps: Vec<IndicatorMap>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetIndicatorMapReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetIndicatorMapReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetIndicatorMapReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9166,12 +9733,19 @@ impl Serialize for GetIndicatorMapReply {
 
 /// Opcode for the SetIndicatorMap request
 pub const SET_INDICATOR_MAP_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetIndicatorMapRequest<'input> {
     pub device_spec: DeviceSpec,
     pub which: u32,
     pub maps: Cow<'input, [IndicatorMap]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetIndicatorMapRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetIndicatorMapRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetIndicatorMapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -9244,13 +9818,20 @@ impl<'input> crate::x11_utils::VoidRequest for SetIndicatorMapRequest<'input> {
 
 /// Opcode for the GetNamedIndicator request
 pub const GET_NAMED_INDICATOR_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamedIndicatorRequest {
     pub device_spec: DeviceSpec,
     pub led_class: LedClass,
     pub led_id: IDSpec,
     pub indicator: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetNamedIndicatorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetNamedIndicatorRequest").finish_non_exhaustive()
+    }
 }
 impl GetNamedIndicatorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9318,7 +9899,8 @@ impl crate::x11_utils::ReplyRequest for GetNamedIndicatorRequest {
     type Reply = GetNamedIndicatorReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamedIndicatorReply {
     pub device_id: u8,
@@ -9338,6 +9920,12 @@ pub struct GetNamedIndicatorReply {
     pub map_vmod: VMod,
     pub map_ctrls: BoolCtrl,
     pub supported: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetNamedIndicatorReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetNamedIndicatorReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetNamedIndicatorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9462,7 +10050,8 @@ impl Serialize for GetNamedIndicatorReply {
 
 /// Opcode for the SetNamedIndicator request
 pub const SET_NAMED_INDICATOR_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetNamedIndicatorRequest {
     pub device_spec: DeviceSpec,
@@ -9480,6 +10069,12 @@ pub struct SetNamedIndicatorRequest {
     pub map_real_mods: xproto::ModMask,
     pub map_vmods: VMod,
     pub map_ctrls: BoolCtrl,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetNamedIndicatorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetNamedIndicatorRequest").finish_non_exhaustive()
+    }
 }
 impl SetNamedIndicatorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9605,11 +10200,18 @@ impl crate::x11_utils::VoidRequest for SetNamedIndicatorRequest {
 
 /// Opcode for the GetNames request
 pub const GET_NAMES_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamesRequest {
     pub device_spec: DeviceSpec,
     pub which: NameDetail,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetNamesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetNamesRequest").finish_non_exhaustive()
+    }
 }
 impl GetNamesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9667,11 +10269,18 @@ impl crate::x11_utils::ReplyRequest for GetNamesRequest {
     type Reply = GetNamesReply;
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamesValueListKTLevelNames {
     pub n_levels_per_type: Vec<u8>,
     pub kt_level_names: Vec<xproto::Atom>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetNamesValueListKTLevelNames {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetNamesValueListKTLevelNames").finish_non_exhaustive()
+    }
 }
 impl GetNamesValueListKTLevelNames {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -9702,7 +10311,8 @@ impl GetNamesValueListKTLevelNames {
         self.kt_level_names.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamesValueList {
     pub keycodes_name: Option<xproto::Atom>,
@@ -9719,6 +10329,12 @@ pub struct GetNamesValueList {
     pub key_names: Option<Vec<KeyName>>,
     pub key_aliases: Option<Vec<KeyAlias>>,
     pub radio_group_names: Option<Vec<xproto::Atom>>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetNamesValueList {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetNamesValueList").finish_non_exhaustive()
+    }
 }
 impl GetNamesValueList {
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -9948,7 +10564,8 @@ impl GetNamesValueList {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetNamesReply {
     pub device_id: u8,
@@ -9966,6 +10583,12 @@ pub struct GetNamesReply {
     pub n_key_aliases: u8,
     pub n_kt_levels: u16,
     pub value_list: GetNamesValueList,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetNamesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetNamesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetNamesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10032,11 +10655,18 @@ impl Serialize for GetNamesReply {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetNamesAuxKTLevelNames {
     pub n_levels_per_type: Vec<u8>,
     pub kt_level_names: Vec<xproto::Atom>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetNamesAuxKTLevelNames {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetNamesAuxKTLevelNames").finish_non_exhaustive()
+    }
 }
 impl SetNamesAuxKTLevelNames {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -10068,7 +10698,8 @@ impl SetNamesAuxKTLevelNames {
     }
 }
 /// Auxiliary and optional information for the `set_names` function
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetNamesAux {
     pub keycodes_name: Option<xproto::Atom>,
@@ -10085,6 +10716,12 @@ pub struct SetNamesAux {
     pub key_names: Option<Vec<KeyName>>,
     pub key_aliases: Option<Vec<KeyAlias>>,
     pub radio_group_names: Option<Vec<xproto::Atom>>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetNamesAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetNamesAux").finish_non_exhaustive()
+    }
 }
 impl SetNamesAux {
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -10406,7 +11043,8 @@ impl SetNamesAux {
 
 /// Opcode for the SetNames request
 pub const SET_NAMES_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetNamesRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -10423,6 +11061,12 @@ pub struct SetNamesRequest<'input> {
     pub n_key_aliases: u8,
     pub total_kt_level_names: u16,
     pub values: Cow<'input, SetNamesAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetNamesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetNamesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetNamesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -10559,7 +11203,8 @@ impl<'input> crate::x11_utils::VoidRequest for SetNamesRequest<'input> {
 
 /// Opcode for the PerClientFlags request
 pub const PER_CLIENT_FLAGS_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PerClientFlagsRequest {
     pub device_spec: DeviceSpec,
@@ -10568,6 +11213,12 @@ pub struct PerClientFlagsRequest {
     pub ctrls_to_change: BoolCtrl,
     pub auto_ctrls: BoolCtrl,
     pub auto_ctrls_values: BoolCtrl,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PerClientFlagsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PerClientFlagsRequest").finish_non_exhaustive()
+    }
 }
 impl PerClientFlagsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10657,7 +11308,8 @@ impl crate::x11_utils::ReplyRequest for PerClientFlagsRequest {
     type Reply = PerClientFlagsReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PerClientFlagsReply {
     pub device_id: u8,
@@ -10667,6 +11319,12 @@ pub struct PerClientFlagsReply {
     pub value: PerClientFlag,
     pub auto_ctrls: BoolCtrl,
     pub auto_ctrls_values: BoolCtrl,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PerClientFlagsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PerClientFlagsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PerClientFlagsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10757,11 +11415,18 @@ impl Serialize for PerClientFlagsReply {
 
 /// Opcode for the ListComponents request
 pub const LIST_COMPONENTS_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListComponentsRequest {
     pub device_spec: DeviceSpec,
     pub max_names: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListComponentsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListComponentsRequest").finish_non_exhaustive()
+    }
 }
 impl ListComponentsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10813,7 +11478,8 @@ impl crate::x11_utils::ReplyRequest for ListComponentsRequest {
     type Reply = ListComponentsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListComponentsReply {
     pub device_id: u8,
@@ -10826,6 +11492,12 @@ pub struct ListComponentsReply {
     pub compat_maps: Vec<Listing>,
     pub symbols: Vec<Listing>,
     pub geometries: Vec<Listing>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListComponentsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListComponentsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListComponentsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10977,13 +11649,20 @@ impl ListComponentsReply {
 
 /// Opcode for the GetKbdByName request
 pub const GET_KBD_BY_NAME_REQUEST: u8 = 23;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRequest {
     pub device_spec: DeviceSpec,
     pub need: GBNDetail,
     pub want: GBNDetail,
     pub load: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKbdByNameRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKbdByNameRequest").finish_non_exhaustive()
+    }
 }
 impl GetKbdByNameRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11048,11 +11727,18 @@ impl crate::x11_utils::ReplyRequest for GetKbdByNameRequest {
     type Reply = GetKbdByNameReply;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesTypesMapKeyActions {
     pub acts_rtrn_count: Vec<u8>,
     pub acts_rtrn_acts: Vec<Action>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKbdByNameRepliesTypesMapKeyActions {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKbdByNameRepliesTypesMapKeyActions").finish_non_exhaustive()
+    }
 }
 impl GetKbdByNameRepliesTypesMapKeyActions {
     pub fn try_parse(remaining: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -11083,7 +11769,8 @@ impl GetKbdByNameRepliesTypesMapKeyActions {
         self.acts_rtrn_acts.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesTypesMap {
     pub types_rtrn: Option<Vec<KeyType>>,
@@ -11094,6 +11781,12 @@ pub struct GetKbdByNameRepliesTypesMap {
     pub explicit_rtrn: Option<Vec<SetExplicit>>,
     pub modmap_rtrn: Option<Vec<KeyModMap>>,
     pub vmodmap_rtrn: Option<Vec<KeyVModMap>>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKbdByNameRepliesTypesMap {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKbdByNameRepliesTypesMap").finish_non_exhaustive()
+    }
 }
 impl GetKbdByNameRepliesTypesMap {
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -11267,7 +11960,8 @@ impl GetKbdByNameRepliesTypesMap {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesTypes {
     pub getmap_type: u8,
@@ -11299,6 +11993,12 @@ pub struct GetKbdByNameRepliesTypes {
     pub total_v_mod_map_keys: u8,
     pub virtual_mods: VMod,
     pub map: GetKbdByNameRepliesTypesMap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKbdByNameRepliesTypes {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKbdByNameRepliesTypes").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetKbdByNameRepliesTypes {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11383,7 +12083,8 @@ impl Serialize for GetKbdByNameRepliesTypes {
         self.map.serialize_into(bytes, u16::from(present), u8::from(self.n_types), u8::from(self.n_key_syms), u8::from(self.n_key_actions), u16::from(self.total_actions), u8::from(self.total_key_behaviors), u16::from(self.virtual_mods), u8::from(self.total_key_explicit), u8::from(self.total_mod_map_keys), u8::from(self.total_v_mod_map_keys));
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesCompatMap {
     pub compatmap_type: u8,
@@ -11395,6 +12096,12 @@ pub struct GetKbdByNameRepliesCompatMap {
     pub n_total_si: u16,
     pub si_rtrn: Vec<SymInterpret>,
     pub group_rtrn: Vec<ModDef>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKbdByNameRepliesCompatMap {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKbdByNameRepliesCompatMap").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetKbdByNameRepliesCompatMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11455,7 +12162,8 @@ impl GetKbdByNameRepliesCompatMap {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesIndicatorMaps {
     pub indicatormap_type: u8,
@@ -11465,6 +12173,12 @@ pub struct GetKbdByNameRepliesIndicatorMaps {
     pub which: u32,
     pub real_indicators: u32,
     pub maps: Vec<IndicatorMap>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKbdByNameRepliesIndicatorMaps {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKbdByNameRepliesIndicatorMaps").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetKbdByNameRepliesIndicatorMaps {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11517,11 +12231,18 @@ impl GetKbdByNameRepliesIndicatorMaps {
             .try_into().unwrap()
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesKeyNamesValueListKTLevelNames {
     pub n_levels_per_type: Vec<u8>,
     pub kt_level_names: Vec<xproto::Atom>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKbdByNameRepliesKeyNamesValueListKTLevelNames {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKbdByNameRepliesKeyNamesValueListKTLevelNames").finish_non_exhaustive()
+    }
 }
 impl GetKbdByNameRepliesKeyNamesValueListKTLevelNames {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -11552,7 +12273,8 @@ impl GetKbdByNameRepliesKeyNamesValueListKTLevelNames {
         self.kt_level_names.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesKeyNamesValueList {
     pub keycodes_name: Option<xproto::Atom>,
@@ -11569,6 +12291,12 @@ pub struct GetKbdByNameRepliesKeyNamesValueList {
     pub key_names: Option<Vec<KeyName>>,
     pub key_aliases: Option<Vec<KeyAlias>>,
     pub radio_group_names: Option<Vec<xproto::Atom>>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKbdByNameRepliesKeyNamesValueList {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKbdByNameRepliesKeyNamesValueList").finish_non_exhaustive()
+    }
 }
 impl GetKbdByNameRepliesKeyNamesValueList {
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -11798,7 +12526,8 @@ impl GetKbdByNameRepliesKeyNamesValueList {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesKeyNames {
     pub keyname_type: u8,
@@ -11817,6 +12546,12 @@ pub struct GetKbdByNameRepliesKeyNames {
     pub n_key_aliases: u8,
     pub n_kt_levels: u16,
     pub value_list: GetKbdByNameRepliesKeyNamesValueList,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKbdByNameRepliesKeyNames {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKbdByNameRepliesKeyNames").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetKbdByNameRepliesKeyNames {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11874,7 +12609,8 @@ impl Serialize for GetKbdByNameRepliesKeyNames {
         self.value_list.serialize_into(bytes, u32::from(which), u8::from(self.n_types), u32::from(self.indicators), u16::from(self.virtual_mods), u8::from(self.group_names), u8::from(self.n_keys), u8::from(self.n_key_aliases), u8::from(self.n_radio_groups));
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameRepliesGeometry {
     pub geometry_type: u8,
@@ -11894,6 +12630,12 @@ pub struct GetKbdByNameRepliesGeometry {
     pub base_color_ndx: u8,
     pub label_color_ndx: u8,
     pub label_font: CountedString16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKbdByNameRepliesGeometry {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKbdByNameRepliesGeometry").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetKbdByNameRepliesGeometry {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11948,7 +12690,8 @@ impl Serialize for GetKbdByNameRepliesGeometry {
         self.label_font.serialize_into(bytes);
     }
 }
-#[derive(Debug, Clone, Default)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameReplies {
     pub types: Option<GetKbdByNameRepliesTypes>,
@@ -11956,6 +12699,12 @@ pub struct GetKbdByNameReplies {
     pub indicator_maps: Option<GetKbdByNameRepliesIndicatorMaps>,
     pub key_names: Option<GetKbdByNameRepliesKeyNames>,
     pub geometry: Option<GetKbdByNameRepliesGeometry>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKbdByNameReplies {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKbdByNameReplies").finish_non_exhaustive()
+    }
 }
 impl GetKbdByNameReplies {
     fn try_parse(value: &[u8], reported: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -12027,7 +12776,8 @@ impl GetKbdByNameReplies {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKbdByNameReply {
     pub device_id: u8,
@@ -12040,6 +12790,12 @@ pub struct GetKbdByNameReply {
     pub found: GBNDetail,
     pub reported: GBNDetail,
     pub replies: GetKbdByNameReplies,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKbdByNameReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKbdByNameReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetKbdByNameReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12095,7 +12851,8 @@ impl Serialize for GetKbdByNameReply {
 
 /// Opcode for the GetDeviceInfo request
 pub const GET_DEVICE_INFO_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceInfoRequest {
     pub device_spec: DeviceSpec,
@@ -12105,6 +12862,12 @@ pub struct GetDeviceInfoRequest {
     pub n_buttons: u8,
     pub led_class: LedClass,
     pub led_id: IDSpec,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceInfoRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceInfoRequest").finish_non_exhaustive()
+    }
 }
 impl GetDeviceInfoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12182,7 +12945,8 @@ impl crate::x11_utils::ReplyRequest for GetDeviceInfoRequest {
     type Reply = GetDeviceInfoReply;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceInfoReply {
     pub device_id: u8,
@@ -12202,6 +12966,12 @@ pub struct GetDeviceInfoReply {
     pub name: Vec<String8>,
     pub btn_actions: Vec<Action>,
     pub leds: Vec<DeviceLedInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceInfoReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceInfoReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDeviceInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12329,7 +13099,8 @@ impl GetDeviceInfoReply {
 
 /// Opcode for the SetDeviceInfo request
 pub const SET_DEVICE_INFO_REQUEST: u8 = 25;
-#[derive(Debug, Clone)]
+#[derive(Clone)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceInfoRequest<'input> {
     pub device_spec: DeviceSpec,
@@ -12337,6 +13108,12 @@ pub struct SetDeviceInfoRequest<'input> {
     pub change: XIFeature,
     pub btn_actions: Cow<'input, [Action]>,
     pub leds: Cow<'input, [DeviceLedInfo]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetDeviceInfoRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDeviceInfoRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetDeviceInfoRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -12423,7 +13200,8 @@ impl<'input> crate::x11_utils::VoidRequest for SetDeviceInfoRequest<'input> {
 
 /// Opcode for the SetDebuggingFlags request
 pub const SET_DEBUGGING_FLAGS_REQUEST: u8 = 101;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDebuggingFlagsRequest<'input> {
     pub affect_flags: u32,
@@ -12431,6 +13209,12 @@ pub struct SetDebuggingFlagsRequest<'input> {
     pub affect_ctrls: u32,
     pub ctrls: u32,
     pub message: Cow<'input, [String8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetDebuggingFlagsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDebuggingFlagsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetDebuggingFlagsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -12523,7 +13307,8 @@ impl<'input> crate::x11_utils::ReplyRequest for SetDebuggingFlagsRequest<'input>
     type Reply = SetDebuggingFlagsReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDebuggingFlagsReply {
     pub sequence: u16,
@@ -12532,6 +13317,12 @@ pub struct SetDebuggingFlagsReply {
     pub current_ctrls: u32,
     pub supported_flags: u32,
     pub supported_ctrls: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetDebuggingFlagsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDebuggingFlagsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetDebuggingFlagsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12617,7 +13408,8 @@ impl Serialize for SetDebuggingFlagsReply {
 
 /// Opcode for the NewKeyboardNotify event
 pub const NEW_KEYBOARD_NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NewKeyboardNotifyEvent {
     pub response_type: u8,
@@ -12633,6 +13425,12 @@ pub struct NewKeyboardNotifyEvent {
     pub request_major: u8,
     pub request_minor: u8,
     pub changed: NKNDetail,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for NewKeyboardNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NewKeyboardNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for NewKeyboardNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12787,7 +13585,8 @@ impl From<NewKeyboardNotifyEvent> for [u8; 32] {
 
 /// Opcode for the MapNotify event
 pub const MAP_NOTIFY_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapNotifyEvent {
     pub response_type: u8,
@@ -12814,6 +13613,12 @@ pub struct MapNotifyEvent {
     pub first_v_mod_map_key: xproto::Keycode,
     pub n_v_mod_map_keys: u8,
     pub virtual_mods: VMod,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MapNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MapNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for MapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13013,7 +13818,8 @@ impl From<MapNotifyEvent> for [u8; 32] {
 
 /// Opcode for the StateNotify event
 pub const STATE_NOTIFY_EVENT: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StateNotifyEvent {
     pub response_type: u8,
@@ -13040,6 +13846,12 @@ pub struct StateNotifyEvent {
     pub event_type: u8,
     pub request_major: u8,
     pub request_minor: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for StateNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StateNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for StateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13248,7 +14060,8 @@ impl From<StateNotifyEvent> for [u8; 32] {
 
 /// Opcode for the ControlsNotify event
 pub const CONTROLS_NOTIFY_EVENT: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ControlsNotifyEvent {
     pub response_type: u8,
@@ -13264,6 +14077,12 @@ pub struct ControlsNotifyEvent {
     pub event_type: u8,
     pub request_major: u8,
     pub request_minor: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ControlsNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ControlsNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ControlsNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13422,7 +14241,8 @@ impl From<ControlsNotifyEvent> for [u8; 32] {
 
 /// Opcode for the IndicatorStateNotify event
 pub const INDICATOR_STATE_NOTIFY_EVENT: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndicatorStateNotifyEvent {
     pub response_type: u8,
@@ -13432,6 +14252,12 @@ pub struct IndicatorStateNotifyEvent {
     pub device_id: u8,
     pub state: u32,
     pub state_changed: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IndicatorStateNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IndicatorStateNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for IndicatorStateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13563,7 +14389,8 @@ impl From<IndicatorStateNotifyEvent> for [u8; 32] {
 
 /// Opcode for the IndicatorMapNotify event
 pub const INDICATOR_MAP_NOTIFY_EVENT: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndicatorMapNotifyEvent {
     pub response_type: u8,
@@ -13573,6 +14400,12 @@ pub struct IndicatorMapNotifyEvent {
     pub device_id: u8,
     pub state: u32,
     pub map_changed: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for IndicatorMapNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("IndicatorMapNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for IndicatorMapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13704,7 +14537,8 @@ impl From<IndicatorMapNotifyEvent> for [u8; 32] {
 
 /// Opcode for the NamesNotify event
 pub const NAMES_NOTIFY_EVENT: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NamesNotifyEvent {
     pub response_type: u8,
@@ -13724,6 +14558,12 @@ pub struct NamesNotifyEvent {
     pub first_key: xproto::Keycode,
     pub n_keys: u8,
     pub changed_indicators: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for NamesNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NamesNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for NamesNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13900,7 +14740,8 @@ impl From<NamesNotifyEvent> for [u8; 32] {
 
 /// Opcode for the CompatMapNotify event
 pub const COMPAT_MAP_NOTIFY_EVENT: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompatMapNotifyEvent {
     pub response_type: u8,
@@ -13912,6 +14753,12 @@ pub struct CompatMapNotifyEvent {
     pub first_si: u16,
     pub n_si: u16,
     pub n_total_si: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CompatMapNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CompatMapNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for CompatMapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14050,7 +14897,8 @@ impl From<CompatMapNotifyEvent> for [u8; 32] {
 
 /// Opcode for the BellNotify event
 pub const BELL_NOTIFY_EVENT: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BellNotifyEvent {
     pub response_type: u8,
@@ -14066,6 +14914,12 @@ pub struct BellNotifyEvent {
     pub name: xproto::Atom,
     pub window: xproto::Window,
     pub event_only: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BellNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BellNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for BellNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14220,7 +15074,8 @@ impl From<BellNotifyEvent> for [u8; 32] {
 
 /// Opcode for the ActionMessage event
 pub const ACTION_MESSAGE_EVENT: u8 = 9;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ActionMessageEvent {
     pub response_type: u8,
@@ -14234,6 +15089,12 @@ pub struct ActionMessageEvent {
     pub mods: xproto::ModMask,
     pub group: Group,
     pub message: [String8; 8],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ActionMessageEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ActionMessageEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ActionMessageEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14379,7 +15240,8 @@ impl From<ActionMessageEvent> for [u8; 32] {
 
 /// Opcode for the AccessXNotify event
 pub const ACCESS_X_NOTIFY_EVENT: u8 = 10;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AccessXNotifyEvent {
     pub response_type: u8,
@@ -14391,6 +15253,12 @@ pub struct AccessXNotifyEvent {
     pub detailt: AXNDetail,
     pub slow_keys_delay: u16,
     pub debounce_delay: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AccessXNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AccessXNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for AccessXNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14529,7 +15397,8 @@ impl From<AccessXNotifyEvent> for [u8; 32] {
 
 /// Opcode for the ExtensionDeviceNotify event
 pub const EXTENSION_DEVICE_NOTIFY_EVENT: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExtensionDeviceNotifyEvent {
     pub response_type: u8,
@@ -14546,6 +15415,12 @@ pub struct ExtensionDeviceNotifyEvent {
     pub n_buttons: u8,
     pub supported: XIFeature,
     pub unsupported: XIFeature,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ExtensionDeviceNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ExtensionDeviceNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ExtensionDeviceNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/xprint.rs
+++ b/x11rb-protocol/src/protocol/xprint.rs
@@ -419,6 +419,7 @@ impl PrintQueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -561,6 +562,7 @@ impl<'input> PrintGetPrinterListRequest<'input> {
         ([request0.into(), self.printer_name, padding0.into(), self.locale, padding1.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_PRINTER_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -700,6 +702,7 @@ impl PrintRehashPrinterListRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_REHASH_PRINTER_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -778,6 +781,7 @@ impl<'input> CreateContextRequest<'input> {
         ([request0.into(), self.printer_name, padding0.into(), self.locale, padding1.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -856,6 +860,7 @@ impl PrintSetContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_SET_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -909,6 +914,7 @@ impl PrintGetContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1033,6 +1039,7 @@ impl PrintDestroyContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_DESTROY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1086,6 +1093,7 @@ impl PrintGetScreenOfContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_SCREEN_OF_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1210,6 +1218,7 @@ impl PrintStartJobRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_START_JOB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1270,6 +1279,7 @@ impl PrintEndJobRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_END_JOB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1330,6 +1340,7 @@ impl PrintStartDocRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_START_DOC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1390,6 +1401,7 @@ impl PrintEndDocRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_END_DOC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1476,6 +1488,7 @@ impl<'input> PrintPutDocumentDataRequest<'input> {
         ([request0.into(), self.data, padding0.into(), self.doc_format, padding1.into(), self.options, padding2.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_PUT_DOCUMENT_DATA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1568,6 +1581,7 @@ impl PrintGetDocumentDataRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_DOCUMENT_DATA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1708,6 +1722,7 @@ impl PrintStartPageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_START_PAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1768,6 +1783,7 @@ impl PrintEndPageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_END_PAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1835,6 +1851,7 @@ impl PrintSelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1897,6 +1914,7 @@ impl PrintInputSelectedRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_INPUT_SELECTED_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2037,6 +2055,7 @@ impl PrintGetAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2188,6 +2207,7 @@ impl<'input> PrintGetOneAttributesRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_ONE_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2352,6 +2372,7 @@ impl<'input> PrintSetAttributesRequest<'input> {
         ([request0.into(), self.attributes, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_SET_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2431,6 +2452,7 @@ impl PrintGetPageDimensionsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_PAGE_DIMENSIONS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2578,6 +2600,7 @@ impl PrintQueryScreensRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_QUERY_SCREENS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2713,6 +2736,7 @@ impl PrintSetImageResolutionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_SET_IMAGE_RESOLUTION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2841,6 +2865,7 @@ impl PrintGetImageResolutionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_IMAGE_RESOLUTION_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xprint.rs
+++ b/x11rb-protocol/src/protocol/xprint.rs
@@ -419,7 +419,7 @@ impl PrintQueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -562,7 +562,7 @@ impl<'input> PrintGetPrinterListRequest<'input> {
         ([request0.into(), self.printer_name, padding0.into(), self.locale, padding1.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_PRINTER_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -702,7 +702,7 @@ impl PrintRehashPrinterListRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_REHASH_PRINTER_LIST_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -781,7 +781,7 @@ impl<'input> CreateContextRequest<'input> {
         ([request0.into(), self.printer_name, padding0.into(), self.locale, padding1.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -860,7 +860,7 @@ impl PrintSetContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_SET_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -914,7 +914,7 @@ impl PrintGetContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1039,7 +1039,7 @@ impl PrintDestroyContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_DESTROY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1093,7 +1093,7 @@ impl PrintGetScreenOfContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_SCREEN_OF_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1218,7 +1218,7 @@ impl PrintStartJobRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_START_JOB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1279,7 +1279,7 @@ impl PrintEndJobRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_END_JOB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1340,7 +1340,7 @@ impl PrintStartDocRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_START_DOC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1401,7 +1401,7 @@ impl PrintEndDocRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_END_DOC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1488,7 +1488,7 @@ impl<'input> PrintPutDocumentDataRequest<'input> {
         ([request0.into(), self.data, padding0.into(), self.doc_format, padding1.into(), self.options, padding2.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_PUT_DOCUMENT_DATA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1581,7 +1581,7 @@ impl PrintGetDocumentDataRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_DOCUMENT_DATA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1722,7 +1722,7 @@ impl PrintStartPageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_START_PAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1783,7 +1783,7 @@ impl PrintEndPageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_END_PAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1851,7 +1851,7 @@ impl PrintSelectInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_SELECT_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1914,7 +1914,7 @@ impl PrintInputSelectedRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_INPUT_SELECTED_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2055,7 +2055,7 @@ impl PrintGetAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2207,7 +2207,7 @@ impl<'input> PrintGetOneAttributesRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_ONE_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2372,7 +2372,7 @@ impl<'input> PrintSetAttributesRequest<'input> {
         ([request0.into(), self.attributes, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_SET_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2452,7 +2452,7 @@ impl PrintGetPageDimensionsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_PAGE_DIMENSIONS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2600,7 +2600,7 @@ impl PrintQueryScreensRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_QUERY_SCREENS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2736,7 +2736,7 @@ impl PrintSetImageResolutionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_SET_IMAGE_RESOLUTION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2865,7 +2865,7 @@ impl PrintGetImageResolutionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PRINT_GET_IMAGE_RESOLUTION_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xprint.rs
+++ b/x11rb-protocol/src/protocol/xprint.rs
@@ -38,11 +38,18 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
 pub type String8 = u8;
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Printer {
     pub name: Vec<String8>,
     pub description: Vec<String8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Printer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Printer").finish_non_exhaustive()
+    }
 }
 impl TryParse for Printer {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -385,9 +392,16 @@ impl core::fmt::Debug for Attr  {
 
 /// Opcode for the PrintQueryVersion request
 pub const PRINT_QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintQueryVersionRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintQueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintQueryVersionRequest").finish_non_exhaustive()
+    }
+}
 impl PrintQueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -428,13 +442,20 @@ impl crate::x11_utils::ReplyRequest for PrintQueryVersionRequest {
     type Reply = PrintQueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintQueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major_version: u16,
     pub minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintQueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintQueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PrintQueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -492,11 +513,18 @@ impl Serialize for PrintQueryVersionReply {
 
 /// Opcode for the PrintGetPrinterList request
 pub const PRINT_GET_PRINTER_LIST_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetPrinterListRequest<'input> {
     pub printer_name: Cow<'input, [String8]>,
     pub locale: Cow<'input, [String8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PrintGetPrinterListRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetPrinterListRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PrintGetPrinterListRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -573,12 +601,19 @@ impl<'input> crate::x11_utils::ReplyRequest for PrintGetPrinterListRequest<'inpu
     type Reply = PrintGetPrinterListReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetPrinterListReply {
     pub sequence: u16,
     pub length: u32,
     pub printers: Vec<Printer>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetPrinterListReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetPrinterListReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PrintGetPrinterListReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -638,9 +673,16 @@ impl PrintGetPrinterListReply {
 
 /// Opcode for the PrintRehashPrinterList request
 pub const PRINT_REHASH_PRINTER_LIST_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintRehashPrinterListRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintRehashPrinterListRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintRehashPrinterListRequest").finish_non_exhaustive()
+    }
+}
 impl PrintRehashPrinterListRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -682,12 +724,19 @@ impl crate::x11_utils::VoidRequest for PrintRehashPrinterListRequest {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextRequest<'input> {
     pub context_id: u32,
     pub printer_name: Cow<'input, [String8]>,
     pub locale: Cow<'input, [String8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateContextRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateContextRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -773,10 +822,17 @@ impl<'input> crate::x11_utils::VoidRequest for CreateContextRequest<'input> {
 
 /// Opcode for the PrintSetContext request
 pub const PRINT_SET_CONTEXT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintSetContextRequest {
     pub context: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintSetContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintSetContextRequest").finish_non_exhaustive()
+    }
 }
 impl PrintSetContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -826,9 +882,16 @@ impl crate::x11_utils::VoidRequest for PrintSetContextRequest {
 
 /// Opcode for the PrintGetContext request
 pub const PRINT_GET_CONTEXT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetContextRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetContextRequest").finish_non_exhaustive()
+    }
+}
 impl PrintGetContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -869,12 +932,19 @@ impl crate::x11_utils::ReplyRequest for PrintGetContextRequest {
     type Reply = PrintGetContextReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PrintGetContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -929,10 +999,17 @@ impl Serialize for PrintGetContextReply {
 
 /// Opcode for the PrintDestroyContext request
 pub const PRINT_DESTROY_CONTEXT_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintDestroyContextRequest {
     pub context: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintDestroyContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintDestroyContextRequest").finish_non_exhaustive()
+    }
 }
 impl PrintDestroyContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -982,9 +1059,16 @@ impl crate::x11_utils::VoidRequest for PrintDestroyContextRequest {
 
 /// Opcode for the PrintGetScreenOfContext request
 pub const PRINT_GET_SCREEN_OF_CONTEXT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetScreenOfContextRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetScreenOfContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetScreenOfContextRequest").finish_non_exhaustive()
+    }
+}
 impl PrintGetScreenOfContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1025,12 +1109,19 @@ impl crate::x11_utils::ReplyRequest for PrintGetScreenOfContextRequest {
     type Reply = PrintGetScreenOfContextReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetScreenOfContextReply {
     pub sequence: u16,
     pub length: u32,
     pub root: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetScreenOfContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetScreenOfContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PrintGetScreenOfContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1085,10 +1176,17 @@ impl Serialize for PrintGetScreenOfContextReply {
 
 /// Opcode for the PrintStartJob request
 pub const PRINT_START_JOB_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintStartJobRequest {
     pub output_mode: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintStartJobRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintStartJobRequest").finish_non_exhaustive()
+    }
 }
 impl PrintStartJobRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1138,10 +1236,17 @@ impl crate::x11_utils::VoidRequest for PrintStartJobRequest {
 
 /// Opcode for the PrintEndJob request
 pub const PRINT_END_JOB_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintEndJobRequest {
     pub cancel: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintEndJobRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintEndJobRequest").finish_non_exhaustive()
+    }
 }
 impl PrintEndJobRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1191,10 +1296,17 @@ impl crate::x11_utils::VoidRequest for PrintEndJobRequest {
 
 /// Opcode for the PrintStartDoc request
 pub const PRINT_START_DOC_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintStartDocRequest {
     pub driver_mode: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintStartDocRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintStartDocRequest").finish_non_exhaustive()
+    }
 }
 impl PrintStartDocRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1244,10 +1356,17 @@ impl crate::x11_utils::VoidRequest for PrintStartDocRequest {
 
 /// Opcode for the PrintEndDoc request
 pub const PRINT_END_DOC_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintEndDocRequest {
     pub cancel: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintEndDocRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintEndDocRequest").finish_non_exhaustive()
+    }
 }
 impl PrintEndDocRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1297,13 +1416,20 @@ impl crate::x11_utils::VoidRequest for PrintEndDocRequest {
 
 /// Opcode for the PrintPutDocumentData request
 pub const PRINT_PUT_DOCUMENT_DATA_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintPutDocumentDataRequest<'input> {
     pub drawable: xproto::Drawable,
     pub data: Cow<'input, [u8]>,
     pub doc_format: Cow<'input, [String8]>,
     pub options: Cow<'input, [String8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PrintPutDocumentDataRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintPutDocumentDataRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PrintPutDocumentDataRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1402,11 +1528,18 @@ impl<'input> crate::x11_utils::VoidRequest for PrintPutDocumentDataRequest<'inpu
 
 /// Opcode for the PrintGetDocumentData request
 pub const PRINT_GET_DOCUMENT_DATA_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetDocumentDataRequest {
     pub context: Pcontext,
     pub max_bytes: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetDocumentDataRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetDocumentDataRequest").finish_non_exhaustive()
+    }
 }
 impl PrintGetDocumentDataRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1462,7 +1595,8 @@ impl crate::x11_utils::ReplyRequest for PrintGetDocumentDataRequest {
     type Reply = PrintGetDocumentDataReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetDocumentDataReply {
     pub sequence: u16,
@@ -1470,6 +1604,12 @@ pub struct PrintGetDocumentDataReply {
     pub status_code: u32,
     pub finished_flag: u32,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetDocumentDataReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetDocumentDataReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PrintGetDocumentDataReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1534,10 +1674,17 @@ impl PrintGetDocumentDataReply {
 
 /// Opcode for the PrintStartPage request
 pub const PRINT_START_PAGE_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintStartPageRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintStartPageRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintStartPageRequest").finish_non_exhaustive()
+    }
 }
 impl PrintStartPageRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1587,10 +1734,17 @@ impl crate::x11_utils::VoidRequest for PrintStartPageRequest {
 
 /// Opcode for the PrintEndPage request
 pub const PRINT_END_PAGE_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintEndPageRequest {
     pub cancel: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintEndPageRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintEndPageRequest").finish_non_exhaustive()
+    }
 }
 impl PrintEndPageRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1641,11 +1795,18 @@ impl crate::x11_utils::VoidRequest for PrintEndPageRequest {
 
 /// Opcode for the PrintSelectInput request
 pub const PRINT_SELECT_INPUT_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintSelectInputRequest {
     pub context: Pcontext,
     pub event_mask: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintSelectInputRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintSelectInputRequest").finish_non_exhaustive()
+    }
 }
 impl PrintSelectInputRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1702,10 +1863,17 @@ impl crate::x11_utils::VoidRequest for PrintSelectInputRequest {
 
 /// Opcode for the PrintInputSelected request
 pub const PRINT_INPUT_SELECTED_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintInputSelectedRequest {
     pub context: Pcontext,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintInputSelectedRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintInputSelectedRequest").finish_non_exhaustive()
+    }
 }
 impl PrintInputSelectedRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1754,13 +1922,20 @@ impl crate::x11_utils::ReplyRequest for PrintInputSelectedRequest {
     type Reply = PrintInputSelectedReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintInputSelectedReply {
     pub sequence: u16,
     pub length: u32,
     pub event_mask: u32,
     pub all_events_mask: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintInputSelectedReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintInputSelectedReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PrintInputSelectedReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1822,11 +1997,18 @@ impl Serialize for PrintInputSelectedReply {
 
 /// Opcode for the PrintGetAttributes request
 pub const PRINT_GET_ATTRIBUTES_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetAttributesRequest {
     pub context: Pcontext,
     pub pool: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetAttributesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetAttributesRequest").finish_non_exhaustive()
+    }
 }
 impl PrintGetAttributesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1883,12 +2065,19 @@ impl crate::x11_utils::ReplyRequest for PrintGetAttributesRequest {
     type Reply = PrintGetAttributesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetAttributesReply {
     pub sequence: u16,
     pub length: u32,
     pub attributes: Vec<String8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetAttributesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetAttributesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PrintGetAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1949,12 +2138,19 @@ impl PrintGetAttributesReply {
 
 /// Opcode for the PrintGetOneAttributes request
 pub const PRINT_GET_ONE_ATTRIBUTES_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetOneAttributesRequest<'input> {
     pub context: Pcontext,
     pub pool: u8,
     pub name: Cow<'input, [String8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PrintGetOneAttributesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetOneAttributesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PrintGetOneAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2031,12 +2227,19 @@ impl<'input> crate::x11_utils::ReplyRequest for PrintGetOneAttributesRequest<'in
     type Reply = PrintGetOneAttributesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetOneAttributesReply {
     pub sequence: u16,
     pub length: u32,
     pub value: Vec<String8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetOneAttributesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetOneAttributesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PrintGetOneAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2097,7 +2300,8 @@ impl PrintGetOneAttributesReply {
 
 /// Opcode for the PrintSetAttributes request
 pub const PRINT_SET_ATTRIBUTES_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintSetAttributesRequest<'input> {
     pub context: Pcontext,
@@ -2105,6 +2309,12 @@ pub struct PrintSetAttributesRequest<'input> {
     pub pool: u8,
     pub rule: u8,
     pub attributes: Cow<'input, [String8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PrintSetAttributesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintSetAttributesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PrintSetAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -2187,10 +2397,17 @@ impl<'input> crate::x11_utils::VoidRequest for PrintSetAttributesRequest<'input>
 
 /// Opcode for the PrintGetPageDimensions request
 pub const PRINT_GET_PAGE_DIMENSIONS_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetPageDimensionsRequest {
     pub context: Pcontext,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetPageDimensionsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetPageDimensionsRequest").finish_non_exhaustive()
+    }
 }
 impl PrintGetPageDimensionsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2239,7 +2456,8 @@ impl crate::x11_utils::ReplyRequest for PrintGetPageDimensionsRequest {
     type Reply = PrintGetPageDimensionsReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetPageDimensionsReply {
     pub sequence: u16,
@@ -2250,6 +2468,12 @@ pub struct PrintGetPageDimensionsReply {
     pub offset_y: u16,
     pub reproducible_width: u16,
     pub reproducible_height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetPageDimensionsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetPageDimensionsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PrintGetPageDimensionsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2327,9 +2551,16 @@ impl Serialize for PrintGetPageDimensionsReply {
 
 /// Opcode for the PrintQueryScreens request
 pub const PRINT_QUERY_SCREENS_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintQueryScreensRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintQueryScreensRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintQueryScreensRequest").finish_non_exhaustive()
+    }
+}
 impl PrintQueryScreensRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2370,12 +2601,19 @@ impl crate::x11_utils::ReplyRequest for PrintQueryScreensRequest {
     type Reply = PrintQueryScreensReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintQueryScreensReply {
     pub sequence: u16,
     pub length: u32,
     pub roots: Vec<xproto::Window>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintQueryScreensReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintQueryScreensReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PrintQueryScreensReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2435,11 +2673,18 @@ impl PrintQueryScreensReply {
 
 /// Opcode for the PrintSetImageResolution request
 pub const PRINT_SET_IMAGE_RESOLUTION_REQUEST: u8 = 23;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintSetImageResolutionRequest {
     pub context: Pcontext,
     pub image_resolution: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintSetImageResolutionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintSetImageResolutionRequest").finish_non_exhaustive()
+    }
 }
 impl PrintSetImageResolutionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2495,13 +2740,20 @@ impl crate::x11_utils::ReplyRequest for PrintSetImageResolutionRequest {
     type Reply = PrintSetImageResolutionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintSetImageResolutionReply {
     pub status: bool,
     pub sequence: u16,
     pub length: u32,
     pub previous_resolutions: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintSetImageResolutionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintSetImageResolutionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PrintSetImageResolutionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2555,10 +2807,17 @@ impl Serialize for PrintSetImageResolutionReply {
 
 /// Opcode for the PrintGetImageResolution request
 pub const PRINT_GET_IMAGE_RESOLUTION_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetImageResolutionRequest {
     pub context: Pcontext,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetImageResolutionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetImageResolutionRequest").finish_non_exhaustive()
+    }
 }
 impl PrintGetImageResolutionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2607,12 +2866,19 @@ impl crate::x11_utils::ReplyRequest for PrintGetImageResolutionRequest {
     type Reply = PrintGetImageResolutionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetImageResolutionReply {
     pub sequence: u16,
     pub length: u32,
     pub image_resolution: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PrintGetImageResolutionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PrintGetImageResolutionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for PrintGetImageResolutionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2665,7 +2931,8 @@ impl Serialize for PrintGetImageResolutionReply {
 
 /// Opcode for the Notify event
 pub const NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NotifyEvent {
     pub response_type: u8,
@@ -2673,6 +2940,12 @@ pub struct NotifyEvent {
     pub sequence: u16,
     pub context: Pcontext,
     pub cancel: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for NotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for NotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2770,13 +3043,20 @@ impl From<NotifyEvent> for [u8; 32] {
 
 /// Opcode for the AttributNotify event
 pub const ATTRIBUT_NOTIFY_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttributNotifyEvent {
     pub response_type: u8,
     pub detail: u8,
     pub sequence: u16,
     pub context: Pcontext,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AttributNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AttributNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for AttributNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -7076,6 +7076,7 @@ impl core::fmt::Debug for CreateWindowAux {
     }
 }
 impl CreateWindowAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
@@ -7551,7 +7552,7 @@ impl<'input> CreateWindowRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CREATE_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -7644,6 +7645,7 @@ impl core::fmt::Debug for ChangeWindowAttributesAux {
     }
 }
 impl ChangeWindowAttributesAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
@@ -8047,7 +8049,7 @@ impl<'input> ChangeWindowAttributesRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_WINDOW_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8194,7 +8196,7 @@ impl GetWindowAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_WINDOW_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8458,7 +8460,7 @@ impl DestroyWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != DESTROY_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8522,7 +8524,7 @@ impl DestroySubwindowsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != DESTROY_SUBWINDOWS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8669,7 +8671,7 @@ impl ChangeSaveSetRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_SAVE_SET_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8781,7 +8783,7 @@ impl ReparentWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != REPARENT_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8886,7 +8888,7 @@ impl MapWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != MAP_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8950,7 +8952,7 @@ impl MapSubwindowsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != MAP_SUBWINDOWS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9035,7 +9037,7 @@ impl UnmapWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNMAP_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9099,7 +9101,7 @@ impl UnmapSubwindowsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNMAP_SUBWINDOWS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9264,6 +9266,7 @@ impl core::fmt::Debug for ConfigureWindowAux {
     }
 }
 impl ConfigureWindowAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u16) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u16::from(value_mask);
         let mut outer_remaining = value;
@@ -9565,7 +9568,7 @@ impl<'input> ConfigureWindowRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CONFIGURE_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9718,7 +9721,7 @@ impl CirculateWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CIRCULATE_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9820,7 +9823,7 @@ impl GetGeometryRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_GEOMETRY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10036,7 +10039,7 @@ impl QueryTreeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_TREE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10231,7 +10234,7 @@ impl<'input> InternAtomRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != INTERN_ATOM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10371,7 +10374,7 @@ impl GetAtomNameRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_ATOM_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10659,7 +10662,7 @@ impl<'input> ChangePropertyRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10754,7 +10757,7 @@ impl DeletePropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != DELETE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10971,7 +10974,7 @@ impl GetPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11276,7 +11279,7 @@ impl ListPropertiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LIST_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11452,7 +11455,7 @@ impl SetSelectionOwnerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_SELECTION_OWNER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11537,7 +11540,7 @@ impl GetSelectionOwnerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_SELECTION_OWNER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11694,7 +11697,7 @@ impl ConvertSelectionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CONVERT_SELECTION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11920,7 +11923,7 @@ impl<'input> SendEventRequest<'input> {
         ([request0.into(), Cow::Owned(self.event.to_vec())], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SEND_EVENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12287,7 +12290,7 @@ impl GrabPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GRAB_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12451,7 +12454,7 @@ impl UngrabPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNGRAB_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12689,7 +12692,7 @@ impl GrabButtonRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GRAB_BUTTON_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12782,7 +12785,7 @@ impl UngrabButtonRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNGRAB_BUTTON_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12864,7 +12867,7 @@ impl ChangeActivePointerGrabRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_ACTIVE_POINTER_GRAB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13012,7 +13015,7 @@ impl GrabKeyboardRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GRAB_KEYBOARD_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13147,7 +13150,7 @@ impl UngrabKeyboardRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNGRAB_KEYBOARD_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13345,7 +13348,7 @@ impl GrabKeyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GRAB_KEY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13455,7 +13458,7 @@ impl UngrabKeyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNGRAB_KEY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13674,7 +13677,7 @@ impl AllowEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != ALLOW_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13733,7 +13736,7 @@ impl GrabServerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GRAB_SERVER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13788,7 +13791,7 @@ impl UngrabServerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNGRAB_SERVER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13863,7 +13866,7 @@ impl QueryPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14117,7 +14120,7 @@ impl GetMotionEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_MOTION_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14270,7 +14273,7 @@ impl TranslateCoordinatesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != TRANSLATE_COORDINATES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14482,7 +14485,7 @@ impl WarpPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != WARP_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14675,7 +14678,7 @@ impl SetInputFocusRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_INPUT_FOCUS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14736,7 +14739,7 @@ impl GetInputFocusRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_INPUT_FOCUS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14860,7 +14863,7 @@ impl QueryKeymapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_KEYMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15044,7 +15047,7 @@ impl<'input> OpenFontRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != OPEN_FONT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15119,7 +15122,7 @@ impl CloseFontRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CLOSE_FONT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15357,7 +15360,7 @@ impl QueryFontRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_FONT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15600,7 +15603,7 @@ impl<'input> QueryTextExtentsRequest<'input> {
         ([request0.into(), string_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_TEXT_EXTENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15863,7 +15866,7 @@ impl<'input> ListFontsRequest<'input> {
         ([request0.into(), self.pattern, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LIST_FONTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -16028,7 +16031,7 @@ impl<'input> ListFontsWithInfoRequest<'input> {
         ([request0.into(), self.pattern, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LIST_FONTS_WITH_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -16249,7 +16252,7 @@ impl<'input> SetFontPathRequest<'input> {
         ([request0.into(), font_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_FONT_PATH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -16314,7 +16317,7 @@ impl GetFontPathRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_FONT_PATH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -16486,7 +16489,7 @@ impl CreatePixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CREATE_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -16569,7 +16572,7 @@ impl FreePixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FREE_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -17241,6 +17244,7 @@ impl core::fmt::Debug for CreateGCAux {
     }
 }
 impl CreateGCAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
@@ -17816,7 +17820,7 @@ impl<'input> CreateGCRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CREATE_GC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -17893,6 +17897,7 @@ impl core::fmt::Debug for ChangeGCAux {
     }
 }
 impl ChangeGCAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
@@ -18483,7 +18488,7 @@ impl<'input> ChangeGCRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_GC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -18569,7 +18574,7 @@ impl CopyGCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != COPY_GC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -18650,7 +18655,7 @@ impl<'input> SetDashesRequest<'input> {
         ([request0.into(), self.dashes, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_DASHES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -18805,7 +18810,7 @@ impl<'input> SetClipRectanglesRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_CLIP_RECTANGLES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -18905,7 +18910,7 @@ impl FreeGCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FREE_GC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -18987,7 +18992,7 @@ impl ClearAreaRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CLEAR_AREA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19117,7 +19122,7 @@ impl CopyAreaRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != COPY_AREA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19239,7 +19244,7 @@ impl CopyPlaneRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != COPY_PLANE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19397,7 +19402,7 @@ impl<'input> PolyPointRequest<'input> {
         ([request0.into(), points_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_POINT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19535,7 +19540,7 @@ impl<'input> PolyLineRequest<'input> {
         ([request0.into(), points_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_LINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19710,7 +19715,7 @@ impl<'input> PolySegmentRequest<'input> {
         ([request0.into(), segments_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_SEGMENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19804,7 +19809,7 @@ impl<'input> PolyRectangleRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_RECTANGLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19898,7 +19903,7 @@ impl<'input> PolyArcRequest<'input> {
         ([request0.into(), arcs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_ARC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20061,7 +20066,7 @@ impl<'input> FillPolyRequest<'input> {
         ([request0.into(), points_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FILL_POLY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20189,7 +20194,7 @@ impl<'input> PolyFillRectangleRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_FILL_RECTANGLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20283,7 +20288,7 @@ impl<'input> PolyFillArcRequest<'input> {
         ([request0.into(), arcs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_FILL_ARC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20463,7 +20468,7 @@ impl<'input> PutImageRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != PUT_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20585,7 +20590,7 @@ impl GetImageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20754,7 +20759,7 @@ impl<'input> PolyText8Request<'input> {
         ([request0.into(), self.items, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_TEXT8_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20854,7 +20859,7 @@ impl<'input> PolyText16Request<'input> {
         ([request0.into(), self.items, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_TEXT16_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20988,7 +20993,7 @@ impl<'input> ImageText8Request<'input> {
         ([request0.into(), self.string, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != IMAGE_TEXT8_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21124,7 +21129,7 @@ impl<'input> ImageText16Request<'input> {
         ([request0.into(), string_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != IMAGE_TEXT16_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21279,7 +21284,7 @@ impl CreateColormapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CREATE_COLORMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21349,7 +21354,7 @@ impl FreeColormapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FREE_COLORMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21419,7 +21424,7 @@ impl CopyColormapAndFreeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != COPY_COLORMAP_AND_FREE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21485,7 +21490,7 @@ impl InstallColormapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != INSTALL_COLORMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21549,7 +21554,7 @@ impl UninstallColormapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNINSTALL_COLORMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21613,7 +21618,7 @@ impl ListInstalledColormapsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LIST_INSTALLED_COLORMAPS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21780,7 +21785,7 @@ impl AllocColorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != ALLOC_COLOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21949,7 +21954,7 @@ impl<'input> AllocNamedColorRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != ALLOC_NAMED_COLOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22136,7 +22141,7 @@ impl AllocColorCellsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != ALLOC_COLOR_CELLS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22313,7 +22318,7 @@ impl AllocColorPlanesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != ALLOC_COLOR_PLANES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22479,7 +22484,7 @@ impl<'input> FreeColorsRequest<'input> {
         ([request0.into(), pixels_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FREE_COLORS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22692,7 +22697,7 @@ impl<'input> StoreColorsRequest<'input> {
         ([request0.into(), items_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != STORE_COLORS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22790,7 +22795,7 @@ impl<'input> StoreNamedColorRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != STORE_NAMED_COLOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22926,7 +22931,7 @@ impl<'input> QueryColorsRequest<'input> {
         ([request0.into(), pixels_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_COLORS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -23087,7 +23092,7 @@ impl<'input> LookupColorRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LOOKUP_COLOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -23357,7 +23362,7 @@ impl CreateCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CREATE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -23575,7 +23580,7 @@ impl CreateGlyphCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CREATE_GLYPH_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -23671,7 +23676,7 @@ impl FreeCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FREE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -23759,7 +23764,7 @@ impl RecolorCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != RECOLOR_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -23906,7 +23911,7 @@ impl QueryBestSizeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_BEST_SIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -24071,7 +24076,7 @@ impl<'input> QueryExtensionRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_EXTENSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -24220,7 +24225,7 @@ impl ListExtensionsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LIST_EXTENSIONS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -24361,7 +24366,7 @@ impl<'input> ChangeKeyboardMappingRequest<'input> {
         ([request0.into(), keysyms_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_KEYBOARD_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -24442,7 +24447,7 @@ impl GetKeyboardMappingRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_KEYBOARD_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -24718,6 +24723,7 @@ impl core::fmt::Debug for ChangeKeyboardControlAux {
     }
 }
 impl ChangeKeyboardControlAux {
+    #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
         let switch_expr = u32::from(value_mask);
         let mut outer_remaining = value;
@@ -24952,7 +24958,7 @@ impl<'input> ChangeKeyboardControlRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_KEYBOARD_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25016,7 +25022,7 @@ impl GetKeyboardControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_KEYBOARD_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25204,7 +25210,7 @@ impl BellRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != BELL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25279,7 +25285,7 @@ impl ChangePointerControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_POINTER_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25344,7 +25350,7 @@ impl GetPointerControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_POINTER_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25634,7 +25640,7 @@ impl SetScreenSaverRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_SCREEN_SAVER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25699,7 +25705,7 @@ impl GetScreenSaverRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_SCREEN_SAVER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25995,7 +26001,7 @@ impl<'input> ChangeHostsRequest<'input> {
         ([request0.into(), self.address, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_HOSTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26130,7 +26136,7 @@ impl ListHostsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LIST_HOSTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26320,7 +26326,7 @@ impl SetAccessControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_ACCESS_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26441,7 +26447,7 @@ impl SetCloseDownModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_CLOSE_DOWN_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26581,7 +26587,7 @@ impl KillClientRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != KILL_CLIENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26658,7 +26664,7 @@ impl<'input> RotatePropertiesRequest<'input> {
         ([request0.into(), atoms_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != ROTATE_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26790,7 +26796,7 @@ impl ForceScreenSaverRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FORCE_SCREEN_SAVER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26915,7 +26921,7 @@ impl<'input> SetPointerMappingRequest<'input> {
         ([request0.into(), self.map, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_POINTER_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -27039,7 +27045,7 @@ impl GetPointerMappingRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_POINTER_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -27243,7 +27249,7 @@ impl<'input> SetModifierMappingRequest<'input> {
         ([request0.into(), self.keycodes, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_MODIFIER_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -27367,7 +27373,7 @@ impl GetModifierMappingRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_MODIFIER_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -27494,7 +27500,7 @@ impl NoOperationRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != NO_OPERATION_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -28,11 +28,18 @@ use crate::utils::{RawFdContainer, pretty_print_bitmask, pretty_print_enum};
 #[allow(unused_imports)]
 use crate::x11_utils::{Request, RequestHeader, Serialize, TryParse, TryParseFd};
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Char2b {
     pub byte1: u8,
     pub byte2: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Char2b {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Char2b").finish_non_exhaustive()
+    }
 }
 impl TryParse for Char2b {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -91,11 +98,18 @@ pub type Keycode32 = u32;
 
 pub type Button = u8;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Point {
     pub x: i16,
     pub y: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Point {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Point").finish_non_exhaustive()
+    }
 }
 impl TryParse for Point {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -124,13 +138,20 @@ impl Serialize for Point {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rectangle {
     pub x: i16,
     pub y: i16,
     pub width: u16,
     pub height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Rectangle {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Rectangle").finish_non_exhaustive()
+    }
 }
 impl TryParse for Rectangle {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -169,7 +190,8 @@ impl Serialize for Rectangle {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Arc {
     pub x: i16,
@@ -178,6 +200,12 @@ pub struct Arc {
     pub height: u16,
     pub angle1: i16,
     pub angle2: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Arc {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Arc").finish_non_exhaustive()
+    }
 }
 impl TryParse for Arc {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -226,12 +254,19 @@ impl Serialize for Arc {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Format {
     pub depth: u8,
     pub bits_per_pixel: u8,
     pub scanline_pad: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Format {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Format").finish_non_exhaustive()
+    }
 }
 impl TryParse for Format {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -336,7 +371,8 @@ impl core::fmt::Debug for VisualClass  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Visualtype {
     pub visual_id: Visualid,
@@ -346,6 +382,12 @@ pub struct Visualtype {
     pub red_mask: u32,
     pub green_mask: u32,
     pub blue_mask: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Visualtype {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Visualtype").finish_non_exhaustive()
+    }
 }
 impl TryParse for Visualtype {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -412,11 +454,18 @@ impl Serialize for Visualtype {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Depth {
     pub depth: u8,
     pub visuals: Vec<Visualtype>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Depth {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Depth").finish_non_exhaustive()
+    }
 }
 impl TryParse for Depth {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -607,7 +656,8 @@ impl core::fmt::Debug for BackingStore  {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Screen {
     pub root: Window,
@@ -626,6 +676,12 @@ pub struct Screen {
     pub save_unders: bool,
     pub root_depth: u8,
     pub allowed_depths: Vec<Depth>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Screen {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Screen").finish_non_exhaustive()
+    }
 }
 impl TryParse for Screen {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -697,7 +753,8 @@ impl Screen {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetupRequest {
     pub byte_order: u8,
@@ -705,6 +762,12 @@ pub struct SetupRequest {
     pub protocol_minor_version: u16,
     pub authorization_protocol_name: Vec<u8>,
     pub authorization_protocol_data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetupRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetupRequest").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetupRequest {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -785,7 +848,8 @@ impl SetupRequest {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetupFailed {
     pub status: u8,
@@ -793,6 +857,12 @@ pub struct SetupFailed {
     pub protocol_minor_version: u16,
     pub length: u16,
     pub reason: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetupFailed {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetupFailed").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetupFailed {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -841,11 +911,18 @@ impl SetupFailed {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetupAuthenticate {
     pub status: u8,
     pub reason: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetupAuthenticate {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetupAuthenticate").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetupAuthenticate {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -951,7 +1028,8 @@ impl core::fmt::Debug for ImageOrder  {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Setup {
     pub status: u8,
@@ -972,6 +1050,12 @@ pub struct Setup {
     pub vendor: Vec<u8>,
     pub pixmap_formats: Vec<Format>,
     pub roots: Vec<Screen>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Setup {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Setup").finish_non_exhaustive()
+    }
 }
 impl TryParse for Setup {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1317,7 +1401,8 @@ pub const KEY_PRESS_EVENT: u8 = 2;
 ///
 /// * `GrabKey`: request
 /// * `GrabKeyboard`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeyPressEvent {
     pub response_type: u8,
@@ -1333,6 +1418,12 @@ pub struct KeyPressEvent {
     pub event_y: i16,
     pub state: KeyButMask,
     pub same_screen: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KeyPressEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeyPressEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for KeyPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1577,7 +1668,8 @@ pub const BUTTON_PRESS_EVENT: u8 = 4;
 ///
 /// * `GrabButton`: request
 /// * `GrabPointer`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ButtonPressEvent {
     pub response_type: u8,
@@ -1593,6 +1685,12 @@ pub struct ButtonPressEvent {
     pub event_y: i16,
     pub state: KeyButMask,
     pub same_screen: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ButtonPressEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ButtonPressEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ButtonPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1834,7 +1932,8 @@ pub const MOTION_NOTIFY_EVENT: u8 = 6;
 ///
 /// * `GrabKey`: request
 /// * `GrabKeyboard`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MotionNotifyEvent {
     pub response_type: u8,
@@ -1850,6 +1949,12 @@ pub struct MotionNotifyEvent {
     pub event_y: i16,
     pub state: KeyButMask,
     pub same_screen: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MotionNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MotionNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for MotionNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2154,7 +2259,8 @@ pub const ENTER_NOTIFY_EVENT: u8 = 7;
 /// * `event_y` - If `event` is on the same screen as `root`, this is the pointer Y coordinate
 /// relative to the event window's origin.
 /// * `mode` -
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnterNotifyEvent {
     pub response_type: u8,
@@ -2171,6 +2277,12 @@ pub struct EnterNotifyEvent {
     pub state: KeyButMask,
     pub mode: NotifyMode,
     pub same_screen_focus: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EnterNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EnterNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for EnterNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2341,7 +2453,8 @@ pub const FOCUS_IN_EVENT: u8 = 9;
 /// the X server to report the event.
 /// * `detail` -
 /// * `mode` -
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FocusInEvent {
     pub response_type: u8,
@@ -2349,6 +2462,12 @@ pub struct FocusInEvent {
     pub sequence: u16,
     pub event: Window,
     pub mode: NotifyMode,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FocusInEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FocusInEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for FocusInEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2457,11 +2576,18 @@ pub type FocusOutEvent = FocusInEvent;
 
 /// Opcode for the KeymapNotify event
 pub const KEYMAP_NOTIFY_EVENT: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KeymapNotifyEvent {
     pub response_type: u8,
     pub keys: [u8; 31],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KeymapNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KeymapNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for KeymapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2582,7 +2708,8 @@ pub const EXPOSE_EVENT: u8 = 12;
 /// not want to optimize redisplay by distinguishing between subareas of its window
 /// can just ignore all Expose events with nonzero counts and perform full
 /// redisplays on events with zero counts.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExposeEvent {
     pub response_type: u8,
@@ -2593,6 +2720,12 @@ pub struct ExposeEvent {
     pub width: u16,
     pub height: u16,
     pub count: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ExposeEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ExposeEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ExposeEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2717,7 +2850,8 @@ impl From<ExposeEvent> for [u8; 32] {
 
 /// Opcode for the GraphicsExposure event
 pub const GRAPHICS_EXPOSURE_EVENT: u8 = 13;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GraphicsExposureEvent {
     pub response_type: u8,
@@ -2730,6 +2864,12 @@ pub struct GraphicsExposureEvent {
     pub minor_opcode: u16,
     pub count: u16,
     pub major_opcode: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GraphicsExposureEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GraphicsExposureEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for GraphicsExposureEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2866,7 +3006,8 @@ impl From<GraphicsExposureEvent> for [u8; 32] {
 
 /// Opcode for the NoExposure event
 pub const NO_EXPOSURE_EVENT: u8 = 14;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NoExposureEvent {
     pub response_type: u8,
@@ -2874,6 +3015,12 @@ pub struct NoExposureEvent {
     pub drawable: Drawable,
     pub minor_opcode: u16,
     pub major_opcode: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for NoExposureEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NoExposureEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for NoExposureEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3039,13 +3186,20 @@ impl core::fmt::Debug for Visibility  {
 
 /// Opcode for the VisibilityNotify event
 pub const VISIBILITY_NOTIFY_EVENT: u8 = 15;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VisibilityNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
     pub window: Window,
     pub state: Visibility,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for VisibilityNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VisibilityNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for VisibilityNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3147,7 +3301,8 @@ impl From<VisibilityNotifyEvent> for [u8; 32] {
 
 /// Opcode for the CreateNotify event
 pub const CREATE_NOTIFY_EVENT: u8 = 16;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateNotifyEvent {
     pub response_type: u8,
@@ -3160,6 +3315,12 @@ pub struct CreateNotifyEvent {
     pub height: u16,
     pub border_width: u16,
     pub override_redirect: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for CreateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3307,13 +3468,20 @@ pub const DESTROY_NOTIFY_EVENT: u8 = 17;
 /// # See
 ///
 /// * `DestroyWindow`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyNotifyEvent {
     pub response_type: u8,
     pub sequence: u16,
     pub event: Window,
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for DestroyNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3425,7 +3593,8 @@ pub const UNMAP_NOTIFY_EVENT: u8 = 18;
 /// # See
 ///
 /// * `UnmapWindow`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnmapNotifyEvent {
     pub response_type: u8,
@@ -3433,6 +3602,12 @@ pub struct UnmapNotifyEvent {
     pub event: Window,
     pub window: Window,
     pub from_configure: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UnmapNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UnmapNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for UnmapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3553,7 +3728,8 @@ pub const MAP_NOTIFY_EVENT: u8 = 19;
 /// # See
 ///
 /// * `MapWindow`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapNotifyEvent {
     pub response_type: u8,
@@ -3561,6 +3737,12 @@ pub struct MapNotifyEvent {
     pub event: Window,
     pub window: Window,
     pub override_redirect: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MapNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MapNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for MapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3679,13 +3861,20 @@ pub const MAP_REQUEST_EVENT: u8 = 20;
 /// # See
 ///
 /// * `MapWindow`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapRequestEvent {
     pub response_type: u8,
     pub sequence: u16,
     pub parent: Window,
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MapRequestEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MapRequestEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for MapRequestEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3784,7 +3973,8 @@ impl From<MapRequestEvent> for [u8; 32] {
 
 /// Opcode for the ReparentNotify event
 pub const REPARENT_NOTIFY_EVENT: u8 = 21;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReparentNotifyEvent {
     pub response_type: u8,
@@ -3795,6 +3985,12 @@ pub struct ReparentNotifyEvent {
     pub x: i16,
     pub y: i16,
     pub override_redirect: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ReparentNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ReparentNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ReparentNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3945,7 +4141,8 @@ pub const CONFIGURE_NOTIFY_EVENT: u8 = 22;
 /// # See
 ///
 /// * `FreeColormap`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureNotifyEvent {
     pub response_type: u8,
@@ -3959,6 +4156,12 @@ pub struct ConfigureNotifyEvent {
     pub height: u16,
     pub border_width: u16,
     pub override_redirect: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ConfigureNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ConfigureNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ConfigureNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4103,7 +4306,8 @@ impl From<ConfigureNotifyEvent> for [u8; 32] {
 
 /// Opcode for the ConfigureRequest event
 pub const CONFIGURE_REQUEST_EVENT: u8 = 23;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureRequestEvent {
     pub response_type: u8,
@@ -4118,6 +4322,12 @@ pub struct ConfigureRequestEvent {
     pub height: u16,
     pub border_width: u16,
     pub value_mask: ConfigWindow,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ConfigureRequestEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ConfigureRequestEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ConfigureRequestEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4264,7 +4474,8 @@ impl From<ConfigureRequestEvent> for [u8; 32] {
 
 /// Opcode for the GravityNotify event
 pub const GRAVITY_NOTIFY_EVENT: u8 = 24;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GravityNotifyEvent {
     pub response_type: u8,
@@ -4273,6 +4484,12 @@ pub struct GravityNotifyEvent {
     pub window: Window,
     pub x: i16,
     pub y: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GravityNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GravityNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for GravityNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4383,7 +4600,8 @@ impl From<GravityNotifyEvent> for [u8; 32] {
 
 /// Opcode for the ResizeRequest event
 pub const RESIZE_REQUEST_EVENT: u8 = 25;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ResizeRequestEvent {
     pub response_type: u8,
@@ -4391,6 +4609,12 @@ pub struct ResizeRequestEvent {
     pub window: Window,
     pub width: u16,
     pub height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ResizeRequestEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ResizeRequestEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ResizeRequestEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4568,7 +4792,8 @@ pub const CIRCULATE_NOTIFY_EVENT: u8 = 26;
 /// # See
 ///
 /// * `CirculateWindow`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CirculateNotifyEvent {
     pub response_type: u8,
@@ -4576,6 +4801,12 @@ pub struct CirculateNotifyEvent {
     pub event: Window,
     pub window: Window,
     pub place: Place,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CirculateNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CirculateNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for CirculateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4766,7 +4997,8 @@ pub const PROPERTY_NOTIFY_EVENT: u8 = 28;
 /// # See
 ///
 /// * `ChangeProperty`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PropertyNotifyEvent {
     pub response_type: u8,
@@ -4775,6 +5007,12 @@ pub struct PropertyNotifyEvent {
     pub atom: Atom,
     pub time: Timestamp,
     pub state: Property,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PropertyNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PropertyNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for PropertyNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -4892,7 +5130,8 @@ impl From<PropertyNotifyEvent> for [u8; 32] {
 
 /// Opcode for the SelectionClear event
 pub const SELECTION_CLEAR_EVENT: u8 = 29;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectionClearEvent {
     pub response_type: u8,
@@ -4900,6 +5139,12 @@ pub struct SelectionClearEvent {
     pub time: Timestamp,
     pub owner: Window,
     pub selection: Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectionClearEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectionClearEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectionClearEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5258,7 +5503,8 @@ impl core::fmt::Debug for AtomEnum  {
 
 /// Opcode for the SelectionRequest event
 pub const SELECTION_REQUEST_EVENT: u8 = 30;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectionRequestEvent {
     pub response_type: u8,
@@ -5269,6 +5515,12 @@ pub struct SelectionRequestEvent {
     pub selection: Atom,
     pub target: Atom,
     pub property: Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectionRequestEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectionRequestEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectionRequestEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5399,7 +5651,8 @@ impl From<SelectionRequestEvent> for [u8; 32] {
 
 /// Opcode for the SelectionNotify event
 pub const SELECTION_NOTIFY_EVENT: u8 = 31;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectionNotifyEvent {
     pub response_type: u8,
@@ -5409,6 +5662,12 @@ pub struct SelectionNotifyEvent {
     pub selection: Atom,
     pub target: Atom,
     pub property: Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectionNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectionNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for SelectionNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5664,7 +5923,8 @@ pub const COLORMAP_NOTIFY_EVENT: u8 = 32;
 /// # See
 ///
 /// * `FreeColormap`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ColormapNotifyEvent {
     pub response_type: u8,
@@ -5673,6 +5933,12 @@ pub struct ColormapNotifyEvent {
     pub colormap: Colormap,
     pub new: bool,
     pub state: ColormapState,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ColormapNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ColormapNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ColormapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -5958,7 +6224,8 @@ pub const CLIENT_MESSAGE_EVENT: u8 = 33;
 /// # See
 ///
 /// * `SendEvent`: request
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "extra-traits", derive(Debug))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientMessageEvent {
     pub response_type: u8,
@@ -5967,6 +6234,12 @@ pub struct ClientMessageEvent {
     pub window: Window,
     pub type_: Atom,
     pub data: ClientMessageData,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ClientMessageEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ClientMessageEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for ClientMessageEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6178,7 +6451,8 @@ pub const MAPPING_NOTIFY_EVENT: u8 = 34;
 /// * `request` -
 /// * `first_keycode` - The first number in the range of the altered mapping.
 /// * `count` - The number of keycodes altered.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MappingNotifyEvent {
     pub response_type: u8,
@@ -6186,6 +6460,12 @@ pub struct MappingNotifyEvent {
     pub request: Mapping,
     pub first_keycode: Keycode,
     pub count: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MappingNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MappingNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for MappingNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6294,7 +6574,8 @@ pub const GE_GENERIC_EVENT: u8 = 35;
 /// * `extension` - The major opcode of the extension creating this event
 /// * `length` - The amount (in 4-byte units) of data beyond 32 bytes
 /// * `evtype` - The extension-specific event type
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GeGenericEvent {
     pub response_type: u8,
@@ -6302,6 +6583,12 @@ pub struct GeGenericEvent {
     pub sequence: u16,
     pub length: u32,
     pub event_type: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GeGenericEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GeGenericEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for GeGenericEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -6762,7 +7049,8 @@ impl core::fmt::Debug for Gravity  {
 }
 
 /// Auxiliary and optional information for the `create_window` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateWindowAux {
     pub background_pixmap: Option<Pixmap>,
@@ -6780,6 +7068,12 @@ pub struct CreateWindowAux {
     pub do_not_propogate_mask: Option<EventMask>,
     pub colormap: Option<Colormap>,
     pub cursor: Option<Cursor>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateWindowAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateWindowAux").finish_non_exhaustive()
+    }
 }
 impl CreateWindowAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -7174,7 +7468,8 @@ pub const CREATE_WINDOW_REQUEST: u8 = 1;
 /// * `xcb_generate_id`: function
 /// * `MapWindow`: request
 /// * `CreateNotify`: event
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateWindowRequest<'input> {
     pub depth: u8,
@@ -7188,6 +7483,12 @@ pub struct CreateWindowRequest<'input> {
     pub class: WindowClass,
     pub visual: Visualid,
     pub value_list: Cow<'input, CreateWindowAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateWindowRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateWindowRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateWindowRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -7315,7 +7616,8 @@ impl<'input> crate::x11_utils::VoidRequest for CreateWindowRequest<'input> {
 }
 
 /// Auxiliary and optional information for the `change_window_attributes` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeWindowAttributesAux {
     pub background_pixmap: Option<Pixmap>,
@@ -7333,6 +7635,12 @@ pub struct ChangeWindowAttributesAux {
     pub do_not_propogate_mask: Option<EventMask>,
     pub colormap: Option<Colormap>,
     pub cursor: Option<Cursor>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeWindowAttributesAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeWindowAttributesAux").finish_non_exhaustive()
+    }
 }
 impl ChangeWindowAttributesAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -7693,11 +8001,18 @@ pub const CHANGE_WINDOW_ATTRIBUTES_REQUEST: u8 = 2;
 /// * `Pixmap` - TODO: reasons?
 /// * `Value` - TODO: reasons?
 /// * `Window` - The specified `window` does not exist.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeWindowAttributesRequest<'input> {
     pub window: Window,
     pub value_list: Cow<'input, ChangeWindowAttributesAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeWindowAttributesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeWindowAttributesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeWindowAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -7843,10 +8158,17 @@ pub const GET_WINDOW_ATTRIBUTES_REQUEST: u8 = 3;
 ///
 /// * `Window` - The specified `window` does not exist.
 /// * `Drawable` - TODO: reasons?
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowAttributesRequest {
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetWindowAttributesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetWindowAttributesRequest").finish_non_exhaustive()
+    }
 }
 impl GetWindowAttributesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -7914,7 +8236,8 @@ impl crate::x11_utils::ReplyRequest for GetWindowAttributesRequest {
 /// * `bit_gravity` -
 /// * `win_gravity` -
 /// * `map_state` -
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowAttributesReply {
     pub backing_store: BackingStore,
@@ -7934,6 +8257,12 @@ pub struct GetWindowAttributesReply {
     pub all_event_masks: EventMask,
     pub your_event_mask: EventMask,
     pub do_not_propagate_mask: EventMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetWindowAttributesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetWindowAttributesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetWindowAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -8092,10 +8421,17 @@ pub const DESTROY_WINDOW_REQUEST: u8 = 4;
 /// * `DestroyNotify`: event
 /// * `MapWindow`: request
 /// * `UnmapWindow`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyWindowRequest {
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyWindowRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyWindowRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyWindowRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8148,10 +8484,17 @@ impl crate::x11_utils::VoidRequest for DestroyWindowRequest {
 
 /// Opcode for the DestroySubwindows request
 pub const DESTROY_SUBWINDOWS_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroySubwindowsRequest {
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroySubwindowsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroySubwindowsRequest").finish_non_exhaustive()
+    }
 }
 impl DestroySubwindowsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8285,11 +8628,18 @@ pub const CHANGE_SAVE_SET_REQUEST: u8 = 6;
 /// # See
 ///
 /// * `ReparentWindow`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeSaveSetRequest {
     pub mode: SetMode,
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeSaveSetRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeSaveSetRequest").finish_non_exhaustive()
+    }
 }
 impl ChangeSaveSetRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8377,13 +8727,20 @@ pub const REPARENT_WINDOW_REQUEST: u8 = 7;
 /// * `ReparentNotify`: event
 /// * `MapWindow`: request
 /// * `UnmapWindow`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReparentWindowRequest {
     pub window: Window,
     pub parent: Window,
     pub x: i16,
     pub y: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ReparentWindowRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ReparentWindowRequest").finish_non_exhaustive()
+    }
 }
 impl ReparentWindowRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8488,10 +8845,17 @@ pub const MAP_WINDOW_REQUEST: u8 = 8;
 /// * `MapNotify`: event
 /// * `Expose`: event
 /// * `UnmapWindow`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapWindowRequest {
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MapWindowRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MapWindowRequest").finish_non_exhaustive()
+    }
 }
 impl MapWindowRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8544,10 +8908,17 @@ impl crate::x11_utils::VoidRequest for MapWindowRequest {
 
 /// Opcode for the MapSubwindows request
 pub const MAP_SUBWINDOWS_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MapSubwindowsRequest {
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for MapSubwindowsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MapSubwindowsRequest").finish_non_exhaustive()
+    }
 }
 impl MapSubwindowsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8621,10 +8992,17 @@ pub const UNMAP_WINDOW_REQUEST: u8 = 10;
 /// * `UnmapNotify`: event
 /// * `Expose`: event
 /// * `MapWindow`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnmapWindowRequest {
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UnmapWindowRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UnmapWindowRequest").finish_non_exhaustive()
+    }
 }
 impl UnmapWindowRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8677,10 +9055,17 @@ impl crate::x11_utils::VoidRequest for UnmapWindowRequest {
 
 /// Opcode for the UnmapSubwindows request
 pub const UNMAP_SUBWINDOWS_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnmapSubwindowsRequest {
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UnmapSubwindowsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UnmapSubwindowsRequest").finish_non_exhaustive()
+    }
 }
 impl UnmapSubwindowsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -8849,7 +9234,8 @@ impl core::fmt::Debug for StackMode  {
 }
 
 /// Auxiliary and optional information for the `configure_window` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureWindowAux {
     pub x: Option<i32>,
@@ -8859,6 +9245,12 @@ pub struct ConfigureWindowAux {
     pub border_width: Option<u32>,
     pub sibling: Option<Window>,
     pub stack_mode: Option<StackMode>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ConfigureWindowAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ConfigureWindowAux").finish_non_exhaustive()
+    }
 }
 impl ConfigureWindowAux {
     fn try_parse(value: &[u8], value_mask: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -9117,11 +9509,18 @@ pub const CONFIGURE_WINDOW_REQUEST: u8 = 12;
 ///     xcb_flush(c);
 /// }
 /// ```
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConfigureWindowRequest<'input> {
     pub window: Window,
     pub value_list: Cow<'input, ConfigureWindowAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ConfigureWindowRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ConfigureWindowRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ConfigureWindowRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -9271,11 +9670,18 @@ pub const CIRCULATE_WINDOW_REQUEST: u8 = 13;
 ///
 /// * `Window` - The specified `window` does not exist.
 /// * `Value` - The specified `direction` is invalid.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CirculateWindowRequest {
     pub direction: Circulate,
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CirculateWindowRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CirculateWindowRequest").finish_non_exhaustive()
+    }
 }
 impl CirculateWindowRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9367,10 +9773,17 @@ pub const GET_GEOMETRY_REQUEST: u8 = 14;
 ///     free(reply);
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGeometryRequest {
     pub drawable: Drawable,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetGeometryRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetGeometryRequest").finish_non_exhaustive()
+    }
 }
 impl GetGeometryRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9435,7 +9848,8 @@ impl crate::x11_utils::ReplyRequest for GetGeometryRequest {
 /// * `height` - The height of `drawable`.
 /// * `border_width` - The border width (in pixels).
 /// * `depth` - The depth of the drawable (bits per pixel for the object).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetGeometryReply {
     pub depth: u8,
@@ -9447,6 +9861,12 @@ pub struct GetGeometryReply {
     pub width: u16,
     pub height: u16,
     pub border_width: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetGeometryReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetGeometryReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetGeometryReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9568,10 +9988,17 @@ pub const QUERY_TREE_REQUEST: u8 = 15;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryTreeRequest {
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryTreeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryTreeRequest").finish_non_exhaustive()
+    }
 }
 impl QueryTreeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9627,7 +10054,8 @@ impl crate::x11_utils::ReplyRequest for QueryTreeRequest {
 ///
 /// * `root` - The root window of `window`.
 /// * `parent` - The parent window of `window`.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryTreeReply {
     pub sequence: u16,
@@ -9635,6 +10063,12 @@ pub struct QueryTreeReply {
     pub root: Window,
     pub parent: Window,
     pub children: Vec<Window>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryTreeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryTreeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryTreeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9742,11 +10176,18 @@ pub const INTERN_ATOM_REQUEST: u8 = 16;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InternAtomRequest<'input> {
     pub only_if_exists: bool,
     pub name: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for InternAtomRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InternAtomRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> InternAtomRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -9813,12 +10254,19 @@ impl<'input> crate::x11_utils::ReplyRequest for InternAtomRequest<'input> {
     type Reply = InternAtomReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InternAtomReply {
     pub sequence: u16,
     pub length: u32,
     pub atom: Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InternAtomReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InternAtomReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for InternAtomReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -9873,10 +10321,17 @@ impl Serialize for InternAtomReply {
 
 /// Opcode for the GetAtomName request
 pub const GET_ATOM_NAME_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetAtomNameRequest {
     pub atom: Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetAtomNameRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetAtomNameRequest").finish_non_exhaustive()
+    }
 }
 impl GetAtomNameRequest {
     /// Serialize this request into bytes for the provided connection
@@ -9928,12 +10383,19 @@ impl crate::x11_utils::ReplyRequest for GetAtomNameRequest {
     type Reply = GetAtomNameReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetAtomNameReply {
     pub sequence: u16,
     pub length: u32,
     pub name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetAtomNameReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetAtomNameReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetAtomNameReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10115,7 +10577,8 @@ pub const CHANGE_PROPERTY_REQUEST: u8 = 18;
 ///     xcb_flush(conn);
 /// }
 /// ```
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangePropertyRequest<'input> {
     pub mode: PropMode,
@@ -10125,6 +10588,12 @@ pub struct ChangePropertyRequest<'input> {
     pub format: u8,
     pub data_len: u32,
     pub data: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangePropertyRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangePropertyRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangePropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -10227,11 +10696,18 @@ impl<'input> crate::x11_utils::VoidRequest for ChangePropertyRequest<'input> {
 
 /// Opcode for the DeleteProperty request
 pub const DELETE_PROPERTY_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeletePropertyRequest {
     pub window: Window,
     pub property: Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DeletePropertyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DeletePropertyRequest").finish_non_exhaustive()
+    }
 }
 impl DeletePropertyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10416,7 +10892,8 @@ pub const GET_PROPERTY_REQUEST: u8 = 20;
 ///     free(reply);
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyRequest {
     pub delete: bool,
@@ -10425,6 +10902,12 @@ pub struct GetPropertyRequest {
     pub type_: Atom,
     pub long_offset: u32,
     pub long_length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPropertyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPropertyRequest").finish_non_exhaustive()
+    }
 }
 impl GetPropertyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10673,7 +11156,8 @@ impl GetPropertyReply {
 /// performed.
 /// * `value_len` - The length of value. You should use the corresponding accessor instead of this
 /// field.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyReply {
     pub format: u8,
@@ -10683,6 +11167,12 @@ pub struct GetPropertyReply {
     pub bytes_after: u32,
     pub value_len: u32,
     pub value: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPropertyReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPropertyReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10732,10 +11222,17 @@ impl Serialize for GetPropertyReply {
 
 /// Opcode for the ListProperties request
 pub const LIST_PROPERTIES_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListPropertiesRequest {
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListPropertiesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListPropertiesRequest").finish_non_exhaustive()
+    }
 }
 impl ListPropertiesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10787,12 +11284,19 @@ impl crate::x11_utils::ReplyRequest for ListPropertiesRequest {
     type Reply = ListPropertiesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListPropertiesReply {
     pub sequence: u16,
     pub length: u32,
     pub atoms: Vec<Atom>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListPropertiesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListPropertiesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListPropertiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -10881,12 +11385,19 @@ pub const SET_SELECTION_OWNER_REQUEST: u8 = 22;
 /// # See
 ///
 /// * `SetSelectionOwner`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetSelectionOwnerRequest {
     pub owner: Window,
     pub selection: Atom,
     pub time: Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetSelectionOwnerRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetSelectionOwnerRequest").finish_non_exhaustive()
+    }
 }
 impl SetSelectionOwnerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -10970,10 +11481,17 @@ pub const GET_SELECTION_OWNER_REQUEST: u8 = 23;
 /// # See
 ///
 /// * `SetSelectionOwner`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionOwnerRequest {
     pub selection: Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSelectionOwnerRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSelectionOwnerRequest").finish_non_exhaustive()
+    }
 }
 impl GetSelectionOwnerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11028,12 +11546,19 @@ impl crate::x11_utils::ReplyRequest for GetSelectionOwnerRequest {
 /// # Fields
 ///
 /// * `owner` - The current selection owner window.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionOwnerReply {
     pub sequence: u16,
     pub length: u32,
     pub owner: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSelectionOwnerReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSelectionOwnerReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetSelectionOwnerReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11088,7 +11613,8 @@ impl Serialize for GetSelectionOwnerReply {
 
 /// Opcode for the ConvertSelection request
 pub const CONVERT_SELECTION_REQUEST: u8 = 24;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConvertSelectionRequest {
     pub requestor: Window,
@@ -11096,6 +11622,12 @@ pub struct ConvertSelectionRequest {
     pub target: Atom,
     pub property: Atom,
     pub time: Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ConvertSelectionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ConvertSelectionRequest").finish_non_exhaustive()
+    }
 }
 impl ConvertSelectionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11320,13 +11852,20 @@ pub const SEND_EVENT_REQUEST: u8 = 25;
 ///     free(event);
 /// }
 /// ```
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SendEventRequest<'input> {
     pub propagate: bool,
     pub destination: Window,
     pub event_mask: EventMask,
     pub event: Cow<'input, [u8; 32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SendEventRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SendEventRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SendEventRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -11659,7 +12198,8 @@ pub const GRAB_POINTER_REQUEST: u8 = 26;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabPointerRequest {
     pub owner_events: bool,
@@ -11670,6 +12210,12 @@ pub struct GrabPointerRequest {
     pub confine_to: Window,
     pub cursor: Cursor,
     pub time: Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GrabPointerRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabPointerRequest").finish_non_exhaustive()
+    }
 }
 impl GrabPointerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -11760,12 +12306,19 @@ impl crate::x11_utils::ReplyRequest for GrabPointerRequest {
     type Reply = GrabPointerReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabPointerReply {
     pub status: GrabStatus,
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GrabPointerReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabPointerReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GrabPointerReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -11838,10 +12391,17 @@ pub const UNGRAB_POINTER_REQUEST: u8 = 27;
 /// * `GrabButton`: request
 /// * `EnterNotify`: event
 /// * `LeaveNotify`: event
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabPointerRequest {
     pub time: Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UngrabPointerRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UngrabPointerRequest").finish_non_exhaustive()
+    }
 }
 impl UngrabPointerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12036,7 +12596,8 @@ pub const GRAB_BUTTON_REQUEST: u8 = 28;
 /// * `Value` - TODO: reasons?
 /// * `Cursor` - The specified `cursor` does not exist.
 /// * `Window` - The specified `window` does not exist.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabButtonRequest {
     pub owner_events: bool,
@@ -12048,6 +12609,12 @@ pub struct GrabButtonRequest {
     pub cursor: Cursor,
     pub button: ButtonIndex,
     pub modifiers: ModMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GrabButtonRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabButtonRequest").finish_non_exhaustive()
+    }
 }
 impl GrabButtonRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12145,12 +12712,19 @@ impl crate::x11_utils::VoidRequest for GrabButtonRequest {
 
 /// Opcode for the UngrabButton request
 pub const UNGRAB_BUTTON_REQUEST: u8 = 29;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabButtonRequest {
     pub button: ButtonIndex,
     pub grab_window: Window,
     pub modifiers: ModMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UngrabButtonRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UngrabButtonRequest").finish_non_exhaustive()
+    }
 }
 impl UngrabButtonRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12215,12 +12789,19 @@ impl crate::x11_utils::VoidRequest for UngrabButtonRequest {
 
 /// Opcode for the ChangeActivePointerGrab request
 pub const CHANGE_ACTIVE_POINTER_GRAB_REQUEST: u8 = 30;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeActivePointerGrabRequest {
     pub cursor: Cursor,
     pub time: Timestamp,
     pub event_mask: EventMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeActivePointerGrabRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeActivePointerGrabRequest").finish_non_exhaustive()
+    }
 }
 impl ChangeActivePointerGrabRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12351,7 +12932,8 @@ pub const GRAB_KEYBOARD_REQUEST: u8 = 31;
 ///     }
 /// }
 /// ```
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabKeyboardRequest {
     pub owner_events: bool,
@@ -12359,6 +12941,12 @@ pub struct GrabKeyboardRequest {
     pub time: Timestamp,
     pub pointer_mode: GrabMode,
     pub keyboard_mode: GrabMode,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GrabKeyboardRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabKeyboardRequest").finish_non_exhaustive()
+    }
 }
 impl GrabKeyboardRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12432,12 +13020,19 @@ impl crate::x11_utils::ReplyRequest for GrabKeyboardRequest {
     type Reply = GrabKeyboardReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabKeyboardReply {
     pub status: GrabStatus,
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GrabKeyboardReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabKeyboardReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GrabKeyboardReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -12487,10 +13082,17 @@ impl Serialize for GrabKeyboardReply {
 
 /// Opcode for the UngrabKeyboard request
 pub const UNGRAB_KEYBOARD_REQUEST: u8 = 32;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabKeyboardRequest {
     pub time: Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UngrabKeyboardRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UngrabKeyboardRequest").finish_non_exhaustive()
+    }
 }
 impl UngrabKeyboardRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12659,7 +13261,8 @@ pub const GRAB_KEY_REQUEST: u8 = 33;
 /// # See
 ///
 /// * `GrabKeyboard`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabKeyRequest {
     pub owner_events: bool,
@@ -12668,6 +13271,12 @@ pub struct GrabKeyRequest {
     pub key: Keycode,
     pub pointer_mode: GrabMode,
     pub keyboard_mode: GrabMode,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GrabKeyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabKeyRequest").finish_non_exhaustive()
+    }
 }
 impl GrabKeyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12771,12 +13380,19 @@ pub const UNGRAB_KEY_REQUEST: u8 = 34;
 ///
 /// * `GrabKey`: request
 /// * `xev`: program
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabKeyRequest {
     pub key: Keycode,
     pub grab_window: Window,
     pub modifiers: ModMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UngrabKeyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UngrabKeyRequest").finish_non_exhaustive()
+    }
 }
 impl UngrabKeyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -12988,11 +13604,18 @@ pub const ALLOW_EVENTS_REQUEST: u8 = 35;
 /// # Errors
 ///
 /// * `Value` - You specified an invalid `mode`.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllowEventsRequest {
     pub mode: Allow,
     pub time: Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AllowEventsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllowEventsRequest").finish_non_exhaustive()
+    }
 }
 impl AllowEventsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -13048,9 +13671,16 @@ impl crate::x11_utils::VoidRequest for AllowEventsRequest {
 
 /// Opcode for the GrabServer request
 pub const GRAB_SERVER_REQUEST: u8 = 36;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabServerRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GrabServerRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabServerRequest").finish_non_exhaustive()
+    }
+}
 impl GrabServerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13095,9 +13725,16 @@ impl crate::x11_utils::VoidRequest for GrabServerRequest {
 
 /// Opcode for the UngrabServer request
 pub const UNGRAB_SERVER_REQUEST: u8 = 37;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabServerRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UngrabServerRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UngrabServerRequest").finish_non_exhaustive()
+    }
+}
 impl UngrabServerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13155,10 +13792,17 @@ pub const QUERY_POINTER_REQUEST: u8 = 38;
 /// # Errors
 ///
 /// * `Window` - The specified `window` does not exist.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPointerRequest {
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryPointerRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryPointerRequest").finish_non_exhaustive()
+    }
 }
 impl QueryPointerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -13229,7 +13873,8 @@ impl crate::x11_utils::ReplyRequest for QueryPointerRequest {
 /// * `mask` - The current logical state of the modifier keys and the buttons. Note that the
 /// logical state of a device (as seen by means of the protocol) may lag the
 /// physical state if device event processing is frozen.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPointerReply {
     pub same_screen: bool,
@@ -13242,6 +13887,12 @@ pub struct QueryPointerReply {
     pub win_x: i16,
     pub win_y: i16,
     pub mask: KeyButMask,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryPointerReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryPointerReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryPointerReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13332,12 +13983,19 @@ impl Serialize for QueryPointerReply {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Timecoord {
     pub time: Timestamp,
     pub x: i16,
     pub y: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Timecoord {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Timecoord").finish_non_exhaustive()
+    }
 }
 impl TryParse for Timecoord {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13375,12 +14033,19 @@ impl Serialize for Timecoord {
 
 /// Opcode for the GetMotionEvents request
 pub const GET_MOTION_EVENTS_REQUEST: u8 = 39;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMotionEventsRequest {
     pub window: Window,
     pub start: Timestamp,
     pub stop: Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMotionEventsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMotionEventsRequest").finish_non_exhaustive()
+    }
 }
 impl GetMotionEventsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -13446,12 +14111,19 @@ impl crate::x11_utils::ReplyRequest for GetMotionEventsRequest {
     type Reply = GetMotionEventsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetMotionEventsReply {
     pub sequence: u16,
     pub length: u32,
     pub events: Vec<Timecoord>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetMotionEventsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetMotionEventsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetMotionEventsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13511,13 +14183,20 @@ impl GetMotionEventsReply {
 
 /// Opcode for the TranslateCoordinates request
 pub const TRANSLATE_COORDINATES_REQUEST: u8 = 40;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TranslateCoordinatesRequest {
     pub src_window: Window,
     pub dst_window: Window,
     pub src_x: i16,
     pub src_y: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for TranslateCoordinatesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TranslateCoordinatesRequest").finish_non_exhaustive()
+    }
 }
 impl TranslateCoordinatesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -13586,7 +14265,8 @@ impl crate::x11_utils::ReplyRequest for TranslateCoordinatesRequest {
     type Reply = TranslateCoordinatesReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct TranslateCoordinatesReply {
     pub same_screen: bool,
@@ -13595,6 +14275,12 @@ pub struct TranslateCoordinatesReply {
     pub child: Window,
     pub dst_x: i16,
     pub dst_y: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for TranslateCoordinatesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TranslateCoordinatesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for TranslateCoordinatesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -13692,7 +14378,8 @@ pub const WARP_POINTER_REQUEST: u8 = 41;
 /// # See
 ///
 /// * `SetInputFocus`: request
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct WarpPointerRequest {
     pub src_window: Window,
@@ -13703,6 +14390,12 @@ pub struct WarpPointerRequest {
     pub src_height: u16,
     pub dst_x: i16,
     pub dst_y: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for WarpPointerRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("WarpPointerRequest").finish_non_exhaustive()
+    }
 }
 impl WarpPointerRequest {
     /// Serialize this request into bytes for the provided connection
@@ -13899,12 +14592,19 @@ pub const SET_INPUT_FOCUS_REQUEST: u8 = 42;
 ///
 /// * `FocusIn`: event
 /// * `FocusOut`: event
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetInputFocusRequest {
     pub revert_to: InputFocus,
     pub focus: Window,
     pub time: Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetInputFocusRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetInputFocusRequest").finish_non_exhaustive()
+    }
 }
 impl SetInputFocusRequest {
     /// Serialize this request into bytes for the provided connection
@@ -13967,9 +14667,16 @@ impl crate::x11_utils::VoidRequest for SetInputFocusRequest {
 
 /// Opcode for the GetInputFocus request
 pub const GET_INPUT_FOCUS_REQUEST: u8 = 43;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetInputFocusRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetInputFocusRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetInputFocusRequest").finish_non_exhaustive()
+    }
+}
 impl GetInputFocusRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -14013,13 +14720,20 @@ impl crate::x11_utils::ReplyRequest for GetInputFocusRequest {
     type Reply = GetInputFocusReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetInputFocusReply {
     pub revert_to: InputFocus,
     pub sequence: u16,
     pub length: u32,
     pub focus: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetInputFocusReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetInputFocusReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetInputFocusReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14076,9 +14790,16 @@ impl Serialize for GetInputFocusReply {
 
 /// Opcode for the QueryKeymap request
 pub const QUERY_KEYMAP_REQUEST: u8 = 44;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryKeymapRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryKeymapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryKeymapRequest").finish_non_exhaustive()
+    }
+}
 impl QueryKeymapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -14122,12 +14843,19 @@ impl crate::x11_utils::ReplyRequest for QueryKeymapRequest {
     type Reply = QueryKeymapReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryKeymapReply {
     pub sequence: u16,
     pub length: u32,
     pub keys: [u8; 32],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryKeymapReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryKeymapReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryKeymapReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14228,11 +14956,18 @@ pub const OPEN_FONT_REQUEST: u8 = 45;
 /// # See
 ///
 /// * `xcb_generate_id`: function
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenFontRequest<'input> {
     pub fid: Font,
     pub name: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for OpenFontRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("OpenFontRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> OpenFontRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -14305,10 +15040,17 @@ impl<'input> crate::x11_utils::VoidRequest for OpenFontRequest<'input> {
 
 /// Opcode for the CloseFont request
 pub const CLOSE_FONT_REQUEST: u8 = 46;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CloseFontRequest {
     pub font: Font,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CloseFontRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CloseFontRequest").finish_non_exhaustive()
+    }
 }
 impl CloseFontRequest {
     /// Serialize this request into bytes for the provided connection
@@ -14418,11 +15160,18 @@ impl core::fmt::Debug for FontDraw  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Fontprop {
     pub name: Atom,
     pub value: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Fontprop {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Fontprop").finish_non_exhaustive()
+    }
 }
 impl TryParse for Fontprop {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14455,7 +15204,8 @@ impl Serialize for Fontprop {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Charinfo {
     pub left_side_bearing: i16,
@@ -14464,6 +15214,12 @@ pub struct Charinfo {
     pub ascent: i16,
     pub descent: i16,
     pub attributes: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Charinfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Charinfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for Charinfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14521,10 +15277,17 @@ pub const QUERY_FONT_REQUEST: u8 = 47;
 /// # Fields
 ///
 /// * `font` - The fontable (Font or Graphics Context) to query.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryFontRequest {
     pub font: Fontable,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryFontRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryFontRequest").finish_non_exhaustive()
+    }
 }
 impl QueryFontRequest {
     /// Serialize this request into bytes for the provided connection
@@ -14587,7 +15350,8 @@ impl crate::x11_utils::ReplyRequest for QueryFontRequest {
 /// * `font_ascent` - baseline to top edge of raster
 /// * `font_descent` - baseline to bottom edge of raster
 /// * `draw_direction` -
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryFontReply {
     pub sequence: u16,
@@ -14605,6 +15369,12 @@ pub struct QueryFontReply {
     pub font_descent: i16,
     pub properties: Vec<Fontprop>,
     pub char_infos: Vec<Charinfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryFontReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryFontReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryFontReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14741,11 +15511,18 @@ pub const QUERY_TEXT_EXTENTS_REQUEST: u8 = 48;
 ///
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Font` - The specified `font` does not exist.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryTextExtentsRequest<'input> {
     pub font: Fontable,
     pub string: Cow<'input, [Char2b]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for QueryTextExtentsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryTextExtentsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> QueryTextExtentsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -14826,7 +15603,8 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryTextExtentsRequest<'input> 
     type Reply = QueryTextExtentsReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryTextExtentsReply {
     pub draw_direction: FontDraw,
@@ -14839,6 +15617,12 @@ pub struct QueryTextExtentsReply {
     pub overall_width: i32,
     pub overall_left: i32,
     pub overall_right: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryTextExtentsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryTextExtentsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryTextExtentsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14927,10 +15711,17 @@ impl Serialize for QueryTextExtentsReply {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Str {
     pub name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Str {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Str").finish_non_exhaustive()
+    }
 }
 impl TryParse for Str {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -14984,11 +15775,18 @@ pub const LIST_FONTS_REQUEST: u8 = 49;
 /// (?) is a wildcard for a single character. Use of uppercase or lowercase does
 /// not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListFontsRequest<'input> {
     pub max_names: u16,
     pub pattern: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ListFontsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListFontsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ListFontsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -15057,12 +15855,19 @@ impl<'input> crate::x11_utils::ReplyRequest for ListFontsRequest<'input> {
 
 /// # Fields
 ///
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListFontsReply {
     pub sequence: u16,
     pub length: u32,
     pub names: Vec<Str>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListFontsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListFontsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListFontsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -15134,11 +15939,18 @@ pub const LIST_FONTS_WITH_INFO_REQUEST: u8 = 50;
 /// (?) is a wildcard for a single character. Use of uppercase or lowercase does
 /// not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListFontsWithInfoRequest<'input> {
     pub max_names: u16,
     pub pattern: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ListFontsWithInfoRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListFontsWithInfoRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ListFontsWithInfoRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -15219,7 +16031,8 @@ impl<'input> crate::x11_utils::ReplyRequest for ListFontsWithInfoRequest<'input>
 /// may be larger or smaller than the number of fonts actually returned. A zero
 /// value does not guarantee that no more fonts will be returned.
 /// * `draw_direction` -
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListFontsWithInfoReply {
     pub sequence: u16,
@@ -15238,6 +16051,12 @@ pub struct ListFontsWithInfoReply {
     pub replies_hint: u32,
     pub properties: Vec<Fontprop>,
     pub name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListFontsWithInfoReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListFontsWithInfoReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListFontsWithInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -15341,10 +16160,17 @@ impl ListFontsWithInfoReply {
 
 /// Opcode for the SetFontPath request
 pub const SET_FONT_PATH_REQUEST: u8 = 51;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetFontPathRequest<'input> {
     pub font: Cow<'input, [Str]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetFontPathRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetFontPathRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetFontPathRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -15410,9 +16236,16 @@ impl<'input> crate::x11_utils::VoidRequest for SetFontPathRequest<'input> {
 
 /// Opcode for the GetFontPath request
 pub const GET_FONT_PATH_REQUEST: u8 = 52;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFontPathRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetFontPathRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetFontPathRequest").finish_non_exhaustive()
+    }
+}
 impl GetFontPathRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -15456,12 +16289,19 @@ impl crate::x11_utils::ReplyRequest for GetFontPathRequest {
     type Reply = GetFontPathReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFontPathReply {
     pub sequence: u16,
     pub length: u32,
     pub path: Vec<Str>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetFontPathReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetFontPathReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetFontPathReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -15544,7 +16384,8 @@ pub const CREATE_PIXMAP_REQUEST: u8 = 53;
 /// # See
 ///
 /// * `xcb_generate_id`: function
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreatePixmapRequest {
     pub depth: u8,
@@ -15552,6 +16393,12 @@ pub struct CreatePixmapRequest {
     pub drawable: Drawable,
     pub width: u16,
     pub height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreatePixmapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreatePixmapRequest").finish_non_exhaustive()
+    }
 }
 impl CreatePixmapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -15635,10 +16482,17 @@ pub const FREE_PIXMAP_REQUEST: u8 = 54;
 /// # Errors
 ///
 /// * `Pixmap` - The specified pixmap does not exist.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreePixmapRequest {
     pub pixmap: Pixmap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FreePixmapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FreePixmapRequest").finish_non_exhaustive()
+    }
 }
 impl FreePixmapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -16298,7 +17152,8 @@ impl core::fmt::Debug for ArcMode  {
 }
 
 /// Auxiliary and optional information for the `create_gc` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateGCAux {
     pub function: Option<GX>,
@@ -16324,6 +17179,12 @@ pub struct CreateGCAux {
     pub dash_offset: Option<u32>,
     pub dashes: Option<u32>,
     pub arc_mode: Option<ArcMode>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateGCAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateGCAux").finish_non_exhaustive()
+    }
 }
 impl CreateGCAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -16850,12 +17711,19 @@ pub const CREATE_GC_REQUEST: u8 = 55;
 /// # See
 ///
 /// * `xcb_generate_id`: function
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateGCRequest<'input> {
     pub cid: Gcontext,
     pub drawable: Drawable,
     pub value_list: Cow<'input, CreateGCAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for CreateGCRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateGCRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> CreateGCRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -16935,7 +17803,8 @@ impl<'input> crate::x11_utils::VoidRequest for CreateGCRequest<'input> {
 }
 
 /// Auxiliary and optional information for the `change_gc` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeGCAux {
     pub function: Option<GX>,
@@ -16961,6 +17830,12 @@ pub struct ChangeGCAux {
     pub dash_offset: Option<u32>,
     pub dashes: Option<u32>,
     pub arc_mode: Option<ArcMode>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeGCAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeGCAux").finish_non_exhaustive()
+    }
 }
 impl ChangeGCAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -17508,11 +18383,18 @@ pub const CHANGE_GC_REQUEST: u8 = 56;
 ///     xcb_flush(conn);
 /// }
 /// ```
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeGCRequest<'input> {
     pub gc: Gcontext,
     pub value_list: Cow<'input, ChangeGCAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeGCRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeGCRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeGCRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -17585,12 +18467,19 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeGCRequest<'input> {
 
 /// Opcode for the CopyGC request
 pub const COPY_GC_REQUEST: u8 = 57;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyGCRequest {
     pub src_gc: Gcontext,
     pub dst_gc: Gcontext,
     pub value_mask: GC,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CopyGCRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CopyGCRequest").finish_non_exhaustive()
+    }
 }
 impl CopyGCRequest {
     /// Serialize this request into bytes for the provided connection
@@ -17658,12 +18547,19 @@ impl crate::x11_utils::VoidRequest for CopyGCRequest {
 
 /// Opcode for the SetDashes request
 pub const SET_DASHES_REQUEST: u8 = 58;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDashesRequest<'input> {
     pub gc: Gcontext,
     pub dash_offset: u16,
     pub dashes: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetDashesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDashesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetDashesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -17802,7 +18698,8 @@ impl core::fmt::Debug for ClipOrdering  {
 
 /// Opcode for the SetClipRectangles request
 pub const SET_CLIP_RECTANGLES_REQUEST: u8 = 59;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetClipRectanglesRequest<'input> {
     pub ordering: ClipOrdering,
@@ -17810,6 +18707,12 @@ pub struct SetClipRectanglesRequest<'input> {
     pub clip_x_origin: i16,
     pub clip_y_origin: i16,
     pub rectangles: Cow<'input, [Rectangle]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetClipRectanglesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetClipRectanglesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetClipRectanglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -17909,10 +18812,17 @@ pub const FREE_GC_REQUEST: u8 = 60;
 /// # Errors
 ///
 /// * `GContext` - The specified graphics context does not exist.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeGCRequest {
     pub gc: Gcontext,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FreeGCRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FreeGCRequest").finish_non_exhaustive()
+    }
 }
 impl FreeGCRequest {
     /// Serialize this request into bytes for the provided connection
@@ -17965,7 +18875,8 @@ impl crate::x11_utils::VoidRequest for FreeGCRequest {
 
 /// Opcode for the ClearArea request
 pub const CLEAR_AREA_REQUEST: u8 = 61;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClearAreaRequest {
     pub exposures: bool,
@@ -17974,6 +18885,12 @@ pub struct ClearAreaRequest {
     pub y: i16,
     pub width: u16,
     pub height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ClearAreaRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ClearAreaRequest").finish_non_exhaustive()
+    }
 }
 impl ClearAreaRequest {
     /// Serialize this request into bytes for the provided connection
@@ -18069,7 +18986,8 @@ pub const COPY_AREA_REQUEST: u8 = 62;
 /// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Match` - `src_drawable` has a different root or depth than `dst_drawable`.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyAreaRequest {
     pub src_drawable: Drawable,
@@ -18081,6 +18999,12 @@ pub struct CopyAreaRequest {
     pub dst_y: i16,
     pub width: u16,
     pub height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CopyAreaRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CopyAreaRequest").finish_non_exhaustive()
+    }
 }
 impl CopyAreaRequest {
     /// Serialize this request into bytes for the provided connection
@@ -18177,7 +19101,8 @@ impl crate::x11_utils::VoidRequest for CopyAreaRequest {
 
 /// Opcode for the CopyPlane request
 pub const COPY_PLANE_REQUEST: u8 = 63;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyPlaneRequest {
     pub src_drawable: Drawable,
@@ -18190,6 +19115,12 @@ pub struct CopyPlaneRequest {
     pub width: u16,
     pub height: u16,
     pub bit_plane: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CopyPlaneRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CopyPlaneRequest").finish_non_exhaustive()
+    }
 }
 impl CopyPlaneRequest {
     /// Serialize this request into bytes for the provided connection
@@ -18356,13 +19287,20 @@ impl core::fmt::Debug for CoordMode  {
 
 /// Opcode for the PolyPoint request
 pub const POLY_POINT_REQUEST: u8 = 64;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyPointRequest<'input> {
     pub coordinate_mode: CoordMode,
     pub drawable: Drawable,
     pub gc: Gcontext,
     pub points: Cow<'input, [Point]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PolyPointRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PolyPointRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PolyPointRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -18486,13 +19424,20 @@ pub const POLY_LINE_REQUEST: u8 = 65;
 ///     xcb_flush(conn);
 /// }
 /// ```
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyLineRequest<'input> {
     pub coordinate_mode: CoordMode,
     pub drawable: Drawable,
     pub gc: Gcontext,
     pub points: Cow<'input, [Point]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PolyLineRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PolyLineRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PolyLineRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -18575,13 +19520,20 @@ impl<'input> Request for PolyLineRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for PolyLineRequest<'input> {
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Segment {
     pub x1: i16,
     pub y1: i16,
     pub x2: i16,
     pub y2: i16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Segment {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Segment").finish_non_exhaustive()
+    }
 }
 impl TryParse for Segment {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -18648,12 +19600,19 @@ pub const POLY_SEGMENT_REQUEST: u8 = 66;
 /// * `Drawable` - The specified `drawable` does not exist.
 /// * `GContext` - The specified `gc` does not exist.
 /// * `Match` - TODO: reasons?
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolySegmentRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
     pub segments: Cow<'input, [Segment]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PolySegmentRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PolySegmentRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PolySegmentRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -18734,12 +19693,19 @@ impl<'input> crate::x11_utils::VoidRequest for PolySegmentRequest<'input> {
 
 /// Opcode for the PolyRectangle request
 pub const POLY_RECTANGLE_REQUEST: u8 = 67;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyRectangleRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
     pub rectangles: Cow<'input, [Rectangle]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PolyRectangleRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PolyRectangleRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PolyRectangleRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -18820,12 +19786,19 @@ impl<'input> crate::x11_utils::VoidRequest for PolyRectangleRequest<'input> {
 
 /// Opcode for the PolyArc request
 pub const POLY_ARC_REQUEST: u8 = 68;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyArcRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
     pub arcs: Cow<'input, [Arc]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PolyArcRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PolyArcRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PolyArcRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -18967,7 +19940,8 @@ impl core::fmt::Debug for PolyShape  {
 
 /// Opcode for the FillPoly request
 pub const FILL_POLY_REQUEST: u8 = 69;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FillPolyRequest<'input> {
     pub drawable: Drawable,
@@ -18975,6 +19949,12 @@ pub struct FillPolyRequest<'input> {
     pub shape: PolyShape,
     pub coordinate_mode: CoordMode,
     pub points: Cow<'input, [Point]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for FillPolyRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FillPolyRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> FillPolyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -19095,12 +20075,19 @@ pub const POLY_FILL_RECTANGLE_REQUEST: u8 = 70;
 /// * `Drawable` - The specified `drawable` (Window or Pixmap) does not exist.
 /// * `GContext` - The specified graphics context does not exist.
 /// * `Match` - TODO: reasons?
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyFillRectangleRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
     pub rectangles: Cow<'input, [Rectangle]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PolyFillRectangleRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PolyFillRectangleRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PolyFillRectangleRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -19181,12 +20168,19 @@ impl<'input> crate::x11_utils::VoidRequest for PolyFillRectangleRequest<'input> 
 
 /// Opcode for the PolyFillArc request
 pub const POLY_FILL_ARC_REQUEST: u8 = 71;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyFillArcRequest<'input> {
     pub drawable: Drawable,
     pub gc: Gcontext,
     pub arcs: Cow<'input, [Arc]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PolyFillArcRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PolyFillArcRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PolyFillArcRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -19328,7 +20322,8 @@ impl core::fmt::Debug for ImageFormat  {
 
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 72;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PutImageRequest<'input> {
     pub format: ImageFormat,
@@ -19341,6 +20336,12 @@ pub struct PutImageRequest<'input> {
     pub left_pad: u8,
     pub depth: u8,
     pub data: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PutImageRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PutImageRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PutImageRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -19454,7 +20455,8 @@ impl<'input> crate::x11_utils::VoidRequest for PutImageRequest<'input> {
 
 /// Opcode for the GetImage request
 pub const GET_IMAGE_REQUEST: u8 = 73;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetImageRequest {
     pub format: ImageFormat,
@@ -19464,6 +20466,12 @@ pub struct GetImageRequest {
     pub width: u16,
     pub height: u16,
     pub plane_mask: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetImageRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetImageRequest").finish_non_exhaustive()
+    }
 }
 impl GetImageRequest {
     /// Serialize this request into bytes for the provided connection
@@ -19545,13 +20553,20 @@ impl crate::x11_utils::ReplyRequest for GetImageRequest {
     type Reply = GetImageReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetImageReply {
     pub depth: u8,
     pub sequence: u16,
     pub visual: Visualid,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetImageReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetImageReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetImageReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -19614,7 +20629,8 @@ impl GetImageReply {
 
 /// Opcode for the PolyText8 request
 pub const POLY_TEXT8_REQUEST: u8 = 74;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyText8Request<'input> {
     pub drawable: Drawable,
@@ -19622,6 +20638,12 @@ pub struct PolyText8Request<'input> {
     pub x: i16,
     pub y: i16,
     pub items: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PolyText8Request<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PolyText8Request").finish_non_exhaustive()
+    }
 }
 impl<'input> PolyText8Request<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -19706,7 +20728,8 @@ impl<'input> crate::x11_utils::VoidRequest for PolyText8Request<'input> {
 
 /// Opcode for the PolyText16 request
 pub const POLY_TEXT16_REQUEST: u8 = 75;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PolyText16Request<'input> {
     pub drawable: Drawable,
@@ -19714,6 +20737,12 @@ pub struct PolyText16Request<'input> {
     pub x: i16,
     pub y: i16,
     pub items: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PolyText16Request<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PolyText16Request").finish_non_exhaustive()
+    }
 }
 impl<'input> PolyText16Request<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -19830,7 +20859,8 @@ pub const IMAGE_TEXT8_REQUEST: u8 = 76;
 /// # See
 ///
 /// * `ImageText16`: request
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageText8Request<'input> {
     pub drawable: Drawable,
@@ -19838,6 +20868,12 @@ pub struct ImageText8Request<'input> {
     pub x: i16,
     pub y: i16,
     pub string: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ImageText8Request<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ImageText8Request").finish_non_exhaustive()
+    }
 }
 impl<'input> ImageText8Request<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -19957,7 +20993,8 @@ pub const IMAGE_TEXT16_REQUEST: u8 = 77;
 /// # See
 ///
 /// * `ImageText8`: request
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageText16Request<'input> {
     pub drawable: Drawable,
@@ -19965,6 +21002,12 @@ pub struct ImageText16Request<'input> {
     pub x: i16,
     pub y: i16,
     pub string: Cow<'input, [Char2b]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ImageText16Request<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ImageText16Request").finish_non_exhaustive()
+    }
 }
 impl<'input> ImageText16Request<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -20111,13 +21154,20 @@ impl core::fmt::Debug for ColormapAlloc  {
 
 /// Opcode for the CreateColormap request
 pub const CREATE_COLORMAP_REQUEST: u8 = 78;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateColormapRequest {
     pub alloc: ColormapAlloc,
     pub mid: Colormap,
     pub window: Window,
     pub visual: Visualid,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateColormapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateColormapRequest").finish_non_exhaustive()
+    }
 }
 impl CreateColormapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -20187,10 +21237,17 @@ impl crate::x11_utils::VoidRequest for CreateColormapRequest {
 
 /// Opcode for the FreeColormap request
 pub const FREE_COLORMAP_REQUEST: u8 = 79;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeColormapRequest {
     pub cmap: Colormap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FreeColormapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FreeColormapRequest").finish_non_exhaustive()
+    }
 }
 impl FreeColormapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -20243,11 +21300,18 @@ impl crate::x11_utils::VoidRequest for FreeColormapRequest {
 
 /// Opcode for the CopyColormapAndFree request
 pub const COPY_COLORMAP_AND_FREE_REQUEST: u8 = 80;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CopyColormapAndFreeRequest {
     pub mid: Colormap,
     pub src_cmap: Colormap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CopyColormapAndFreeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CopyColormapAndFreeRequest").finish_non_exhaustive()
+    }
 }
 impl CopyColormapAndFreeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -20307,10 +21371,17 @@ impl crate::x11_utils::VoidRequest for CopyColormapAndFreeRequest {
 
 /// Opcode for the InstallColormap request
 pub const INSTALL_COLORMAP_REQUEST: u8 = 81;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InstallColormapRequest {
     pub cmap: Colormap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for InstallColormapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InstallColormapRequest").finish_non_exhaustive()
+    }
 }
 impl InstallColormapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -20363,10 +21434,17 @@ impl crate::x11_utils::VoidRequest for InstallColormapRequest {
 
 /// Opcode for the UninstallColormap request
 pub const UNINSTALL_COLORMAP_REQUEST: u8 = 82;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UninstallColormapRequest {
     pub cmap: Colormap,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UninstallColormapRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UninstallColormapRequest").finish_non_exhaustive()
+    }
 }
 impl UninstallColormapRequest {
     /// Serialize this request into bytes for the provided connection
@@ -20419,10 +21497,17 @@ impl crate::x11_utils::VoidRequest for UninstallColormapRequest {
 
 /// Opcode for the ListInstalledColormaps request
 pub const LIST_INSTALLED_COLORMAPS_REQUEST: u8 = 83;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListInstalledColormapsRequest {
     pub window: Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListInstalledColormapsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListInstalledColormapsRequest").finish_non_exhaustive()
+    }
 }
 impl ListInstalledColormapsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -20474,12 +21559,19 @@ impl crate::x11_utils::ReplyRequest for ListInstalledColormapsRequest {
     type Reply = ListInstalledColormapsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListInstalledColormapsReply {
     pub sequence: u16,
     pub length: u32,
     pub cmaps: Vec<Colormap>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListInstalledColormapsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListInstalledColormapsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListInstalledColormapsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -20557,13 +21649,20 @@ pub const ALLOC_COLOR_REQUEST: u8 = 84;
 /// # Errors
 ///
 /// * `Colormap` - The specified colormap `cmap` does not exist.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocColorRequest {
     pub cmap: Colormap,
     pub red: u16,
     pub green: u16,
     pub blue: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AllocColorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllocColorRequest").finish_non_exhaustive()
+    }
 }
 impl AllocColorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -20633,7 +21732,8 @@ impl crate::x11_utils::ReplyRequest for AllocColorRequest {
     type Reply = AllocColorReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocColorReply {
     pub sequence: u16,
@@ -20642,6 +21742,12 @@ pub struct AllocColorReply {
     pub green: u16,
     pub blue: u16,
     pub pixel: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AllocColorReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllocColorReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for AllocColorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -20715,11 +21821,18 @@ impl Serialize for AllocColorReply {
 
 /// Opcode for the AllocNamedColor request
 pub const ALLOC_NAMED_COLOR_REQUEST: u8 = 85;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocNamedColorRequest<'input> {
     pub cmap: Colormap,
     pub name: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for AllocNamedColorRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllocNamedColorRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> AllocNamedColorRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -20791,7 +21904,8 @@ impl<'input> crate::x11_utils::ReplyRequest for AllocNamedColorRequest<'input> {
     type Reply = AllocNamedColorReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocNamedColorReply {
     pub sequence: u16,
@@ -20803,6 +21917,12 @@ pub struct AllocNamedColorReply {
     pub visual_red: u16,
     pub visual_green: u16,
     pub visual_blue: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AllocNamedColorReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllocNamedColorReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for AllocNamedColorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -20887,13 +22007,20 @@ impl Serialize for AllocNamedColorReply {
 
 /// Opcode for the AllocColorCells request
 pub const ALLOC_COLOR_CELLS_REQUEST: u8 = 86;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocColorCellsRequest {
     pub contiguous: bool,
     pub cmap: Colormap,
     pub colors: u16,
     pub planes: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AllocColorCellsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllocColorCellsRequest").finish_non_exhaustive()
+    }
 }
 impl AllocColorCellsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -20957,13 +22084,20 @@ impl crate::x11_utils::ReplyRequest for AllocColorCellsRequest {
     type Reply = AllocColorCellsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocColorCellsReply {
     pub sequence: u16,
     pub length: u32,
     pub pixels: Vec<u32>,
     pub masks: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AllocColorCellsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllocColorCellsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for AllocColorCellsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -21041,7 +22175,8 @@ impl AllocColorCellsReply {
 
 /// Opcode for the AllocColorPlanes request
 pub const ALLOC_COLOR_PLANES_REQUEST: u8 = 87;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocColorPlanesRequest {
     pub contiguous: bool,
@@ -21050,6 +22185,12 @@ pub struct AllocColorPlanesRequest {
     pub reds: u16,
     pub greens: u16,
     pub blues: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AllocColorPlanesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllocColorPlanesRequest").finish_non_exhaustive()
+    }
 }
 impl AllocColorPlanesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -21123,7 +22264,8 @@ impl crate::x11_utils::ReplyRequest for AllocColorPlanesRequest {
     type Reply = AllocColorPlanesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AllocColorPlanesReply {
     pub sequence: u16,
@@ -21132,6 +22274,12 @@ pub struct AllocColorPlanesReply {
     pub green_mask: u32,
     pub blue_mask: u32,
     pub pixels: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AllocColorPlanesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllocColorPlanesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for AllocColorPlanesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -21199,12 +22347,19 @@ impl AllocColorPlanesReply {
 
 /// Opcode for the FreeColors request
 pub const FREE_COLORS_REQUEST: u8 = 88;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeColorsRequest<'input> {
     pub cmap: Colormap,
     pub plane_mask: u32,
     pub pixels: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for FreeColorsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FreeColorsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> FreeColorsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -21345,7 +22500,8 @@ impl core::fmt::Debug for ColorFlag  {
 }
 bitmask_binop!(ColorFlag, u8);
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Coloritem {
     pub pixel: u32,
@@ -21353,6 +22509,12 @@ pub struct Coloritem {
     pub green: u16,
     pub blue: u16,
     pub flags: ColorFlag,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Coloritem {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Coloritem").finish_non_exhaustive()
+    }
 }
 impl TryParse for Coloritem {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -21403,11 +22565,18 @@ impl Serialize for Coloritem {
 
 /// Opcode for the StoreColors request
 pub const STORE_COLORS_REQUEST: u8 = 89;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StoreColorsRequest<'input> {
     pub cmap: Colormap,
     pub items: Cow<'input, [Coloritem]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for StoreColorsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StoreColorsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> StoreColorsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -21480,13 +22649,20 @@ impl<'input> crate::x11_utils::VoidRequest for StoreColorsRequest<'input> {
 
 /// Opcode for the StoreNamedColor request
 pub const STORE_NAMED_COLOR_REQUEST: u8 = 90;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StoreNamedColorRequest<'input> {
     pub flags: ColorFlag,
     pub cmap: Colormap,
     pub pixel: u32,
     pub name: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for StoreNamedColorRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StoreNamedColorRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> StoreNamedColorRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -21569,12 +22745,19 @@ impl<'input> Request for StoreNamedColorRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for StoreNamedColorRequest<'input> {
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rgb {
     pub red: u16,
     pub green: u16,
     pub blue: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Rgb {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Rgb").finish_non_exhaustive()
+    }
 }
 impl TryParse for Rgb {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -21614,11 +22797,18 @@ impl Serialize for Rgb {
 
 /// Opcode for the QueryColors request
 pub const QUERY_COLORS_REQUEST: u8 = 91;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryColorsRequest<'input> {
     pub cmap: Colormap,
     pub pixels: Cow<'input, [u32]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for QueryColorsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryColorsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> QueryColorsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -21690,12 +22880,19 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryColorsRequest<'input> {
     type Reply = QueryColorsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryColorsReply {
     pub sequence: u16,
     pub length: u32,
     pub colors: Vec<Rgb>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryColorsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryColorsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryColorsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -21755,11 +22952,18 @@ impl QueryColorsReply {
 
 /// Opcode for the LookupColor request
 pub const LOOKUP_COLOR_REQUEST: u8 = 92;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LookupColorRequest<'input> {
     pub cmap: Colormap,
     pub name: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for LookupColorRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LookupColorRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> LookupColorRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -21831,7 +23035,8 @@ impl<'input> crate::x11_utils::ReplyRequest for LookupColorRequest<'input> {
     type Reply = LookupColorReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct LookupColorReply {
     pub sequence: u16,
@@ -21842,6 +23047,12 @@ pub struct LookupColorReply {
     pub visual_red: u16,
     pub visual_green: u16,
     pub visual_blue: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for LookupColorReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LookupColorReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for LookupColorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -21976,7 +23187,8 @@ impl core::fmt::Debug for PixmapEnum  {
 
 /// Opcode for the CreateCursor request
 pub const CREATE_CURSOR_REQUEST: u8 = 93;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateCursorRequest {
     pub cid: Cursor,
@@ -21990,6 +23202,12 @@ pub struct CreateCursorRequest {
     pub back_blue: u16,
     pub x: u16,
     pub y: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateCursorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateCursorRequest").finish_non_exhaustive()
+    }
 }
 impl CreateCursorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -22186,7 +23404,8 @@ pub const CREATE_GLYPH_CURSOR_REQUEST: u8 = 94;
 /// * `Alloc` - The X server could not allocate the requested resources (no memory?).
 /// * `Font` - The specified `source_font` or `mask_font` does not exist.
 /// * `Value` - Either `source_char` or `mask_char` are not defined in `source_font` or `mask_font`, respectively.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateGlyphCursorRequest {
     pub cid: Cursor,
@@ -22200,6 +23419,12 @@ pub struct CreateGlyphCursorRequest {
     pub back_red: u16,
     pub back_green: u16,
     pub back_blue: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateGlyphCursorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateGlyphCursorRequest").finish_non_exhaustive()
+    }
 }
 impl CreateGlyphCursorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -22318,10 +23543,17 @@ pub const FREE_CURSOR_REQUEST: u8 = 95;
 /// # Errors
 ///
 /// * `Cursor` - The specified cursor does not exist.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FreeCursorRequest {
     pub cursor: Cursor,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FreeCursorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FreeCursorRequest").finish_non_exhaustive()
+    }
 }
 impl FreeCursorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -22374,7 +23606,8 @@ impl crate::x11_utils::VoidRequest for FreeCursorRequest {
 
 /// Opcode for the RecolorCursor request
 pub const RECOLOR_CURSOR_REQUEST: u8 = 96;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RecolorCursorRequest {
     pub cursor: Cursor,
@@ -22384,6 +23617,12 @@ pub struct RecolorCursorRequest {
     pub back_red: u16,
     pub back_green: u16,
     pub back_blue: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for RecolorCursorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RecolorCursorRequest").finish_non_exhaustive()
+    }
 }
 impl RecolorCursorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -22527,13 +23766,20 @@ impl core::fmt::Debug for QueryShapeOf  {
 
 /// Opcode for the QueryBestSize request
 pub const QUERY_BEST_SIZE_REQUEST: u8 = 97;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryBestSizeRequest {
     pub class: QueryShapeOf,
     pub drawable: Drawable,
     pub width: u16,
     pub height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryBestSizeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryBestSizeRequest").finish_non_exhaustive()
+    }
 }
 impl QueryBestSizeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -22598,13 +23844,20 @@ impl crate::x11_utils::ReplyRequest for QueryBestSizeRequest {
     type Reply = QueryBestSizeReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryBestSizeReply {
     pub sequence: u16,
     pub length: u32,
     pub width: u16,
     pub height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryBestSizeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryBestSizeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryBestSizeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -22683,10 +23936,17 @@ pub const QUERY_EXTENSION_REQUEST: u8 = 98;
 ///
 /// * `xdpyinfo`: program
 /// * `xcb_get_extension_data`: function
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionRequest<'input> {
     pub name: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for QueryExtensionRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryExtensionRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> QueryExtensionRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -22756,7 +24016,8 @@ impl<'input> crate::x11_utils::ReplyRequest for QueryExtensionRequest<'input> {
 /// * `major_opcode` - The major opcode for requests.
 /// * `first_event` - The first event code, if any.
 /// * `first_error` - The first error code, if any.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionReply {
     pub sequence: u16,
@@ -22765,6 +24026,12 @@ pub struct QueryExtensionReply {
     pub major_opcode: u8,
     pub first_event: u8,
     pub first_error: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryExtensionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryExtensionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryExtensionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -22828,9 +24095,16 @@ impl Serialize for QueryExtensionReply {
 
 /// Opcode for the ListExtensions request
 pub const LIST_EXTENSIONS_REQUEST: u8 = 99;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListExtensionsRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListExtensionsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListExtensionsRequest").finish_non_exhaustive()
+    }
+}
 impl ListExtensionsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -22874,12 +24148,19 @@ impl crate::x11_utils::ReplyRequest for ListExtensionsRequest {
     type Reply = ListExtensionsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListExtensionsReply {
     pub sequence: u16,
     pub length: u32,
     pub names: Vec<Str>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListExtensionsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListExtensionsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListExtensionsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -22937,13 +24218,20 @@ impl ListExtensionsReply {
 
 /// Opcode for the ChangeKeyboardMapping request
 pub const CHANGE_KEYBOARD_MAPPING_REQUEST: u8 = 100;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeKeyboardMappingRequest<'input> {
     pub keycode_count: u8,
     pub first_keycode: Keycode,
     pub keysyms_per_keycode: u8,
     pub keysyms: Cow<'input, [Keysym]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeKeyboardMappingRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeKeyboardMappingRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeKeyboardMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -23018,11 +24306,18 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeKeyboardMappingRequest<'inp
 
 /// Opcode for the GetKeyboardMapping request
 pub const GET_KEYBOARD_MAPPING_REQUEST: u8 = 101;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKeyboardMappingRequest {
     pub first_keycode: Keycode,
     pub count: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKeyboardMappingRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKeyboardMappingRequest").finish_non_exhaustive()
+    }
 }
 impl GetKeyboardMappingRequest {
     /// Serialize this request into bytes for the provided connection
@@ -23077,12 +24372,19 @@ impl crate::x11_utils::ReplyRequest for GetKeyboardMappingRequest {
     type Reply = GetKeyboardMappingReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKeyboardMappingReply {
     pub keysyms_per_keycode: u8,
     pub sequence: u16,
     pub keysyms: Vec<Keysym>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKeyboardMappingReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKeyboardMappingReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetKeyboardMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -23295,7 +24597,8 @@ impl core::fmt::Debug for AutoRepeatMode  {
 }
 
 /// Auxiliary and optional information for the `change_keyboard_control` function
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeKeyboardControlAux {
     pub key_click_percent: Option<i32>,
@@ -23306,6 +24609,12 @@ pub struct ChangeKeyboardControlAux {
     pub led_mode: Option<LedMode>,
     pub key: Option<Keycode32>,
     pub auto_repeat_mode: Option<AutoRepeatMode>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangeKeyboardControlAux {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeKeyboardControlAux").finish_non_exhaustive()
+    }
 }
 impl ChangeKeyboardControlAux {
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -23503,10 +24812,17 @@ impl ChangeKeyboardControlAux {
 
 /// Opcode for the ChangeKeyboardControl request
 pub const CHANGE_KEYBOARD_CONTROL_REQUEST: u8 = 102;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeKeyboardControlRequest<'input> {
     pub value_list: Cow<'input, ChangeKeyboardControlAux>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeKeyboardControlRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeKeyboardControlRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeKeyboardControlRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -23571,9 +24887,16 @@ impl<'input> crate::x11_utils::VoidRequest for ChangeKeyboardControlRequest<'inp
 
 /// Opcode for the GetKeyboardControl request
 pub const GET_KEYBOARD_CONTROL_REQUEST: u8 = 103;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKeyboardControlRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKeyboardControlRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKeyboardControlRequest").finish_non_exhaustive()
+    }
+}
 impl GetKeyboardControlRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -23617,7 +24940,8 @@ impl crate::x11_utils::ReplyRequest for GetKeyboardControlRequest {
     type Reply = GetKeyboardControlReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKeyboardControlReply {
     pub global_auto_repeat: AutoRepeatMode,
@@ -23629,6 +24953,12 @@ pub struct GetKeyboardControlReply {
     pub bell_pitch: u16,
     pub bell_duration: u16,
     pub auto_repeats: [u8; 32],
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetKeyboardControlReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetKeyboardControlReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetKeyboardControlReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -23741,10 +25071,17 @@ impl Serialize for GetKeyboardControlReply {
 
 /// Opcode for the Bell request
 pub const BELL_REQUEST: u8 = 104;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BellRequest {
     pub percent: i8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for BellRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BellRequest").finish_non_exhaustive()
+    }
 }
 impl BellRequest {
     /// Serialize this request into bytes for the provided connection
@@ -23792,7 +25129,8 @@ impl crate::x11_utils::VoidRequest for BellRequest {
 
 /// Opcode for the ChangePointerControl request
 pub const CHANGE_POINTER_CONTROL_REQUEST: u8 = 105;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangePointerControlRequest {
     pub acceleration_numerator: i16,
@@ -23800,6 +25138,12 @@ pub struct ChangePointerControlRequest {
     pub threshold: i16,
     pub do_acceleration: bool,
     pub do_threshold: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ChangePointerControlRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangePointerControlRequest").finish_non_exhaustive()
+    }
 }
 impl ChangePointerControlRequest {
     /// Serialize this request into bytes for the provided connection
@@ -23868,9 +25212,16 @@ impl crate::x11_utils::VoidRequest for ChangePointerControlRequest {
 
 /// Opcode for the GetPointerControl request
 pub const GET_POINTER_CONTROL_REQUEST: u8 = 106;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPointerControlRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPointerControlRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPointerControlRequest").finish_non_exhaustive()
+    }
+}
 impl GetPointerControlRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -23914,7 +25265,8 @@ impl crate::x11_utils::ReplyRequest for GetPointerControlRequest {
     type Reply = GetPointerControlReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPointerControlReply {
     pub sequence: u16,
@@ -23922,6 +25274,12 @@ pub struct GetPointerControlReply {
     pub acceleration_numerator: u16,
     pub acceleration_denominator: u16,
     pub threshold: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPointerControlReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPointerControlReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPointerControlReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -24126,13 +25484,20 @@ impl core::fmt::Debug for Exposures  {
 
 /// Opcode for the SetScreenSaver request
 pub const SET_SCREEN_SAVER_REQUEST: u8 = 107;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetScreenSaverRequest {
     pub timeout: i16,
     pub interval: i16,
     pub prefer_blanking: Blanking,
     pub allow_exposures: Exposures,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetScreenSaverRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetScreenSaverRequest").finish_non_exhaustive()
+    }
 }
 impl SetScreenSaverRequest {
     /// Serialize this request into bytes for the provided connection
@@ -24200,9 +25565,16 @@ impl crate::x11_utils::VoidRequest for SetScreenSaverRequest {
 
 /// Opcode for the GetScreenSaver request
 pub const GET_SCREEN_SAVER_REQUEST: u8 = 108;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSaverRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenSaverRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenSaverRequest").finish_non_exhaustive()
+    }
+}
 impl GetScreenSaverRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -24246,7 +25618,8 @@ impl crate::x11_utils::ReplyRequest for GetScreenSaverRequest {
     type Reply = GetScreenSaverReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSaverReply {
     pub sequence: u16,
@@ -24255,6 +25628,12 @@ pub struct GetScreenSaverReply {
     pub interval: u16,
     pub prefer_blanking: Blanking,
     pub allow_exposures: Exposures,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetScreenSaverReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetScreenSaverReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetScreenSaverReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -24466,12 +25845,19 @@ impl core::fmt::Debug for Family  {
 
 /// Opcode for the ChangeHosts request
 pub const CHANGE_HOSTS_REQUEST: u8 = 109;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChangeHostsRequest<'input> {
     pub mode: HostMode,
     pub family: Family,
     pub address: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for ChangeHostsRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ChangeHostsRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> ChangeHostsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -24543,11 +25929,18 @@ impl<'input> Request for ChangeHostsRequest<'input> {
 impl<'input> crate::x11_utils::VoidRequest for ChangeHostsRequest<'input> {
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Host {
     pub family: Family,
     pub address: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Host {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Host").finish_non_exhaustive()
+    }
 }
 impl TryParse for Host {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -24601,9 +25994,16 @@ impl Host {
 
 /// Opcode for the ListHosts request
 pub const LIST_HOSTS_REQUEST: u8 = 110;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListHostsRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListHostsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListHostsRequest").finish_non_exhaustive()
+    }
+}
 impl ListHostsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -24647,13 +26047,20 @@ impl crate::x11_utils::ReplyRequest for ListHostsRequest {
     type Reply = ListHostsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListHostsReply {
     pub mode: AccessControl,
     pub sequence: u16,
     pub length: u32,
     pub hosts: Vec<Host>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListHostsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListHostsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListHostsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -24773,10 +26180,17 @@ impl core::fmt::Debug for AccessControl  {
 
 /// Opcode for the SetAccessControl request
 pub const SET_ACCESS_CONTROL_REQUEST: u8 = 111;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetAccessControlRequest {
     pub mode: AccessControl,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetAccessControlRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetAccessControlRequest").finish_non_exhaustive()
+    }
 }
 impl SetAccessControlRequest {
     /// Serialize this request into bytes for the provided connection
@@ -24886,10 +26300,17 @@ impl core::fmt::Debug for CloseDown  {
 
 /// Opcode for the SetCloseDownMode request
 pub const SET_CLOSE_DOWN_MODE_REQUEST: u8 = 112;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetCloseDownModeRequest {
     pub mode: CloseDown,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetCloseDownModeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetCloseDownModeRequest").finish_non_exhaustive()
+    }
 }
 impl SetCloseDownModeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -25014,10 +26435,17 @@ pub const KILL_CLIENT_REQUEST: u8 = 113;
 /// # See
 ///
 /// * `xkill`: program
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct KillClientRequest {
     pub resource: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for KillClientRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("KillClientRequest").finish_non_exhaustive()
+    }
 }
 impl KillClientRequest {
     /// Serialize this request into bytes for the provided connection
@@ -25070,12 +26498,19 @@ impl crate::x11_utils::VoidRequest for KillClientRequest {
 
 /// Opcode for the RotateProperties request
 pub const ROTATE_PROPERTIES_REQUEST: u8 = 114;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RotatePropertiesRequest<'input> {
     pub window: Window,
     pub delta: i16,
     pub atoms: Cow<'input, [Atom]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for RotatePropertiesRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RotatePropertiesRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> RotatePropertiesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -25211,10 +26646,17 @@ impl core::fmt::Debug for ScreenSaver  {
 
 /// Opcode for the ForceScreenSaver request
 pub const FORCE_SCREEN_SAVER_REQUEST: u8 = 115;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ForceScreenSaverRequest {
     pub mode: ScreenSaver,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ForceScreenSaverRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ForceScreenSaverRequest").finish_non_exhaustive()
+    }
 }
 impl ForceScreenSaverRequest {
     /// Serialize this request into bytes for the provided connection
@@ -25324,10 +26766,17 @@ impl core::fmt::Debug for MappingStatus  {
 
 /// Opcode for the SetPointerMapping request
 pub const SET_POINTER_MAPPING_REQUEST: u8 = 116;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPointerMappingRequest<'input> {
     pub map: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetPointerMappingRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetPointerMappingRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetPointerMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -25385,12 +26834,19 @@ impl<'input> crate::x11_utils::ReplyRequest for SetPointerMappingRequest<'input>
     type Reply = SetPointerMappingReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPointerMappingReply {
     pub status: MappingStatus,
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetPointerMappingReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetPointerMappingReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetPointerMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -25440,9 +26896,16 @@ impl Serialize for SetPointerMappingReply {
 
 /// Opcode for the GetPointerMapping request
 pub const GET_POINTER_MAPPING_REQUEST: u8 = 117;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPointerMappingRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPointerMappingRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPointerMappingRequest").finish_non_exhaustive()
+    }
+}
 impl GetPointerMappingRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -25486,12 +26949,19 @@ impl crate::x11_utils::ReplyRequest for GetPointerMappingRequest {
     type Reply = GetPointerMappingReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPointerMappingReply {
     pub sequence: u16,
     pub length: u32,
     pub map: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPointerMappingReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPointerMappingReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPointerMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -25621,10 +27091,17 @@ impl core::fmt::Debug for MapIndex  {
 
 /// Opcode for the SetModifierMapping request
 pub const SET_MODIFIER_MAPPING_REQUEST: u8 = 118;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetModifierMappingRequest<'input> {
     pub keycodes: Cow<'input, [Keycode]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetModifierMappingRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetModifierMappingRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetModifierMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -25683,12 +27160,19 @@ impl<'input> crate::x11_utils::ReplyRequest for SetModifierMappingRequest<'input
     type Reply = SetModifierMappingReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetModifierMappingReply {
     pub status: MappingStatus,
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetModifierMappingReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetModifierMappingReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for SetModifierMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -25738,9 +27222,16 @@ impl Serialize for SetModifierMappingReply {
 
 /// Opcode for the GetModifierMapping request
 pub const GET_MODIFIER_MAPPING_REQUEST: u8 = 119;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetModifierMappingRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetModifierMappingRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetModifierMappingRequest").finish_non_exhaustive()
+    }
+}
 impl GetModifierMappingRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -25784,12 +27275,19 @@ impl crate::x11_utils::ReplyRequest for GetModifierMappingRequest {
     type Reply = GetModifierMappingReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetModifierMappingReply {
     pub sequence: u16,
     pub length: u32,
     pub keycodes: Vec<Keycode>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetModifierMappingReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetModifierMappingReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetModifierMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -25850,9 +27348,16 @@ impl GetModifierMappingReply {
 
 /// Opcode for the NoOperation request
 pub const NO_OPERATION_REQUEST: u8 = 127;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NoOperationRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for NoOperationRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("NoOperationRequest").finish_non_exhaustive()
+    }
+}
 impl NoOperationRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -7551,6 +7551,7 @@ impl<'input> CreateWindowRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CREATE_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8046,6 +8047,7 @@ impl<'input> ChangeWindowAttributesRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_WINDOW_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8192,6 +8194,7 @@ impl GetWindowAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_WINDOW_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8455,6 +8458,7 @@ impl DestroyWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != DESTROY_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8518,6 +8522,7 @@ impl DestroySubwindowsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != DESTROY_SUBWINDOWS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8664,6 +8669,7 @@ impl ChangeSaveSetRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_SAVE_SET_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8775,6 +8781,7 @@ impl ReparentWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != REPARENT_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8879,6 +8886,7 @@ impl MapWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != MAP_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -8942,6 +8950,7 @@ impl MapSubwindowsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != MAP_SUBWINDOWS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9026,6 +9035,7 @@ impl UnmapWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNMAP_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9089,6 +9099,7 @@ impl UnmapSubwindowsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNMAP_SUBWINDOWS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9554,6 +9565,7 @@ impl<'input> ConfigureWindowRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CONFIGURE_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9706,6 +9718,7 @@ impl CirculateWindowRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CIRCULATE_WINDOW_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -9807,6 +9820,7 @@ impl GetGeometryRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_GEOMETRY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10022,6 +10036,7 @@ impl QueryTreeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_TREE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10216,6 +10231,7 @@ impl<'input> InternAtomRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != INTERN_ATOM_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10355,6 +10371,7 @@ impl GetAtomNameRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_ATOM_NAME_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10642,6 +10659,7 @@ impl<'input> ChangePropertyRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10736,6 +10754,7 @@ impl DeletePropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != DELETE_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -10952,6 +10971,7 @@ impl GetPropertyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_PROPERTY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11256,6 +11276,7 @@ impl ListPropertiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LIST_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11431,6 +11452,7 @@ impl SetSelectionOwnerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_SELECTION_OWNER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11515,6 +11537,7 @@ impl GetSelectionOwnerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_SELECTION_OWNER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11671,6 +11694,7 @@ impl ConvertSelectionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CONVERT_SELECTION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -11896,6 +11920,7 @@ impl<'input> SendEventRequest<'input> {
         ([request0.into(), Cow::Owned(self.event.to_vec())], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SEND_EVENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12262,6 +12287,7 @@ impl GrabPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GRAB_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12425,6 +12451,7 @@ impl UngrabPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNGRAB_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12662,6 +12689,7 @@ impl GrabButtonRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GRAB_BUTTON_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12754,6 +12782,7 @@ impl UngrabButtonRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNGRAB_BUTTON_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12835,6 +12864,7 @@ impl ChangeActivePointerGrabRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_ACTIVE_POINTER_GRAB_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -12982,6 +13012,7 @@ impl GrabKeyboardRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GRAB_KEYBOARD_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13116,6 +13147,7 @@ impl UngrabKeyboardRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNGRAB_KEYBOARD_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13313,6 +13345,7 @@ impl GrabKeyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GRAB_KEY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13422,6 +13455,7 @@ impl UngrabKeyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNGRAB_KEY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13640,6 +13674,7 @@ impl AllowEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != ALLOW_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13698,6 +13733,7 @@ impl GrabServerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GRAB_SERVER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13752,6 +13788,7 @@ impl UngrabServerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNGRAB_SERVER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -13826,6 +13863,7 @@ impl QueryPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14079,6 +14117,7 @@ impl GetMotionEventsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_MOTION_EVENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14231,6 +14270,7 @@ impl TranslateCoordinatesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != TRANSLATE_COORDINATES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14442,6 +14482,7 @@ impl WarpPointerRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != WARP_POINTER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14634,6 +14675,7 @@ impl SetInputFocusRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_INPUT_FOCUS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14694,6 +14736,7 @@ impl GetInputFocusRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_INPUT_FOCUS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -14817,6 +14860,7 @@ impl QueryKeymapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_KEYMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15000,6 +15044,7 @@ impl<'input> OpenFontRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != OPEN_FONT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15074,6 +15119,7 @@ impl CloseFontRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CLOSE_FONT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15311,6 +15357,7 @@ impl QueryFontRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_FONT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15553,6 +15600,7 @@ impl<'input> QueryTextExtentsRequest<'input> {
         ([request0.into(), string_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_TEXT_EXTENTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15815,6 +15863,7 @@ impl<'input> ListFontsRequest<'input> {
         ([request0.into(), self.pattern, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LIST_FONTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -15979,6 +16028,7 @@ impl<'input> ListFontsWithInfoRequest<'input> {
         ([request0.into(), self.pattern, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LIST_FONTS_WITH_INFO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -16199,6 +16249,7 @@ impl<'input> SetFontPathRequest<'input> {
         ([request0.into(), font_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_FONT_PATH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -16263,6 +16314,7 @@ impl GetFontPathRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_FONT_PATH_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -16434,6 +16486,7 @@ impl CreatePixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CREATE_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -16516,6 +16569,7 @@ impl FreePixmapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FREE_PIXMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -17762,6 +17816,7 @@ impl<'input> CreateGCRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CREATE_GC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -18428,6 +18483,7 @@ impl<'input> ChangeGCRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_GC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -18513,6 +18569,7 @@ impl CopyGCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != COPY_GC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -18593,6 +18650,7 @@ impl<'input> SetDashesRequest<'input> {
         ([request0.into(), self.dashes, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_DASHES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -18747,6 +18805,7 @@ impl<'input> SetClipRectanglesRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_CLIP_RECTANGLES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -18846,6 +18905,7 @@ impl FreeGCRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FREE_GC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -18927,6 +18987,7 @@ impl ClearAreaRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CLEAR_AREA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19056,6 +19117,7 @@ impl CopyAreaRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != COPY_AREA_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19177,6 +19239,7 @@ impl CopyPlaneRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != COPY_PLANE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19334,6 +19397,7 @@ impl<'input> PolyPointRequest<'input> {
         ([request0.into(), points_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_POINT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19471,6 +19535,7 @@ impl<'input> PolyLineRequest<'input> {
         ([request0.into(), points_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_LINE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19645,6 +19710,7 @@ impl<'input> PolySegmentRequest<'input> {
         ([request0.into(), segments_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_SEGMENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19738,6 +19804,7 @@ impl<'input> PolyRectangleRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_RECTANGLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19831,6 +19898,7 @@ impl<'input> PolyArcRequest<'input> {
         ([request0.into(), arcs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_ARC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -19993,6 +20061,7 @@ impl<'input> FillPolyRequest<'input> {
         ([request0.into(), points_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FILL_POLY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20120,6 +20189,7 @@ impl<'input> PolyFillRectangleRequest<'input> {
         ([request0.into(), rectangles_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_FILL_RECTANGLE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20213,6 +20283,7 @@ impl<'input> PolyFillArcRequest<'input> {
         ([request0.into(), arcs_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_FILL_ARC_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20392,6 +20463,7 @@ impl<'input> PutImageRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != PUT_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20513,6 +20585,7 @@ impl GetImageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20681,6 +20754,7 @@ impl<'input> PolyText8Request<'input> {
         ([request0.into(), self.items, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_TEXT8_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20780,6 +20854,7 @@ impl<'input> PolyText16Request<'input> {
         ([request0.into(), self.items, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != POLY_TEXT16_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -20913,6 +20988,7 @@ impl<'input> ImageText8Request<'input> {
         ([request0.into(), self.string, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != IMAGE_TEXT8_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21048,6 +21124,7 @@ impl<'input> ImageText16Request<'input> {
         ([request0.into(), string_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != IMAGE_TEXT16_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21202,6 +21279,7 @@ impl CreateColormapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CREATE_COLORMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21271,6 +21349,7 @@ impl FreeColormapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FREE_COLORMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21340,6 +21419,7 @@ impl CopyColormapAndFreeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != COPY_COLORMAP_AND_FREE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21405,6 +21485,7 @@ impl InstallColormapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != INSTALL_COLORMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21468,6 +21549,7 @@ impl UninstallColormapRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != UNINSTALL_COLORMAP_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21531,6 +21613,7 @@ impl ListInstalledColormapsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LIST_INSTALLED_COLORMAPS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21697,6 +21780,7 @@ impl AllocColorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != ALLOC_COLOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -21865,6 +21949,7 @@ impl<'input> AllocNamedColorRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != ALLOC_NAMED_COLOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22051,6 +22136,7 @@ impl AllocColorCellsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != ALLOC_COLOR_CELLS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22227,6 +22313,7 @@ impl AllocColorPlanesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != ALLOC_COLOR_PLANES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22392,6 +22479,7 @@ impl<'input> FreeColorsRequest<'input> {
         ([request0.into(), pixels_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FREE_COLORS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22604,6 +22692,7 @@ impl<'input> StoreColorsRequest<'input> {
         ([request0.into(), items_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != STORE_COLORS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22701,6 +22790,7 @@ impl<'input> StoreNamedColorRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != STORE_NAMED_COLOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22836,6 +22926,7 @@ impl<'input> QueryColorsRequest<'input> {
         ([request0.into(), pixels_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_COLORS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -22996,6 +23087,7 @@ impl<'input> LookupColorRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LOOKUP_COLOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -23265,6 +23357,7 @@ impl CreateCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CREATE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -23482,6 +23575,7 @@ impl CreateGlyphCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CREATE_GLYPH_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -23577,6 +23671,7 @@ impl FreeCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FREE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -23664,6 +23759,7 @@ impl RecolorCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != RECOLOR_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -23810,6 +23906,7 @@ impl QueryBestSizeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_BEST_SIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -23974,6 +24071,7 @@ impl<'input> QueryExtensionRequest<'input> {
         ([request0.into(), self.name, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != QUERY_EXTENSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -24122,6 +24220,7 @@ impl ListExtensionsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LIST_EXTENSIONS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -24262,6 +24361,7 @@ impl<'input> ChangeKeyboardMappingRequest<'input> {
         ([request0.into(), keysyms_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_KEYBOARD_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -24342,6 +24442,7 @@ impl GetKeyboardMappingRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_KEYBOARD_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -24851,6 +24952,7 @@ impl<'input> ChangeKeyboardControlRequest<'input> {
         ([request0.into(), value_list_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_KEYBOARD_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -24914,6 +25016,7 @@ impl GetKeyboardControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_KEYBOARD_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25101,6 +25204,7 @@ impl BellRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != BELL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25175,6 +25279,7 @@ impl ChangePointerControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_POINTER_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25239,6 +25344,7 @@ impl GetPointerControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_POINTER_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25528,6 +25634,7 @@ impl SetScreenSaverRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_SCREEN_SAVER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25592,6 +25699,7 @@ impl GetScreenSaverRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_SCREEN_SAVER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -25887,6 +25995,7 @@ impl<'input> ChangeHostsRequest<'input> {
         ([request0.into(), self.address, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != CHANGE_HOSTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26021,6 +26130,7 @@ impl ListHostsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != LIST_HOSTS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26210,6 +26320,7 @@ impl SetAccessControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_ACCESS_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26330,6 +26441,7 @@ impl SetCloseDownModeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_CLOSE_DOWN_MODE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26469,6 +26581,7 @@ impl KillClientRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != KILL_CLIENT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26545,6 +26658,7 @@ impl<'input> RotatePropertiesRequest<'input> {
         ([request0.into(), atoms_bytes.into(), padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != ROTATE_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26676,6 +26790,7 @@ impl ForceScreenSaverRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != FORCE_SCREEN_SAVER_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26800,6 +26915,7 @@ impl<'input> SetPointerMappingRequest<'input> {
         ([request0.into(), self.map, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_POINTER_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -26923,6 +27039,7 @@ impl GetPointerMappingRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_POINTER_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -27126,6 +27243,7 @@ impl<'input> SetModifierMappingRequest<'input> {
         ([request0.into(), self.keycodes, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.major_opcode != SET_MODIFIER_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -27249,6 +27367,7 @@ impl GetModifierMappingRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != GET_MODIFIER_MAPPING_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -27375,6 +27494,7 @@ impl NoOperationRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.major_opcode != NO_OPERATION_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xselinux.rs
+++ b/x11rb-protocol/src/protocol/xselinux.rs
@@ -74,7 +74,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -211,7 +211,7 @@ impl<'input> SetDeviceCreateContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -272,7 +272,7 @@ impl GetDeviceCreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -413,7 +413,7 @@ impl<'input> SetDeviceContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -484,7 +484,7 @@ impl GetDeviceContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -621,7 +621,7 @@ impl<'input> SetWindowCreateContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_WINDOW_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -682,7 +682,7 @@ impl GetWindowCreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_WINDOW_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -813,7 +813,7 @@ impl GetWindowContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_WINDOW_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1035,7 +1035,7 @@ impl<'input> SetPropertyCreateContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PROPERTY_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1096,7 +1096,7 @@ impl GetPropertyCreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROPERTY_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1231,7 +1231,7 @@ impl<'input> SetPropertyUseContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PROPERTY_USE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1292,7 +1292,7 @@ impl GetPropertyUseContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROPERTY_USE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1429,7 +1429,7 @@ impl GetPropertyContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROPERTY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1570,7 +1570,7 @@ impl GetPropertyDataContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROPERTY_DATA_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1705,7 +1705,7 @@ impl ListPropertiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1841,7 +1841,7 @@ impl<'input> SetSelectionCreateContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_SELECTION_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1902,7 +1902,7 @@ impl GetSelectionCreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SELECTION_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2037,7 +2037,7 @@ impl<'input> SetSelectionUseContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_SELECTION_USE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2098,7 +2098,7 @@ impl GetSelectionUseContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SELECTION_USE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2229,7 +2229,7 @@ impl GetSelectionContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SELECTION_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2362,7 +2362,7 @@ impl GetSelectionDataContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SELECTION_DATA_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2488,7 +2488,7 @@ impl ListSelectionsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_SELECTIONS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2618,7 +2618,7 @@ impl GetClientContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CLIENT_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xselinux.rs
+++ b/x11rb-protocol/src/protocol/xselinux.rs
@@ -74,6 +74,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -210,6 +211,7 @@ impl<'input> SetDeviceCreateContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -270,6 +272,7 @@ impl GetDeviceCreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -410,6 +413,7 @@ impl<'input> SetDeviceContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_DEVICE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -480,6 +484,7 @@ impl GetDeviceContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_DEVICE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -616,6 +621,7 @@ impl<'input> SetWindowCreateContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_WINDOW_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -676,6 +682,7 @@ impl GetWindowCreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_WINDOW_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -806,6 +813,7 @@ impl GetWindowContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_WINDOW_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1027,6 +1035,7 @@ impl<'input> SetPropertyCreateContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PROPERTY_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1087,6 +1096,7 @@ impl GetPropertyCreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROPERTY_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1221,6 +1231,7 @@ impl<'input> SetPropertyUseContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PROPERTY_USE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1281,6 +1292,7 @@ impl GetPropertyUseContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROPERTY_USE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1417,6 +1429,7 @@ impl GetPropertyContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROPERTY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1557,6 +1570,7 @@ impl GetPropertyDataContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PROPERTY_DATA_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1691,6 +1705,7 @@ impl ListPropertiesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_PROPERTIES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1826,6 +1841,7 @@ impl<'input> SetSelectionCreateContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_SELECTION_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1886,6 +1902,7 @@ impl GetSelectionCreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SELECTION_CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2020,6 +2037,7 @@ impl<'input> SetSelectionUseContextRequest<'input> {
         ([request0.into(), self.context, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_SELECTION_USE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2080,6 +2098,7 @@ impl GetSelectionUseContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SELECTION_USE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2210,6 +2229,7 @@ impl GetSelectionContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SELECTION_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2342,6 +2362,7 @@ impl GetSelectionDataContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_SELECTION_DATA_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2467,6 +2488,7 @@ impl ListSelectionsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_SELECTIONS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2596,6 +2618,7 @@ impl GetClientContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_CLIENT_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xselinux.rs
+++ b/x11rb-protocol/src/protocol/xselinux.rs
@@ -38,11 +38,18 @@ pub const X11_XML_VERSION: (u32, u32) = (1, 0);
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest {
     pub client_major: u8,
     pub client_minor: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
 }
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -94,13 +101,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub server_major: u16,
     pub server_minor: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -158,10 +172,17 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the SetDeviceCreateContext request
 pub const SET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetDeviceCreateContextRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDeviceCreateContextRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetDeviceCreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -222,9 +243,16 @@ impl<'input> crate::x11_utils::VoidRequest for SetDeviceCreateContextRequest<'in
 
 /// Opcode for the GetDeviceCreateContext request
 pub const GET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceCreateContextRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceCreateContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceCreateContextRequest").finish_non_exhaustive()
+    }
+}
 impl GetDeviceCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -265,12 +293,19 @@ impl crate::x11_utils::ReplyRequest for GetDeviceCreateContextRequest {
     type Reply = GetDeviceCreateContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceCreateContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceCreateContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceCreateContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDeviceCreateContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -331,11 +366,18 @@ impl GetDeviceCreateContextReply {
 
 /// Opcode for the SetDeviceContext request
 pub const SET_DEVICE_CONTEXT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetDeviceContextRequest<'input> {
     pub device: u32,
     pub context: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetDeviceContextRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetDeviceContextRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetDeviceContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -404,10 +446,17 @@ impl<'input> crate::x11_utils::VoidRequest for SetDeviceContextRequest<'input> {
 
 /// Opcode for the GetDeviceContext request
 pub const GET_DEVICE_CONTEXT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceContextRequest {
     pub device: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceContextRequest").finish_non_exhaustive()
+    }
 }
 impl GetDeviceContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -456,12 +505,19 @@ impl crate::x11_utils::ReplyRequest for GetDeviceContextRequest {
     type Reply = GetDeviceContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetDeviceContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetDeviceContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetDeviceContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -522,10 +578,17 @@ impl GetDeviceContextReply {
 
 /// Opcode for the SetWindowCreateContext request
 pub const SET_WINDOW_CREATE_CONTEXT_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetWindowCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetWindowCreateContextRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetWindowCreateContextRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetWindowCreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -586,9 +649,16 @@ impl<'input> crate::x11_utils::VoidRequest for SetWindowCreateContextRequest<'in
 
 /// Opcode for the GetWindowCreateContext request
 pub const GET_WINDOW_CREATE_CONTEXT_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowCreateContextRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetWindowCreateContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetWindowCreateContextRequest").finish_non_exhaustive()
+    }
+}
 impl GetWindowCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -629,12 +699,19 @@ impl crate::x11_utils::ReplyRequest for GetWindowCreateContextRequest {
     type Reply = GetWindowCreateContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowCreateContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetWindowCreateContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetWindowCreateContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetWindowCreateContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -695,10 +772,17 @@ impl GetWindowCreateContextReply {
 
 /// Opcode for the GetWindowContext request
 pub const GET_WINDOW_CONTEXT_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowContextRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetWindowContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetWindowContextRequest").finish_non_exhaustive()
+    }
 }
 impl GetWindowContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -747,12 +831,19 @@ impl crate::x11_utils::ReplyRequest for GetWindowContextRequest {
     type Reply = GetWindowContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetWindowContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetWindowContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetWindowContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -811,12 +902,19 @@ impl GetWindowContextReply {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListItem {
     pub name: xproto::Atom,
     pub object_context: Vec<u8>,
     pub data_context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListItem {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListItem").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListItem {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -891,10 +989,17 @@ impl ListItem {
 
 /// Opcode for the SetPropertyCreateContext request
 pub const SET_PROPERTY_CREATE_CONTEXT_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPropertyCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetPropertyCreateContextRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetPropertyCreateContextRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetPropertyCreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -955,9 +1060,16 @@ impl<'input> crate::x11_utils::VoidRequest for SetPropertyCreateContextRequest<'
 
 /// Opcode for the GetPropertyCreateContext request
 pub const GET_PROPERTY_CREATE_CONTEXT_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyCreateContextRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPropertyCreateContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPropertyCreateContextRequest").finish_non_exhaustive()
+    }
+}
 impl GetPropertyCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -998,12 +1110,19 @@ impl crate::x11_utils::ReplyRequest for GetPropertyCreateContextRequest {
     type Reply = GetPropertyCreateContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyCreateContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPropertyCreateContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPropertyCreateContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPropertyCreateContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1064,10 +1183,17 @@ impl GetPropertyCreateContextReply {
 
 /// Opcode for the SetPropertyUseContext request
 pub const SET_PROPERTY_USE_CONTEXT_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPropertyUseContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetPropertyUseContextRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetPropertyUseContextRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetPropertyUseContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1128,9 +1254,16 @@ impl<'input> crate::x11_utils::VoidRequest for SetPropertyUseContextRequest<'inp
 
 /// Opcode for the GetPropertyUseContext request
 pub const GET_PROPERTY_USE_CONTEXT_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyUseContextRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPropertyUseContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPropertyUseContextRequest").finish_non_exhaustive()
+    }
+}
 impl GetPropertyUseContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1171,12 +1304,19 @@ impl crate::x11_utils::ReplyRequest for GetPropertyUseContextRequest {
     type Reply = GetPropertyUseContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyUseContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPropertyUseContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPropertyUseContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPropertyUseContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1237,11 +1377,18 @@ impl GetPropertyUseContextReply {
 
 /// Opcode for the GetPropertyContext request
 pub const GET_PROPERTY_CONTEXT_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyContextRequest {
     pub window: xproto::Window,
     pub property: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPropertyContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPropertyContextRequest").finish_non_exhaustive()
+    }
 }
 impl GetPropertyContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1297,12 +1444,19 @@ impl crate::x11_utils::ReplyRequest for GetPropertyContextRequest {
     type Reply = GetPropertyContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPropertyContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPropertyContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPropertyContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1363,11 +1517,18 @@ impl GetPropertyContextReply {
 
 /// Opcode for the GetPropertyDataContext request
 pub const GET_PROPERTY_DATA_CONTEXT_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyDataContextRequest {
     pub window: xproto::Window,
     pub property: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPropertyDataContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPropertyDataContextRequest").finish_non_exhaustive()
+    }
 }
 impl GetPropertyDataContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1423,12 +1584,19 @@ impl crate::x11_utils::ReplyRequest for GetPropertyDataContextRequest {
     type Reply = GetPropertyDataContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyDataContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPropertyDataContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPropertyDataContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPropertyDataContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1489,10 +1657,17 @@ impl GetPropertyDataContextReply {
 
 /// Opcode for the ListProperties request
 pub const LIST_PROPERTIES_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListPropertiesRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListPropertiesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListPropertiesRequest").finish_non_exhaustive()
+    }
 }
 impl ListPropertiesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1541,12 +1716,19 @@ impl crate::x11_utils::ReplyRequest for ListPropertiesRequest {
     type Reply = ListPropertiesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListPropertiesReply {
     pub sequence: u16,
     pub length: u32,
     pub properties: Vec<ListItem>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListPropertiesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListPropertiesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListPropertiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1606,10 +1788,17 @@ impl ListPropertiesReply {
 
 /// Opcode for the SetSelectionCreateContext request
 pub const SET_SELECTION_CREATE_CONTEXT_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetSelectionCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetSelectionCreateContextRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetSelectionCreateContextRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetSelectionCreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1670,9 +1859,16 @@ impl<'input> crate::x11_utils::VoidRequest for SetSelectionCreateContextRequest<
 
 /// Opcode for the GetSelectionCreateContext request
 pub const GET_SELECTION_CREATE_CONTEXT_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionCreateContextRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSelectionCreateContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSelectionCreateContextRequest").finish_non_exhaustive()
+    }
+}
 impl GetSelectionCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1713,12 +1909,19 @@ impl crate::x11_utils::ReplyRequest for GetSelectionCreateContextRequest {
     type Reply = GetSelectionCreateContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionCreateContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSelectionCreateContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSelectionCreateContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetSelectionCreateContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1779,10 +1982,17 @@ impl GetSelectionCreateContextReply {
 
 /// Opcode for the SetSelectionUseContext request
 pub const SET_SELECTION_USE_CONTEXT_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetSelectionUseContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for SetSelectionUseContextRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetSelectionUseContextRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> SetSelectionUseContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -1843,9 +2053,16 @@ impl<'input> crate::x11_utils::VoidRequest for SetSelectionUseContextRequest<'in
 
 /// Opcode for the GetSelectionUseContext request
 pub const GET_SELECTION_USE_CONTEXT_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionUseContextRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSelectionUseContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSelectionUseContextRequest").finish_non_exhaustive()
+    }
+}
 impl GetSelectionUseContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1886,12 +2103,19 @@ impl crate::x11_utils::ReplyRequest for GetSelectionUseContextRequest {
     type Reply = GetSelectionUseContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionUseContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSelectionUseContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSelectionUseContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetSelectionUseContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1952,10 +2176,17 @@ impl GetSelectionUseContextReply {
 
 /// Opcode for the GetSelectionContext request
 pub const GET_SELECTION_CONTEXT_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionContextRequest {
     pub selection: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSelectionContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSelectionContextRequest").finish_non_exhaustive()
+    }
 }
 impl GetSelectionContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2004,12 +2235,19 @@ impl crate::x11_utils::ReplyRequest for GetSelectionContextRequest {
     type Reply = GetSelectionContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSelectionContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSelectionContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetSelectionContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2070,10 +2308,17 @@ impl GetSelectionContextReply {
 
 /// Opcode for the GetSelectionDataContext request
 pub const GET_SELECTION_DATA_CONTEXT_REQUEST: u8 = 20;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionDataContextRequest {
     pub selection: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSelectionDataContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSelectionDataContextRequest").finish_non_exhaustive()
+    }
 }
 impl GetSelectionDataContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2122,12 +2367,19 @@ impl crate::x11_utils::ReplyRequest for GetSelectionDataContextRequest {
     type Reply = GetSelectionDataContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionDataContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetSelectionDataContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetSelectionDataContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetSelectionDataContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2188,9 +2440,16 @@ impl GetSelectionDataContextReply {
 
 /// Opcode for the ListSelections request
 pub const LIST_SELECTIONS_REQUEST: u8 = 21;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSelectionsRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListSelectionsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListSelectionsRequest").finish_non_exhaustive()
+    }
+}
 impl ListSelectionsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2231,12 +2490,19 @@ impl crate::x11_utils::ReplyRequest for ListSelectionsRequest {
     type Reply = ListSelectionsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSelectionsReply {
     pub sequence: u16,
     pub length: u32,
     pub selections: Vec<ListItem>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListSelectionsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListSelectionsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListSelectionsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2296,10 +2562,17 @@ impl ListSelectionsReply {
 
 /// Opcode for the GetClientContext request
 pub const GET_CLIENT_CONTEXT_REQUEST: u8 = 22;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClientContextRequest {
     pub resource: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetClientContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetClientContextRequest").finish_non_exhaustive()
+    }
 }
 impl GetClientContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2348,12 +2621,19 @@ impl crate::x11_utils::ReplyRequest for GetClientContextRequest {
     type Reply = GetClientContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClientContextReply {
     pub sequence: u16,
     pub length: u32,
     pub context: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetClientContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetClientContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetClientContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/xtest.rs
+++ b/x11rb-protocol/src/protocol/xtest.rs
@@ -74,7 +74,7 @@ impl GetVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -281,7 +281,7 @@ impl CompareCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COMPARE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -444,7 +444,7 @@ impl FakeInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FAKE_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -520,7 +520,7 @@ impl GrabControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GRAB_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xtest.rs
+++ b/x11rb-protocol/src/protocol/xtest.rs
@@ -74,6 +74,7 @@ impl GetVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -280,6 +281,7 @@ impl CompareCursorRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != COMPARE_CURSOR_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -442,6 +444,7 @@ impl FakeInputRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != FAKE_INPUT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -517,6 +520,7 @@ impl GrabControlRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GRAB_CONTROL_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xtest.rs
+++ b/x11rb-protocol/src/protocol/xtest.rs
@@ -38,11 +38,18 @@ pub const X11_XML_VERSION: (u32, u32) = (2, 2);
 
 /// Opcode for the GetVersion request
 pub const GET_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVersionRequest {
     pub major_version: u8,
     pub minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetVersionRequest").finish_non_exhaustive()
+    }
 }
 impl GetVersionRequest {
     /// Serialize this request into bytes for the provided connection
@@ -95,13 +102,20 @@ impl crate::x11_utils::ReplyRequest for GetVersionRequest {
     type Reply = GetVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVersionReply {
     pub major_version: u8,
     pub sequence: u16,
     pub length: u32,
     pub minor_version: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -226,11 +240,18 @@ impl core::fmt::Debug for Cursor  {
 
 /// Opcode for the CompareCursor request
 pub const COMPARE_CURSOR_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompareCursorRequest {
     pub window: xproto::Window,
     pub cursor: xproto::Cursor,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CompareCursorRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CompareCursorRequest").finish_non_exhaustive()
+    }
 }
 impl CompareCursorRequest {
     /// Serialize this request into bytes for the provided connection
@@ -286,12 +307,19 @@ impl crate::x11_utils::ReplyRequest for CompareCursorRequest {
     type Reply = CompareCursorReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CompareCursorReply {
     pub same: bool,
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CompareCursorReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CompareCursorReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for CompareCursorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -340,7 +368,8 @@ impl Serialize for CompareCursorReply {
 
 /// Opcode for the FakeInput request
 pub const FAKE_INPUT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FakeInputRequest {
     pub type_: u8,
@@ -350,6 +379,12 @@ pub struct FakeInputRequest {
     pub root_x: i16,
     pub root_y: i16,
     pub deviceid: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for FakeInputRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FakeInputRequest").finish_non_exhaustive()
+    }
 }
 impl FakeInputRequest {
     /// Serialize this request into bytes for the provided connection
@@ -448,10 +483,17 @@ impl crate::x11_utils::VoidRequest for FakeInputRequest {
 
 /// Opcode for the GrabControl request
 pub const GRAB_CONTROL_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabControlRequest {
     pub impervious: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GrabControlRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabControlRequest").finish_non_exhaustive()
+    }
 }
 impl GrabControlRequest {
     /// Serialize this request into bytes for the provided connection

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -1413,6 +1413,7 @@ impl QueryExtensionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_EXTENSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1541,6 +1542,7 @@ impl QueryAdaptorsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_ADAPTORS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1672,6 +1674,7 @@ impl QueryEncodingsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_ENCODINGS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1809,6 +1812,7 @@ impl GrabPortRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GRAB_PORT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1938,6 +1942,7 @@ impl UngrabPortRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNGRAB_PORT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2044,6 +2049,7 @@ impl PutVideoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PUT_VIDEO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2168,6 +2174,7 @@ impl PutStillRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PUT_STILL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2292,6 +2299,7 @@ impl GetVideoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VIDEO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2416,6 +2424,7 @@ impl GetStillRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_STILL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2502,6 +2511,7 @@ impl StopVideoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != STOP_VIDEO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2570,6 +2580,7 @@ impl SelectVideoNotifyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_VIDEO_NOTIFY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2639,6 +2650,7 @@ impl SelectPortNotifyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_PORT_NOTIFY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2724,6 +2736,7 @@ impl QueryBestSizeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_BEST_SIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2877,6 +2890,7 @@ impl SetPortAttributeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PORT_ATTRIBUTE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2947,6 +2961,7 @@ impl GetPortAttributeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PORT_ATTRIBUTE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3075,6 +3090,7 @@ impl QueryPortAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_PORT_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3209,6 +3225,7 @@ impl ListImageFormatsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_IMAGE_FORMATS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3354,6 +3371,7 @@ impl QueryImageAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_IMAGE_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3566,6 +3584,7 @@ impl<'input> PutImageRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PUT_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3750,6 +3769,7 @@ impl ShmPutImageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SHM_PUT_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -465,11 +465,18 @@ impl core::fmt::Debug for GrabPortStatus  {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rational {
     pub numerator: i32,
     pub denominator: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Rational {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Rational").finish_non_exhaustive()
+    }
 }
 impl TryParse for Rational {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -502,11 +509,18 @@ impl Serialize for Rational {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Format {
     pub visual: xproto::Visualid,
     pub depth: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Format {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Format").finish_non_exhaustive()
+    }
 }
 impl TryParse for Format {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -541,7 +555,8 @@ impl Serialize for Format {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AdaptorInfo {
     pub base_id: Port,
@@ -549,6 +564,12 @@ pub struct AdaptorInfo {
     pub type_: Type,
     pub name: Vec<u8>,
     pub formats: Vec<Format>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AdaptorInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AdaptorInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for AdaptorInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -622,7 +643,8 @@ impl AdaptorInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EncodingInfo {
     pub encoding: Encoding,
@@ -630,6 +652,12 @@ pub struct EncodingInfo {
     pub height: u16,
     pub rate: Rational,
     pub name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for EncodingInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EncodingInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for EncodingInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -686,7 +714,8 @@ impl EncodingInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Image {
     pub id: u32,
@@ -695,6 +724,12 @@ pub struct Image {
     pub pitches: Vec<u32>,
     pub offsets: Vec<u32>,
     pub data: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for Image {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Image").finish_non_exhaustive()
+    }
 }
 impl TryParse for Image {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -762,13 +797,20 @@ impl Image {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AttributeInfo {
     pub flags: AttributeFlag,
     pub min: i32,
     pub max: i32,
     pub name: Vec<u8>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for AttributeInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AttributeInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for AttributeInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -822,7 +864,8 @@ impl AttributeInfo {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImageFormatInfo {
     pub id: u32,
@@ -847,6 +890,12 @@ pub struct ImageFormatInfo {
     pub vvert_v_period: u32,
     pub vcomp_order: [u8; 32],
     pub vscanline_order: ScanlineOrder,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ImageFormatInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ImageFormatInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for ImageFormatInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1082,7 +1131,8 @@ pub const BAD_CONTROL_ERROR: u8 = 2;
 
 /// Opcode for the VideoNotify event
 pub const VIDEO_NOTIFY_EVENT: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VideoNotifyEvent {
     pub response_type: u8,
@@ -1091,6 +1141,12 @@ pub struct VideoNotifyEvent {
     pub time: xproto::Timestamp,
     pub drawable: xproto::Drawable,
     pub port: Port,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for VideoNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VideoNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for VideoNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1200,7 +1256,8 @@ impl From<VideoNotifyEvent> for [u8; 32] {
 
 /// Opcode for the PortNotify event
 pub const PORT_NOTIFY_EVENT: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PortNotifyEvent {
     pub response_type: u8,
@@ -1209,6 +1266,12 @@ pub struct PortNotifyEvent {
     pub port: Port,
     pub attribute: xproto::Atom,
     pub value: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PortNotifyEvent {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PortNotifyEvent").finish_non_exhaustive()
+    }
 }
 impl TryParse for PortNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1323,9 +1386,16 @@ impl From<PortNotifyEvent> for [u8; 32] {
 
 /// Opcode for the QueryExtension request
 pub const QUERY_EXTENSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryExtensionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryExtensionRequest").finish_non_exhaustive()
+    }
+}
 impl QueryExtensionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1366,13 +1436,20 @@ impl crate::x11_utils::ReplyRequest for QueryExtensionRequest {
     type Reply = QueryExtensionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionReply {
     pub sequence: u16,
     pub length: u32,
     pub major: u16,
     pub minor: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryExtensionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryExtensionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryExtensionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1430,10 +1507,17 @@ impl Serialize for QueryExtensionReply {
 
 /// Opcode for the QueryAdaptors request
 pub const QUERY_ADAPTORS_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryAdaptorsRequest {
     pub window: xproto::Window,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryAdaptorsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryAdaptorsRequest").finish_non_exhaustive()
+    }
 }
 impl QueryAdaptorsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1482,12 +1566,19 @@ impl crate::x11_utils::ReplyRequest for QueryAdaptorsRequest {
     type Reply = QueryAdaptorsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryAdaptorsReply {
     pub sequence: u16,
     pub length: u32,
     pub info: Vec<AdaptorInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryAdaptorsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryAdaptorsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryAdaptorsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1547,10 +1638,17 @@ impl QueryAdaptorsReply {
 
 /// Opcode for the QueryEncodings request
 pub const QUERY_ENCODINGS_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryEncodingsRequest {
     pub port: Port,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryEncodingsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryEncodingsRequest").finish_non_exhaustive()
+    }
 }
 impl QueryEncodingsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1599,12 +1697,19 @@ impl crate::x11_utils::ReplyRequest for QueryEncodingsRequest {
     type Reply = QueryEncodingsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryEncodingsReply {
     pub sequence: u16,
     pub length: u32,
     pub info: Vec<EncodingInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryEncodingsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryEncodingsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryEncodingsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1664,11 +1769,18 @@ impl QueryEncodingsReply {
 
 /// Opcode for the GrabPort request
 pub const GRAB_PORT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabPortRequest {
     pub port: Port,
     pub time: xproto::Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GrabPortRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabPortRequest").finish_non_exhaustive()
+    }
 }
 impl GrabPortRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1724,12 +1836,19 @@ impl crate::x11_utils::ReplyRequest for GrabPortRequest {
     type Reply = GrabPortReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabPortReply {
     pub result: GrabPortStatus,
     pub sequence: u16,
     pub length: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GrabPortReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GrabPortReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GrabPortReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -1779,11 +1898,18 @@ impl Serialize for GrabPortReply {
 
 /// Opcode for the UngrabPort request
 pub const UNGRAB_PORT_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabPortRequest {
     pub port: Port,
     pub time: xproto::Timestamp,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for UngrabPortRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("UngrabPortRequest").finish_non_exhaustive()
+    }
 }
 impl UngrabPortRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1840,7 +1966,8 @@ impl crate::x11_utils::VoidRequest for UngrabPortRequest {
 
 /// Opcode for the PutVideo request
 pub const PUT_VIDEO_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PutVideoRequest {
     pub port: Port,
@@ -1854,6 +1981,12 @@ pub struct PutVideoRequest {
     pub drw_y: i16,
     pub drw_w: u16,
     pub drw_h: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PutVideoRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PutVideoRequest").finish_non_exhaustive()
+    }
 }
 impl PutVideoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1957,7 +2090,8 @@ impl crate::x11_utils::VoidRequest for PutVideoRequest {
 
 /// Opcode for the PutStill request
 pub const PUT_STILL_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PutStillRequest {
     pub port: Port,
@@ -1971,6 +2105,12 @@ pub struct PutStillRequest {
     pub drw_y: i16,
     pub drw_w: u16,
     pub drw_h: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for PutStillRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PutStillRequest").finish_non_exhaustive()
+    }
 }
 impl PutStillRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2074,7 +2214,8 @@ impl crate::x11_utils::VoidRequest for PutStillRequest {
 
 /// Opcode for the GetVideo request
 pub const GET_VIDEO_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetVideoRequest {
     pub port: Port,
@@ -2088,6 +2229,12 @@ pub struct GetVideoRequest {
     pub drw_y: i16,
     pub drw_w: u16,
     pub drw_h: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetVideoRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetVideoRequest").finish_non_exhaustive()
+    }
 }
 impl GetVideoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2191,7 +2338,8 @@ impl crate::x11_utils::VoidRequest for GetVideoRequest {
 
 /// Opcode for the GetStill request
 pub const GET_STILL_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetStillRequest {
     pub port: Port,
@@ -2205,6 +2353,12 @@ pub struct GetStillRequest {
     pub drw_y: i16,
     pub drw_w: u16,
     pub drw_h: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetStillRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetStillRequest").finish_non_exhaustive()
+    }
 }
 impl GetStillRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2308,11 +2462,18 @@ impl crate::x11_utils::VoidRequest for GetStillRequest {
 
 /// Opcode for the StopVideo request
 pub const STOP_VIDEO_REQUEST: u8 = 9;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct StopVideoRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for StopVideoRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StopVideoRequest").finish_non_exhaustive()
+    }
 }
 impl StopVideoRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2369,11 +2530,18 @@ impl crate::x11_utils::VoidRequest for StopVideoRequest {
 
 /// Opcode for the SelectVideoNotify request
 pub const SELECT_VIDEO_NOTIFY_REQUEST: u8 = 10;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectVideoNotifyRequest {
     pub drawable: xproto::Drawable,
     pub onoff: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectVideoNotifyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectVideoNotifyRequest").finish_non_exhaustive()
+    }
 }
 impl SelectVideoNotifyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2431,11 +2599,18 @@ impl crate::x11_utils::VoidRequest for SelectVideoNotifyRequest {
 
 /// Opcode for the SelectPortNotify request
 pub const SELECT_PORT_NOTIFY_REQUEST: u8 = 11;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SelectPortNotifyRequest {
     pub port: Port,
     pub onoff: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SelectPortNotifyRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SelectPortNotifyRequest").finish_non_exhaustive()
+    }
 }
 impl SelectPortNotifyRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2493,7 +2668,8 @@ impl crate::x11_utils::VoidRequest for SelectPortNotifyRequest {
 
 /// Opcode for the QueryBestSize request
 pub const QUERY_BEST_SIZE_REQUEST: u8 = 12;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryBestSizeRequest {
     pub port: Port,
@@ -2502,6 +2678,12 @@ pub struct QueryBestSizeRequest {
     pub drw_w: u16,
     pub drw_h: u16,
     pub motion: bool,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryBestSizeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryBestSizeRequest").finish_non_exhaustive()
+    }
 }
 impl QueryBestSizeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2578,13 +2760,20 @@ impl crate::x11_utils::ReplyRequest for QueryBestSizeRequest {
     type Reply = QueryBestSizeReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryBestSizeReply {
     pub sequence: u16,
     pub length: u32,
     pub actual_width: u16,
     pub actual_height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryBestSizeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryBestSizeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryBestSizeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2642,12 +2831,19 @@ impl Serialize for QueryBestSizeReply {
 
 /// Opcode for the SetPortAttribute request
 pub const SET_PORT_ATTRIBUTE_REQUEST: u8 = 13;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetPortAttributeRequest {
     pub port: Port,
     pub attribute: xproto::Atom,
     pub value: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SetPortAttributeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SetPortAttributeRequest").finish_non_exhaustive()
+    }
 }
 impl SetPortAttributeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2711,11 +2907,18 @@ impl crate::x11_utils::VoidRequest for SetPortAttributeRequest {
 
 /// Opcode for the GetPortAttribute request
 pub const GET_PORT_ATTRIBUTE_REQUEST: u8 = 14;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPortAttributeRequest {
     pub port: Port,
     pub attribute: xproto::Atom,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPortAttributeRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPortAttributeRequest").finish_non_exhaustive()
+    }
 }
 impl GetPortAttributeRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2771,12 +2974,19 @@ impl crate::x11_utils::ReplyRequest for GetPortAttributeRequest {
     type Reply = GetPortAttributeReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPortAttributeReply {
     pub sequence: u16,
     pub length: u32,
     pub value: i32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for GetPortAttributeReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("GetPortAttributeReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for GetPortAttributeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2831,10 +3041,17 @@ impl Serialize for GetPortAttributeReply {
 
 /// Opcode for the QueryPortAttributes request
 pub const QUERY_PORT_ATTRIBUTES_REQUEST: u8 = 15;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPortAttributesRequest {
     pub port: Port,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryPortAttributesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryPortAttributesRequest").finish_non_exhaustive()
+    }
 }
 impl QueryPortAttributesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -2883,13 +3100,20 @@ impl crate::x11_utils::ReplyRequest for QueryPortAttributesRequest {
     type Reply = QueryPortAttributesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPortAttributesReply {
     pub sequence: u16,
     pub length: u32,
     pub text_size: u32,
     pub attributes: Vec<AttributeInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryPortAttributesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryPortAttributesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryPortAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -2951,10 +3175,17 @@ impl QueryPortAttributesReply {
 
 /// Opcode for the ListImageFormats request
 pub const LIST_IMAGE_FORMATS_REQUEST: u8 = 16;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListImageFormatsRequest {
     pub port: Port,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListImageFormatsRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListImageFormatsRequest").finish_non_exhaustive()
+    }
 }
 impl ListImageFormatsRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3003,12 +3234,19 @@ impl crate::x11_utils::ReplyRequest for ListImageFormatsRequest {
     type Reply = ListImageFormatsReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListImageFormatsReply {
     pub sequence: u16,
     pub length: u32,
     pub format: Vec<ImageFormatInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListImageFormatsReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListImageFormatsReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListImageFormatsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3068,13 +3306,20 @@ impl ListImageFormatsReply {
 
 /// Opcode for the QueryImageAttributes request
 pub const QUERY_IMAGE_ATTRIBUTES_REQUEST: u8 = 17;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryImageAttributesRequest {
     pub port: Port,
     pub id: u32,
     pub width: u16,
     pub height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryImageAttributesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryImageAttributesRequest").finish_non_exhaustive()
+    }
 }
 impl QueryImageAttributesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -3140,7 +3385,8 @@ impl crate::x11_utils::ReplyRequest for QueryImageAttributesRequest {
     type Reply = QueryImageAttributesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryImageAttributesReply {
     pub sequence: u16,
@@ -3150,6 +3396,12 @@ pub struct QueryImageAttributesReply {
     pub height: u16,
     pub pitches: Vec<u32>,
     pub offsets: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryImageAttributesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryImageAttributesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryImageAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -3218,7 +3470,8 @@ impl QueryImageAttributesReply {
 
 /// Opcode for the PutImage request
 pub const PUT_IMAGE_REQUEST: u8 = 18;
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PutImageRequest<'input> {
     pub port: Port,
@@ -3236,6 +3489,12 @@ pub struct PutImageRequest<'input> {
     pub width: u16,
     pub height: u16,
     pub data: Cow<'input, [u8]>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl<'input> core::fmt::Debug for PutImageRequest<'input> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("PutImageRequest").finish_non_exhaustive()
+    }
 }
 impl<'input> PutImageRequest<'input> {
     /// Serialize this request into bytes for the provided connection
@@ -3381,7 +3640,8 @@ impl<'input> crate::x11_utils::VoidRequest for PutImageRequest<'input> {
 
 /// Opcode for the ShmPutImage request
 pub const SHM_PUT_IMAGE_REQUEST: u8 = 19;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ShmPutImageRequest {
     pub port: Port,
@@ -3401,6 +3661,12 @@ pub struct ShmPutImageRequest {
     pub width: u16,
     pub height: u16,
     pub send_event: u8,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ShmPutImageRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ShmPutImageRequest").finish_non_exhaustive()
+    }
 }
 impl ShmPutImageRequest {
     /// Serialize this request into bytes for the provided connection

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -1413,7 +1413,7 @@ impl QueryExtensionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_EXTENSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1542,7 +1542,7 @@ impl QueryAdaptorsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_ADAPTORS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1674,7 +1674,7 @@ impl QueryEncodingsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_ENCODINGS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1812,7 +1812,7 @@ impl GrabPortRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GRAB_PORT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1942,7 +1942,7 @@ impl UngrabPortRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != UNGRAB_PORT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2049,7 +2049,7 @@ impl PutVideoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PUT_VIDEO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2174,7 +2174,7 @@ impl PutStillRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PUT_STILL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2299,7 +2299,7 @@ impl GetVideoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_VIDEO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2424,7 +2424,7 @@ impl GetStillRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_STILL_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2511,7 +2511,7 @@ impl StopVideoRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != STOP_VIDEO_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2580,7 +2580,7 @@ impl SelectVideoNotifyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_VIDEO_NOTIFY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2650,7 +2650,7 @@ impl SelectPortNotifyRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SELECT_PORT_NOTIFY_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2736,7 +2736,7 @@ impl QueryBestSizeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_BEST_SIZE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2890,7 +2890,7 @@ impl SetPortAttributeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SET_PORT_ATTRIBUTE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -2961,7 +2961,7 @@ impl GetPortAttributeRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != GET_PORT_ATTRIBUTE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3090,7 +3090,7 @@ impl QueryPortAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_PORT_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3225,7 +3225,7 @@ impl ListImageFormatsRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_IMAGE_FORMATS_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3371,7 +3371,7 @@ impl QueryImageAttributesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_IMAGE_ATTRIBUTES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3584,7 +3584,7 @@ impl<'input> PutImageRequest<'input> {
         ([request0.into(), self.data, padding0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &'input [u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != PUT_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -3769,7 +3769,7 @@ impl ShmPutImageRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != SHM_PUT_IMAGE_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xvmc.rs
+++ b/x11rb-protocol/src/protocol/xvmc.rs
@@ -42,7 +42,8 @@ pub type Surface = u32;
 
 pub type Subpicture = u32;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SurfaceInfo {
     pub id: Surface,
@@ -54,6 +55,12 @@ pub struct SurfaceInfo {
     pub subpicture_max_height: u16,
     pub mc_type: u32,
     pub flags: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for SurfaceInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SurfaceInfo").finish_non_exhaustive()
+    }
 }
 impl TryParse for SurfaceInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -125,9 +132,16 @@ impl Serialize for SurfaceInfo {
 
 /// Opcode for the QueryVersion request
 pub const QUERY_VERSION_REQUEST: u8 = 0;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
+    }
+}
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -168,13 +182,20 @@ impl crate::x11_utils::ReplyRequest for QueryVersionRequest {
     type Reply = QueryVersionReply;
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionReply {
     pub sequence: u16,
     pub length: u32,
     pub major: u32,
     pub minor: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for QueryVersionReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -236,10 +257,17 @@ impl Serialize for QueryVersionReply {
 
 /// Opcode for the ListSurfaceTypes request
 pub const LIST_SURFACE_TYPES_REQUEST: u8 = 1;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSurfaceTypesRequest {
     pub port_id: xv::Port,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListSurfaceTypesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListSurfaceTypesRequest").finish_non_exhaustive()
+    }
 }
 impl ListSurfaceTypesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -288,12 +316,19 @@ impl crate::x11_utils::ReplyRequest for ListSurfaceTypesRequest {
     type Reply = ListSurfaceTypesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSurfaceTypesReply {
     pub sequence: u16,
     pub length: u32,
     pub surfaces: Vec<SurfaceInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListSurfaceTypesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListSurfaceTypesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListSurfaceTypesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -353,7 +388,8 @@ impl ListSurfaceTypesReply {
 
 /// Opcode for the CreateContext request
 pub const CREATE_CONTEXT_REQUEST: u8 = 2;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextRequest {
     pub context_id: Context,
@@ -362,6 +398,12 @@ pub struct CreateContextRequest {
     pub width: u16,
     pub height: u16,
     pub flags: u32,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateContextRequest").finish_non_exhaustive()
+    }
 }
 impl CreateContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -441,7 +483,8 @@ impl crate::x11_utils::ReplyRequest for CreateContextRequest {
     type Reply = CreateContextReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateContextReply {
     pub sequence: u16,
@@ -449,6 +492,12 @@ pub struct CreateContextReply {
     pub height_actual: u16,
     pub flags_return: u32,
     pub priv_data: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateContextReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateContextReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for CreateContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -512,10 +561,17 @@ impl CreateContextReply {
 
 /// Opcode for the DestroyContext request
 pub const DESTROY_CONTEXT_REQUEST: u8 = 3;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroyContextRequest {
     pub context_id: Context,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroyContextRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroyContextRequest").finish_non_exhaustive()
+    }
 }
 impl DestroyContextRequest {
     /// Serialize this request into bytes for the provided connection
@@ -565,11 +621,18 @@ impl crate::x11_utils::VoidRequest for DestroyContextRequest {
 
 /// Opcode for the CreateSurface request
 pub const CREATE_SURFACE_REQUEST: u8 = 4;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateSurfaceRequest {
     pub surface_id: Surface,
     pub context_id: Context,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateSurfaceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateSurfaceRequest").finish_non_exhaustive()
+    }
 }
 impl CreateSurfaceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -625,11 +688,18 @@ impl crate::x11_utils::ReplyRequest for CreateSurfaceRequest {
     type Reply = CreateSurfaceReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateSurfaceReply {
     pub sequence: u16,
     pub priv_data: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateSurfaceReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateSurfaceReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for CreateSurfaceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -687,10 +757,17 @@ impl CreateSurfaceReply {
 
 /// Opcode for the DestroySurface request
 pub const DESTROY_SURFACE_REQUEST: u8 = 5;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroySurfaceRequest {
     pub surface_id: Surface,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroySurfaceRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroySurfaceRequest").finish_non_exhaustive()
+    }
 }
 impl DestroySurfaceRequest {
     /// Serialize this request into bytes for the provided connection
@@ -740,7 +817,8 @@ impl crate::x11_utils::VoidRequest for DestroySurfaceRequest {
 
 /// Opcode for the CreateSubpicture request
 pub const CREATE_SUBPICTURE_REQUEST: u8 = 6;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateSubpictureRequest {
     pub subpicture_id: Subpicture,
@@ -748,6 +826,12 @@ pub struct CreateSubpictureRequest {
     pub xvimage_id: u32,
     pub width: u16,
     pub height: u16,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateSubpictureRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateSubpictureRequest").finish_non_exhaustive()
+    }
 }
 impl CreateSubpictureRequest {
     /// Serialize this request into bytes for the provided connection
@@ -820,7 +904,8 @@ impl crate::x11_utils::ReplyRequest for CreateSubpictureRequest {
     type Reply = CreateSubpictureReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateSubpictureReply {
     pub sequence: u16,
@@ -830,6 +915,12 @@ pub struct CreateSubpictureReply {
     pub entry_bytes: u16,
     pub component_order: [u8; 4],
     pub priv_data: Vec<u32>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for CreateSubpictureReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("CreateSubpictureReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for CreateSubpictureReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
@@ -897,10 +988,17 @@ impl CreateSubpictureReply {
 
 /// Opcode for the DestroySubpicture request
 pub const DESTROY_SUBPICTURE_REQUEST: u8 = 7;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DestroySubpictureRequest {
     pub subpicture_id: Subpicture,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for DestroySubpictureRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DestroySubpictureRequest").finish_non_exhaustive()
+    }
 }
 impl DestroySubpictureRequest {
     /// Serialize this request into bytes for the provided connection
@@ -950,11 +1048,18 @@ impl crate::x11_utils::VoidRequest for DestroySubpictureRequest {
 
 /// Opcode for the ListSubpictureTypes request
 pub const LIST_SUBPICTURE_TYPES_REQUEST: u8 = 8;
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSubpictureTypesRequest {
     pub port_id: xv::Port,
     pub surface_id: Surface,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListSubpictureTypesRequest {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListSubpictureTypesRequest").finish_non_exhaustive()
+    }
 }
 impl ListSubpictureTypesRequest {
     /// Serialize this request into bytes for the provided connection
@@ -1010,12 +1115,19 @@ impl crate::x11_utils::ReplyRequest for ListSubpictureTypesRequest {
     type Reply = ListSubpictureTypesReply;
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default)]
+#[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSubpictureTypesReply {
     pub sequence: u16,
     pub length: u32,
     pub types: Vec<xv::ImageFormatInfo>,
+}
+#[cfg(not(feature = "extra-traits"))]
+impl core::fmt::Debug for ListSubpictureTypesReply {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ListSubpictureTypesReply").finish_non_exhaustive()
+    }
 }
 impl TryParse for ListSubpictureTypesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {

--- a/x11rb-protocol/src/protocol/xvmc.rs
+++ b/x11rb-protocol/src/protocol/xvmc.rs
@@ -159,6 +159,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -291,6 +292,7 @@ impl ListSurfaceTypesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_SURFACE_TYPES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -448,6 +450,7 @@ impl CreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -595,6 +598,7 @@ impl DestroyContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -661,6 +665,7 @@ impl CreateSurfaceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_SURFACE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -791,6 +796,7 @@ impl DestroySurfaceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_SURFACE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -871,6 +877,7 @@ impl CreateSubpictureRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_SUBPICTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1022,6 +1029,7 @@ impl DestroySubpictureRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_SUBPICTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1088,6 +1096,7 @@ impl ListSubpictureTypesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
+    #[cfg(feature = "extra-traits")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_SUBPICTURE_TYPES_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/src/protocol/xvmc.rs
+++ b/x11rb-protocol/src/protocol/xvmc.rs
@@ -159,7 +159,7 @@ impl QueryVersionRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != QUERY_VERSION_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -292,7 +292,7 @@ impl ListSurfaceTypesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_SURFACE_TYPES_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -450,7 +450,7 @@ impl CreateContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -598,7 +598,7 @@ impl DestroyContextRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_CONTEXT_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -665,7 +665,7 @@ impl CreateSurfaceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_SURFACE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -796,7 +796,7 @@ impl DestroySurfaceRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_SURFACE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -877,7 +877,7 @@ impl CreateSubpictureRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != CREATE_SUBPICTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1029,7 +1029,7 @@ impl DestroySubpictureRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != DESTROY_SUBPICTURE_REQUEST {
             return Err(ParseError::InvalidValue);
@@ -1096,7 +1096,7 @@ impl ListSubpictureTypesRequest {
         ([request0.into()], vec![])
     }
     /// Parse this request given its header, its body, and any fds that go along with it
-    #[cfg(feature = "extra-traits")]
+    #[cfg(feature = "request-parsing")]
     pub fn try_parse_request(header: RequestHeader, value: &[u8]) -> Result<Self, ParseError> {
         if header.minor_opcode != LIST_SUBPICTURE_TYPES_REQUEST {
             return Err(ParseError::InvalidValue);

--- a/x11rb-protocol/tests/parsing_tests.rs
+++ b/x11rb-protocol/tests/parsing_tests.rs
@@ -1,6 +1,8 @@
-use x11rb::errors::ParseError;
-use x11rb::protocol::xproto::{Setup, VisualClass};
-use x11rb::x11_utils::TryParse;
+#![cfg(feature = "extra-traits")]
+
+use x11rb_protocol::errors::ParseError;
+use x11rb_protocol::protocol::xproto::{Setup, VisualClass};
+use x11rb_protocol::x11_utils::TryParse;
 
 fn get_setup_data() -> Vec<u8> {
     let mut s = Vec::new();
@@ -149,7 +151,7 @@ fn parse_xi_get_property_reply_format_0() {
     s.push(0); // format
     s.extend([0; 11]); // pad
 
-    use x11rb::protocol::xinput::{XIGetPropertyItems, XIGetPropertyReply};
+    use x11rb_protocol::protocol::xinput::{XIGetPropertyItems, XIGetPropertyReply};
     let empty: &[u8] = &[];
     assert_eq!(
         XIGetPropertyReply::try_parse(&s),

--- a/x11rb-protocol/tests/request_parsing_tests.rs
+++ b/x11rb-protocol/tests/request_parsing_tests.rs
@@ -1,7 +1,9 @@
+#![cfg(feature = "request-parsing")]
+
 use std::borrow::Cow;
 
-use x11rb::errors::ParseError;
-use x11rb::x11_utils::RequestHeader;
+use x11rb_protocol::errors::ParseError;
+use x11rb_protocol::x11_utils::RequestHeader;
 
 macro_rules! add_ne {
     ($data:expr, $add:expr) => {
@@ -11,7 +13,7 @@ macro_rules! add_ne {
 
 #[test]
 fn test_bad_request_header_opcode() {
-    use x11rb::protocol::xproto::GetInputFocusRequest;
+    use x11rb_protocol::protocol::xproto::GetInputFocusRequest;
     let header = RequestHeader {
         major_opcode: 1,
         minor_opcode: 0,
@@ -26,7 +28,7 @@ fn test_bad_request_header_opcode() {
 
 #[test]
 fn test_bad_request_header_length() {
-    use x11rb::protocol::xproto::CreateWindowRequest;
+    use x11rb_protocol::protocol::xproto::CreateWindowRequest;
     let header = RequestHeader {
         major_opcode: 1,
         minor_opcode: 0,
@@ -41,7 +43,9 @@ fn test_bad_request_header_length() {
 
 #[test]
 fn test_create_window1() {
-    use x11rb::protocol::xproto::{CreateWindowAux, CreateWindowRequest, Gravity, WindowClass};
+    use x11rb_protocol::protocol::xproto::{
+        CreateWindowAux, CreateWindowRequest, Gravity, WindowClass,
+    };
     let header = RequestHeader {
         major_opcode: 1,
         minor_opcode: 0x18,
@@ -87,7 +91,9 @@ fn test_create_window1() {
 
 #[test]
 fn test_create_window2() {
-    use x11rb::protocol::xproto::{CreateWindowAux, CreateWindowRequest, Gravity, WindowClass};
+    use x11rb_protocol::protocol::xproto::{
+        CreateWindowAux, CreateWindowRequest, Gravity, WindowClass,
+    };
     let header = RequestHeader {
         major_opcode: 1,
         minor_opcode: 0x18,
@@ -134,7 +140,7 @@ fn test_create_window2() {
 
 #[test]
 fn test_change_window_attributes() {
-    use x11rb::protocol::xproto::{
+    use x11rb_protocol::protocol::xproto::{
         ChangeWindowAttributesAux, ChangeWindowAttributesRequest, EventMask,
     };
     let header = RequestHeader {
@@ -161,7 +167,7 @@ fn test_change_window_attributes() {
 
 #[test]
 fn test_get_window_attributes() {
-    use x11rb::protocol::xproto::GetWindowAttributesRequest;
+    use x11rb_protocol::protocol::xproto::GetWindowAttributesRequest;
     let header = RequestHeader {
         major_opcode: 3,
         minor_opcode: 0,
@@ -180,7 +186,7 @@ fn test_get_window_attributes() {
 
 #[test]
 fn test_get_input_focus() {
-    use x11rb::protocol::xproto::GetInputFocusRequest;
+    use x11rb_protocol::protocol::xproto::GetInputFocusRequest;
     let header = RequestHeader {
         major_opcode: 43,
         minor_opcode: 0,
@@ -193,7 +199,7 @@ fn test_get_input_focus() {
 
 #[test]
 fn test_query_text_extents() {
-    use x11rb::protocol::xproto::{Char2b, QueryTextExtentsRequest};
+    use x11rb_protocol::protocol::xproto::{Char2b, QueryTextExtentsRequest};
     let header = RequestHeader {
         major_opcode: 48,
         minor_opcode: 0,
@@ -223,7 +229,7 @@ fn test_query_text_extents() {
 
 #[test]
 fn test_query_text_extents_odd_length() {
-    use x11rb::protocol::xproto::{Char2b, QueryTextExtentsRequest};
+    use x11rb_protocol::protocol::xproto::{Char2b, QueryTextExtentsRequest};
     let header = RequestHeader {
         major_opcode: 48,
         minor_opcode: 1,
@@ -248,7 +254,7 @@ fn test_query_text_extents_odd_length() {
 #[cfg(feature = "randr")]
 #[test]
 fn test_randr_get_output_property() {
-    use x11rb::protocol::randr::GetOutputPropertyRequest;
+    use x11rb_protocol::protocol::randr::GetOutputPropertyRequest;
     let header = RequestHeader {
         major_opcode: 140,
         minor_opcode: 15,

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -51,6 +51,9 @@ dl-libxcb = ["allow-unsafe-code", "libloading", "once_cell"]
 # Enable extra traits on protocol types.
 extra-traits = ["x11rb-protocol/extra-traits"]
 
+# Add the ability to parse X11 requests (not normally needed).
+request-parsing = ["x11rb-protocol/request-parsing"]
+
 # Enable this feature to enable all the X11 extensions
 all-extensions = [
     "x11rb-protocol/all-extensions",

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["xcb", "X11"]
 
 [dependencies]
-x11rb-protocol = { version = "0.12.0", path = "../x11rb-protocol" }
+x11rb-protocol = { version = "0.12.0", default-features = false, features = ["std"], path = "../x11rb-protocol" }
 libc = { version = "0.2", optional = true }
 libloading = { version = "0.8.0", optional = true }
 once_cell = { version = "1.17", optional = true }
@@ -47,6 +47,9 @@ image = []
 resource_manager = ["x11rb-protocol/resource_manager"]
 
 dl-libxcb = ["allow-unsafe-code", "libloading", "once_cell"]
+
+# Enable extra traits on protocol types.
+extra-traits = ["x11rb-protocol/extra-traits"]
 
 # Enable this feature to enable all the X11 extensions
 all-extensions = [

--- a/x11rb/src/lib.rs
+++ b/x11rb/src/lib.rs
@@ -108,6 +108,9 @@
 //!   resulting executable. Instead libxcb will be dynamically loaded at runtime.
 //!   This feature adds the [`crate::xcb_ffi::load_libxcb`] function, that allows to load
 //!   libxcb and check for success or failure.
+//! * `extra-traits`: Enable some additional traits for generated code, like `Eq`, `Ord` and
+//!   `Hash`. This is not needed by default and adds a large amount of code that bloats codegen
+//!   time
 //!
 //! # Integrating x11rb with an Event Loop
 //!

--- a/x11rb/src/lib.rs
+++ b/x11rb/src/lib.rs
@@ -111,6 +111,7 @@
 //! * `extra-traits`: Enable some additional traits for generated code, like `Eq`, `Ord` and
 //!   `Hash`. This is not needed by default and adds a large amount of code that bloats codegen
 //!   time
+//! * `request-parsing`: Add the ability to parse X11 requests. Not normally needed.
 //!
 //! # Integrating x11rb with an Event Loop
 //!

--- a/xtrace-example/Cargo.toml
+++ b/xtrace-example/Cargo.toml
@@ -11,7 +11,7 @@ smol = "1.3"
 
 [dependencies.x11rb-protocol]
 path = "../x11rb-protocol"
-features = ["all-extensions"]
+features = ["all-extensions", "request-parsing"]
 
 [dependencies.futures-util]
 version = "0.3"


### PR DESCRIPTION
Adds an `extra-traits` feature that gates some of the less-commonly-used traits. It also reimplements `Debug` using a more simple implementation if it is disabled and disables request parsing.

Using this as a benchmark:

```
$ cargo clean && cargo build --no-default-features -F xfixes,randr,xkb,xinput
```

`master` is currently 19.62s to build on my laptop. This branch builds in 10.41s. That is almost halving the compile time, by my measurements. Definitely still needs improvement but at least we aren't the slowest build in `alacritty`'s tree anymore.

This is a breaking change.

cc https://github.com/psychon/x11rb/issues/883