### PR TITLE
generator: Mark hyperlinks as such

### DIFF
--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -9,3 +9,4 @@ publish = false
 [dependencies]
 roxmltree = "0.18.0"
 xcbgen = { path = "../xcbgen-rs" }
+regex = "1.9"

--- a/x11rb-async/src/protocol/damage.rs
+++ b/x11rb-async/src/protocol/damage.rs
@@ -131,7 +131,7 @@ where
 /// Remove regions from a previously created Damage object..
 ///
 /// This updates the regions of damage recorded in a a Damage object.
-/// See https://www.x.org/releases/current/doc/damageproto/damageproto.txt
+/// See <https://www.x.org/releases/current/doc/damageproto/damageproto.txt>
 /// for details.
 ///
 /// # Fields
@@ -158,7 +158,7 @@ where
 /// Add a region to a previously created Damage object..
 ///
 /// This updates the regions of damage recorded in a a Damage object.
-/// See https://www.x.org/releases/current/doc/damageproto/damageproto.txt
+/// See <https://www.x.org/releases/current/doc/damageproto/damageproto.txt>
 /// for details.
 ///
 /// # Fields
@@ -245,7 +245,7 @@ pub trait ConnectionExt: RequestConnection {
     /// Remove regions from a previously created Damage object..
     ///
     /// This updates the regions of damage recorded in a a Damage object.
-    /// See https://www.x.org/releases/current/doc/damageproto/damageproto.txt
+    /// See <https://www.x.org/releases/current/doc/damageproto/damageproto.txt>
     /// for details.
     ///
     /// # Fields
@@ -261,7 +261,7 @@ pub trait ConnectionExt: RequestConnection {
     /// Add a region to a previously created Damage object..
     ///
     /// This updates the regions of damage recorded in a a Damage object.
-    /// See https://www.x.org/releases/current/doc/damageproto/damageproto.txt
+    /// See <https://www.x.org/releases/current/doc/damageproto/damageproto.txt>
     /// for details.
     ///
     /// # Fields

--- a/x11rb-protocol/src/protocol/damage.rs
+++ b/x11rb-protocol/src/protocol/damage.rs
@@ -441,7 +441,7 @@ pub const SUBTRACT_REQUEST: u8 = 3;
 /// Remove regions from a previously created Damage object..
 ///
 /// This updates the regions of damage recorded in a a Damage object.
-/// See https://www.x.org/releases/current/doc/damageproto/damageproto.txt
+/// See <https://www.x.org/releases/current/doc/damageproto/damageproto.txt>
 /// for details.
 ///
 /// # Fields
@@ -519,7 +519,7 @@ pub const ADD_REQUEST: u8 = 4;
 /// Add a region to a previously created Damage object..
 ///
 /// This updates the regions of damage recorded in a a Damage object.
-/// See https://www.x.org/releases/current/doc/damageproto/damageproto.txt
+/// See <https://www.x.org/releases/current/doc/damageproto/damageproto.txt>
 /// for details.
 ///
 /// # Fields

--- a/x11rb/src/protocol/damage.rs
+++ b/x11rb/src/protocol/damage.rs
@@ -132,7 +132,7 @@ where
 /// Remove regions from a previously created Damage object..
 ///
 /// This updates the regions of damage recorded in a a Damage object.
-/// See https://www.x.org/releases/current/doc/damageproto/damageproto.txt
+/// See <https://www.x.org/releases/current/doc/damageproto/damageproto.txt>
 /// for details.
 ///
 /// # Fields
@@ -160,7 +160,7 @@ where
 /// Add a region to a previously created Damage object..
 ///
 /// This updates the regions of damage recorded in a a Damage object.
-/// See https://www.x.org/releases/current/doc/damageproto/damageproto.txt
+/// See <https://www.x.org/releases/current/doc/damageproto/damageproto.txt>
 /// for details.
 ///
 /// # Fields
@@ -248,7 +248,7 @@ pub trait ConnectionExt: RequestConnection {
     /// Remove regions from a previously created Damage object..
     ///
     /// This updates the regions of damage recorded in a a Damage object.
-    /// See https://www.x.org/releases/current/doc/damageproto/damageproto.txt
+    /// See <https://www.x.org/releases/current/doc/damageproto/damageproto.txt>
     /// for details.
     ///
     /// # Fields
@@ -264,7 +264,7 @@ pub trait ConnectionExt: RequestConnection {
     /// Add a region to a previously created Damage object..
     ///
     /// This updates the regions of damage recorded in a a Damage object.
-    /// See https://www.x.org/releases/current/doc/damageproto/damageproto.txt
+    /// See <https://www.x.org/releases/current/doc/damageproto/damageproto.txt>
     /// for details.
     ///
     /// # Fields


### PR DESCRIPTION
"cargo doc" reports (in a CI build):

    warning: this URL is not a hyperlink
       --> x11rb-protocol/src/protocol/damage.rs:444:9
        |
    444 | /// See https://www.x.org/releases/current/doc/damageproto/damageproto.txt
        |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://www.x.org/releases/current/doc/damageproto/damageproto.txt>`
        |
        = note: bare URLs are not automatically turned into clickable links
        = note: `#[warn(rustdoc::bare_urls)]` on by default

The URL in question comes from the XML and is not marked as anything. Thus, this commit adds the regex crate as a dependency to the code generator and uses a regex to find and mark URLs. The regex used for URLs is quite basic, but seems to work for now.