### PR TITLE
Shorten some code

### DIFF
--- a/generator/src/generator/namespace/helpers.rs
+++ b/generator/src/generator/namespace/helpers.rs
@@ -13,19 +13,12 @@ pub(crate) struct EnumInfo {
 }
 
 pub(super) fn default_debug_impl(name: &str, out: &mut crate::generator::Output) {
-    outln!(out, "#[cfg(not(feature = \"extra-traits\"))]");
-    outln!(out, "impl core::fmt::Debug for {} {{", name);
-    out.indented(|out| {
-        outln!(
-            out,
-            "fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {{"
-        );
-        out.indented(|out| {
-            outln!(out, "f.debug_struct(\"{}\").finish_non_exhaustive()", name);
-        });
-        outln!(out, "}}");
-    });
-    outln!(out, "}}");
+    outln!(
+        out,
+        "impl_debug_if_no_extra_traits!({}, \"{}\");",
+        name,
+        name
+    );
 }
 
 /// Caches to avoid repeating some operations.

--- a/generator/src/generator/namespace/request.rs
+++ b/generator/src/generator/namespace/request.rs
@@ -476,28 +476,17 @@ fn emit_request_struct(
     }
 
     // Implement `Debug` manually if `extra-traits` is not enabled.
-    outln!(out, "#[cfg(not(feature = \"extra-traits\"))]");
     outln!(
         out,
-        "impl{lifetime} core::fmt::Debug for {name}Request{lifetime} {{",
-        lifetime = struct_lifetime_block,
-        name = name
+        "impl_debug_if_no_extra_traits!({}Request{}, \"{}Request\");",
+        name,
+        if struct_lifetime_block.is_empty() {
+            ""
+        } else {
+            "<'_>"
+        },
+        name
     );
-    out.indented(|out| {
-        outln!(
-            out,
-            "fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {{"
-        );
-        out.indented(|out| {
-            outln!(
-                out,
-                "f.debug_struct(\"{name}Request\").finish_non_exhaustive()",
-                name = name
-            );
-        });
-        outln!(out, "}}");
-    });
-    outln!(out, "}}");
 
     // Methods implemented on every request
     outln!(

--- a/x11rb-protocol/src/protocol/bigreq.rs
+++ b/x11rb-protocol/src/protocol/bigreq.rs
@@ -46,12 +46,7 @@ pub const ENABLE_REQUEST: u8 = 0;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnableRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EnableRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EnableRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EnableRequest, "EnableRequest");
 impl EnableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/bigreq.rs
+++ b/x11rb-protocol/src/protocol/bigreq.rs
@@ -104,12 +104,7 @@ pub struct EnableReply {
     pub length: u32,
     pub maximum_request_length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EnableReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EnableReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EnableReply, "EnableReply");
 impl TryParse for EnableReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/composite.rs
+++ b/x11rb-protocol/src/protocol/composite.rs
@@ -194,12 +194,7 @@ pub struct QueryVersionReply {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -818,12 +813,7 @@ pub struct GetOverlayWindowReply {
     pub length: u32,
     pub overlay_win: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetOverlayWindowReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetOverlayWindowReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetOverlayWindowReply, "GetOverlayWindowReply");
 impl TryParse for GetOverlayWindowReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/composite.rs
+++ b/x11rb-protocol/src/protocol/composite.rs
@@ -115,12 +115,7 @@ pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -295,12 +290,7 @@ pub struct RedirectWindowRequest {
     pub window: xproto::Window,
     pub update: Redirect,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RedirectWindowRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RedirectWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RedirectWindowRequest, "RedirectWindowRequest");
 impl RedirectWindowRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -379,12 +369,7 @@ pub struct RedirectSubwindowsRequest {
     pub window: xproto::Window,
     pub update: Redirect,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RedirectSubwindowsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RedirectSubwindowsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RedirectSubwindowsRequest, "RedirectSubwindowsRequest");
 impl RedirectSubwindowsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -461,12 +446,7 @@ pub struct UnredirectWindowRequest {
     pub window: xproto::Window,
     pub update: Redirect,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UnredirectWindowRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UnredirectWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UnredirectWindowRequest, "UnredirectWindowRequest");
 impl UnredirectWindowRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -543,12 +523,7 @@ pub struct UnredirectSubwindowsRequest {
     pub window: xproto::Window,
     pub update: Redirect,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UnredirectSubwindowsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UnredirectSubwindowsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UnredirectSubwindowsRequest, "UnredirectSubwindowsRequest");
 impl UnredirectSubwindowsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -614,12 +589,7 @@ pub struct CreateRegionFromBorderClipRequest {
     pub region: xfixes::Region,
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateRegionFromBorderClipRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateRegionFromBorderClipRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateRegionFromBorderClipRequest, "CreateRegionFromBorderClipRequest");
 impl CreateRegionFromBorderClipRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -683,12 +653,7 @@ pub struct NameWindowPixmapRequest {
     pub window: xproto::Window,
     pub pixmap: xproto::Pixmap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for NameWindowPixmapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("NameWindowPixmapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(NameWindowPixmapRequest, "NameWindowPixmapRequest");
 impl NameWindowPixmapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -751,12 +716,7 @@ pub const GET_OVERLAY_WINDOW_REQUEST: u8 = 7;
 pub struct GetOverlayWindowRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetOverlayWindowRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetOverlayWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetOverlayWindowRequest, "GetOverlayWindowRequest");
 impl GetOverlayWindowRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -895,12 +855,7 @@ pub const RELEASE_OVERLAY_WINDOW_REQUEST: u8 = 8;
 pub struct ReleaseOverlayWindowRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ReleaseOverlayWindowRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ReleaseOverlayWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ReleaseOverlayWindowRequest, "ReleaseOverlayWindowRequest");
 impl ReleaseOverlayWindowRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/damage.rs
+++ b/x11rb-protocol/src/protocol/damage.rs
@@ -125,12 +125,7 @@ pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -324,12 +319,7 @@ pub struct CreateRequest {
     pub drawable: xproto::Drawable,
     pub level: ReportLevel,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateRequest, "CreateRequest");
 impl CreateRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -409,12 +399,7 @@ pub const DESTROY_REQUEST: u8 = 2;
 pub struct DestroyRequest {
     pub damage: Damage,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyRequest, "DestroyRequest");
 impl DestroyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -481,12 +466,7 @@ pub struct SubtractRequest {
     pub repair: xfixes::Region,
     pub parts: xfixes::Region,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SubtractRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SubtractRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SubtractRequest, "SubtractRequest");
 impl SubtractRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -566,12 +546,7 @@ pub struct AddRequest {
     pub drawable: xproto::Drawable,
     pub region: xfixes::Region,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AddRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AddRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AddRequest, "AddRequest");
 impl AddRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/damage.rs
+++ b/x11rb-protocol/src/protocol/damage.rs
@@ -204,12 +204,7 @@ pub struct QueryVersionReply {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -662,12 +657,7 @@ pub struct NotifyEvent {
     pub area: xproto::Rectangle,
     pub geometry: xproto::Rectangle,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for NotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("NotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(NotifyEvent, "NotifyEvent");
 impl TryParse for NotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/dbe.rs
+++ b/x11rb-protocol/src/protocol/dbe.rs
@@ -291,12 +291,7 @@ pub struct QueryVersionRequest {
     pub major_version: u8,
     pub minor_version: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -454,12 +449,7 @@ pub struct AllocateBackBufferRequest {
     pub buffer: BackBuffer,
     pub swap_action: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AllocateBackBufferRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AllocateBackBufferRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AllocateBackBufferRequest, "AllocateBackBufferRequest");
 impl AllocateBackBufferRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -537,12 +527,7 @@ pub const DEALLOCATE_BACK_BUFFER_REQUEST: u8 = 2;
 pub struct DeallocateBackBufferRequest {
     pub buffer: BackBuffer,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeallocateBackBufferRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeallocateBackBufferRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeallocateBackBufferRequest, "DeallocateBackBufferRequest");
 impl DeallocateBackBufferRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -605,12 +590,7 @@ pub const SWAP_BUFFERS_REQUEST: u8 = 3;
 pub struct SwapBuffersRequest<'input> {
     pub actions: Cow<'input, [SwapInfo]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SwapBuffersRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SwapBuffersRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SwapBuffersRequest<'_>, "SwapBuffersRequest");
 impl<'input> SwapBuffersRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -679,12 +659,7 @@ pub const BEGIN_IDIOM_REQUEST: u8 = 4;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BeginIdiomRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BeginIdiomRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BeginIdiomRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BeginIdiomRequest, "BeginIdiomRequest");
 impl BeginIdiomRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -732,12 +707,7 @@ pub const END_IDIOM_REQUEST: u8 = 5;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EndIdiomRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EndIdiomRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EndIdiomRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EndIdiomRequest, "EndIdiomRequest");
 impl EndIdiomRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -787,12 +757,7 @@ pub const GET_VISUAL_INFO_REQUEST: u8 = 6;
 pub struct GetVisualInfoRequest<'input> {
     pub drawables: Cow<'input, [xproto::Drawable]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for GetVisualInfoRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetVisualInfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetVisualInfoRequest<'_>, "GetVisualInfoRequest");
 impl<'input> GetVisualInfoRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -934,12 +899,7 @@ pub const GET_BACK_BUFFER_ATTRIBUTES_REQUEST: u8 = 7;
 pub struct GetBackBufferAttributesRequest {
     pub buffer: BackBuffer,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetBackBufferAttributesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetBackBufferAttributesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetBackBufferAttributesRequest, "GetBackBufferAttributesRequest");
 impl GetBackBufferAttributesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/dbe.rs
+++ b/x11rb-protocol/src/protocol/dbe.rs
@@ -116,12 +116,7 @@ pub struct SwapInfo {
     pub window: xproto::Window,
     pub swap_action: SwapAction,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SwapInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SwapInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SwapInfo, "SwapInfo");
 impl TryParse for SwapInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (window, remaining) = xproto::Window::try_parse(remaining)?;
@@ -162,12 +157,7 @@ impl Serialize for SwapInfo {
 pub struct BufferAttributes {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BufferAttributes {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BufferAttributes").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BufferAttributes, "BufferAttributes");
 impl TryParse for BufferAttributes {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (window, remaining) = xproto::Window::try_parse(remaining)?;
@@ -200,12 +190,7 @@ pub struct VisualInfo {
     pub depth: u8,
     pub perf_level: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for VisualInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("VisualInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(VisualInfo, "VisualInfo");
 impl TryParse for VisualInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (visual_id, remaining) = xproto::Visualid::try_parse(remaining)?;
@@ -248,12 +233,7 @@ impl Serialize for VisualInfo {
 pub struct VisualInfos {
     pub infos: Vec<VisualInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for VisualInfos {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("VisualInfos").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(VisualInfos, "VisualInfos");
 impl TryParse for VisualInfos {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (n_infos, remaining) = u32::try_parse(remaining)?;
@@ -378,12 +358,7 @@ pub struct QueryVersionReply {
     pub major_version: u8,
     pub minor_version: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -886,12 +861,7 @@ pub struct GetVisualInfoReply {
     pub length: u32,
     pub supported_visuals: Vec<VisualInfos>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetVisualInfoReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetVisualInfoReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetVisualInfoReply, "GetVisualInfoReply");
 impl TryParse for GetVisualInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1026,12 +996,7 @@ pub struct GetBackBufferAttributesReply {
     pub length: u32,
     pub attributes: BufferAttributes,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetBackBufferAttributesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetBackBufferAttributesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetBackBufferAttributesReply, "GetBackBufferAttributesReply");
 impl TryParse for GetBackBufferAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/dpms.rs
+++ b/x11rb-protocol/src/protocol/dpms.rs
@@ -45,12 +45,7 @@ pub struct GetVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetVersionRequest, "GetVersionRequest");
 impl GetVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -172,12 +167,7 @@ pub const CAPABLE_REQUEST: u8 = 1;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CapableRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CapableRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CapableRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CapableRequest, "CapableRequest");
 impl CapableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -307,12 +297,7 @@ pub const GET_TIMEOUTS_REQUEST: u8 = 2;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetTimeoutsRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTimeoutsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTimeoutsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTimeoutsRequest, "GetTimeoutsRequest");
 impl GetTimeoutsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -454,12 +439,7 @@ pub struct SetTimeoutsRequest {
     pub suspend_timeout: u16,
     pub off_timeout: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetTimeoutsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetTimeoutsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetTimeoutsRequest, "SetTimeoutsRequest");
 impl SetTimeoutsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -523,12 +503,7 @@ pub const ENABLE_REQUEST: u8 = 4;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnableRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EnableRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EnableRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EnableRequest, "EnableRequest");
 impl EnableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -575,12 +550,7 @@ pub const DISABLE_REQUEST: u8 = 5;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DisableRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DisableRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DisableRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DisableRequest, "DisableRequest");
 impl DisableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -686,12 +656,7 @@ pub const FORCE_LEVEL_REQUEST: u8 = 6;
 pub struct ForceLevelRequest {
     pub power_level: DPMSMode,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ForceLevelRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ForceLevelRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ForceLevelRequest, "ForceLevelRequest");
 impl ForceLevelRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -746,12 +711,7 @@ pub const INFO_REQUEST: u8 = 7;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InfoRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InfoRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InfoRequest, "InfoRequest");
 impl InfoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -934,12 +894,7 @@ pub const SELECT_INPUT_REQUEST: u8 = 8;
 pub struct SelectInputRequest {
     pub event_mask: EventMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectInputRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectInputRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectInputRequest, "SelectInputRequest");
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/dpms.rs
+++ b/x11rb-protocol/src/protocol/dpms.rs
@@ -111,12 +111,7 @@ pub struct GetVersionReply {
     pub server_major_version: u16,
     pub server_minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetVersionReply, "GetVersionReply");
 impl TryParse for GetVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -232,12 +227,7 @@ pub struct CapableReply {
     pub length: u32,
     pub capable: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CapableReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CapableReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CapableReply, "CapableReply");
 impl TryParse for CapableReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -374,12 +364,7 @@ pub struct GetTimeoutsReply {
     pub suspend_timeout: u16,
     pub off_timeout: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTimeoutsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTimeoutsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTimeoutsReply, "GetTimeoutsReply");
 impl TryParse for GetTimeoutsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -817,12 +802,7 @@ pub struct InfoReply {
     pub power_level: DPMSMode,
     pub state: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InfoReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InfoReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InfoReply, "InfoReply");
 impl TryParse for InfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1023,12 +1003,7 @@ pub struct InfoNotifyEvent {
     pub power_level: DPMSMode,
     pub state: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InfoNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InfoNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InfoNotifyEvent, "InfoNotifyEvent");
 impl TryParse for InfoNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/dri2.rs
+++ b/x11rb-protocol/src/protocol/dri2.rs
@@ -213,12 +213,7 @@ pub struct DRI2Buffer {
     pub cpp: u32,
     pub flags: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DRI2Buffer {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DRI2Buffer").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DRI2Buffer, "DRI2Buffer");
 impl TryParse for DRI2Buffer {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (attachment, remaining) = u32::try_parse(remaining)?;
@@ -279,12 +274,7 @@ pub struct AttachFormat {
     pub attachment: Attachment,
     pub format: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AttachFormat {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AttachFormat").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AttachFormat, "AttachFormat");
 impl TryParse for AttachFormat {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (attachment, remaining) = u32::try_parse(remaining)?;
@@ -396,12 +386,7 @@ pub struct QueryVersionReply {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -541,12 +526,7 @@ pub struct ConnectReply {
     pub alignment_pad: Vec<u8>,
     pub device_name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ConnectReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ConnectReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ConnectReply, "ConnectReply");
 impl TryParse for ConnectReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -705,12 +685,7 @@ pub struct AuthenticateReply {
     pub length: u32,
     pub authenticated: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AuthenticateReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AuthenticateReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AuthenticateReply, "AuthenticateReply");
 impl TryParse for AuthenticateReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -986,12 +961,7 @@ pub struct GetBuffersReply {
     pub height: u32,
     pub buffers: Vec<DRI2Buffer>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetBuffersReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetBuffersReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetBuffersReply, "GetBuffersReply");
 impl TryParse for GetBuffersReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1145,12 +1115,7 @@ pub struct CopyRegionReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CopyRegionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CopyRegionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CopyRegionReply, "CopyRegionReply");
 impl TryParse for CopyRegionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1297,12 +1262,7 @@ pub struct GetBuffersWithFormatReply {
     pub height: u32,
     pub buffers: Vec<DRI2Buffer>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetBuffersWithFormatReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetBuffersWithFormatReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetBuffersWithFormatReply, "GetBuffersWithFormatReply");
 impl TryParse for GetBuffersWithFormatReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1482,12 +1442,7 @@ pub struct SwapBuffersReply {
     pub swap_hi: u32,
     pub swap_lo: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SwapBuffersReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SwapBuffersReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SwapBuffersReply, "SwapBuffersReply");
 impl TryParse for SwapBuffersReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1621,12 +1576,7 @@ pub struct GetMSCReply {
     pub sbc_hi: u32,
     pub sbc_lo: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMSCReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMSCReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMSCReply, "GetMSCReply");
 impl TryParse for GetMSCReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1836,12 +1786,7 @@ pub struct WaitMSCReply {
     pub sbc_hi: u32,
     pub sbc_lo: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for WaitMSCReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("WaitMSCReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(WaitMSCReply, "WaitMSCReply");
 impl TryParse for WaitMSCReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2019,12 +1964,7 @@ pub struct WaitSBCReply {
     pub sbc_hi: u32,
     pub sbc_lo: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for WaitSBCReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("WaitSBCReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(WaitSBCReply, "WaitSBCReply");
 impl TryParse for WaitSBCReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2260,12 +2200,7 @@ pub struct GetParamReply {
     pub value_hi: u32,
     pub value_lo: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetParamReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetParamReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetParamReply, "GetParamReply");
 impl TryParse for GetParamReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2341,12 +2276,7 @@ pub struct BufferSwapCompleteEvent {
     pub msc_lo: u32,
     pub sbc: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BufferSwapCompleteEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BufferSwapCompleteEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BufferSwapCompleteEvent, "BufferSwapCompleteEvent");
 impl TryParse for BufferSwapCompleteEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2494,12 +2424,7 @@ pub struct InvalidateBuffersEvent {
     pub sequence: u16,
     pub drawable: xproto::Drawable,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InvalidateBuffersEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InvalidateBuffersEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InvalidateBuffersEvent, "InvalidateBuffersEvent");
 impl TryParse for InvalidateBuffersEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/dri2.rs
+++ b/x11rb-protocol/src/protocol/dri2.rs
@@ -316,12 +316,7 @@ pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -454,12 +449,7 @@ pub struct ConnectRequest {
     pub window: xproto::Window,
     pub driver_type: DriverType,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ConnectRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ConnectRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ConnectRequest, "ConnectRequest");
 impl ConnectRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -616,12 +606,7 @@ pub struct AuthenticateRequest {
     pub window: xproto::Window,
     pub magic: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AuthenticateRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AuthenticateRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AuthenticateRequest, "AuthenticateRequest");
 impl AuthenticateRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -745,12 +730,7 @@ pub const CREATE_DRAWABLE_REQUEST: u8 = 3;
 pub struct CreateDrawableRequest {
     pub drawable: xproto::Drawable,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateDrawableRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateDrawableRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateDrawableRequest, "CreateDrawableRequest");
 impl CreateDrawableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -806,12 +786,7 @@ pub const DESTROY_DRAWABLE_REQUEST: u8 = 4;
 pub struct DestroyDrawableRequest {
     pub drawable: xproto::Drawable,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyDrawableRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyDrawableRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyDrawableRequest, "DestroyDrawableRequest");
 impl DestroyDrawableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -869,12 +844,7 @@ pub struct GetBuffersRequest<'input> {
     pub count: u32,
     pub attachments: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for GetBuffersRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetBuffersRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetBuffersRequest<'_>, "GetBuffersRequest");
 impl<'input> GetBuffersRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1033,12 +1003,7 @@ pub struct CopyRegionRequest {
     pub dest: u32,
     pub src: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CopyRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CopyRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CopyRegionRequest, "CopyRegionRequest");
 impl CopyRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1170,12 +1135,7 @@ pub struct GetBuffersWithFormatRequest<'input> {
     pub count: u32,
     pub attachments: Cow<'input, [AttachFormat]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for GetBuffersWithFormatRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetBuffersWithFormatRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetBuffersWithFormatRequest<'_>, "GetBuffersWithFormatRequest");
 impl<'input> GetBuffersWithFormatRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1337,12 +1297,7 @@ pub struct SwapBuffersRequest {
     pub remainder_hi: u32,
     pub remainder_lo: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SwapBuffersRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SwapBuffersRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SwapBuffersRequest, "SwapBuffersRequest");
 impl SwapBuffersRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1509,12 +1464,7 @@ pub const GET_MSC_REQUEST: u8 = 9;
 pub struct GetMSCRequest {
     pub drawable: xproto::Drawable,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMSCRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMSCRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMSCRequest, "GetMSCRequest");
 impl GetMSCRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1677,12 +1627,7 @@ pub struct WaitMSCRequest {
     pub remainder_hi: u32,
     pub remainder_lo: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for WaitMSCRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("WaitMSCRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(WaitMSCRequest, "WaitMSCRequest");
 impl WaitMSCRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1883,12 +1828,7 @@ pub struct WaitSBCRequest {
     pub target_sbc_hi: u32,
     pub target_sbc_lo: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for WaitSBCRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("WaitSBCRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(WaitSBCRequest, "WaitSBCRequest");
 impl WaitSBCRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2060,12 +2000,7 @@ pub struct SwapIntervalRequest {
     pub drawable: xproto::Drawable,
     pub interval: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SwapIntervalRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SwapIntervalRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SwapIntervalRequest, "SwapIntervalRequest");
 impl SwapIntervalRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2129,12 +2064,7 @@ pub struct GetParamRequest {
     pub drawable: xproto::Drawable,
     pub param: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetParamRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetParamRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetParamRequest, "GetParamRequest");
 impl GetParamRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/dri3.rs
+++ b/x11rb-protocol/src/protocol/dri3.rs
@@ -45,12 +45,7 @@ pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -183,12 +178,7 @@ pub struct OpenRequest {
     pub drawable: xproto::Drawable,
     pub provider: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for OpenRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OpenRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OpenRequest, "OpenRequest");
 impl OpenRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -339,12 +329,7 @@ pub struct PixmapFromBufferRequest {
     pub bpp: u8,
     pub pixmap_fd: RawFdContainer,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PixmapFromBufferRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PixmapFromBufferRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PixmapFromBufferRequest, "PixmapFromBufferRequest");
 impl PixmapFromBufferRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -440,12 +425,7 @@ pub const BUFFER_FROM_PIXMAP_REQUEST: u8 = 3;
 pub struct BufferFromPixmapRequest {
     pub pixmap: xproto::Pixmap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BufferFromPixmapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BufferFromPixmapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BufferFromPixmapRequest, "BufferFromPixmapRequest");
 impl BufferFromPixmapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -608,12 +588,7 @@ pub struct FenceFromFDRequest {
     pub initially_triggered: bool,
     pub fence_fd: RawFdContainer,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FenceFromFDRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FenceFromFDRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FenceFromFDRequest, "FenceFromFDRequest");
 impl FenceFromFDRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -688,12 +663,7 @@ pub struct FDFromFenceRequest {
     pub drawable: xproto::Drawable,
     pub fence: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FDFromFenceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FDFromFenceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FDFromFenceRequest, "FDFromFenceRequest");
 impl FDFromFenceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -840,12 +810,7 @@ pub struct GetSupportedModifiersRequest {
     pub depth: u8,
     pub bpp: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSupportedModifiersRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSupportedModifiersRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSupportedModifiersRequest, "GetSupportedModifiersRequest");
 impl GetSupportedModifiersRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1010,12 +975,7 @@ pub struct PixmapFromBuffersRequest {
     pub modifier: u64,
     pub buffers: Vec<RawFdContainer>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PixmapFromBuffersRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PixmapFromBuffersRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PixmapFromBuffersRequest, "PixmapFromBuffersRequest");
 impl PixmapFromBuffersRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1179,12 +1139,7 @@ pub const BUFFERS_FROM_PIXMAP_REQUEST: u8 = 8;
 pub struct BuffersFromPixmapRequest {
     pub pixmap: xproto::Pixmap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BuffersFromPixmapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BuffersFromPixmapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BuffersFromPixmapRequest, "BuffersFromPixmapRequest");
 impl BuffersFromPixmapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1331,12 +1286,7 @@ pub struct SetDRMDeviceInUseRequest {
     pub drm_major: u32,
     pub drm_minor: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetDRMDeviceInUseRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDRMDeviceInUseRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDRMDeviceInUseRequest, "SetDRMDeviceInUseRequest");
 impl SetDRMDeviceInUseRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/dri3.rs
+++ b/x11rb-protocol/src/protocol/dri3.rs
@@ -115,12 +115,7 @@ pub struct QueryVersionReply {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -256,12 +251,7 @@ pub struct OpenReply {
     pub length: u32,
     pub device_fd: RawFdContainer,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for OpenReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OpenReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OpenReply, "OpenReply");
 impl TryParseFd for OpenReply {
     fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
         let remaining = initial_value;
@@ -517,12 +507,7 @@ pub struct BufferFromPixmapReply {
     pub bpp: u8,
     pub pixmap_fd: RawFdContainer,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BufferFromPixmapReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BufferFromPixmapReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BufferFromPixmapReply, "BufferFromPixmapReply");
 impl TryParseFd for BufferFromPixmapReply {
     fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
         let remaining = initial_value;
@@ -771,12 +756,7 @@ pub struct FDFromFenceReply {
     pub length: u32,
     pub fence_fd: RawFdContainer,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FDFromFenceReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FDFromFenceReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FDFromFenceReply, "FDFromFenceReply");
 impl TryParseFd for FDFromFenceReply {
     fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
         let remaining = initial_value;
@@ -934,12 +914,7 @@ pub struct GetSupportedModifiersReply {
     pub window_modifiers: Vec<u64>,
     pub screen_modifiers: Vec<u64>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSupportedModifiersReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSupportedModifiersReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSupportedModifiersReply, "GetSupportedModifiersReply");
 impl TryParse for GetSupportedModifiersReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1271,12 +1246,7 @@ pub struct BuffersFromPixmapReply {
     pub offsets: Vec<u32>,
     pub buffers: Vec<RawFdContainer>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BuffersFromPixmapReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BuffersFromPixmapReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BuffersFromPixmapReply, "BuffersFromPixmapReply");
 impl TryParseFd for BuffersFromPixmapReply {
     fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/ge.rs
+++ b/x11rb-protocol/src/protocol/ge.rs
@@ -43,12 +43,7 @@ pub struct QueryVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/ge.rs
+++ b/x11rb-protocol/src/protocol/ge.rs
@@ -109,12 +109,7 @@ pub struct QueryVersionReply {
     pub major_version: u16,
     pub minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/glx.rs
+++ b/x11rb-protocol/src/protocol/glx.rs
@@ -118,12 +118,7 @@ pub struct PbufferClobberEvent {
     pub height: u16,
     pub count: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PbufferClobberEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PbufferClobberEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PbufferClobberEvent, "PbufferClobberEvent");
 impl TryParse for PbufferClobberEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -288,12 +283,7 @@ pub struct BufferSwapCompleteEvent {
     pub msc_lo: u32,
     pub sbc: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BufferSwapCompleteEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BufferSwapCompleteEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BufferSwapCompleteEvent, "BufferSwapCompleteEvent");
 impl TryParse for BufferSwapCompleteEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -946,12 +936,7 @@ pub struct MakeCurrentReply {
     pub length: u32,
     pub context_tag: ContextTag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MakeCurrentReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MakeCurrentReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MakeCurrentReply, "MakeCurrentReply");
 impl TryParse for MakeCurrentReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1095,12 +1080,7 @@ pub struct IsDirectReply {
     pub length: u32,
     pub is_direct: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IsDirectReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IsDirectReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IsDirectReply, "IsDirectReply");
 impl TryParse for IsDirectReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1253,12 +1233,7 @@ pub struct QueryVersionReply {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1945,12 +1920,7 @@ pub struct GetVisualConfigsReply {
     pub num_properties: u32,
     pub property_list: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetVisualConfigsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetVisualConfigsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetVisualConfigsReply, "GetVisualConfigsReply");
 impl TryParse for GetVisualConfigsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2246,12 +2216,7 @@ pub struct VendorPrivateWithReplyReply {
     pub data1: [u8; 24],
     pub data2: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for VendorPrivateWithReplyReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("VendorPrivateWithReplyReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(VendorPrivateWithReplyReply, "VendorPrivateWithReplyReply");
 impl TryParse for VendorPrivateWithReplyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2381,12 +2346,7 @@ pub struct QueryExtensionsStringReply {
     pub length: u32,
     pub n: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryExtensionsStringReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryExtensionsStringReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryExtensionsStringReply, "QueryExtensionsStringReply");
 impl TryParse for QueryExtensionsStringReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2540,12 +2500,7 @@ pub struct QueryServerStringReply {
     pub length: u32,
     pub string: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryServerStringReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryServerStringReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryServerStringReply, "QueryServerStringReply");
 impl TryParse for QueryServerStringReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2766,12 +2721,7 @@ pub struct GetFBConfigsReply {
     pub num_properties: u32,
     pub property_list: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetFBConfigsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetFBConfigsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetFBConfigsReply, "GetFBConfigsReply");
 impl TryParse for GetFBConfigsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3173,12 +3123,7 @@ pub struct QueryContextReply {
     pub length: u32,
     pub attribs: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryContextReply, "QueryContextReply");
 impl TryParse for QueryContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3331,12 +3276,7 @@ pub struct MakeContextCurrentReply {
     pub length: u32,
     pub context_tag: ContextTag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MakeContextCurrentReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MakeContextCurrentReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MakeContextCurrentReply, "MakeContextCurrentReply");
 impl TryParse for MakeContextCurrentReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3642,12 +3582,7 @@ pub struct GetDrawableAttributesReply {
     pub length: u32,
     pub attribs: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDrawableAttributesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDrawableAttributesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDrawableAttributesReply, "GetDrawableAttributesReply");
 impl TryParse for GetDrawableAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4617,12 +4552,7 @@ pub struct GenListsReply {
     pub length: u32,
     pub ret_val: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GenListsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GenListsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GenListsReply, "GenListsReply");
 impl TryParse for GenListsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4900,12 +4830,7 @@ pub struct RenderModeReply {
     pub new_mode: u32,
     pub data: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RenderModeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RenderModeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RenderModeReply, "RenderModeReply");
 impl TryParse for RenderModeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5090,12 +5015,7 @@ pub struct FinishReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FinishReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FinishReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FinishReply, "FinishReply");
 impl TryParse for FinishReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5423,12 +5343,7 @@ pub struct ReadPixelsReply {
     pub sequence: u16,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ReadPixelsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ReadPixelsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ReadPixelsReply, "ReadPixelsReply");
 impl TryParse for ReadPixelsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5565,12 +5480,7 @@ pub struct GetBooleanvReply {
     pub datum: bool,
     pub data: Vec<bool>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetBooleanvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetBooleanvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetBooleanvReply, "GetBooleanvReply");
 impl TryParse for GetBooleanvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5708,12 +5618,7 @@ pub struct GetClipPlaneReply {
     pub sequence: u16,
     pub data: Vec<Float64>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetClipPlaneReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetClipPlaneReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetClipPlaneReply, "GetClipPlaneReply");
 impl TryParse for GetClipPlaneReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5848,12 +5753,7 @@ pub struct GetDoublevReply {
     pub datum: Float64,
     pub data: Vec<Float64>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDoublevReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDoublevReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDoublevReply, "GetDoublevReply");
 impl TryParse for GetDoublevReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5984,12 +5884,7 @@ pub struct GetErrorReply {
     pub length: u32,
     pub error: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetErrorReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetErrorReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetErrorReply, "GetErrorReply");
 impl TryParse for GetErrorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6120,12 +6015,7 @@ pub struct GetFloatvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetFloatvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetFloatvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetFloatvReply, "GetFloatvReply");
 impl TryParse for GetFloatvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6265,12 +6155,7 @@ pub struct GetIntegervReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetIntegervReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetIntegervReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetIntegervReply, "GetIntegervReply");
 impl TryParse for GetIntegervReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6418,12 +6303,7 @@ pub struct GetLightfvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetLightfvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetLightfvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetLightfvReply, "GetLightfvReply");
 impl TryParse for GetLightfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6571,12 +6451,7 @@ pub struct GetLightivReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetLightivReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetLightivReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetLightivReply, "GetLightivReply");
 impl TryParse for GetLightivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6724,12 +6599,7 @@ pub struct GetMapdvReply {
     pub datum: Float64,
     pub data: Vec<Float64>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMapdvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMapdvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMapdvReply, "GetMapdvReply");
 impl TryParse for GetMapdvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6877,12 +6747,7 @@ pub struct GetMapfvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMapfvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMapfvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMapfvReply, "GetMapfvReply");
 impl TryParse for GetMapfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -7030,12 +6895,7 @@ pub struct GetMapivReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMapivReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMapivReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMapivReply, "GetMapivReply");
 impl TryParse for GetMapivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -7183,12 +7043,7 @@ pub struct GetMaterialfvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMaterialfvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMaterialfvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMaterialfvReply, "GetMaterialfvReply");
 impl TryParse for GetMaterialfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -7336,12 +7191,7 @@ pub struct GetMaterialivReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMaterialivReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMaterialivReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMaterialivReply, "GetMaterialivReply");
 impl TryParse for GetMaterialivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -7481,12 +7331,7 @@ pub struct GetPixelMapfvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPixelMapfvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPixelMapfvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPixelMapfvReply, "GetPixelMapfvReply");
 impl TryParse for GetPixelMapfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -7626,12 +7471,7 @@ pub struct GetPixelMapuivReply {
     pub datum: u32,
     pub data: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPixelMapuivReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPixelMapuivReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPixelMapuivReply, "GetPixelMapuivReply");
 impl TryParse for GetPixelMapuivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -7771,12 +7611,7 @@ pub struct GetPixelMapusvReply {
     pub datum: u16,
     pub data: Vec<u16>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPixelMapusvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPixelMapusvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPixelMapusvReply, "GetPixelMapusvReply");
 impl TryParse for GetPixelMapusvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -7914,12 +7749,7 @@ pub struct GetPolygonStippleReply {
     pub sequence: u16,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPolygonStippleReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPolygonStippleReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPolygonStippleReply, "GetPolygonStippleReply");
 impl TryParse for GetPolygonStippleReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -8055,12 +7885,7 @@ pub struct GetStringReply {
     pub length: u32,
     pub string: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetStringReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetStringReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetStringReply, "GetStringReply");
 impl TryParse for GetStringReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -8207,12 +8032,7 @@ pub struct GetTexEnvfvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexEnvfvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexEnvfvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexEnvfvReply, "GetTexEnvfvReply");
 impl TryParse for GetTexEnvfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -8360,12 +8180,7 @@ pub struct GetTexEnvivReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexEnvivReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexEnvivReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexEnvivReply, "GetTexEnvivReply");
 impl TryParse for GetTexEnvivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -8513,12 +8328,7 @@ pub struct GetTexGendvReply {
     pub datum: Float64,
     pub data: Vec<Float64>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexGendvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexGendvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexGendvReply, "GetTexGendvReply");
 impl TryParse for GetTexGendvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -8666,12 +8476,7 @@ pub struct GetTexGenfvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexGenfvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexGenfvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexGenfvReply, "GetTexGenfvReply");
 impl TryParse for GetTexGenfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -8819,12 +8624,7 @@ pub struct GetTexGenivReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexGenivReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexGenivReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexGenivReply, "GetTexGenivReply");
 impl TryParse for GetTexGenivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -8997,12 +8797,7 @@ pub struct GetTexImageReply {
     pub depth: i32,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexImageReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexImageReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexImageReply, "GetTexImageReply");
 impl TryParse for GetTexImageReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -9155,12 +8950,7 @@ pub struct GetTexParameterfvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexParameterfvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexParameterfvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexParameterfvReply, "GetTexParameterfvReply");
 impl TryParse for GetTexParameterfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -9308,12 +9098,7 @@ pub struct GetTexParameterivReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexParameterivReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexParameterivReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexParameterivReply, "GetTexParameterivReply");
 impl TryParse for GetTexParameterivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -9469,12 +9254,7 @@ pub struct GetTexLevelParameterfvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexLevelParameterfvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexLevelParameterfvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexLevelParameterfvReply, "GetTexLevelParameterfvReply");
 impl TryParse for GetTexLevelParameterfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -9630,12 +9410,7 @@ pub struct GetTexLevelParameterivReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexLevelParameterivReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexLevelParameterivReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexLevelParameterivReply, "GetTexLevelParameterivReply");
 impl TryParse for GetTexLevelParameterivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -9774,12 +9549,7 @@ pub struct IsEnabledReply {
     pub length: u32,
     pub ret_val: Bool32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IsEnabledReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IsEnabledReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IsEnabledReply, "IsEnabledReply");
 impl TryParse for IsEnabledReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -9909,12 +9679,7 @@ pub struct IsListReply {
     pub length: u32,
     pub ret_val: Bool32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IsListReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IsListReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IsListReply, "IsListReply");
 impl TryParse for IsListReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10118,12 +9883,7 @@ pub struct AreTexturesResidentReply {
     pub ret_val: Bool32,
     pub data: Vec<bool>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AreTexturesResidentReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AreTexturesResidentReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AreTexturesResidentReply, "AreTexturesResidentReply");
 impl TryParse for AreTexturesResidentReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10341,12 +10101,7 @@ pub struct GenTexturesReply {
     pub sequence: u16,
     pub data: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GenTexturesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GenTexturesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GenTexturesReply, "GenTexturesReply");
 impl TryParse for GenTexturesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10479,12 +10234,7 @@ pub struct IsTextureReply {
     pub length: u32,
     pub ret_val: Bool32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IsTextureReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IsTextureReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IsTextureReply, "IsTextureReply");
 impl TryParse for IsTextureReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10638,12 +10388,7 @@ pub struct GetColorTableReply {
     pub width: i32,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetColorTableReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetColorTableReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetColorTableReply, "GetColorTableReply");
 impl TryParse for GetColorTableReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10792,12 +10537,7 @@ pub struct GetColorTableParameterfvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetColorTableParameterfvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetColorTableParameterfvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetColorTableParameterfvReply, "GetColorTableParameterfvReply");
 impl TryParse for GetColorTableParameterfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10945,12 +10685,7 @@ pub struct GetColorTableParameterivReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetColorTableParameterivReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetColorTableParameterivReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetColorTableParameterivReply, "GetColorTableParameterivReply");
 impl TryParse for GetColorTableParameterivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -11114,12 +10849,7 @@ pub struct GetConvolutionFilterReply {
     pub height: i32,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetConvolutionFilterReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetConvolutionFilterReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetConvolutionFilterReply, "GetConvolutionFilterReply");
 impl TryParse for GetConvolutionFilterReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -11270,12 +11000,7 @@ pub struct GetConvolutionParameterfvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetConvolutionParameterfvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetConvolutionParameterfvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetConvolutionParameterfvReply, "GetConvolutionParameterfvReply");
 impl TryParse for GetConvolutionParameterfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -11423,12 +11148,7 @@ pub struct GetConvolutionParameterivReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetConvolutionParameterivReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetConvolutionParameterivReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetConvolutionParameterivReply, "GetConvolutionParameterivReply");
 impl TryParse for GetConvolutionParameterivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -11592,12 +11312,7 @@ pub struct GetSeparableFilterReply {
     pub col_h: i32,
     pub rows_and_cols: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSeparableFilterReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSeparableFilterReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSeparableFilterReply, "GetSeparableFilterReply");
 impl TryParse for GetSeparableFilterReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -11767,12 +11482,7 @@ pub struct GetHistogramReply {
     pub width: i32,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetHistogramReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetHistogramReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetHistogramReply, "GetHistogramReply");
 impl TryParse for GetHistogramReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -11921,12 +11631,7 @@ pub struct GetHistogramParameterfvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetHistogramParameterfvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetHistogramParameterfvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetHistogramParameterfvReply, "GetHistogramParameterfvReply");
 impl TryParse for GetHistogramParameterfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -12074,12 +11779,7 @@ pub struct GetHistogramParameterivReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetHistogramParameterivReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetHistogramParameterivReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetHistogramParameterivReply, "GetHistogramParameterivReply");
 impl TryParse for GetHistogramParameterivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -12245,12 +11945,7 @@ pub struct GetMinmaxReply {
     pub sequence: u16,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMinmaxReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMinmaxReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMinmaxReply, "GetMinmaxReply");
 impl TryParse for GetMinmaxReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -12395,12 +12090,7 @@ pub struct GetMinmaxParameterfvReply {
     pub datum: Float32,
     pub data: Vec<Float32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMinmaxParameterfvReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMinmaxParameterfvReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMinmaxParameterfvReply, "GetMinmaxParameterfvReply");
 impl TryParse for GetMinmaxParameterfvReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -12548,12 +12238,7 @@ pub struct GetMinmaxParameterivReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMinmaxParameterivReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMinmaxParameterivReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMinmaxParameterivReply, "GetMinmaxParameterivReply");
 impl TryParse for GetMinmaxParameterivReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -12700,12 +12385,7 @@ pub struct GetCompressedTexImageARBReply {
     pub size: i32,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCompressedTexImageARBReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCompressedTexImageARBReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCompressedTexImageARBReply, "GetCompressedTexImageARBReply");
 impl TryParse for GetCompressedTexImageARBReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -12926,12 +12606,7 @@ pub struct GenQueriesARBReply {
     pub sequence: u16,
     pub data: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GenQueriesARBReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GenQueriesARBReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GenQueriesARBReply, "GenQueriesARBReply");
 impl TryParse for GenQueriesARBReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -13064,12 +12739,7 @@ pub struct IsQueryARBReply {
     pub length: u32,
     pub ret_val: Bool32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IsQueryARBReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IsQueryARBReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IsQueryARBReply, "IsQueryARBReply");
 impl TryParse for IsQueryARBReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -13208,12 +12878,7 @@ pub struct GetQueryivARBReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetQueryivARBReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetQueryivARBReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetQueryivARBReply, "GetQueryivARBReply");
 impl TryParse for GetQueryivARBReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -13361,12 +13026,7 @@ pub struct GetQueryObjectivARBReply {
     pub datum: i32,
     pub data: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetQueryObjectivARBReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetQueryObjectivARBReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetQueryObjectivARBReply, "GetQueryObjectivARBReply");
 impl TryParse for GetQueryObjectivARBReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -13514,12 +13174,7 @@ pub struct GetQueryObjectuivARBReply {
     pub datum: u32,
     pub data: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetQueryObjectuivARBReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetQueryObjectuivARBReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetQueryObjectuivARBReply, "GetQueryObjectuivARBReply");
 impl TryParse for GetQueryObjectuivARBReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/glx.rs
+++ b/x11rb-protocol/src/protocol/glx.rs
@@ -535,12 +535,7 @@ pub struct RenderRequest<'input> {
     pub context_tag: ContextTag,
     pub data: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for RenderRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RenderRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RenderRequest<'_>, "RenderRequest");
 impl<'input> RenderRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -611,12 +606,7 @@ pub struct RenderLargeRequest<'input> {
     pub request_total: u16,
     pub data: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for RenderLargeRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RenderLargeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RenderLargeRequest<'_>, "RenderLargeRequest");
 impl<'input> RenderLargeRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -707,12 +697,7 @@ pub struct CreateContextRequest {
     pub share_list: Context,
     pub is_direct: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateContextRequest, "CreateContextRequest");
 impl CreateContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -797,12 +782,7 @@ pub const DESTROY_CONTEXT_REQUEST: u8 = 4;
 pub struct DestroyContextRequest {
     pub context: Context,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyContextRequest, "DestroyContextRequest");
 impl DestroyContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -860,12 +840,7 @@ pub struct MakeCurrentRequest {
     pub context: Context,
     pub old_context_tag: ContextTag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MakeCurrentRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MakeCurrentRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MakeCurrentRequest, "MakeCurrentRequest");
 impl MakeCurrentRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1018,12 +993,7 @@ pub const IS_DIRECT_REQUEST: u8 = 6;
 pub struct IsDirectRequest {
     pub context: Context,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IsDirectRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IsDirectRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IsDirectRequest, "IsDirectRequest");
 impl IsDirectRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1163,12 +1133,7 @@ pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1318,12 +1283,7 @@ pub const WAIT_GL_REQUEST: u8 = 8;
 pub struct WaitGLRequest {
     pub context_tag: ContextTag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for WaitGLRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("WaitGLRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(WaitGLRequest, "WaitGLRequest");
 impl WaitGLRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1379,12 +1339,7 @@ pub const WAIT_X_REQUEST: u8 = 9;
 pub struct WaitXRequest {
     pub context_tag: ContextTag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for WaitXRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("WaitXRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(WaitXRequest, "WaitXRequest");
 impl WaitXRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1443,12 +1398,7 @@ pub struct CopyContextRequest {
     pub mask: u32,
     pub src_context_tag: ContextTag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CopyContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CopyContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CopyContextRequest, "CopyContextRequest");
 impl CopyContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1611,12 +1561,7 @@ pub struct SwapBuffersRequest {
     pub context_tag: ContextTag,
     pub drawable: Drawable,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SwapBuffersRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SwapBuffersRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SwapBuffersRequest, "SwapBuffersRequest");
 impl SwapBuffersRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1683,12 +1628,7 @@ pub struct UseXFontRequest {
     pub count: u32,
     pub list_base: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UseXFontRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UseXFontRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UseXFontRequest, "UseXFontRequest");
 impl UseXFontRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1775,12 +1715,7 @@ pub struct CreateGLXPixmapRequest {
     pub pixmap: xproto::Pixmap,
     pub glx_pixmap: Pixmap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateGLXPixmapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateGLXPixmapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateGLXPixmapRequest, "CreateGLXPixmapRequest");
 impl CreateGLXPixmapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1857,12 +1792,7 @@ pub const GET_VISUAL_CONFIGS_REQUEST: u8 = 14;
 pub struct GetVisualConfigsRequest {
     pub screen: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetVisualConfigsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetVisualConfigsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetVisualConfigsRequest, "GetVisualConfigsRequest");
 impl GetVisualConfigsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1987,12 +1917,7 @@ pub const DESTROY_GLX_PIXMAP_REQUEST: u8 = 15;
 pub struct DestroyGLXPixmapRequest {
     pub glx_pixmap: Pixmap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyGLXPixmapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyGLXPixmapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyGLXPixmapRequest, "DestroyGLXPixmapRequest");
 impl DestroyGLXPixmapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2050,12 +1975,7 @@ pub struct VendorPrivateRequest<'input> {
     pub context_tag: ContextTag,
     pub data: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for VendorPrivateRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("VendorPrivateRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(VendorPrivateRequest<'_>, "VendorPrivateRequest");
 impl<'input> VendorPrivateRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2133,12 +2053,7 @@ pub struct VendorPrivateWithReplyRequest<'input> {
     pub context_tag: ContextTag,
     pub data: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for VendorPrivateWithReplyRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("VendorPrivateWithReplyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(VendorPrivateWithReplyRequest<'_>, "VendorPrivateWithReplyRequest");
 impl<'input> VendorPrivateWithReplyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2284,12 +2199,7 @@ pub const QUERY_EXTENSIONS_STRING_REQUEST: u8 = 18;
 pub struct QueryExtensionsStringRequest {
     pub screen: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryExtensionsStringRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryExtensionsStringRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryExtensionsStringRequest, "QueryExtensionsStringRequest");
 impl QueryExtensionsStringRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2431,12 +2341,7 @@ pub struct QueryServerStringRequest {
     pub screen: u32,
     pub name: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryServerStringRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryServerStringRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryServerStringRequest, "QueryServerStringRequest");
 impl QueryServerStringRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2570,12 +2475,7 @@ pub struct ClientInfoRequest<'input> {
     pub minor_version: u32,
     pub string: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ClientInfoRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ClientInfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ClientInfoRequest<'_>, "ClientInfoRequest");
 impl<'input> ClientInfoRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2658,12 +2558,7 @@ pub const GET_FB_CONFIGS_REQUEST: u8 = 21;
 pub struct GetFBConfigsRequest {
     pub screen: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetFBConfigsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetFBConfigsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetFBConfigsRequest, "GetFBConfigsRequest");
 impl GetFBConfigsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2792,12 +2687,7 @@ pub struct CreatePixmapRequest<'input> {
     pub glx_pixmap: Pixmap,
     pub attribs: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreatePixmapRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreatePixmapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreatePixmapRequest<'_>, "CreatePixmapRequest");
 impl<'input> CreatePixmapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2898,12 +2788,7 @@ pub const DESTROY_PIXMAP_REQUEST: u8 = 23;
 pub struct DestroyPixmapRequest {
     pub glx_pixmap: Pixmap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyPixmapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyPixmapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyPixmapRequest, "DestroyPixmapRequest");
 impl DestroyPixmapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2964,12 +2849,7 @@ pub struct CreateNewContextRequest {
     pub share_list: Context,
     pub is_direct: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateNewContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateNewContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateNewContextRequest, "CreateNewContextRequest");
 impl CreateNewContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3061,12 +2941,7 @@ pub const QUERY_CONTEXT_REQUEST: u8 = 25;
 pub struct QueryContextRequest {
     pub context: Context,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryContextRequest, "QueryContextRequest");
 impl QueryContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3193,12 +3068,7 @@ pub struct MakeContextCurrentRequest {
     pub read_drawable: Drawable,
     pub context: Context,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MakeContextCurrentRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MakeContextCurrentRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MakeContextCurrentRequest, "MakeContextCurrentRequest");
 impl MakeContextCurrentRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3361,12 +3231,7 @@ pub struct CreatePbufferRequest<'input> {
     pub pbuffer: Pbuffer,
     pub attribs: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreatePbufferRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreatePbufferRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreatePbufferRequest<'_>, "CreatePbufferRequest");
 impl<'input> CreatePbufferRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3459,12 +3324,7 @@ pub const DESTROY_PBUFFER_REQUEST: u8 = 28;
 pub struct DestroyPbufferRequest {
     pub pbuffer: Pbuffer,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyPbufferRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyPbufferRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyPbufferRequest, "DestroyPbufferRequest");
 impl DestroyPbufferRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3520,12 +3380,7 @@ pub const GET_DRAWABLE_ATTRIBUTES_REQUEST: u8 = 29;
 pub struct GetDrawableAttributesRequest {
     pub drawable: Drawable,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDrawableAttributesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDrawableAttributesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDrawableAttributesRequest, "GetDrawableAttributesRequest");
 impl GetDrawableAttributesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3650,12 +3505,7 @@ pub struct ChangeDrawableAttributesRequest<'input> {
     pub drawable: Drawable,
     pub attribs: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeDrawableAttributesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeDrawableAttributesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeDrawableAttributesRequest<'_>, "ChangeDrawableAttributesRequest");
 impl<'input> ChangeDrawableAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3736,12 +3586,7 @@ pub struct CreateWindowRequest<'input> {
     pub glx_window: Window,
     pub attribs: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateWindowRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateWindowRequest<'_>, "CreateWindowRequest");
 impl<'input> CreateWindowRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3842,12 +3687,7 @@ pub const DELETE_WINDOW_REQUEST: u8 = 32;
 pub struct DeleteWindowRequest {
     pub glxwindow: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeleteWindowRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeleteWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeleteWindowRequest, "DeleteWindowRequest");
 impl DeleteWindowRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3907,12 +3747,7 @@ pub struct SetClientInfoARBRequest<'input> {
     pub gl_extension_string: Cow<'input, [u8]>,
     pub glx_extension_string: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetClientInfoARBRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetClientInfoARBRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetClientInfoARBRequest<'_>, "SetClientInfoARBRequest");
 impl<'input> SetClientInfoARBRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 6]> {
@@ -4030,12 +3865,7 @@ pub struct CreateContextAttribsARBRequest<'input> {
     pub is_direct: bool,
     pub attribs: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateContextAttribsARBRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateContextAttribsARBRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateContextAttribsARBRequest<'_>, "CreateContextAttribsARBRequest");
 impl<'input> CreateContextAttribsARBRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -4149,12 +3979,7 @@ pub struct SetClientInfo2ARBRequest<'input> {
     pub gl_extension_string: Cow<'input, [u8]>,
     pub glx_extension_string: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetClientInfo2ARBRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetClientInfo2ARBRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetClientInfo2ARBRequest<'_>, "SetClientInfo2ARBRequest");
 impl<'input> SetClientInfo2ARBRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 6]> {
@@ -4269,12 +4094,7 @@ pub struct NewListRequest {
     pub list: u32,
     pub mode: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for NewListRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("NewListRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(NewListRequest, "NewListRequest");
 impl NewListRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4344,12 +4164,7 @@ pub const END_LIST_REQUEST: u8 = 102;
 pub struct EndListRequest {
     pub context_tag: ContextTag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EndListRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EndListRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EndListRequest, "EndListRequest");
 impl EndListRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4407,12 +4222,7 @@ pub struct DeleteListsRequest {
     pub list: u32,
     pub range: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeleteListsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeleteListsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeleteListsRequest, "DeleteListsRequest");
 impl DeleteListsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4483,12 +4293,7 @@ pub struct GenListsRequest {
     pub context_tag: ContextTag,
     pub range: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GenListsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GenListsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GenListsRequest, "GenListsRequest");
 impl GenListsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4614,12 +4419,7 @@ pub struct FeedbackBufferRequest {
     pub size: i32,
     pub type_: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackBufferRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackBufferRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackBufferRequest, "FeedbackBufferRequest");
 impl FeedbackBufferRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4690,12 +4490,7 @@ pub struct SelectBufferRequest {
     pub context_tag: ContextTag,
     pub size: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectBufferRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectBufferRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectBufferRequest, "SelectBufferRequest");
 impl SelectBufferRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4759,12 +4554,7 @@ pub struct RenderModeRequest {
     pub context_tag: ContextTag,
     pub mode: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RenderModeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RenderModeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RenderModeRequest, "RenderModeRequest");
 impl RenderModeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4954,12 +4744,7 @@ pub const FINISH_REQUEST: u8 = 108;
 pub struct FinishRequest {
     pub context_tag: ContextTag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FinishRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FinishRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FinishRequest, "FinishRequest");
 impl FinishRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5070,12 +4855,7 @@ pub struct PixelStorefRequest {
     pub pname: u32,
     pub datum: Float32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PixelStorefRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PixelStorefRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PixelStorefRequest, "PixelStorefRequest");
 impl PixelStorefRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5147,12 +4927,7 @@ pub struct PixelStoreiRequest {
     pub pname: u32,
     pub datum: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PixelStoreiRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PixelStoreiRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PixelStoreiRequest, "PixelStoreiRequest");
 impl PixelStoreiRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5230,12 +5005,7 @@ pub struct ReadPixelsRequest {
     pub swap_bytes: bool,
     pub lsb_first: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ReadPixelsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ReadPixelsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ReadPixelsRequest, "ReadPixelsRequest");
 impl ReadPixelsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5410,12 +5180,7 @@ pub struct GetBooleanvRequest {
     pub context_tag: ContextTag,
     pub pname: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetBooleanvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetBooleanvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetBooleanvRequest, "GetBooleanvRequest");
 impl GetBooleanvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5550,12 +5315,7 @@ pub struct GetClipPlaneRequest {
     pub context_tag: ContextTag,
     pub plane: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetClipPlaneRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetClipPlaneRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetClipPlaneRequest, "GetClipPlaneRequest");
 impl GetClipPlaneRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5683,12 +5443,7 @@ pub struct GetDoublevRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDoublevRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDoublevRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDoublevRequest, "GetDoublevRequest");
 impl GetDoublevRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5822,12 +5577,7 @@ pub const GET_ERROR_REQUEST: u8 = 115;
 pub struct GetErrorRequest {
     pub context_tag: ContextTag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetErrorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetErrorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetErrorRequest, "GetErrorRequest");
 impl GetErrorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5945,12 +5695,7 @@ pub struct GetFloatvRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetFloatvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetFloatvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetFloatvRequest, "GetFloatvRequest");
 impl GetFloatvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6085,12 +5830,7 @@ pub struct GetIntegervRequest {
     pub context_tag: ContextTag,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetIntegervRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetIntegervRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetIntegervRequest, "GetIntegervRequest");
 impl GetIntegervRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6226,12 +5966,7 @@ pub struct GetLightfvRequest {
     pub light: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetLightfvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetLightfvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetLightfvRequest, "GetLightfvRequest");
 impl GetLightfvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6374,12 +6109,7 @@ pub struct GetLightivRequest {
     pub light: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetLightivRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetLightivRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetLightivRequest, "GetLightivRequest");
 impl GetLightivRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6522,12 +6252,7 @@ pub struct GetMapdvRequest {
     pub target: u32,
     pub query: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMapdvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMapdvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMapdvRequest, "GetMapdvRequest");
 impl GetMapdvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6670,12 +6395,7 @@ pub struct GetMapfvRequest {
     pub target: u32,
     pub query: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMapfvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMapfvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMapfvRequest, "GetMapfvRequest");
 impl GetMapfvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6818,12 +6538,7 @@ pub struct GetMapivRequest {
     pub target: u32,
     pub query: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMapivRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMapivRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMapivRequest, "GetMapivRequest");
 impl GetMapivRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6966,12 +6681,7 @@ pub struct GetMaterialfvRequest {
     pub face: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMaterialfvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMaterialfvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMaterialfvRequest, "GetMaterialfvRequest");
 impl GetMaterialfvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7114,12 +6824,7 @@ pub struct GetMaterialivRequest {
     pub face: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMaterialivRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMaterialivRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMaterialivRequest, "GetMaterialivRequest");
 impl GetMaterialivRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7261,12 +6966,7 @@ pub struct GetPixelMapfvRequest {
     pub context_tag: ContextTag,
     pub map: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPixelMapfvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPixelMapfvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPixelMapfvRequest, "GetPixelMapfvRequest");
 impl GetPixelMapfvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7401,12 +7101,7 @@ pub struct GetPixelMapuivRequest {
     pub context_tag: ContextTag,
     pub map: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPixelMapuivRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPixelMapuivRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPixelMapuivRequest, "GetPixelMapuivRequest");
 impl GetPixelMapuivRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7541,12 +7236,7 @@ pub struct GetPixelMapusvRequest {
     pub context_tag: ContextTag,
     pub map: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPixelMapusvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPixelMapusvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPixelMapusvRequest, "GetPixelMapusvRequest");
 impl GetPixelMapusvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7681,12 +7371,7 @@ pub struct GetPolygonStippleRequest {
     pub context_tag: ContextTag,
     pub lsb_first: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPolygonStippleRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPolygonStippleRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPolygonStippleRequest, "GetPolygonStippleRequest");
 impl GetPolygonStippleRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7816,12 +7501,7 @@ pub struct GetStringRequest {
     pub context_tag: ContextTag,
     pub name: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetStringRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetStringRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetStringRequest, "GetStringRequest");
 impl GetStringRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7955,12 +7635,7 @@ pub struct GetTexEnvfvRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexEnvfvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexEnvfvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexEnvfvRequest, "GetTexEnvfvRequest");
 impl GetTexEnvfvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8103,12 +7778,7 @@ pub struct GetTexEnvivRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexEnvivRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexEnvivRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexEnvivRequest, "GetTexEnvivRequest");
 impl GetTexEnvivRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8251,12 +7921,7 @@ pub struct GetTexGendvRequest {
     pub coord: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexGendvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexGendvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexGendvRequest, "GetTexGendvRequest");
 impl GetTexGendvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8399,12 +8064,7 @@ pub struct GetTexGenfvRequest {
     pub coord: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexGenfvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexGenfvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexGenfvRequest, "GetTexGenfvRequest");
 impl GetTexGenfvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8547,12 +8207,7 @@ pub struct GetTexGenivRequest {
     pub coord: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexGenivRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexGenivRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexGenivRequest, "GetTexGenivRequest");
 impl GetTexGenivRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8698,12 +8353,7 @@ pub struct GetTexImageRequest {
     pub type_: u32,
     pub swap_bytes: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexImageRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexImageRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexImageRequest, "GetTexImageRequest");
 impl GetTexImageRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8873,12 +8523,7 @@ pub struct GetTexParameterfvRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexParameterfvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexParameterfvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexParameterfvRequest, "GetTexParameterfvRequest");
 impl GetTexParameterfvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9021,12 +8666,7 @@ pub struct GetTexParameterivRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexParameterivRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexParameterivRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexParameterivRequest, "GetTexParameterivRequest");
 impl GetTexParameterivRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9170,12 +8810,7 @@ pub struct GetTexLevelParameterfvRequest {
     pub level: i32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexLevelParameterfvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexLevelParameterfvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexLevelParameterfvRequest, "GetTexLevelParameterfvRequest");
 impl GetTexLevelParameterfvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9326,12 +8961,7 @@ pub struct GetTexLevelParameterivRequest {
     pub level: i32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetTexLevelParameterivRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetTexLevelParameterivRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetTexLevelParameterivRequest, "GetTexLevelParameterivRequest");
 impl GetTexLevelParameterivRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9480,12 +9110,7 @@ pub struct IsEnabledRequest {
     pub context_tag: ContextTag,
     pub capability: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IsEnabledRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IsEnabledRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IsEnabledRequest, "IsEnabledRequest");
 impl IsEnabledRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9610,12 +9235,7 @@ pub struct IsListRequest {
     pub context_tag: ContextTag,
     pub list: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IsListRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IsListRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IsListRequest, "IsListRequest");
 impl IsListRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9739,12 +9359,7 @@ pub const FLUSH_REQUEST: u8 = 142;
 pub struct FlushRequest {
     pub context_tag: ContextTag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FlushRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FlushRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FlushRequest, "FlushRequest");
 impl FlushRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9801,12 +9416,7 @@ pub struct AreTexturesResidentRequest<'input> {
     pub context_tag: ContextTag,
     pub textures: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for AreTexturesResidentRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AreTexturesResidentRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AreTexturesResidentRequest<'_>, "AreTexturesResidentRequest");
 impl<'input> AreTexturesResidentRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -9951,12 +9561,7 @@ pub struct DeleteTexturesRequest<'input> {
     pub context_tag: ContextTag,
     pub textures: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for DeleteTexturesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeleteTexturesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeleteTexturesRequest<'_>, "DeleteTexturesRequest");
 impl<'input> DeleteTexturesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -10033,12 +9638,7 @@ pub struct GenTexturesRequest {
     pub context_tag: ContextTag,
     pub n: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GenTexturesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GenTexturesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GenTexturesRequest, "GenTexturesRequest");
 impl GenTexturesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -10165,12 +9765,7 @@ pub struct IsTextureRequest {
     pub context_tag: ContextTag,
     pub texture: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IsTextureRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IsTextureRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IsTextureRequest, "IsTextureRequest");
 impl IsTextureRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -10298,12 +9893,7 @@ pub struct GetColorTableRequest {
     pub type_: u32,
     pub swap_bytes: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetColorTableRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetColorTableRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetColorTableRequest, "GetColorTableRequest");
 impl GetColorTableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -10460,12 +10050,7 @@ pub struct GetColorTableParameterfvRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetColorTableParameterfvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetColorTableParameterfvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetColorTableParameterfvRequest, "GetColorTableParameterfvRequest");
 impl GetColorTableParameterfvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -10608,12 +10193,7 @@ pub struct GetColorTableParameterivRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetColorTableParameterivRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetColorTableParameterivRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetColorTableParameterivRequest, "GetColorTableParameterivRequest");
 impl GetColorTableParameterivRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -10758,12 +10338,7 @@ pub struct GetConvolutionFilterRequest {
     pub type_: u32,
     pub swap_bytes: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetConvolutionFilterRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetConvolutionFilterRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetConvolutionFilterRequest, "GetConvolutionFilterRequest");
 impl GetConvolutionFilterRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -10923,12 +10498,7 @@ pub struct GetConvolutionParameterfvRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetConvolutionParameterfvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetConvolutionParameterfvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetConvolutionParameterfvRequest, "GetConvolutionParameterfvRequest");
 impl GetConvolutionParameterfvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11071,12 +10641,7 @@ pub struct GetConvolutionParameterivRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetConvolutionParameterivRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetConvolutionParameterivRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetConvolutionParameterivRequest, "GetConvolutionParameterivRequest");
 impl GetConvolutionParameterivRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11221,12 +10786,7 @@ pub struct GetSeparableFilterRequest {
     pub type_: u32,
     pub swap_bytes: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSeparableFilterRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSeparableFilterRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSeparableFilterRequest, "GetSeparableFilterRequest");
 impl GetSeparableFilterRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11389,12 +10949,7 @@ pub struct GetHistogramRequest {
     pub swap_bytes: bool,
     pub reset: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetHistogramRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetHistogramRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetHistogramRequest, "GetHistogramRequest");
 impl GetHistogramRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11554,12 +11109,7 @@ pub struct GetHistogramParameterfvRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetHistogramParameterfvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetHistogramParameterfvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetHistogramParameterfvRequest, "GetHistogramParameterfvRequest");
 impl GetHistogramParameterfvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11702,12 +11252,7 @@ pub struct GetHistogramParameterivRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetHistogramParameterivRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetHistogramParameterivRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetHistogramParameterivRequest, "GetHistogramParameterivRequest");
 impl GetHistogramParameterivRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11853,12 +11398,7 @@ pub struct GetMinmaxRequest {
     pub swap_bytes: bool,
     pub reset: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMinmaxRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMinmaxRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMinmaxRequest, "GetMinmaxRequest");
 impl GetMinmaxRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12013,12 +11553,7 @@ pub struct GetMinmaxParameterfvRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMinmaxParameterfvRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMinmaxParameterfvRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMinmaxParameterfvRequest, "GetMinmaxParameterfvRequest");
 impl GetMinmaxParameterfvRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12161,12 +11696,7 @@ pub struct GetMinmaxParameterivRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMinmaxParameterivRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMinmaxParameterivRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMinmaxParameterivRequest, "GetMinmaxParameterivRequest");
 impl GetMinmaxParameterivRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12309,12 +11839,7 @@ pub struct GetCompressedTexImageARBRequest {
     pub target: u32,
     pub level: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCompressedTexImageARBRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCompressedTexImageARBRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCompressedTexImageARBRequest, "GetCompressedTexImageARBRequest");
 impl GetCompressedTexImageARBRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12456,12 +11981,7 @@ pub struct DeleteQueriesARBRequest<'input> {
     pub context_tag: ContextTag,
     pub ids: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for DeleteQueriesARBRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeleteQueriesARBRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeleteQueriesARBRequest<'_>, "DeleteQueriesARBRequest");
 impl<'input> DeleteQueriesARBRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -12538,12 +12058,7 @@ pub struct GenQueriesARBRequest {
     pub context_tag: ContextTag,
     pub n: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GenQueriesARBRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GenQueriesARBRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GenQueriesARBRequest, "GenQueriesARBRequest");
 impl GenQueriesARBRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12670,12 +12185,7 @@ pub struct IsQueryARBRequest {
     pub context_tag: ContextTag,
     pub id: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IsQueryARBRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IsQueryARBRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IsQueryARBRequest, "IsQueryARBRequest");
 impl IsQueryARBRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12801,12 +12311,7 @@ pub struct GetQueryivARBRequest {
     pub target: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetQueryivARBRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetQueryivARBRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetQueryivARBRequest, "GetQueryivARBRequest");
 impl GetQueryivARBRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12949,12 +12454,7 @@ pub struct GetQueryObjectivARBRequest {
     pub id: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetQueryObjectivARBRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetQueryObjectivARBRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetQueryObjectivARBRequest, "GetQueryObjectivARBRequest");
 impl GetQueryObjectivARBRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13097,12 +12597,7 @@ pub struct GetQueryObjectuivARBRequest {
     pub id: u32,
     pub pname: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetQueryObjectuivARBRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetQueryObjectuivARBRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetQueryObjectuivARBRequest, "GetQueryObjectuivARBRequest");
 impl GetQueryObjectuivARBRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -463,12 +463,7 @@ pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -614,12 +609,7 @@ pub struct PixmapRequest<'input> {
     pub remainder: u64,
     pub notifies: Cow<'input, [Notify]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PixmapRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PixmapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PixmapRequest<'_>, "PixmapRequest");
 impl<'input> PixmapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -816,12 +806,7 @@ pub struct NotifyMSCRequest {
     pub divisor: u64,
     pub remainder: u64,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for NotifyMSCRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("NotifyMSCRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(NotifyMSCRequest, "NotifyMSCRequest");
 impl NotifyMSCRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -926,12 +911,7 @@ pub struct SelectInputRequest {
     pub window: xproto::Window,
     pub event_mask: EventMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectInputRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectInputRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectInputRequest, "SelectInputRequest");
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1002,12 +982,7 @@ pub const QUERY_CAPABILITIES_REQUEST: u8 = 4;
 pub struct QueryCapabilitiesRequest {
     pub target: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryCapabilitiesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryCapabilitiesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryCapabilitiesRequest, "QueryCapabilitiesRequest");
 impl QueryCapabilitiesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/present.rs
+++ b/x11rb-protocol/src/protocol/present.rs
@@ -422,12 +422,7 @@ pub struct Notify {
     pub window: xproto::Window,
     pub serial: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Notify {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Notify").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Notify, "Notify");
 impl TryParse for Notify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (window, remaining) = xproto::Window::try_parse(remaining)?;
@@ -538,12 +533,7 @@ pub struct QueryVersionReply {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1074,12 +1064,7 @@ pub struct QueryCapabilitiesReply {
     pub length: u32,
     pub capabilities: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryCapabilitiesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryCapabilitiesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryCapabilitiesReply, "QueryCapabilitiesReply");
 impl TryParse for QueryCapabilitiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1144,12 +1129,7 @@ pub struct GenericEvent {
     pub evtype: u16,
     pub event: Event,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GenericEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GenericEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GenericEvent, "GenericEvent");
 impl TryParse for GenericEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1280,12 +1260,7 @@ pub struct ConfigureNotifyEvent {
     pub pixmap_height: u16,
     pub pixmap_flags: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ConfigureNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ConfigureNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ConfigureNotifyEvent, "ConfigureNotifyEvent");
 impl TryParse for ConfigureNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1416,12 +1391,7 @@ pub struct CompleteNotifyEvent {
     pub ust: u64,
     pub msc: u64,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CompleteNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CompleteNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CompleteNotifyEvent, "CompleteNotifyEvent");
 impl TryParse for CompleteNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1538,12 +1508,7 @@ pub struct IdleNotifyEvent {
     pub pixmap: xproto::Pixmap,
     pub idle_fence: sync::Fence,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IdleNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IdleNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IdleNotifyEvent, "IdleNotifyEvent");
 impl TryParse for IdleNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1661,12 +1626,7 @@ pub struct RedirectNotifyEvent {
     pub remainder: u64,
     pub notifies: Vec<Notify>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RedirectNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RedirectNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RedirectNotifyEvent, "RedirectNotifyEvent");
 impl TryParse for RedirectNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -222,12 +222,7 @@ pub struct QueryVersionRequest {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -445,12 +440,7 @@ pub struct SetScreenConfigRequest {
     pub rotation: Rotation,
     pub rate: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetScreenConfigRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetScreenConfigRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetScreenConfigRequest, "SetScreenConfigRequest");
 impl SetScreenConfigRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -705,12 +695,7 @@ pub struct SelectInputRequest {
     pub window: xproto::Window,
     pub enable: NotifyMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectInputRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectInputRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectInputRequest, "SelectInputRequest");
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -775,12 +760,7 @@ pub const GET_SCREEN_INFO_REQUEST: u8 = 5;
 pub struct GetScreenInfoRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenInfoRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenInfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenInfoRequest, "GetScreenInfoRequest");
 impl GetScreenInfoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -930,12 +910,7 @@ pub const GET_SCREEN_SIZE_RANGE_REQUEST: u8 = 6;
 pub struct GetScreenSizeRangeRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenSizeRangeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenSizeRangeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenSizeRangeRequest, "GetScreenSizeRangeRequest");
 impl GetScreenSizeRangeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1090,12 +1065,7 @@ pub struct SetScreenSizeRequest {
     pub mm_width: u32,
     pub mm_height: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetScreenSizeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetScreenSizeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetScreenSizeRequest, "SetScreenSizeRequest");
 impl SetScreenSizeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1355,12 +1325,7 @@ pub const GET_SCREEN_RESOURCES_REQUEST: u8 = 8;
 pub struct GetScreenResourcesRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenResourcesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenResourcesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenResourcesRequest, "GetScreenResourcesRequest");
 impl GetScreenResourcesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1608,12 +1573,7 @@ pub struct GetOutputInfoRequest {
     pub output: Output,
     pub config_timestamp: xproto::Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetOutputInfoRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetOutputInfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetOutputInfoRequest, "GetOutputInfoRequest");
 impl GetOutputInfoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1823,12 +1783,7 @@ pub const LIST_OUTPUT_PROPERTIES_REQUEST: u8 = 10;
 pub struct ListOutputPropertiesRequest {
     pub output: Output,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListOutputPropertiesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListOutputPropertiesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListOutputPropertiesRequest, "ListOutputPropertiesRequest");
 impl ListOutputPropertiesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1951,12 +1906,7 @@ pub struct QueryOutputPropertyRequest {
     pub output: Output,
     pub property: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryOutputPropertyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryOutputPropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryOutputPropertyRequest, "QueryOutputPropertyRequest");
 impl QueryOutputPropertyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2095,12 +2045,7 @@ pub struct ConfigureOutputPropertyRequest<'input> {
     pub range: bool,
     pub values: Cow<'input, [i32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ConfigureOutputPropertyRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ConfigureOutputPropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ConfigureOutputPropertyRequest<'_>, "ConfigureOutputPropertyRequest");
 impl<'input> ConfigureOutputPropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2203,12 +2148,7 @@ pub struct ChangeOutputPropertyRequest<'input> {
     pub num_units: u32,
     pub data: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeOutputPropertyRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeOutputPropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeOutputPropertyRequest<'_>, "ChangeOutputPropertyRequest");
 impl<'input> ChangeOutputPropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2316,12 +2256,7 @@ pub struct DeleteOutputPropertyRequest {
     pub output: Output,
     pub property: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeleteOutputPropertyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeleteOutputPropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeleteOutputPropertyRequest, "DeleteOutputPropertyRequest");
 impl DeleteOutputPropertyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2390,12 +2325,7 @@ pub struct GetOutputPropertyRequest {
     pub delete: bool,
     pub pending: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetOutputPropertyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetOutputPropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetOutputPropertyRequest, "GetOutputPropertyRequest");
 impl GetOutputPropertyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2552,12 +2482,7 @@ pub struct CreateModeRequest<'input> {
     pub mode_info: ModeInfo,
     pub name: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateModeRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateModeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateModeRequest<'_>, "CreateModeRequest");
 impl<'input> CreateModeRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2744,12 +2669,7 @@ pub const DESTROY_MODE_REQUEST: u8 = 17;
 pub struct DestroyModeRequest {
     pub mode: Mode,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyModeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyModeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyModeRequest, "DestroyModeRequest");
 impl DestroyModeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2806,12 +2726,7 @@ pub struct AddOutputModeRequest {
     pub output: Output,
     pub mode: Mode,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AddOutputModeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AddOutputModeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AddOutputModeRequest, "AddOutputModeRequest");
 impl AddOutputModeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2875,12 +2790,7 @@ pub struct DeleteOutputModeRequest {
     pub output: Output,
     pub mode: Mode,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeleteOutputModeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeleteOutputModeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeleteOutputModeRequest, "DeleteOutputModeRequest");
 impl DeleteOutputModeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2944,12 +2854,7 @@ pub struct GetCrtcInfoRequest {
     pub crtc: Crtc,
     pub config_timestamp: xproto::Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCrtcInfoRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCrtcInfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCrtcInfoRequest, "GetCrtcInfoRequest");
 impl GetCrtcInfoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3130,12 +3035,7 @@ pub struct SetCrtcConfigRequest<'input> {
     pub rotation: Rotation,
     pub outputs: Cow<'input, [Output]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetCrtcConfigRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetCrtcConfigRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetCrtcConfigRequest<'_>, "SetCrtcConfigRequest");
 impl<'input> SetCrtcConfigRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3343,12 +3243,7 @@ pub const GET_CRTC_GAMMA_SIZE_REQUEST: u8 = 22;
 pub struct GetCrtcGammaSizeRequest {
     pub crtc: Crtc,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCrtcGammaSizeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCrtcGammaSizeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCrtcGammaSizeRequest, "GetCrtcGammaSizeRequest");
 impl GetCrtcGammaSizeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3487,12 +3382,7 @@ pub const GET_CRTC_GAMMA_REQUEST: u8 = 23;
 pub struct GetCrtcGammaRequest {
     pub crtc: Crtc,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCrtcGammaRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCrtcGammaRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCrtcGammaRequest, "GetCrtcGammaRequest");
 impl GetCrtcGammaRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3625,12 +3515,7 @@ pub struct SetCrtcGammaRequest<'input> {
     pub green: Cow<'input, [u16]>,
     pub blue: Cow<'input, [u16]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetCrtcGammaRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetCrtcGammaRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetCrtcGammaRequest<'_>, "SetCrtcGammaRequest");
 impl<'input> SetCrtcGammaRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 5]> {
@@ -3719,12 +3604,7 @@ pub const GET_SCREEN_RESOURCES_CURRENT_REQUEST: u8 = 25;
 pub struct GetScreenResourcesCurrentRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenResourcesCurrentRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenResourcesCurrentRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenResourcesCurrentRequest, "GetScreenResourcesCurrentRequest");
 impl GetScreenResourcesCurrentRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3977,12 +3857,7 @@ pub struct SetCrtcTransformRequest<'input> {
     pub filter_name: Cow<'input, [u8]>,
     pub filter_params: Cow<'input, [render::Fixed]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetCrtcTransformRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetCrtcTransformRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetCrtcTransformRequest<'_>, "SetCrtcTransformRequest");
 impl<'input> SetCrtcTransformRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 5]> {
@@ -4116,12 +3991,7 @@ pub const GET_CRTC_TRANSFORM_REQUEST: u8 = 27;
 pub struct GetCrtcTransformRequest {
     pub crtc: Crtc,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCrtcTransformRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCrtcTransformRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCrtcTransformRequest, "GetCrtcTransformRequest");
 impl GetCrtcTransformRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4324,12 +4194,7 @@ pub const GET_PANNING_REQUEST: u8 = 28;
 pub struct GetPanningRequest {
     pub crtc: Crtc,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPanningRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPanningRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPanningRequest, "GetPanningRequest");
 impl GetPanningRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4534,12 +4399,7 @@ pub struct SetPanningRequest {
     pub border_right: i16,
     pub border_bottom: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetPanningRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetPanningRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetPanningRequest, "SetPanningRequest");
 impl SetPanningRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4727,12 +4587,7 @@ pub struct SetOutputPrimaryRequest {
     pub window: xproto::Window,
     pub output: Output,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetOutputPrimaryRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetOutputPrimaryRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetOutputPrimaryRequest, "SetOutputPrimaryRequest");
 impl SetOutputPrimaryRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4795,12 +4650,7 @@ pub const GET_OUTPUT_PRIMARY_REQUEST: u8 = 31;
 pub struct GetOutputPrimaryRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetOutputPrimaryRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetOutputPrimaryRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetOutputPrimaryRequest, "GetOutputPrimaryRequest");
 impl GetOutputPrimaryRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4917,12 +4767,7 @@ pub const GET_PROVIDERS_REQUEST: u8 = 32;
 pub struct GetProvidersRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetProvidersRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetProvidersRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetProvidersRequest, "GetProvidersRequest");
 impl GetProvidersRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5100,12 +4945,7 @@ pub struct GetProviderInfoRequest {
     pub provider: Provider,
     pub config_timestamp: xproto::Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetProviderInfoRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetProviderInfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetProviderInfoRequest, "GetProviderInfoRequest");
 impl GetProviderInfoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5306,12 +5146,7 @@ pub struct SetProviderOffloadSinkRequest {
     pub sink_provider: Provider,
     pub config_timestamp: xproto::Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetProviderOffloadSinkRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetProviderOffloadSinkRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetProviderOffloadSinkRequest, "SetProviderOffloadSinkRequest");
 impl SetProviderOffloadSinkRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5383,12 +5218,7 @@ pub struct SetProviderOutputSourceRequest {
     pub source_provider: Provider,
     pub config_timestamp: xproto::Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetProviderOutputSourceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetProviderOutputSourceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetProviderOutputSourceRequest, "SetProviderOutputSourceRequest");
 impl SetProviderOutputSourceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5458,12 +5288,7 @@ pub const LIST_PROVIDER_PROPERTIES_REQUEST: u8 = 36;
 pub struct ListProviderPropertiesRequest {
     pub provider: Provider,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListProviderPropertiesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListProviderPropertiesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListProviderPropertiesRequest, "ListProviderPropertiesRequest");
 impl ListProviderPropertiesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5586,12 +5411,7 @@ pub struct QueryProviderPropertyRequest {
     pub provider: Provider,
     pub property: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryProviderPropertyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryProviderPropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryProviderPropertyRequest, "QueryProviderPropertyRequest");
 impl QueryProviderPropertyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5730,12 +5550,7 @@ pub struct ConfigureProviderPropertyRequest<'input> {
     pub range: bool,
     pub values: Cow<'input, [i32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ConfigureProviderPropertyRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ConfigureProviderPropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ConfigureProviderPropertyRequest<'_>, "ConfigureProviderPropertyRequest");
 impl<'input> ConfigureProviderPropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -5838,12 +5653,7 @@ pub struct ChangeProviderPropertyRequest<'input> {
     pub num_items: u32,
     pub data: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeProviderPropertyRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeProviderPropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeProviderPropertyRequest<'_>, "ChangeProviderPropertyRequest");
 impl<'input> ChangeProviderPropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -5950,12 +5760,7 @@ pub struct DeleteProviderPropertyRequest {
     pub provider: Provider,
     pub property: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeleteProviderPropertyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeleteProviderPropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeleteProviderPropertyRequest, "DeleteProviderPropertyRequest");
 impl DeleteProviderPropertyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6024,12 +5829,7 @@ pub struct GetProviderPropertyRequest {
     pub delete: bool,
     pub pending: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetProviderPropertyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetProviderPropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetProviderPropertyRequest, "GetProviderPropertyRequest");
 impl GetProviderPropertyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6950,12 +6750,7 @@ pub struct GetMonitorsRequest {
     pub window: xproto::Window,
     pub get_active: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMonitorsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMonitorsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMonitorsRequest, "GetMonitorsRequest");
 impl GetMonitorsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7091,12 +6886,7 @@ pub struct SetMonitorRequest {
     pub window: xproto::Window,
     pub monitorinfo: MonitorInfo,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetMonitorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetMonitorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetMonitorRequest, "SetMonitorRequest");
 impl SetMonitorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 3]> {
@@ -7159,12 +6949,7 @@ pub struct DeleteMonitorRequest {
     pub window: xproto::Window,
     pub name: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeleteMonitorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeleteMonitorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeleteMonitorRequest, "DeleteMonitorRequest");
 impl DeleteMonitorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7230,12 +7015,7 @@ pub struct CreateLeaseRequest<'input> {
     pub crtcs: Cow<'input, [Crtc]>,
     pub outputs: Cow<'input, [Output]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateLeaseRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateLeaseRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateLeaseRequest<'_>, "CreateLeaseRequest");
 impl<'input> CreateLeaseRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 4]> {
@@ -7410,12 +7190,7 @@ pub struct FreeLeaseRequest {
     pub lid: Lease,
     pub terminate: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FreeLeaseRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FreeLeaseRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FreeLeaseRequest, "FreeLeaseRequest");
 impl FreeLeaseRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/randr.rs
+++ b/x11rb-protocol/src/protocol/randr.rs
@@ -131,12 +131,7 @@ pub struct ScreenSize {
     pub mwidth: u16,
     pub mheight: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ScreenSize {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ScreenSize").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ScreenSize, "ScreenSize");
 impl TryParse for ScreenSize {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -180,12 +175,7 @@ impl Serialize for ScreenSize {
 pub struct RefreshRates {
     pub rates: Vec<u16>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RefreshRates {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RefreshRates").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RefreshRates, "RefreshRates");
 impl TryParse for RefreshRates {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (n_rates, remaining) = u16::try_parse(remaining)?;
@@ -302,12 +292,7 @@ pub struct QueryVersionReply {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -559,12 +544,7 @@ pub struct SetScreenConfigReply {
     pub root: xproto::Window,
     pub subpixel_order: render::SubPixel,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetScreenConfigReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetScreenConfigReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetScreenConfigReply, "SetScreenConfigReply");
 impl TryParse for SetScreenConfigReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -866,12 +846,7 @@ pub struct GetScreenInfoReply {
     pub sizes: Vec<ScreenSize>,
     pub rates: Vec<RefreshRates>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenInfoReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenInfoReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenInfoReply, "GetScreenInfoReply");
 impl TryParse for GetScreenInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1020,12 +995,7 @@ pub struct GetScreenSizeRangeReply {
     pub max_width: u16,
     pub max_height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenSizeRangeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenSizeRangeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenSizeRangeReply, "GetScreenSizeRangeReply");
 impl TryParse for GetScreenSizeRangeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1287,12 +1257,7 @@ pub struct ModeInfo {
     pub name_len: u16,
     pub mode_flags: ModeFlag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ModeInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ModeInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ModeInfo, "ModeInfo");
 impl TryParse for ModeInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (id, remaining) = u32::try_parse(remaining)?;
@@ -1457,12 +1422,7 @@ pub struct GetScreenResourcesReply {
     pub modes: Vec<ModeInfo>,
     pub names: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenResourcesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenResourcesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenResourcesReply, "GetScreenResourcesReply");
 impl TryParse for GetScreenResourcesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1728,12 +1688,7 @@ pub struct GetOutputInfoReply {
     pub clones: Vec<Output>,
     pub name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetOutputInfoReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetOutputInfoReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetOutputInfoReply, "GetOutputInfoReply");
 impl TryParse for GetOutputInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1930,12 +1885,7 @@ pub struct ListOutputPropertiesReply {
     pub length: u32,
     pub atoms: Vec<xproto::Atom>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListOutputPropertiesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListOutputPropertiesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListOutputPropertiesReply, "ListOutputPropertiesReply");
 impl TryParse for ListOutputPropertiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2072,12 +2022,7 @@ pub struct QueryOutputPropertyReply {
     pub immutable: bool,
     pub valid_values: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryOutputPropertyReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryOutputPropertyReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryOutputPropertyReply, "QueryOutputPropertyReply");
 impl TryParse for QueryOutputPropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2550,12 +2495,7 @@ pub struct GetOutputPropertyReply {
     pub num_items: u32,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetOutputPropertyReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetOutputPropertyReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetOutputPropertyReply, "GetOutputPropertyReply");
 impl TryParse for GetOutputPropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2722,12 +2662,7 @@ pub struct CreateModeReply {
     pub length: u32,
     pub mode: Mode,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateModeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateModeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateModeReply, "CreateModeReply");
 impl TryParse for CreateModeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3088,12 +3023,7 @@ pub struct GetCrtcInfoReply {
     pub outputs: Vec<Output>,
     pub possible: Vec<Output>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCrtcInfoReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCrtcInfoReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCrtcInfoReply, "GetCrtcInfoReply");
 impl TryParse for GetCrtcInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3329,12 +3259,7 @@ pub struct SetCrtcConfigReply {
     pub length: u32,
     pub timestamp: xproto::Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetCrtcConfigReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetCrtcConfigReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetCrtcConfigReply, "SetCrtcConfigReply");
 impl TryParse for SetCrtcConfigReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3480,12 +3405,7 @@ pub struct GetCrtcGammaSizeReply {
     pub length: u32,
     pub size: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCrtcGammaSizeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCrtcGammaSizeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCrtcGammaSizeReply, "GetCrtcGammaSizeReply");
 impl TryParse for GetCrtcGammaSizeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3631,12 +3551,7 @@ pub struct GetCrtcGammaReply {
     pub green: Vec<u16>,
     pub blue: Vec<u16>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCrtcGammaReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCrtcGammaReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCrtcGammaReply, "GetCrtcGammaReply");
 impl TryParse for GetCrtcGammaReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3871,12 +3786,7 @@ pub struct GetScreenResourcesCurrentReply {
     pub modes: Vec<ModeInfo>,
     pub names: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenResourcesCurrentReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenResourcesCurrentReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenResourcesCurrentReply, "GetScreenResourcesCurrentReply");
 impl TryParse for GetScreenResourcesCurrentReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4274,12 +4184,7 @@ pub struct GetCrtcTransformReply {
     pub current_filter_name: Vec<u8>,
     pub current_params: Vec<render::Fixed>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCrtcTransformReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCrtcTransformReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCrtcTransformReply, "GetCrtcTransformReply");
 impl TryParse for GetCrtcTransformReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4494,12 +4399,7 @@ pub struct GetPanningReply {
     pub border_right: i16,
     pub border_bottom: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPanningReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPanningReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPanningReply, "GetPanningReply");
 impl TryParse for GetPanningReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4764,12 +4664,7 @@ pub struct SetPanningReply {
     pub length: u32,
     pub timestamp: xproto::Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetPanningReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetPanningReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetPanningReply, "SetPanningReply");
 impl TryParse for SetPanningReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4962,12 +4857,7 @@ pub struct GetOutputPrimaryReply {
     pub length: u32,
     pub output: Output,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetOutputPrimaryReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetOutputPrimaryReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetOutputPrimaryReply, "GetOutputPrimaryReply");
 impl TryParse for GetOutputPrimaryReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5090,12 +4980,7 @@ pub struct GetProvidersReply {
     pub timestamp: xproto::Timestamp,
     pub providers: Vec<Provider>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetProvidersReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetProvidersReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetProvidersReply, "GetProvidersReply");
 impl TryParse for GetProvidersReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5291,12 +5176,7 @@ pub struct GetProviderInfoReply {
     pub associated_capability: Vec<u32>,
     pub name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetProviderInfoReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetProviderInfoReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetProviderInfoReply, "GetProviderInfoReply");
 impl TryParse for GetProviderInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5640,12 +5520,7 @@ pub struct ListProviderPropertiesReply {
     pub length: u32,
     pub atoms: Vec<xproto::Atom>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListProviderPropertiesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListProviderPropertiesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListProviderPropertiesReply, "ListProviderPropertiesReply");
 impl TryParse for ListProviderPropertiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5782,12 +5657,7 @@ pub struct QueryProviderPropertyReply {
     pub immutable: bool,
     pub valid_values: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryProviderPropertyReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryProviderPropertyReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryProviderPropertyReply, "QueryProviderPropertyReply");
 impl TryParse for QueryProviderPropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6259,12 +6129,7 @@ pub struct GetProviderPropertyReply {
     pub num_items: u32,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetProviderPropertyReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetProviderPropertyReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetProviderPropertyReply, "GetProviderPropertyReply");
 impl TryParse for GetProviderPropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6331,12 +6196,7 @@ pub struct ScreenChangeNotifyEvent {
     pub mwidth: u16,
     pub mheight: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ScreenChangeNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ScreenChangeNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ScreenChangeNotifyEvent, "ScreenChangeNotifyEvent");
 impl TryParse for ScreenChangeNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6570,12 +6430,7 @@ pub struct CrtcChange {
     pub width: u16,
     pub height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CrtcChange {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CrtcChange").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CrtcChange, "CrtcChange");
 impl TryParse for CrtcChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
@@ -6665,12 +6520,7 @@ pub struct OutputChange {
     pub connection: Connection,
     pub subpixel_order: render::SubPixel,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for OutputChange {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OutputChange").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OutputChange, "OutputChange");
 impl TryParse for OutputChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
@@ -6756,12 +6606,7 @@ pub struct OutputProperty {
     pub timestamp: xproto::Timestamp,
     pub status: xproto::Property,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for OutputProperty {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OutputProperty").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OutputProperty, "OutputProperty");
 impl TryParse for OutputProperty {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (window, remaining) = xproto::Window::try_parse(remaining)?;
@@ -6833,12 +6678,7 @@ pub struct ProviderChange {
     pub window: xproto::Window,
     pub provider: Provider,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ProviderChange {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ProviderChange").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ProviderChange, "ProviderChange");
 impl TryParse for ProviderChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
@@ -6905,12 +6745,7 @@ pub struct ProviderProperty {
     pub timestamp: xproto::Timestamp,
     pub state: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ProviderProperty {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ProviderProperty").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ProviderProperty, "ProviderProperty");
 impl TryParse for ProviderProperty {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (window, remaining) = xproto::Window::try_parse(remaining)?;
@@ -6980,12 +6815,7 @@ pub struct ResourceChange {
     pub timestamp: xproto::Timestamp,
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ResourceChange {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ResourceChange").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ResourceChange, "ResourceChange");
 impl TryParse for ResourceChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
@@ -7054,12 +6884,7 @@ pub struct MonitorInfo {
     pub height_in_millimeters: u32,
     pub outputs: Vec<Output>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MonitorInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MonitorInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MonitorInfo, "MonitorInfo");
 impl TryParse for MonitorInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (name, remaining) = xproto::Atom::try_parse(remaining)?;
@@ -7196,12 +7021,7 @@ pub struct GetMonitorsReply {
     pub n_outputs: u32,
     pub monitors: Vec<MonitorInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMonitorsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMonitorsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMonitorsReply, "GetMonitorsReply");
 impl TryParse for GetMonitorsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -7507,12 +7327,7 @@ pub struct CreateLeaseReply {
     pub length: u32,
     pub master_fd: RawFdContainer,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateLeaseReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateLeaseReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateLeaseReply, "CreateLeaseReply");
 impl TryParseFd for CreateLeaseReply {
     fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
         let remaining = initial_value;
@@ -7664,12 +7479,7 @@ pub struct LeaseNotify {
     pub lease: Lease,
     pub created: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for LeaseNotify {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("LeaseNotify").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(LeaseNotify, "LeaseNotify");
 impl TryParse for LeaseNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (timestamp, remaining) = xproto::Timestamp::try_parse(remaining)?;
@@ -7863,12 +7673,7 @@ pub struct NotifyEvent {
     pub sequence: u16,
     pub u: NotifyData,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for NotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("NotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(NotifyEvent, "NotifyEvent");
 impl TryParse for NotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/record.rs
+++ b/x11rb-protocol/src/protocol/record.rs
@@ -43,12 +43,7 @@ pub struct Range8 {
     pub first: u8,
     pub last: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Range8 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Range8").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Range8, "Range8");
 impl TryParse for Range8 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (first, remaining) = u8::try_parse(remaining)?;
@@ -81,12 +76,7 @@ pub struct Range16 {
     pub first: u16,
     pub last: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Range16 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Range16").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Range16, "Range16");
 impl TryParse for Range16 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (first, remaining) = u16::try_parse(remaining)?;
@@ -121,12 +111,7 @@ pub struct ExtRange {
     pub major: Range8,
     pub minor: Range16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ExtRange {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ExtRange").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ExtRange, "ExtRange");
 impl TryParse for ExtRange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (major, remaining) = Range8::try_parse(remaining)?;
@@ -170,12 +155,7 @@ pub struct Range {
     pub client_started: bool,
     pub client_died: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Range {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Range").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Range, "Range");
 impl TryParse for Range {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (core_requests, remaining) = Range8::try_parse(remaining)?;
@@ -378,12 +358,7 @@ pub struct ClientInfo {
     pub client_resource: ClientSpec,
     pub ranges: Vec<Range>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ClientInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ClientInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ClientInfo, "ClientInfo");
 impl TryParse for ClientInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (client_resource, remaining) = ClientSpec::try_parse(remaining)?;
@@ -502,12 +477,7 @@ pub struct QueryVersionReply {
     pub major_version: u16,
     pub minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -926,12 +896,7 @@ pub struct GetContextReply {
     pub element_header: ElementHeader,
     pub intercepted_clients: Vec<ClientInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetContextReply, "GetContextReply");
 impl TryParse for GetContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1067,12 +1032,7 @@ pub struct EnableContextReply {
     pub rec_sequence_num: u32,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EnableContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EnableContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EnableContextReply, "EnableContextReply");
 impl TryParse for EnableContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/record.rs
+++ b/x11rb-protocol/src/protocol/record.rs
@@ -411,12 +411,7 @@ pub struct QueryVersionRequest {
     pub major_version: u16,
     pub minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -543,12 +538,7 @@ pub struct CreateContextRequest<'input> {
     pub client_specs: Cow<'input, [ClientSpec]>,
     pub ranges: Cow<'input, [Range]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateContextRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateContextRequest<'_>, "CreateContextRequest");
 impl<'input> CreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 4]> {
@@ -648,12 +638,7 @@ pub struct RegisterClientsRequest<'input> {
     pub client_specs: Cow<'input, [ClientSpec]>,
     pub ranges: Cow<'input, [Range]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for RegisterClientsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RegisterClientsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RegisterClientsRequest<'_>, "RegisterClientsRequest");
 impl<'input> RegisterClientsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 4]> {
@@ -751,12 +736,7 @@ pub struct UnregisterClientsRequest<'input> {
     pub context: Context,
     pub client_specs: Cow<'input, [ClientSpec]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for UnregisterClientsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UnregisterClientsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UnregisterClientsRequest<'_>, "UnregisterClientsRequest");
 impl<'input> UnregisterClientsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -832,12 +812,7 @@ pub const GET_CONTEXT_REQUEST: u8 = 4;
 pub struct GetContextRequest {
     pub context: Context,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetContextRequest, "GetContextRequest");
 impl GetContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -965,12 +940,7 @@ pub const ENABLE_CONTEXT_REQUEST: u8 = 5;
 pub struct EnableContextRequest {
     pub context: Context,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EnableContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EnableContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EnableContextRequest, "EnableContextRequest");
 impl EnableContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1110,12 +1080,7 @@ pub const DISABLE_CONTEXT_REQUEST: u8 = 6;
 pub struct DisableContextRequest {
     pub context: Context,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DisableContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DisableContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DisableContextRequest, "DisableContextRequest");
 impl DisableContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1171,12 +1136,7 @@ pub const FREE_CONTEXT_REQUEST: u8 = 7;
 pub struct FreeContextRequest {
     pub context: Context,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FreeContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FreeContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FreeContextRequest, "FreeContextRequest");
 impl FreeContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -621,12 +621,7 @@ pub struct Directformat {
     pub alpha_shift: u16,
     pub alpha_mask: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Directformat {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Directformat").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Directformat, "Directformat");
 impl TryParse for Directformat {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (red_shift, remaining) = u16::try_parse(remaining)?;
@@ -694,12 +689,7 @@ pub struct Pictforminfo {
     pub direct: Directformat,
     pub colormap: xproto::Colormap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Pictforminfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Pictforminfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Pictforminfo, "Pictforminfo");
 impl TryParse for Pictforminfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (id, remaining) = Pictformat::try_parse(remaining)?;
@@ -770,12 +760,7 @@ pub struct Pictvisual {
     pub visual: xproto::Visualid,
     pub format: Pictformat,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Pictvisual {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Pictvisual").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Pictvisual, "Pictvisual");
 impl TryParse for Pictvisual {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (visual, remaining) = xproto::Visualid::try_parse(remaining)?;
@@ -814,12 +799,7 @@ pub struct Pictdepth {
     pub depth: u8,
     pub visuals: Vec<Pictvisual>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Pictdepth {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Pictdepth").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Pictdepth, "Pictdepth");
 impl TryParse for Pictdepth {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (depth, remaining) = u8::try_parse(remaining)?;
@@ -871,12 +851,7 @@ pub struct Pictscreen {
     pub fallback: Pictformat,
     pub depths: Vec<Pictdepth>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Pictscreen {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Pictscreen").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Pictscreen, "Pictscreen");
 impl TryParse for Pictscreen {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_depths, remaining) = u32::try_parse(remaining)?;
@@ -927,12 +902,7 @@ pub struct Indexvalue {
     pub blue: u16,
     pub alpha: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Indexvalue {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Indexvalue").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Indexvalue, "Indexvalue");
 impl TryParse for Indexvalue {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (pixel, remaining) = u32::try_parse(remaining)?;
@@ -986,12 +956,7 @@ pub struct Color {
     pub blue: u16,
     pub alpha: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Color {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Color").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Color, "Color");
 impl TryParse for Color {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (red, remaining) = u16::try_parse(remaining)?;
@@ -1036,12 +1001,7 @@ pub struct Pointfix {
     pub x: Fixed,
     pub y: Fixed,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Pointfix {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Pointfix").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Pointfix, "Pointfix");
 impl TryParse for Pointfix {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (x, remaining) = Fixed::try_parse(remaining)?;
@@ -1080,12 +1040,7 @@ pub struct Linefix {
     pub p1: Pointfix,
     pub p2: Pointfix,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Linefix {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Linefix").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Linefix, "Linefix");
 impl TryParse for Linefix {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (p1, remaining) = Pointfix::try_parse(remaining)?;
@@ -1133,12 +1088,7 @@ pub struct Triangle {
     pub p2: Pointfix,
     pub p3: Pointfix,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Triangle {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Triangle").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Triangle, "Triangle");
 impl TryParse for Triangle {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (p1, remaining) = Pointfix::try_parse(remaining)?;
@@ -1198,12 +1148,7 @@ pub struct Trapezoid {
     pub left: Linefix,
     pub right: Linefix,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Trapezoid {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Trapezoid").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Trapezoid, "Trapezoid");
 impl TryParse for Trapezoid {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (top, remaining) = Fixed::try_parse(remaining)?;
@@ -1284,12 +1229,7 @@ pub struct Glyphinfo {
     pub x_off: i16,
     pub y_off: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Glyphinfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Glyphinfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Glyphinfo, "Glyphinfo");
 impl TryParse for Glyphinfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (width, remaining) = u16::try_parse(remaining)?;
@@ -1416,12 +1356,7 @@ pub struct QueryVersionReply {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1563,12 +1498,7 @@ pub struct QueryPictFormatsReply {
     pub screens: Vec<Pictscreen>,
     pub subpixels: Vec<SubPixel>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryPictFormatsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryPictFormatsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryPictFormatsReply, "QueryPictFormatsReply");
 impl TryParse for QueryPictFormatsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1745,12 +1675,7 @@ pub struct QueryPictIndexValuesReply {
     pub length: u32,
     pub values: Vec<Indexvalue>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryPictIndexValuesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryPictIndexValuesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryPictIndexValuesReply, "QueryPictIndexValuesReply");
 impl TryParse for QueryPictIndexValuesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1826,12 +1751,7 @@ pub struct CreatePictureAux {
     pub dither: Option<xproto::Atom>,
     pub componentalpha: Option<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreatePictureAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreatePictureAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreatePictureAux, "CreatePictureAux");
 impl CreatePictureAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -2248,12 +2168,7 @@ pub struct ChangePictureAux {
     pub dither: Option<xproto::Atom>,
     pub componentalpha: Option<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangePictureAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangePictureAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangePictureAux, "ChangePictureAux");
 impl ChangePictureAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -4379,12 +4294,7 @@ pub struct Transform {
     pub matrix32: Fixed,
     pub matrix33: Fixed,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Transform {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Transform").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Transform, "Transform");
 impl TryParse for Transform {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (matrix11, remaining) = Fixed::try_parse(remaining)?;
@@ -4637,12 +4547,7 @@ pub struct QueryFiltersReply {
     pub aliases: Vec<u16>,
     pub filters: Vec<xproto::Str>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryFiltersReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryFiltersReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryFiltersReply, "QueryFiltersReply");
 impl TryParse for QueryFiltersReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4825,12 +4730,7 @@ pub struct Animcursorelt {
     pub cursor: xproto::Cursor,
     pub delay: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Animcursorelt {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Animcursorelt").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Animcursorelt, "Animcursorelt");
 impl TryParse for Animcursorelt {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (cursor, remaining) = xproto::Cursor::try_parse(remaining)?;
@@ -4952,12 +4852,7 @@ pub struct Spanfix {
     pub r: Fixed,
     pub y: Fixed,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Spanfix {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Spanfix").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Spanfix, "Spanfix");
 impl TryParse for Spanfix {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (l, remaining) = Fixed::try_parse(remaining)?;
@@ -5003,12 +4898,7 @@ pub struct Trap {
     pub top: Spanfix,
     pub bot: Spanfix,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Trap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Trap").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Trap, "Trap");
 impl TryParse for Trap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (top, remaining) = Spanfix::try_parse(remaining)?;

--- a/x11rb-protocol/src/protocol/render.rs
+++ b/x11rb-protocol/src/protocol/render.rs
@@ -1286,12 +1286,7 @@ pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1439,12 +1434,7 @@ pub const QUERY_PICT_FORMATS_REQUEST: u8 = 1;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryPictFormatsRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryPictFormatsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryPictFormatsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryPictFormatsRequest, "QueryPictFormatsRequest");
 impl QueryPictFormatsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1613,12 +1603,7 @@ pub const QUERY_PICT_INDEX_VALUES_REQUEST: u8 = 2;
 pub struct QueryPictIndexValuesRequest {
     pub format: Pictformat,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryPictIndexValuesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryPictIndexValuesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryPictIndexValuesRequest, "QueryPictIndexValuesRequest");
 impl QueryPictIndexValuesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2060,12 +2045,7 @@ pub struct CreatePictureRequest<'input> {
     pub format: Pictformat,
     pub value_list: Cow<'input, CreatePictureAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreatePictureRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreatePictureRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreatePictureRequest<'_>, "CreatePictureRequest");
 impl<'input> CreatePictureRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2475,12 +2455,7 @@ pub struct ChangePictureRequest<'input> {
     pub picture: Picture,
     pub value_list: Cow<'input, ChangePictureAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangePictureRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangePictureRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangePictureRequest<'_>, "ChangePictureRequest");
 impl<'input> ChangePictureRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2559,12 +2534,7 @@ pub struct SetPictureClipRectanglesRequest<'input> {
     pub clip_y_origin: i16,
     pub rectangles: Cow<'input, [xproto::Rectangle]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetPictureClipRectanglesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetPictureClipRectanglesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetPictureClipRectanglesRequest<'_>, "SetPictureClipRectanglesRequest");
 impl<'input> SetPictureClipRectanglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2652,12 +2622,7 @@ pub const FREE_PICTURE_REQUEST: u8 = 7;
 pub struct FreePictureRequest {
     pub picture: Picture,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FreePictureRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FreePictureRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FreePictureRequest, "FreePictureRequest");
 impl FreePictureRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2724,12 +2689,7 @@ pub struct CompositeRequest {
     pub width: u16,
     pub height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CompositeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CompositeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CompositeRequest, "CompositeRequest");
 impl CompositeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2854,12 +2814,7 @@ pub struct TrapezoidsRequest<'input> {
     pub src_y: i16,
     pub traps: Cow<'input, [Trapezoid]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for TrapezoidsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TrapezoidsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(TrapezoidsRequest<'_>, "TrapezoidsRequest");
 impl<'input> TrapezoidsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2979,12 +2934,7 @@ pub struct TrianglesRequest<'input> {
     pub src_y: i16,
     pub triangles: Cow<'input, [Triangle]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for TrianglesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TrianglesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(TrianglesRequest<'_>, "TrianglesRequest");
 impl<'input> TrianglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3104,12 +3054,7 @@ pub struct TriStripRequest<'input> {
     pub src_y: i16,
     pub points: Cow<'input, [Pointfix]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for TriStripRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TriStripRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(TriStripRequest<'_>, "TriStripRequest");
 impl<'input> TriStripRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3229,12 +3174,7 @@ pub struct TriFanRequest<'input> {
     pub src_y: i16,
     pub points: Cow<'input, [Pointfix]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for TriFanRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TriFanRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(TriFanRequest<'_>, "TriFanRequest");
 impl<'input> TriFanRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3349,12 +3289,7 @@ pub struct CreateGlyphSetRequest {
     pub gsid: Glyphset,
     pub format: Pictformat,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateGlyphSetRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateGlyphSetRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateGlyphSetRequest, "CreateGlyphSetRequest");
 impl CreateGlyphSetRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3418,12 +3353,7 @@ pub struct ReferenceGlyphSetRequest {
     pub gsid: Glyphset,
     pub existing: Glyphset,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ReferenceGlyphSetRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ReferenceGlyphSetRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ReferenceGlyphSetRequest, "ReferenceGlyphSetRequest");
 impl ReferenceGlyphSetRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3486,12 +3416,7 @@ pub const FREE_GLYPH_SET_REQUEST: u8 = 19;
 pub struct FreeGlyphSetRequest {
     pub glyphset: Glyphset,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FreeGlyphSetRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FreeGlyphSetRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FreeGlyphSetRequest, "FreeGlyphSetRequest");
 impl FreeGlyphSetRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3550,12 +3475,7 @@ pub struct AddGlyphsRequest<'input> {
     pub glyphs: Cow<'input, [Glyphinfo]>,
     pub data: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for AddGlyphsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AddGlyphsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AddGlyphsRequest<'_>, "AddGlyphsRequest");
 impl<'input> AddGlyphsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 5]> {
@@ -3642,12 +3562,7 @@ pub struct FreeGlyphsRequest<'input> {
     pub glyphset: Glyphset,
     pub glyphs: Cow<'input, [Glyph]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for FreeGlyphsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FreeGlyphsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FreeGlyphsRequest<'_>, "FreeGlyphsRequest");
 impl<'input> FreeGlyphsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3730,12 +3645,7 @@ pub struct CompositeGlyphs8Request<'input> {
     pub src_y: i16,
     pub glyphcmds: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CompositeGlyphs8Request<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CompositeGlyphs8Request").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CompositeGlyphs8Request<'_>, "CompositeGlyphs8Request");
 impl<'input> CompositeGlyphs8Request<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3856,12 +3766,7 @@ pub struct CompositeGlyphs16Request<'input> {
     pub src_y: i16,
     pub glyphcmds: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CompositeGlyphs16Request<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CompositeGlyphs16Request").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CompositeGlyphs16Request<'_>, "CompositeGlyphs16Request");
 impl<'input> CompositeGlyphs16Request<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3982,12 +3887,7 @@ pub struct CompositeGlyphs32Request<'input> {
     pub src_y: i16,
     pub glyphcmds: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CompositeGlyphs32Request<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CompositeGlyphs32Request").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CompositeGlyphs32Request<'_>, "CompositeGlyphs32Request");
 impl<'input> CompositeGlyphs32Request<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -4104,12 +4004,7 @@ pub struct FillRectanglesRequest<'input> {
     pub color: Color,
     pub rects: Cow<'input, [xproto::Rectangle]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for FillRectanglesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FillRectanglesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FillRectanglesRequest<'_>, "FillRectanglesRequest");
 impl<'input> FillRectanglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -4210,12 +4105,7 @@ pub struct CreateCursorRequest {
     pub x: u16,
     pub y: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateCursorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateCursorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateCursorRequest, "CreateCursorRequest");
 impl CreateCursorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4384,12 +4274,7 @@ pub struct SetPictureTransformRequest {
     pub picture: Picture,
     pub transform: Transform,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetPictureTransformRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetPictureTransformRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetPictureTransformRequest, "SetPictureTransformRequest");
 impl SetPictureTransformRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4484,12 +4369,7 @@ pub const QUERY_FILTERS_REQUEST: u8 = 29;
 pub struct QueryFiltersRequest {
     pub drawable: xproto::Drawable,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryFiltersRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryFiltersRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryFiltersRequest, "QueryFiltersRequest");
 impl QueryFiltersRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4632,12 +4512,7 @@ pub struct SetPictureFilterRequest<'input> {
     pub filter: Cow<'input, [u8]>,
     pub values: Cow<'input, [Fixed]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetPictureFilterRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetPictureFilterRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetPictureFilterRequest<'_>, "SetPictureFilterRequest");
 impl<'input> SetPictureFilterRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 5]> {
@@ -4771,12 +4646,7 @@ pub struct CreateAnimCursorRequest<'input> {
     pub cid: xproto::Cursor,
     pub cursors: Cow<'input, [Animcursorelt]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateAnimCursorRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateAnimCursorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateAnimCursorRequest<'_>, "CreateAnimCursorRequest");
 impl<'input> CreateAnimCursorRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -4957,12 +4827,7 @@ pub struct AddTrapsRequest<'input> {
     pub y_off: i16,
     pub traps: Cow<'input, [Trap]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for AddTrapsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AddTrapsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AddTrapsRequest<'_>, "AddTrapsRequest");
 impl<'input> AddTrapsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -5051,12 +4916,7 @@ pub struct CreateSolidFillRequest {
     pub picture: Picture,
     pub color: Color,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateSolidFillRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateSolidFillRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateSolidFillRequest, "CreateSolidFillRequest");
 impl CreateSolidFillRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5127,12 +4987,7 @@ pub struct CreateLinearGradientRequest<'input> {
     pub stops: Cow<'input, [Fixed]>,
     pub colors: Cow<'input, [Color]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateLinearGradientRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateLinearGradientRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateLinearGradientRequest<'_>, "CreateLinearGradientRequest");
 impl<'input> CreateLinearGradientRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 4]> {
@@ -5244,12 +5099,7 @@ pub struct CreateRadialGradientRequest<'input> {
     pub stops: Cow<'input, [Fixed]>,
     pub colors: Cow<'input, [Color]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateRadialGradientRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateRadialGradientRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateRadialGradientRequest<'_>, "CreateRadialGradientRequest");
 impl<'input> CreateRadialGradientRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 4]> {
@@ -5375,12 +5225,7 @@ pub struct CreateConicalGradientRequest<'input> {
     pub stops: Cow<'input, [Fixed]>,
     pub colors: Cow<'input, [Color]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateConicalGradientRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateConicalGradientRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateConicalGradientRequest<'_>, "CreateConicalGradientRequest");
 impl<'input> CreateConicalGradientRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 4]> {

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -43,12 +43,7 @@ pub struct Client {
     pub resource_base: u32,
     pub resource_mask: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Client {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Client").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Client, "Client");
 impl TryParse for Client {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (resource_base, remaining) = u32::try_parse(remaining)?;
@@ -87,12 +82,7 @@ pub struct Type {
     pub resource_type: xproto::Atom,
     pub count: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Type {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Type").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Type, "Type");
 impl TryParse for Type {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (resource_type, remaining) = xproto::Atom::try_parse(remaining)?;
@@ -179,12 +169,7 @@ pub struct ClientIdSpec {
     pub client: u32,
     pub mask: ClientIdMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ClientIdSpec {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ClientIdSpec").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ClientIdSpec, "ClientIdSpec");
 impl TryParse for ClientIdSpec {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (client, remaining) = u32::try_parse(remaining)?;
@@ -224,12 +209,7 @@ pub struct ClientIdValue {
     pub spec: ClientIdSpec,
     pub value: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ClientIdValue {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ClientIdValue").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ClientIdValue, "ClientIdValue");
 impl TryParse for ClientIdValue {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (spec, remaining) = ClientIdSpec::try_parse(remaining)?;
@@ -278,12 +258,7 @@ pub struct ResourceIdSpec {
     pub resource: u32,
     pub type_: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ResourceIdSpec {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ResourceIdSpec").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ResourceIdSpec, "ResourceIdSpec");
 impl TryParse for ResourceIdSpec {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (resource, remaining) = u32::try_parse(remaining)?;
@@ -324,12 +299,7 @@ pub struct ResourceSizeSpec {
     pub ref_count: u32,
     pub use_count: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ResourceSizeSpec {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ResourceSizeSpec").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ResourceSizeSpec, "ResourceSizeSpec");
 impl TryParse for ResourceSizeSpec {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (spec, remaining) = ResourceIdSpec::try_parse(remaining)?;
@@ -386,12 +356,7 @@ pub struct ResourceSizeValue {
     pub size: ResourceSizeSpec,
     pub cross_references: Vec<ResourceSizeSpec>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ResourceSizeValue {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ResourceSizeValue").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ResourceSizeValue, "ResourceSizeValue");
 impl TryParse for ResourceSizeValue {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (size, remaining) = ResourceSizeSpec::try_parse(remaining)?;
@@ -507,12 +472,7 @@ pub struct QueryVersionReply {
     pub server_major: u16,
     pub server_minor: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -628,12 +588,7 @@ pub struct QueryClientsReply {
     pub length: u32,
     pub clients: Vec<Client>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryClientsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryClientsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryClientsReply, "QueryClientsReply");
 impl TryParse for QueryClientsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -760,12 +715,7 @@ pub struct QueryClientResourcesReply {
     pub length: u32,
     pub types: Vec<Type>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryClientResourcesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryClientResourcesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryClientResourcesReply, "QueryClientResourcesReply");
 impl TryParse for QueryClientResourcesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -893,12 +843,7 @@ pub struct QueryClientPixmapBytesReply {
     pub bytes: u32,
     pub bytes_overflow: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryClientPixmapBytesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryClientPixmapBytesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryClientPixmapBytesReply, "QueryClientPixmapBytesReply");
 impl TryParse for QueryClientPixmapBytesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1039,12 +984,7 @@ pub struct QueryClientIdsReply {
     pub length: u32,
     pub ids: Vec<ClientIdValue>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryClientIdsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryClientIdsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryClientIdsReply, "QueryClientIdsReply");
 impl TryParse for QueryClientIdsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1192,12 +1132,7 @@ pub struct QueryResourceBytesReply {
     pub length: u32,
     pub sizes: Vec<ResourceSizeValue>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryResourceBytesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryResourceBytesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryResourceBytesReply, "QueryResourceBytesReply");
 impl TryParse for QueryResourceBytesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/res.rs
+++ b/x11rb-protocol/src/protocol/res.rs
@@ -406,12 +406,7 @@ pub struct QueryVersionRequest {
     pub client_major: u8,
     pub client_minor: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -533,12 +528,7 @@ pub const QUERY_CLIENTS_REQUEST: u8 = 1;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryClientsRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryClientsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryClientsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryClientsRequest, "QueryClientsRequest");
 impl QueryClientsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -653,12 +643,7 @@ pub const QUERY_CLIENT_RESOURCES_REQUEST: u8 = 2;
 pub struct QueryClientResourcesRequest {
     pub xid: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryClientResourcesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryClientResourcesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryClientResourcesRequest, "QueryClientResourcesRequest");
 impl QueryClientResourcesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -780,12 +765,7 @@ pub const QUERY_CLIENT_PIXMAP_BYTES_REQUEST: u8 = 3;
 pub struct QueryClientPixmapBytesRequest {
     pub xid: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryClientPixmapBytesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryClientPixmapBytesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryClientPixmapBytesRequest, "QueryClientPixmapBytesRequest");
 impl QueryClientPixmapBytesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -910,12 +890,7 @@ pub const QUERY_CLIENT_IDS_REQUEST: u8 = 4;
 pub struct QueryClientIdsRequest<'input> {
     pub specs: Cow<'input, [ClientIdSpec]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for QueryClientIdsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryClientIdsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryClientIdsRequest<'_>, "QueryClientIdsRequest");
 impl<'input> QueryClientIdsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1050,12 +1025,7 @@ pub struct QueryResourceBytesRequest<'input> {
     pub client: u32,
     pub specs: Cow<'input, [ResourceIdSpec]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for QueryResourceBytesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryResourceBytesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryResourceBytesRequest<'_>, "QueryResourceBytesRequest");
 impl<'input> QueryResourceBytesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -284,12 +284,7 @@ pub struct QueryVersionReply {
     pub server_major_version: u16,
     pub server_minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -441,12 +436,7 @@ pub struct QueryInfoReply {
     pub event_mask: u32,
     pub kind: Kind,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryInfoReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryInfoReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryInfoReply, "QueryInfoReply");
 impl TryParse for QueryInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -625,12 +615,7 @@ pub struct SetAttributesAux {
     pub colormap: Option<xproto::Colormap>,
     pub cursor: Option<xproto::Cursor>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetAttributesAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetAttributesAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetAttributesAux, "SetAttributesAux");
 impl SetAttributesAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -1245,12 +1230,7 @@ pub struct NotifyEvent {
     pub kind: Kind,
     pub forced: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for NotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("NotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(NotifyEvent, "NotifyEvent");
 impl TryParse for NotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/screensaver.rs
+++ b/x11rb-protocol/src/protocol/screensaver.rs
@@ -217,12 +217,7 @@ pub struct QueryVersionRequest {
     pub client_major_version: u8,
     pub client_minor_version: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -369,12 +364,7 @@ pub const QUERY_INFO_REQUEST: u8 = 1;
 pub struct QueryInfoRequest {
     pub drawable: xproto::Drawable,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryInfoRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryInfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryInfoRequest, "QueryInfoRequest");
 impl QueryInfoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -533,12 +523,7 @@ pub struct SelectInputRequest {
     pub drawable: xproto::Drawable,
     pub event_mask: Event,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectInputRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectInputRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectInputRequest, "SelectInputRequest");
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -971,12 +956,7 @@ pub struct SetAttributesRequest<'input> {
     pub visual: xproto::Visualid,
     pub value_list: Cow<'input, SetAttributesAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetAttributesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetAttributesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetAttributesRequest<'_>, "SetAttributesRequest");
 impl<'input> SetAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1101,12 +1081,7 @@ pub const UNSET_ATTRIBUTES_REQUEST: u8 = 4;
 pub struct UnsetAttributesRequest {
     pub drawable: xproto::Drawable,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UnsetAttributesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UnsetAttributesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UnsetAttributesRequest, "UnsetAttributesRequest");
 impl UnsetAttributesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1162,12 +1137,7 @@ pub const SUSPEND_REQUEST: u8 = 5;
 pub struct SuspendRequest {
     pub suspend: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SuspendRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SuspendRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SuspendRequest, "SuspendRequest");
 impl SuspendRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/shape.rs
+++ b/x11rb-protocol/src/protocol/shape.rs
@@ -183,12 +183,7 @@ pub struct NotifyEvent {
     pub server_time: xproto::Timestamp,
     pub shaped: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for NotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("NotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(NotifyEvent, "NotifyEvent");
 impl TryParse for NotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -390,12 +385,7 @@ pub struct QueryVersionReply {
     pub major_version: u16,
     pub minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -928,12 +918,7 @@ pub struct QueryExtentsReply {
     pub clip_shape_extents_width: u16,
     pub clip_shape_extents_height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryExtentsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryExtentsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryExtentsReply, "QueryExtentsReply");
 impl TryParse for QueryExtentsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1170,12 +1155,7 @@ pub struct InputSelectedReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputSelectedReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputSelectedReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputSelectedReply, "InputSelectedReply");
 impl TryParse for InputSelectedReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1302,12 +1282,7 @@ pub struct GetRectanglesReply {
     pub length: u32,
     pub rectangles: Vec<xproto::Rectangle>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetRectanglesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetRectanglesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetRectanglesReply, "GetRectanglesReply");
 impl TryParse for GetRectanglesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/shape.rs
+++ b/x11rb-protocol/src/protocol/shape.rs
@@ -329,12 +329,7 @@ pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -454,12 +449,7 @@ pub struct RectanglesRequest<'input> {
     pub y_offset: i16,
     pub rectangles: Cow<'input, [xproto::Rectangle]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for RectanglesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RectanglesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RectanglesRequest<'_>, "RectanglesRequest");
 impl<'input> RectanglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -572,12 +562,7 @@ pub struct MaskRequest {
     pub y_offset: i16,
     pub source_bitmap: xproto::Pixmap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MaskRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MaskRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MaskRequest, "MaskRequest");
 impl MaskRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -669,12 +654,7 @@ pub struct CombineRequest {
     pub y_offset: i16,
     pub source_window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CombineRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CombineRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CombineRequest, "CombineRequest");
 impl CombineRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -767,12 +747,7 @@ pub struct OffsetRequest {
     pub x_offset: i16,
     pub y_offset: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for OffsetRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OffsetRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OffsetRequest, "OffsetRequest");
 impl OffsetRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -847,12 +822,7 @@ pub const QUERY_EXTENTS_REQUEST: u8 = 5;
 pub struct QueryExtentsRequest {
     pub destination_window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryExtentsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryExtentsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryExtentsRequest, "QueryExtentsRequest");
 impl QueryExtentsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1024,12 +994,7 @@ pub struct SelectInputRequest {
     pub destination_window: xproto::Window,
     pub enable: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectInputRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectInputRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectInputRequest, "SelectInputRequest");
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1093,12 +1058,7 @@ pub const INPUT_SELECTED_REQUEST: u8 = 7;
 pub struct InputSelectedRequest {
     pub destination_window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputSelectedRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputSelectedRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputSelectedRequest, "InputSelectedRequest");
 impl InputSelectedRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1210,12 +1170,7 @@ pub struct GetRectanglesRequest {
     pub window: xproto::Window,
     pub source_kind: SK,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetRectanglesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetRectanglesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetRectanglesRequest, "GetRectanglesRequest");
 impl GetRectanglesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/shm.rs
+++ b/x11rb-protocol/src/protocol/shm.rs
@@ -65,12 +65,7 @@ pub struct CompletionEvent {
     pub shmseg: Seg,
     pub offset: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CompletionEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CompletionEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CompletionEvent, "CompletionEvent");
 impl TryParse for CompletionEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -280,12 +275,7 @@ pub struct QueryVersionReply {
     pub gid: u16,
     pub pixmap_format: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -867,12 +857,7 @@ pub struct GetImageReply {
     pub visual: xproto::Visualid,
     pub size: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetImageReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetImageReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetImageReply, "GetImageReply");
 impl TryParse for GetImageReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1240,12 +1225,7 @@ pub struct CreateSegmentReply {
     pub length: u32,
     pub shm_fd: RawFdContainer,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateSegmentReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateSegmentReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateSegmentReply, "CreateSegmentReply");
 impl TryParseFd for CreateSegmentReply {
     fn try_parse_fd<'a>(initial_value: &'a [u8], fds: &mut Vec<RawFdContainer>) -> Result<(Self, &'a [u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/shm.rs
+++ b/x11rb-protocol/src/protocol/shm.rs
@@ -197,12 +197,7 @@ pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -384,12 +379,7 @@ pub struct AttachRequest {
     pub shmid: u32,
     pub read_only: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AttachRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AttachRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AttachRequest, "AttachRequest");
 impl AttachRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -468,12 +458,7 @@ pub const DETACH_REQUEST: u8 = 2;
 pub struct DetachRequest {
     pub shmseg: Seg,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DetachRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DetachRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DetachRequest, "DetachRequest");
 impl DetachRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -574,12 +559,7 @@ pub struct PutImageRequest {
     pub shmseg: Seg,
     pub offset: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PutImageRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PutImageRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PutImageRequest, "PutImageRequest");
 impl PutImageRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -735,12 +715,7 @@ pub struct GetImageRequest {
     pub shmseg: Seg,
     pub offset: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetImageRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetImageRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetImageRequest, "GetImageRequest");
 impl GetImageRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -946,12 +921,7 @@ pub struct CreatePixmapRequest {
     pub shmseg: Seg,
     pub offset: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreatePixmapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreatePixmapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreatePixmapRequest, "CreatePixmapRequest");
 impl CreatePixmapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1057,12 +1027,7 @@ pub struct AttachFdRequest {
     pub shm_fd: RawFdContainer,
     pub read_only: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AttachFdRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AttachFdRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AttachFdRequest, "AttachFdRequest");
 impl AttachFdRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1141,12 +1106,7 @@ pub struct CreateSegmentRequest {
     pub size: u32,
     pub read_only: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateSegmentRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateSegmentRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateSegmentRequest, "CreateSegmentRequest");
 impl CreateSegmentRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -489,12 +489,7 @@ pub struct InitializeRequest {
     pub desired_major_version: u8,
     pub desired_minor_version: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InitializeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InitializeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InitializeRequest, "InitializeRequest");
 impl InitializeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -638,12 +633,7 @@ pub const LIST_SYSTEM_COUNTERS_REQUEST: u8 = 1;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSystemCountersRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListSystemCountersRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListSystemCountersRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListSystemCountersRequest, "ListSystemCountersRequest");
 impl ListSystemCountersRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -759,12 +749,7 @@ pub struct CreateCounterRequest {
     pub id: Counter,
     pub initial_value: Int64,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateCounterRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateCounterRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateCounterRequest, "CreateCounterRequest");
 impl CreateCounterRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -831,12 +816,7 @@ pub const DESTROY_COUNTER_REQUEST: u8 = 6;
 pub struct DestroyCounterRequest {
     pub counter: Counter,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyCounterRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyCounterRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyCounterRequest, "DestroyCounterRequest");
 impl DestroyCounterRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -892,12 +872,7 @@ pub const QUERY_COUNTER_REQUEST: u8 = 5;
 pub struct QueryCounterRequest {
     pub counter: Counter,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryCounterRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryCounterRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryCounterRequest, "QueryCounterRequest");
 impl QueryCounterRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1018,12 +993,7 @@ pub const AWAIT_REQUEST: u8 = 7;
 pub struct AwaitRequest<'input> {
     pub wait_list: Cow<'input, [Waitcondition]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for AwaitRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AwaitRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AwaitRequest<'_>, "AwaitRequest");
 impl<'input> AwaitRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1092,12 +1062,7 @@ pub struct ChangeCounterRequest {
     pub counter: Counter,
     pub amount: Int64,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeCounterRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeCounterRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeCounterRequest, "ChangeCounterRequest");
 impl ChangeCounterRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1165,12 +1130,7 @@ pub struct SetCounterRequest {
     pub counter: Counter,
     pub value: Int64,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetCounterRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetCounterRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetCounterRequest, "SetCounterRequest");
 impl SetCounterRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1406,12 +1366,7 @@ pub struct CreateAlarmRequest<'input> {
     pub id: Alarm,
     pub value_list: Cow<'input, CreateAlarmAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateAlarmRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateAlarmRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateAlarmRequest<'_>, "CreateAlarmRequest");
 impl<'input> CreateAlarmRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1656,12 +1611,7 @@ pub struct ChangeAlarmRequest<'input> {
     pub id: Alarm,
     pub value_list: Cow<'input, ChangeAlarmAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeAlarmRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeAlarmRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeAlarmRequest<'_>, "ChangeAlarmRequest");
 impl<'input> ChangeAlarmRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1737,12 +1687,7 @@ pub const DESTROY_ALARM_REQUEST: u8 = 11;
 pub struct DestroyAlarmRequest {
     pub alarm: Alarm,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyAlarmRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyAlarmRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyAlarmRequest, "DestroyAlarmRequest");
 impl DestroyAlarmRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1798,12 +1743,7 @@ pub const QUERY_ALARM_REQUEST: u8 = 10;
 pub struct QueryAlarmRequest {
     pub alarm: Alarm,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryAlarmRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryAlarmRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryAlarmRequest, "QueryAlarmRequest");
 impl QueryAlarmRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1964,12 +1904,7 @@ pub struct SetPriorityRequest {
     pub id: u32,
     pub priority: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetPriorityRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetPriorityRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetPriorityRequest, "SetPriorityRequest");
 impl SetPriorityRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2032,12 +1967,7 @@ pub const GET_PRIORITY_REQUEST: u8 = 13;
 pub struct GetPriorityRequest {
     pub id: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPriorityRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPriorityRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPriorityRequest, "GetPriorityRequest");
 impl GetPriorityRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2156,12 +2086,7 @@ pub struct CreateFenceRequest {
     pub fence: Fence,
     pub initially_triggered: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateFenceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateFenceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateFenceRequest, "CreateFenceRequest");
 impl CreateFenceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2231,12 +2156,7 @@ pub const TRIGGER_FENCE_REQUEST: u8 = 15;
 pub struct TriggerFenceRequest {
     pub fence: Fence,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for TriggerFenceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TriggerFenceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(TriggerFenceRequest, "TriggerFenceRequest");
 impl TriggerFenceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2292,12 +2212,7 @@ pub const RESET_FENCE_REQUEST: u8 = 16;
 pub struct ResetFenceRequest {
     pub fence: Fence,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ResetFenceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ResetFenceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ResetFenceRequest, "ResetFenceRequest");
 impl ResetFenceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2353,12 +2268,7 @@ pub const DESTROY_FENCE_REQUEST: u8 = 17;
 pub struct DestroyFenceRequest {
     pub fence: Fence,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyFenceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyFenceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyFenceRequest, "DestroyFenceRequest");
 impl DestroyFenceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2414,12 +2324,7 @@ pub const QUERY_FENCE_REQUEST: u8 = 18;
 pub struct QueryFenceRequest {
     pub fence: Fence,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryFenceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryFenceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryFenceRequest, "QueryFenceRequest");
 impl QueryFenceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2558,12 +2463,7 @@ pub const AWAIT_FENCE_REQUEST: u8 = 19;
 pub struct AwaitFenceRequest<'input> {
     pub fence_list: Cow<'input, [Fence]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for AwaitFenceRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AwaitFenceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AwaitFenceRequest<'_>, "AwaitFenceRequest");
 impl<'input> AwaitFenceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {

--- a/x11rb-protocol/src/protocol/sync.rs
+++ b/x11rb-protocol/src/protocol/sync.rs
@@ -264,12 +264,7 @@ pub struct Int64 {
     pub hi: i32,
     pub lo: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Int64 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Int64").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Int64, "Int64");
 impl TryParse for Int64 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (hi, remaining) = i32::try_parse(remaining)?;
@@ -309,12 +304,7 @@ pub struct Systemcounter {
     pub resolution: Int64,
     pub name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Systemcounter {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Systemcounter").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Systemcounter, "Systemcounter");
 impl TryParse for Systemcounter {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -373,12 +363,7 @@ pub struct Trigger {
     pub wait_value: Int64,
     pub test_type: TESTTYPE,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Trigger {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Trigger").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Trigger, "Trigger");
 impl TryParse for Trigger {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (counter, remaining) = Counter::try_parse(remaining)?;
@@ -437,12 +422,7 @@ pub struct Waitcondition {
     pub trigger: Trigger,
     pub event_threshold: Int64,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Waitcondition {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Waitcondition").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Waitcondition, "Waitcondition");
 impl TryParse for Waitcondition {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (trigger, remaining) = Trigger::try_parse(remaining)?;
@@ -575,12 +555,7 @@ pub struct InitializeReply {
     pub major_version: u8,
     pub minor_version: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InitializeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InitializeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InitializeReply, "InitializeReply");
 impl TryParse for InitializeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -718,12 +693,7 @@ pub struct ListSystemCountersReply {
     pub length: u32,
     pub counters: Vec<Systemcounter>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListSystemCountersReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListSystemCountersReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListSystemCountersReply, "ListSystemCountersReply");
 impl TryParse for ListSystemCountersReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -984,12 +954,7 @@ pub struct QueryCounterReply {
     pub length: u32,
     pub counter_value: Int64,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryCounterReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryCounterReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryCounterReply, "QueryCounterReply");
 impl TryParse for QueryCounterReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1276,12 +1241,7 @@ pub struct CreateAlarmAux {
     pub delta: Option<Int64>,
     pub events: Option<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateAlarmAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateAlarmAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateAlarmAux, "CreateAlarmAux");
 impl CreateAlarmAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -1531,12 +1491,7 @@ pub struct ChangeAlarmAux {
     pub delta: Option<Int64>,
     pub events: Option<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeAlarmAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeAlarmAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeAlarmAux, "ChangeAlarmAux");
 impl ChangeAlarmAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -1908,12 +1863,7 @@ pub struct QueryAlarmReply {
     pub events: bool,
     pub state: ALARMSTATE,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryAlarmReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryAlarmReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryAlarmReply, "QueryAlarmReply");
 impl TryParse for QueryAlarmReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2144,12 +2094,7 @@ pub struct GetPriorityReply {
     pub length: u32,
     pub priority: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPriorityReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPriorityReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPriorityReply, "GetPriorityReply");
 impl TryParse for GetPriorityReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2531,12 +2476,7 @@ pub struct QueryFenceReply {
     pub length: u32,
     pub triggered: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryFenceReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryFenceReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryFenceReply, "QueryFenceReply");
 impl TryParse for QueryFenceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2699,12 +2639,7 @@ pub struct CounterNotifyEvent {
     pub count: u16,
     pub destroyed: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CounterNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CounterNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CounterNotifyEvent, "CounterNotifyEvent");
 impl TryParse for CounterNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2854,12 +2789,7 @@ pub struct AlarmNotifyEvent {
     pub timestamp: xproto::Timestamp,
     pub state: ALARMSTATE,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AlarmNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AlarmNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AlarmNotifyEvent, "AlarmNotifyEvent");
 impl TryParse for AlarmNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xc_misc.rs
+++ b/x11rb-protocol/src/protocol/xc_misc.rs
@@ -43,12 +43,7 @@ pub struct GetVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetVersionRequest, "GetVersionRequest");
 impl GetVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -170,12 +165,7 @@ pub const GET_XID_RANGE_REQUEST: u8 = 1;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetXIDRangeRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetXIDRangeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetXIDRangeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetXIDRangeRequest, "GetXIDRangeRequest");
 impl GetXIDRangeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -293,12 +283,7 @@ pub const GET_XID_LIST_REQUEST: u8 = 2;
 pub struct GetXIDListRequest {
     pub count: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetXIDListRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetXIDListRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetXIDListRequest, "GetXIDListRequest");
 impl GetXIDListRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xc_misc.rs
+++ b/x11rb-protocol/src/protocol/xc_misc.rs
@@ -109,12 +109,7 @@ pub struct GetVersionReply {
     pub server_major_version: u16,
     pub server_minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetVersionReply, "GetVersionReply");
 impl TryParse for GetVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -231,12 +226,7 @@ pub struct GetXIDRangeReply {
     pub start_id: u32,
     pub count: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetXIDRangeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetXIDRangeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetXIDRangeReply, "GetXIDRangeReply");
 impl TryParse for GetXIDRangeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -365,12 +355,7 @@ pub struct GetXIDListReply {
     pub length: u32,
     pub ids: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetXIDListReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetXIDListReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetXIDListReply, "GetXIDListReply");
 impl TryParse for GetXIDListReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xevie.rs
+++ b/x11rb-protocol/src/protocol/xevie.rs
@@ -43,12 +43,7 @@ pub struct QueryVersionRequest {
     pub client_major_version: u16,
     pub client_minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -194,12 +189,7 @@ pub const START_REQUEST: u8 = 1;
 pub struct StartRequest {
     pub screen: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for StartRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("StartRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(StartRequest, "StartRequest");
 impl StartRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -334,12 +324,7 @@ pub const END_REQUEST: u8 = 2;
 pub struct EndRequest {
     pub cmap: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EndRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EndRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EndRequest, "EndRequest");
 impl EndRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -603,12 +588,7 @@ pub struct SendRequest {
     pub event: Event,
     pub data_type: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SendRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SendRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SendRequest, "SendRequest");
 impl SendRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -843,12 +823,7 @@ pub const SELECT_INPUT_REQUEST: u8 = 4;
 pub struct SelectInputRequest {
     pub event_mask: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectInputRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectInputRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectInputRequest, "SelectInputRequest");
 impl SelectInputRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xevie.rs
+++ b/x11rb-protocol/src/protocol/xevie.rs
@@ -109,12 +109,7 @@ pub struct QueryVersionReply {
     pub server_major_version: u16,
     pub server_minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -260,12 +255,7 @@ pub struct StartReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for StartReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("StartReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(StartReply, "StartReply");
 impl TryParse for StartReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -405,12 +395,7 @@ pub struct EndReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EndReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EndReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EndReply, "EndReply");
 impl TryParse for EndReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -557,12 +542,7 @@ impl core::fmt::Debug for Datatype  {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Event {
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Event {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Event").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Event, "Event");
 impl TryParse for Event {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = remaining.get(32..).ok_or(ParseError::InsufficientData)?;
@@ -784,12 +764,7 @@ pub struct SendReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SendReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SendReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SendReply, "SendReply");
 impl TryParse for SendReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -929,12 +904,7 @@ pub struct SelectInputReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectInputReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectInputReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectInputReply, "SelectInputReply");
 impl TryParse for SelectInputReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xf86dri.rs
+++ b/x11rb-protocol/src/protocol/xf86dri.rs
@@ -43,12 +43,7 @@ pub struct DrmClipRect {
     pub x2: i16,
     pub x3: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DrmClipRect {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DrmClipRect").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DrmClipRect, "DrmClipRect");
 impl TryParse for DrmClipRect {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (x1, remaining) = i16::try_parse(remaining)?;
@@ -149,12 +144,7 @@ pub struct QueryVersionReply {
     pub dri_minor_version: u16,
     pub dri_minor_patch: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -286,12 +276,7 @@ pub struct QueryDirectRenderingCapableReply {
     pub length: u32,
     pub is_capable: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryDirectRenderingCapableReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryDirectRenderingCapableReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryDirectRenderingCapableReply, "QueryDirectRenderingCapableReply");
 impl TryParse for QueryDirectRenderingCapableReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -412,12 +397,7 @@ pub struct OpenConnectionReply {
     pub sarea_handle_high: u32,
     pub bus_id: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for OpenConnectionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OpenConnectionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OpenConnectionReply, "OpenConnectionReply");
 impl TryParse for OpenConnectionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -613,12 +593,7 @@ pub struct GetClientDriverNameReply {
     pub client_driver_patch_version: u32,
     pub client_driver_name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetClientDriverNameReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetClientDriverNameReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetClientDriverNameReply, "GetClientDriverNameReply");
 impl TryParse for GetClientDriverNameReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -768,12 +743,7 @@ pub struct CreateContextReply {
     pub length: u32,
     pub hw_context: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateContextReply, "CreateContextReply");
 impl TryParse for CreateContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -972,12 +942,7 @@ pub struct CreateDrawableReply {
     pub length: u32,
     pub hw_drawable_handle: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateDrawableReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateDrawableReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateDrawableReply, "CreateDrawableReply");
 impl TryParse for CreateDrawableReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1185,12 +1150,7 @@ pub struct GetDrawableInfoReply {
     pub clip_rects: Vec<DrmClipRect>,
     pub back_clip_rects: Vec<DrmClipRect>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDrawableInfoReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDrawableInfoReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDrawableInfoReply, "GetDrawableInfoReply");
 impl TryParse for GetDrawableInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1354,12 +1314,7 @@ pub struct GetDeviceInfoReply {
     pub framebuffer_stride: u32,
     pub device_private: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceInfoReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceInfoReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceInfoReply, "GetDeviceInfoReply");
 impl TryParse for GetDeviceInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1502,12 +1457,7 @@ pub struct AuthConnectionReply {
     pub length: u32,
     pub authenticated: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AuthConnectionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AuthConnectionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AuthConnectionReply, "AuthConnectionReply");
 impl TryParse for AuthConnectionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xf86dri.rs
+++ b/x11rb-protocol/src/protocol/xf86dri.rs
@@ -87,12 +87,7 @@ pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -214,12 +209,7 @@ pub const QUERY_DIRECT_RENDERING_CAPABLE_REQUEST: u8 = 1;
 pub struct QueryDirectRenderingCapableRequest {
     pub screen: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryDirectRenderingCapableRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryDirectRenderingCapableRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryDirectRenderingCapableRequest, "QueryDirectRenderingCapableRequest");
 impl QueryDirectRenderingCapableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -333,12 +323,7 @@ pub const OPEN_CONNECTION_REQUEST: u8 = 2;
 pub struct OpenConnectionRequest {
     pub screen: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for OpenConnectionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OpenConnectionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OpenConnectionRequest, "OpenConnectionRequest");
 impl OpenConnectionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -467,12 +452,7 @@ pub const CLOSE_CONNECTION_REQUEST: u8 = 3;
 pub struct CloseConnectionRequest {
     pub screen: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CloseConnectionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CloseConnectionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CloseConnectionRequest, "CloseConnectionRequest");
 impl CloseConnectionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -528,12 +508,7 @@ pub const GET_CLIENT_DRIVER_NAME_REQUEST: u8 = 4;
 pub struct GetClientDriverNameRequest {
     pub screen: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetClientDriverNameRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetClientDriverNameRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetClientDriverNameRequest, "GetClientDriverNameRequest");
 impl GetClientDriverNameRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -667,12 +642,7 @@ pub struct CreateContextRequest {
     pub visual: u32,
     pub context: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateContextRequest, "CreateContextRequest");
 impl CreateContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -804,12 +774,7 @@ pub struct DestroyContextRequest {
     pub screen: u32,
     pub context: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyContextRequest, "DestroyContextRequest");
 impl DestroyContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -873,12 +838,7 @@ pub struct CreateDrawableRequest {
     pub screen: u32,
     pub drawable: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateDrawableRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateDrawableRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateDrawableRequest, "CreateDrawableRequest");
 impl CreateDrawableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1003,12 +963,7 @@ pub struct DestroyDrawableRequest {
     pub screen: u32,
     pub drawable: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyDrawableRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyDrawableRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyDrawableRequest, "DestroyDrawableRequest");
 impl DestroyDrawableRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1072,12 +1027,7 @@ pub struct GetDrawableInfoRequest {
     pub screen: u32,
     pub drawable: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDrawableInfoRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDrawableInfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDrawableInfoRequest, "GetDrawableInfoRequest");
 impl GetDrawableInfoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1247,12 +1197,7 @@ pub const GET_DEVICE_INFO_REQUEST: u8 = 10;
 pub struct GetDeviceInfoRequest {
     pub screen: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceInfoRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceInfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceInfoRequest, "GetDeviceInfoRequest");
 impl GetDeviceInfoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1388,12 +1333,7 @@ pub struct AuthConnectionRequest {
     pub screen: u32,
     pub magic: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AuthConnectionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AuthConnectionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AuthConnectionRequest, "AuthConnectionRequest");
 impl AuthConnectionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -332,12 +332,7 @@ pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -451,12 +446,7 @@ pub const GET_MODE_LINE_REQUEST: u8 = 1;
 pub struct GetModeLineRequest {
     pub screen: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetModeLineRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetModeLineRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetModeLineRequest, "GetModeLineRequest");
 impl GetModeLineRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -627,12 +617,7 @@ pub struct ModModeLineRequest<'input> {
     pub flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ModModeLineRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ModModeLineRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ModModeLineRequest<'_>, "ModModeLineRequest");
 impl<'input> ModModeLineRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -787,12 +772,7 @@ pub struct SwitchModeRequest {
     pub screen: u16,
     pub zoom: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SwitchModeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SwitchModeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SwitchModeRequest, "SwitchModeRequest");
 impl SwitchModeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -851,12 +831,7 @@ pub const GET_MONITOR_REQUEST: u8 = 4;
 pub struct GetMonitorRequest {
     pub screen: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMonitorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMonitorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMonitorRequest, "GetMonitorRequest");
 impl GetMonitorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1044,12 +1019,7 @@ pub struct LockModeSwitchRequest {
     pub screen: u16,
     pub lock: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for LockModeSwitchRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("LockModeSwitchRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(LockModeSwitchRequest, "LockModeSwitchRequest");
 impl LockModeSwitchRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1108,12 +1078,7 @@ pub const GET_ALL_MODE_LINES_REQUEST: u8 = 6;
 pub struct GetAllModeLinesRequest {
     pub screen: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetAllModeLinesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetAllModeLinesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetAllModeLinesRequest, "GetAllModeLinesRequest");
 impl GetAllModeLinesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1259,12 +1224,7 @@ pub struct AddModeLineRequest<'input> {
     pub after_flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for AddModeLineRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AddModeLineRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AddModeLineRequest<'_>, "AddModeLineRequest");
 impl<'input> AddModeLineRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1525,12 +1485,7 @@ pub struct DeleteModeLineRequest<'input> {
     pub flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for DeleteModeLineRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeleteModeLineRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeleteModeLineRequest<'_>, "DeleteModeLineRequest");
 impl<'input> DeleteModeLineRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1704,12 +1659,7 @@ pub struct ValidateModeLineRequest<'input> {
     pub flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ValidateModeLineRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ValidateModeLineRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ValidateModeLineRequest<'_>, "ValidateModeLineRequest");
 impl<'input> ValidateModeLineRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1966,12 +1916,7 @@ pub struct SwitchToModeRequest<'input> {
     pub flags: ModeFlag,
     pub private: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SwitchToModeRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SwitchToModeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SwitchToModeRequest<'_>, "SwitchToModeRequest");
 impl<'input> SwitchToModeRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2133,12 +2078,7 @@ pub const GET_VIEW_PORT_REQUEST: u8 = 11;
 pub struct GetViewPortRequest {
     pub screen: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetViewPortRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetViewPortRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetViewPortRequest, "GetViewPortRequest");
 impl GetViewPortRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2284,12 +2224,7 @@ pub struct SetViewPortRequest {
     pub x: u32,
     pub y: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetViewPortRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetViewPortRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetViewPortRequest, "SetViewPortRequest");
 impl SetViewPortRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2360,12 +2295,7 @@ pub const GET_DOT_CLOCKS_REQUEST: u8 = 13;
 pub struct GetDotClocksRequest {
     pub screen: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDotClocksRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDotClocksRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDotClocksRequest, "GetDotClocksRequest");
 impl GetDotClocksRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2482,12 +2412,7 @@ pub struct SetClientVersionRequest {
     pub major: u16,
     pub minor: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetClientVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetClientVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetClientVersionRequest, "SetClientVersionRequest");
 impl SetClientVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2549,12 +2474,7 @@ pub struct SetGammaRequest {
     pub green: u32,
     pub blue: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetGammaRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetGammaRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetGammaRequest, "SetGammaRequest");
 impl SetGammaRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2645,12 +2565,7 @@ pub const GET_GAMMA_REQUEST: u8 = 16;
 pub struct GetGammaRequest {
     pub screen: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetGammaRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetGammaRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetGammaRequest, "GetGammaRequest");
 impl GetGammaRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2823,12 +2738,7 @@ pub struct GetGammaRampRequest {
     pub screen: u16,
     pub size: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetGammaRampRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetGammaRampRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetGammaRampRequest, "GetGammaRampRequest");
 impl GetGammaRampRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2951,12 +2861,7 @@ pub struct SetGammaRampRequest<'input> {
     pub green: Cow<'input, [u16]>,
     pub blue: Cow<'input, [u16]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetGammaRampRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetGammaRampRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetGammaRampRequest<'_>, "SetGammaRampRequest");
 impl<'input> SetGammaRampRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 5]> {
@@ -3042,12 +2947,7 @@ pub const GET_GAMMA_RAMP_SIZE_REQUEST: u8 = 19;
 pub struct GetGammaRampSizeRequest {
     pub screen: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetGammaRampSizeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetGammaRampSizeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetGammaRampSizeRequest, "GetGammaRampSizeRequest");
 impl GetGammaRampSizeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3187,12 +3087,7 @@ pub const GET_PERMISSIONS_REQUEST: u8 = 20;
 pub struct GetPermissionsRequest {
     pub screen: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPermissionsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPermissionsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPermissionsRequest, "GetPermissionsRequest");
 impl GetPermissionsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xf86vidmode.rs
+++ b/x11rb-protocol/src/protocol/xf86vidmode.rs
@@ -219,12 +219,7 @@ pub struct ModeInfo {
     pub flags: ModeFlag,
     pub privsize: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ModeInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ModeInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ModeInfo, "ModeInfo");
 impl TryParse for ModeInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (dotclock, remaining) = Dotclock::try_parse(remaining)?;
@@ -393,12 +388,7 @@ pub struct QueryVersionReply {
     pub major_version: u16,
     pub minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -535,12 +525,7 @@ pub struct GetModeLineReply {
     pub flags: ModeFlag,
     pub private: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetModeLineReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetModeLineReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetModeLineReply, "GetModeLineReply");
 impl TryParse for GetModeLineReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -933,12 +918,7 @@ pub struct GetMonitorReply {
     pub alignment_pad: Vec<u8>,
     pub model: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMonitorReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMonitorReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMonitorReply, "GetMonitorReply");
 impl TryParse for GetMonitorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1191,12 +1171,7 @@ pub struct GetAllModeLinesReply {
     pub length: u32,
     pub modeinfo: Vec<ModeInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetAllModeLinesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetAllModeLinesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetAllModeLinesReply, "GetAllModeLinesReply");
 impl TryParse for GetAllModeLinesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1897,12 +1872,7 @@ pub struct ValidateModeLineReply {
     pub length: u32,
     pub status: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ValidateModeLineReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ValidateModeLineReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ValidateModeLineReply, "ValidateModeLineReply");
 impl TryParse for ValidateModeLineReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2227,12 +2197,7 @@ pub struct GetViewPortReply {
     pub x: u32,
     pub y: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetViewPortReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetViewPortReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetViewPortReply, "GetViewPortReply");
 impl TryParse for GetViewPortReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2461,12 +2426,7 @@ pub struct GetDotClocksReply {
     pub maxclocks: u32,
     pub clock: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDotClocksReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDotClocksReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDotClocksReply, "GetDotClocksReply");
 impl TryParse for GetDotClocksReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2774,12 +2734,7 @@ pub struct GetGammaReply {
     pub green: u32,
     pub blue: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetGammaReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetGammaReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetGammaReply, "GetGammaReply");
 impl TryParse for GetGammaReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2936,12 +2891,7 @@ pub struct GetGammaRampReply {
     pub green: Vec<u16>,
     pub blue: Vec<u16>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetGammaRampReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetGammaRampReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetGammaRampReply, "GetGammaRampReply");
 impl TryParse for GetGammaRampReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3155,12 +3105,7 @@ pub struct GetGammaRampSizeReply {
     pub length: u32,
     pub size: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetGammaRampSizeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetGammaRampSizeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetGammaRampSizeReply, "GetGammaRampSizeReply");
 impl TryParse for GetGammaRampSizeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3305,12 +3250,7 @@ pub struct GetPermissionsReply {
     pub length: u32,
     pub permissions: Permission,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPermissionsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPermissionsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPermissionsReply, "GetPermissionsReply");
 impl TryParse for GetPermissionsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -119,12 +119,7 @@ pub struct QueryVersionReply {
     pub major_version: u32,
     pub minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -585,12 +580,7 @@ pub struct SelectionNotifyEvent {
     pub timestamp: xproto::Timestamp,
     pub selection_timestamp: xproto::Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectionNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectionNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectionNotifyEvent, "SelectionNotifyEvent");
 impl TryParse for SelectionNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -917,12 +907,7 @@ pub struct CursorNotifyEvent {
     pub timestamp: xproto::Timestamp,
     pub name: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CursorNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CursorNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CursorNotifyEvent, "CursorNotifyEvent");
 impl TryParse for CursorNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1188,12 +1173,7 @@ pub struct GetCursorImageReply {
     pub cursor_serial: u32,
     pub cursor_image: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCursorImageReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCursorImageReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCursorImageReply, "GetCursorImageReply");
 impl TryParse for GetCursorImageReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2413,12 +2393,7 @@ pub struct FetchRegionReply {
     pub extents: xproto::Rectangle,
     pub rectangles: Vec<xproto::Rectangle>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FetchRegionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FetchRegionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FetchRegionReply, "FetchRegionReply");
 impl TryParse for FetchRegionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2882,12 +2857,7 @@ pub struct GetCursorNameReply {
     pub atom: xproto::Atom,
     pub name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCursorNameReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCursorNameReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCursorNameReply, "GetCursorNameReply");
 impl TryParse for GetCursorNameReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3017,12 +2987,7 @@ pub struct GetCursorImageAndNameReply {
     pub cursor_image: Vec<u32>,
     pub name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCursorImageAndNameReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCursorImageAndNameReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCursorImageAndNameReply, "GetCursorImageAndNameReply");
 impl TryParse for GetCursorImageAndNameReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3899,12 +3864,7 @@ pub struct GetClientDisconnectModeReply {
     pub length: u32,
     pub disconnect_mode: ClientDisconnectFlags,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetClientDisconnectModeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetClientDisconnectModeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetClientDisconnectModeReply, "GetClientDisconnectModeReply");
 impl TryParse for GetClientDisconnectModeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -49,12 +49,7 @@ pub struct QueryVersionRequest {
     pub client_major_version: u32,
     pub client_minor_version: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -384,12 +379,7 @@ pub struct ChangeSaveSetRequest {
     pub map: SaveSetMapping,
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeSaveSetRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeSaveSetRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeSaveSetRequest, "ChangeSaveSetRequest");
 impl ChangeSaveSetRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -722,12 +712,7 @@ pub struct SelectSelectionInputRequest {
     pub selection: xproto::Atom,
     pub event_mask: SelectionEventMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectSelectionInputRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectSelectionInputRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectSelectionInputRequest, "SelectSelectionInputRequest");
 impl SelectSelectionInputRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1044,12 +1029,7 @@ pub struct SelectCursorInputRequest {
     pub window: xproto::Window,
     pub event_mask: CursorNotifyMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectCursorInputRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectCursorInputRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectCursorInputRequest, "SelectCursorInputRequest");
 impl SelectCursorInputRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1111,12 +1091,7 @@ pub const GET_CURSOR_IMAGE_REQUEST: u8 = 4;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorImageRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCursorImageRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCursorImageRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCursorImageRequest, "GetCursorImageRequest");
 impl GetCursorImageRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1298,12 +1273,7 @@ pub struct CreateRegionRequest<'input> {
     pub region: Region,
     pub rectangles: Cow<'input, [xproto::Rectangle]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateRegionRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateRegionRequest<'_>, "CreateRegionRequest");
 impl<'input> CreateRegionRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1380,12 +1350,7 @@ pub struct CreateRegionFromBitmapRequest {
     pub region: Region,
     pub bitmap: xproto::Pixmap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateRegionFromBitmapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateRegionFromBitmapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateRegionFromBitmapRequest, "CreateRegionFromBitmapRequest");
 impl CreateRegionFromBitmapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1450,12 +1415,7 @@ pub struct CreateRegionFromWindowRequest {
     pub window: xproto::Window,
     pub kind: shape::SK,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateRegionFromWindowRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateRegionFromWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateRegionFromWindowRequest, "CreateRegionFromWindowRequest");
 impl CreateRegionFromWindowRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1528,12 +1488,7 @@ pub struct CreateRegionFromGCRequest {
     pub region: Region,
     pub gc: xproto::Gcontext,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateRegionFromGCRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateRegionFromGCRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateRegionFromGCRequest, "CreateRegionFromGCRequest");
 impl CreateRegionFromGCRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1597,12 +1552,7 @@ pub struct CreateRegionFromPictureRequest {
     pub region: Region,
     pub picture: render::Picture,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateRegionFromPictureRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateRegionFromPictureRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateRegionFromPictureRequest, "CreateRegionFromPictureRequest");
 impl CreateRegionFromPictureRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1665,12 +1615,7 @@ pub const DESTROY_REGION_REQUEST: u8 = 10;
 pub struct DestroyRegionRequest {
     pub region: Region,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyRegionRequest, "DestroyRegionRequest");
 impl DestroyRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1727,12 +1672,7 @@ pub struct SetRegionRequest<'input> {
     pub region: Region,
     pub rectangles: Cow<'input, [xproto::Rectangle]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetRegionRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetRegionRequest<'_>, "SetRegionRequest");
 impl<'input> SetRegionRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1809,12 +1749,7 @@ pub struct CopyRegionRequest {
     pub source: Region,
     pub destination: Region,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CopyRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CopyRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CopyRegionRequest, "CopyRegionRequest");
 impl CopyRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1879,12 +1814,7 @@ pub struct UnionRegionRequest {
     pub source2: Region,
     pub destination: Region,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UnionRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UnionRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UnionRegionRequest, "UnionRegionRequest");
 impl UnionRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1956,12 +1886,7 @@ pub struct IntersectRegionRequest {
     pub source2: Region,
     pub destination: Region,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IntersectRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IntersectRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IntersectRegionRequest, "IntersectRegionRequest");
 impl IntersectRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2033,12 +1958,7 @@ pub struct SubtractRegionRequest {
     pub source2: Region,
     pub destination: Region,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SubtractRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SubtractRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SubtractRegionRequest, "SubtractRegionRequest");
 impl SubtractRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2110,12 +2030,7 @@ pub struct InvertRegionRequest {
     pub bounds: xproto::Rectangle,
     pub destination: Region,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InvertRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InvertRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InvertRegionRequest, "InvertRegionRequest");
 impl InvertRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2191,12 +2106,7 @@ pub struct TranslateRegionRequest {
     pub dx: i16,
     pub dy: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for TranslateRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TranslateRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(TranslateRegionRequest, "TranslateRegionRequest");
 impl TranslateRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2263,12 +2173,7 @@ pub struct RegionExtentsRequest {
     pub source: Region,
     pub destination: Region,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RegionExtentsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RegionExtentsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RegionExtentsRequest, "RegionExtentsRequest");
 impl RegionExtentsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2331,12 +2236,7 @@ pub const FETCH_REGION_REQUEST: u8 = 19;
 pub struct FetchRegionRequest {
     pub region: Region,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FetchRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FetchRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FetchRegionRequest, "FetchRegionRequest");
 impl FetchRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2462,12 +2362,7 @@ pub struct SetGCClipRegionRequest {
     pub x_origin: i16,
     pub y_origin: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetGCClipRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetGCClipRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetGCClipRegionRequest, "SetGCClipRegionRequest");
 impl SetGCClipRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2544,12 +2439,7 @@ pub struct SetWindowShapeRegionRequest {
     pub y_offset: i16,
     pub region: Region,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetWindowShapeRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetWindowShapeRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetWindowShapeRegionRequest, "SetWindowShapeRegionRequest");
 impl SetWindowShapeRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2634,12 +2524,7 @@ pub struct SetPictureClipRegionRequest {
     pub x_origin: i16,
     pub y_origin: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetPictureClipRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetPictureClipRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetPictureClipRegionRequest, "SetPictureClipRegionRequest");
 impl SetPictureClipRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2713,12 +2598,7 @@ pub struct SetCursorNameRequest<'input> {
     pub cursor: xproto::Cursor,
     pub name: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetCursorNameRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetCursorNameRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetCursorNameRequest<'_>, "SetCursorNameRequest");
 impl<'input> SetCursorNameRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2794,12 +2674,7 @@ pub const GET_CURSOR_NAME_REQUEST: u8 = 24;
 pub struct GetCursorNameRequest {
     pub cursor: xproto::Cursor,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCursorNameRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCursorNameRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCursorNameRequest, "GetCursorNameRequest");
 impl GetCursorNameRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2923,12 +2798,7 @@ pub const GET_CURSOR_IMAGE_AND_NAME_REQUEST: u8 = 25;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetCursorImageAndNameRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCursorImageAndNameRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCursorImageAndNameRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCursorImageAndNameRequest, "GetCursorImageAndNameRequest");
 impl GetCursorImageAndNameRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3073,12 +2943,7 @@ pub struct ChangeCursorRequest {
     pub source: xproto::Cursor,
     pub destination: xproto::Cursor,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeCursorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeCursorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeCursorRequest, "ChangeCursorRequest");
 impl ChangeCursorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3142,12 +3007,7 @@ pub struct ChangeCursorByNameRequest<'input> {
     pub src: xproto::Cursor,
     pub name: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeCursorByNameRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeCursorByNameRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeCursorByNameRequest<'_>, "ChangeCursorByNameRequest");
 impl<'input> ChangeCursorByNameRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3228,12 +3088,7 @@ pub struct ExpandRegionRequest {
     pub top: u16,
     pub bottom: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ExpandRegionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ExpandRegionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ExpandRegionRequest, "ExpandRegionRequest");
 impl ExpandRegionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3316,12 +3171,7 @@ pub const HIDE_CURSOR_REQUEST: u8 = 29;
 pub struct HideCursorRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for HideCursorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("HideCursorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(HideCursorRequest, "HideCursorRequest");
 impl HideCursorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3377,12 +3227,7 @@ pub const SHOW_CURSOR_REQUEST: u8 = 30;
 pub struct ShowCursorRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ShowCursorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ShowCursorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ShowCursorRequest, "ShowCursorRequest");
 impl ShowCursorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3499,12 +3344,7 @@ pub struct CreatePointerBarrierRequest<'input> {
     pub directions: BarrierDirections,
     pub devices: Cow<'input, [u16]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreatePointerBarrierRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreatePointerBarrierRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreatePointerBarrierRequest<'_>, "CreatePointerBarrierRequest");
 impl<'input> CreatePointerBarrierRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3622,12 +3462,7 @@ pub const DELETE_POINTER_BARRIER_REQUEST: u8 = 32;
 pub struct DeletePointerBarrierRequest {
     pub barrier: Barrier,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeletePointerBarrierRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeletePointerBarrierRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeletePointerBarrierRequest, "DeletePointerBarrierRequest");
 impl DeletePointerBarrierRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3744,12 +3579,7 @@ pub const SET_CLIENT_DISCONNECT_MODE_REQUEST: u8 = 33;
 pub struct SetClientDisconnectModeRequest {
     pub disconnect_mode: ClientDisconnectFlags,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetClientDisconnectModeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetClientDisconnectModeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetClientDisconnectModeRequest, "SetClientDisconnectModeRequest");
 impl SetClientDisconnectModeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3804,12 +3634,7 @@ pub const GET_CLIENT_DISCONNECT_MODE_REQUEST: u8 = 34;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetClientDisconnectModeRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetClientDisconnectModeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetClientDisconnectModeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetClientDisconnectModeRequest, "GetClientDisconnectModeRequest");
 impl GetClientDisconnectModeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xinerama.rs
+++ b/x11rb-protocol/src/protocol/xinerama.rs
@@ -45,12 +45,7 @@ pub struct ScreenInfo {
     pub width: u16,
     pub height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ScreenInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ScreenInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ScreenInfo, "ScreenInfo");
 impl TryParse for ScreenInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (x_org, remaining) = i16::try_parse(remaining)?;
@@ -163,12 +158,7 @@ pub struct QueryVersionReply {
     pub major: u16,
     pub minor: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -294,12 +284,7 @@ pub struct GetStateReply {
     pub length: u32,
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetStateReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetStateReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetStateReply, "GetStateReply");
 impl TryParse for GetStateReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -423,12 +408,7 @@ pub struct GetScreenCountReply {
     pub length: u32,
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenCountReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenCountReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenCountReply, "GetScreenCountReply");
 impl TryParse for GetScreenCountReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -562,12 +542,7 @@ pub struct GetScreenSizeReply {
     pub window: xproto::Window,
     pub screen: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenSizeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenSizeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenSizeReply, "GetScreenSizeReply");
 impl TryParse for GetScreenSizeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -701,12 +676,7 @@ pub struct IsActiveReply {
     pub length: u32,
     pub state: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IsActiveReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IsActiveReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IsActiveReply, "IsActiveReply");
 impl TryParse for IsActiveReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -819,12 +789,7 @@ pub struct QueryScreensReply {
     pub length: u32,
     pub screen_info: Vec<ScreenInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryScreensReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryScreensReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryScreensReply, "QueryScreensReply");
 impl TryParse for QueryScreensReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xinerama.rs
+++ b/x11rb-protocol/src/protocol/xinerama.rs
@@ -92,12 +92,7 @@ pub struct QueryVersionRequest {
     pub major: u8,
     pub minor: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -221,12 +216,7 @@ pub const GET_STATE_REQUEST: u8 = 1;
 pub struct GetStateRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetStateRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetStateRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetStateRequest, "GetStateRequest");
 impl GetStateRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -345,12 +335,7 @@ pub const GET_SCREEN_COUNT_REQUEST: u8 = 2;
 pub struct GetScreenCountRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenCountRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenCountRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenCountRequest, "GetScreenCountRequest");
 impl GetScreenCountRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -470,12 +455,7 @@ pub struct GetScreenSizeRequest {
     pub window: xproto::Window,
     pub screen: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenSizeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenSizeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenSizeRequest, "GetScreenSizeRequest");
 impl GetScreenSizeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -621,12 +601,7 @@ pub const IS_ACTIVE_REQUEST: u8 = 4;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IsActiveRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IsActiveRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IsActiveRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IsActiveRequest, "IsActiveRequest");
 impl IsActiveRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -734,12 +709,7 @@ pub const QUERY_SCREENS_REQUEST: u8 = 5;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryScreensRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryScreensRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryScreensRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryScreensRequest, "QueryScreensRequest");
 impl QueryScreensRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -53,12 +53,7 @@ pub struct Fp3232 {
     pub integral: i32,
     pub frac: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Fp3232 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Fp3232").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Fp3232, "Fp3232");
 impl TryParse for Fp3232 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (integral, remaining) = i32::try_parse(remaining)?;
@@ -175,12 +170,7 @@ pub struct GetExtensionVersionReply {
     pub server_minor: u16,
     pub present: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetExtensionVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetExtensionVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetExtensionVersionReply, "GetExtensionVersionReply");
 impl TryParse for GetExtensionVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -463,12 +453,7 @@ pub struct DeviceInfo {
     pub num_class_info: u8,
     pub device_use: DeviceUse,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceInfo, "DeviceInfo");
 impl TryParse for DeviceInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (device_type, remaining) = xproto::Atom::try_parse(remaining)?;
@@ -519,12 +504,7 @@ pub struct KeyInfo {
     pub max_keycode: KeyCode,
     pub num_keys: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KeyInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KeyInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KeyInfo, "KeyInfo");
 impl TryParse for KeyInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -576,12 +556,7 @@ pub struct ButtonInfo {
     pub len: u8,
     pub num_buttons: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ButtonInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ButtonInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ButtonInfo, "ButtonInfo");
 impl TryParse for ButtonInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -621,12 +596,7 @@ pub struct AxisInfo {
     pub minimum: i32,
     pub maximum: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AxisInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AxisInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AxisInfo, "AxisInfo");
 impl TryParse for AxisInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (resolution, remaining) = u32::try_parse(remaining)?;
@@ -675,12 +645,7 @@ pub struct ValuatorInfo {
     pub motion_size: u32,
     pub axes: Vec<AxisInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ValuatorInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ValuatorInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ValuatorInfo, "ValuatorInfo");
 impl TryParse for ValuatorInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -737,12 +702,7 @@ pub struct InputInfoInfoKey {
     pub max_keycode: KeyCode,
     pub num_keys: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputInfoInfoKey {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputInfoInfoKey").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputInfoInfoKey, "InputInfoInfoKey");
 impl TryParse for InputInfoInfoKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (min_keycode, remaining) = KeyCode::try_parse(remaining)?;
@@ -782,12 +742,7 @@ impl Serialize for InputInfoInfoKey {
 pub struct InputInfoInfoButton {
     pub num_buttons: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputInfoInfoButton {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputInfoInfoButton").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputInfoInfoButton, "InputInfoInfoButton");
 impl TryParse for InputInfoInfoButton {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_buttons, remaining) = u16::try_parse(remaining)?;
@@ -817,12 +772,7 @@ pub struct InputInfoInfoValuator {
     pub motion_size: u32,
     pub axes: Vec<AxisInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputInfoInfoValuator {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputInfoInfoValuator").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputInfoInfoValuator, "InputInfoInfoValuator");
 impl TryParse for InputInfoInfoValuator {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (axes_len, remaining) = u8::try_parse(remaining)?;
@@ -882,12 +832,7 @@ pub enum InputInfoInfo {
     /// will raise a panic.
     InvalidValue(u8),
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputInfoInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputInfoInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputInfoInfo, "InputInfoInfo");
 impl InputInfoInfo {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -973,12 +918,7 @@ pub struct InputInfo {
     pub len: u8,
     pub info: InputInfoInfo,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputInfo, "InputInfo");
 impl TryParse for InputInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -1010,12 +950,7 @@ impl Serialize for InputInfo {
 pub struct DeviceName {
     pub string: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceName {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceName").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceName, "DeviceName");
 impl TryParse for DeviceName {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (len, remaining) = u8::try_parse(remaining)?;
@@ -1119,12 +1054,7 @@ pub struct ListInputDevicesReply {
     pub infos: Vec<InputInfo>,
     pub names: Vec<xproto::Str>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListInputDevicesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListInputDevicesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListInputDevicesReply, "ListInputDevicesReply");
 impl TryParse for ListInputDevicesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1202,12 +1132,7 @@ pub struct InputClassInfo {
     pub class_id: InputClass,
     pub event_type_base: EventTypeBase,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputClassInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputClassInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputClassInfo, "InputClassInfo");
 impl TryParse for InputClassInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -1306,12 +1231,7 @@ pub struct OpenDeviceReply {
     pub length: u32,
     pub class_info: Vec<InputClassInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for OpenDeviceReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OpenDeviceReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OpenDeviceReply, "OpenDeviceReply");
 impl TryParse for OpenDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1513,12 +1433,7 @@ pub struct SetDeviceModeReply {
     pub length: u32,
     pub status: xproto::GrabStatus,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetDeviceModeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDeviceModeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDeviceModeReply, "SetDeviceModeReply");
 impl TryParse for SetDeviceModeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1749,12 +1664,7 @@ pub struct GetSelectedExtensionEventsReply {
     pub this_classes: Vec<EventClass>,
     pub all_classes: Vec<EventClass>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSelectedExtensionEventsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSelectedExtensionEventsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSelectedExtensionEventsReply, "GetSelectedExtensionEventsReply");
 impl TryParse for GetSelectedExtensionEventsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2048,12 +1958,7 @@ pub struct GetDeviceDontPropagateListReply {
     pub length: u32,
     pub classes: Vec<EventClass>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceDontPropagateListReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceDontPropagateListReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceDontPropagateListReply, "GetDeviceDontPropagateListReply");
 impl TryParse for GetDeviceDontPropagateListReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2117,12 +2022,7 @@ pub struct DeviceTimeCoord {
     pub time: xproto::Timestamp,
     pub axisvalues: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceTimeCoord {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceTimeCoord").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceTimeCoord, "DeviceTimeCoord");
 impl DeviceTimeCoord {
     pub fn try_parse(remaining: &[u8], num_axes: u8) -> Result<(Self, &[u8]), ParseError> {
         let (time, remaining) = xproto::Timestamp::try_parse(remaining)?;
@@ -2235,12 +2135,7 @@ pub struct GetDeviceMotionEventsReply {
     pub device_mode: ValuatorMode,
     pub events: Vec<DeviceTimeCoord>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceMotionEventsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceMotionEventsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceMotionEventsReply, "GetDeviceMotionEventsReply");
 impl TryParse for GetDeviceMotionEventsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2383,12 +2278,7 @@ pub struct ChangeKeyboardDeviceReply {
     pub length: u32,
     pub status: xproto::GrabStatus,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeKeyboardDeviceReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeKeyboardDeviceReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeKeyboardDeviceReply, "ChangeKeyboardDeviceReply");
 impl TryParse for ChangeKeyboardDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2544,12 +2434,7 @@ pub struct ChangePointerDeviceReply {
     pub length: u32,
     pub status: xproto::GrabStatus,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangePointerDeviceReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangePointerDeviceReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangePointerDeviceReply, "ChangePointerDeviceReply");
 impl TryParse for ChangePointerDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2753,12 +2638,7 @@ pub struct GrabDeviceReply {
     pub length: u32,
     pub status: xproto::GrabStatus,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GrabDeviceReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabDeviceReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabDeviceReply, "GrabDeviceReply");
 impl TryParse for GrabDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3608,12 +3488,7 @@ pub struct GetDeviceFocusReply {
     pub time: xproto::Timestamp,
     pub revert_to: xproto::InputFocus,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceFocusReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceFocusReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceFocusReply, "GetDeviceFocusReply");
 impl TryParse for GetDeviceFocusReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3861,12 +3736,7 @@ pub struct KbdFeedbackState {
     pub percent: u8,
     pub auto_repeats: [u8; 32],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KbdFeedbackState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KbdFeedbackState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KbdFeedbackState, "KbdFeedbackState");
 impl TryParse for KbdFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -3982,12 +3852,7 @@ pub struct PtrFeedbackState {
     pub accel_denom: u16,
     pub threshold: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PtrFeedbackState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PtrFeedbackState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PtrFeedbackState, "PtrFeedbackState");
 impl TryParse for PtrFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -4049,12 +3914,7 @@ pub struct IntegerFeedbackState {
     pub min_value: i32,
     pub max_value: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IntegerFeedbackState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IntegerFeedbackState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IntegerFeedbackState, "IntegerFeedbackState");
 impl TryParse for IntegerFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -4117,12 +3977,7 @@ pub struct StringFeedbackState {
     pub max_symbols: u16,
     pub keysyms: Vec<xproto::Keysym>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for StringFeedbackState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("StringFeedbackState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(StringFeedbackState, "StringFeedbackState");
 impl TryParse for StringFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -4181,12 +4036,7 @@ pub struct BellFeedbackState {
     pub pitch: u16,
     pub duration: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BellFeedbackState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BellFeedbackState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BellFeedbackState, "BellFeedbackState");
 impl TryParse for BellFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -4247,12 +4097,7 @@ pub struct LedFeedbackState {
     pub led_mask: u32,
     pub led_values: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for LedFeedbackState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("LedFeedbackState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(LedFeedbackState, "LedFeedbackState");
 impl TryParse for LedFeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -4311,12 +4156,7 @@ pub struct FeedbackStateDataKeyboard {
     pub percent: u8,
     pub auto_repeats: [u8; 32],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackStateDataKeyboard {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackStateDataKeyboard").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackStateDataKeyboard, "FeedbackStateDataKeyboard");
 impl TryParse for FeedbackStateDataKeyboard {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (pitch, remaining) = u16::try_parse(remaining)?;
@@ -4414,12 +4254,7 @@ pub struct FeedbackStateDataPointer {
     pub accel_denom: u16,
     pub threshold: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackStateDataPointer {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackStateDataPointer").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackStateDataPointer, "FeedbackStateDataPointer");
 impl TryParse for FeedbackStateDataPointer {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
@@ -4462,12 +4297,7 @@ pub struct FeedbackStateDataString {
     pub max_symbols: u16,
     pub keysyms: Vec<xproto::Keysym>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackStateDataString {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackStateDataString").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackStateDataString, "FeedbackStateDataString");
 impl TryParse for FeedbackStateDataString {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (max_symbols, remaining) = u16::try_parse(remaining)?;
@@ -4515,12 +4345,7 @@ pub struct FeedbackStateDataInteger {
     pub min_value: i32,
     pub max_value: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackStateDataInteger {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackStateDataInteger").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackStateDataInteger, "FeedbackStateDataInteger");
 impl TryParse for FeedbackStateDataInteger {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (resolution, remaining) = u32::try_parse(remaining)?;
@@ -4565,12 +4390,7 @@ pub struct FeedbackStateDataLed {
     pub led_mask: u32,
     pub led_values: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackStateDataLed {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackStateDataLed").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackStateDataLed, "FeedbackStateDataLed");
 impl TryParse for FeedbackStateDataLed {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (led_mask, remaining) = u32::try_parse(remaining)?;
@@ -4609,12 +4429,7 @@ pub struct FeedbackStateDataBell {
     pub pitch: u16,
     pub duration: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackStateDataBell {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackStateDataBell").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackStateDataBell, "FeedbackStateDataBell");
 impl TryParse for FeedbackStateDataBell {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (percent, remaining) = u8::try_parse(remaining)?;
@@ -4670,12 +4485,7 @@ pub enum FeedbackStateData {
     /// will raise a panic.
     InvalidValue(u8),
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackStateData {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackStateData").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackStateData, "FeedbackStateData");
 impl FeedbackStateData {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -4804,12 +4614,7 @@ pub struct FeedbackState {
     pub len: u16,
     pub data: FeedbackStateData,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackState, "FeedbackState");
 impl TryParse for FeedbackState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -4909,12 +4714,7 @@ pub struct GetFeedbackControlReply {
     pub length: u32,
     pub feedbacks: Vec<FeedbackState>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetFeedbackControlReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetFeedbackControlReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetFeedbackControlReply, "GetFeedbackControlReply");
 impl TryParse for GetFeedbackControlReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4987,12 +4787,7 @@ pub struct KbdFeedbackCtl {
     pub led_mask: u32,
     pub led_values: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KbdFeedbackCtl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KbdFeedbackCtl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KbdFeedbackCtl, "KbdFeedbackCtl");
 impl TryParse for KbdFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -5075,12 +4870,7 @@ pub struct PtrFeedbackCtl {
     pub denom: i16,
     pub threshold: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PtrFeedbackCtl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PtrFeedbackCtl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PtrFeedbackCtl, "PtrFeedbackCtl");
 impl TryParse for PtrFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -5140,12 +4930,7 @@ pub struct IntegerFeedbackCtl {
     pub len: u16,
     pub int_to_display: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IntegerFeedbackCtl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IntegerFeedbackCtl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IntegerFeedbackCtl, "IntegerFeedbackCtl");
 impl TryParse for IntegerFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -5193,12 +4978,7 @@ pub struct StringFeedbackCtl {
     pub len: u16,
     pub keysyms: Vec<xproto::Keysym>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for StringFeedbackCtl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("StringFeedbackCtl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(StringFeedbackCtl, "StringFeedbackCtl");
 impl TryParse for StringFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -5257,12 +5037,7 @@ pub struct BellFeedbackCtl {
     pub pitch: i16,
     pub duration: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BellFeedbackCtl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BellFeedbackCtl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BellFeedbackCtl, "BellFeedbackCtl");
 impl TryParse for BellFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -5323,12 +5098,7 @@ pub struct LedFeedbackCtl {
     pub led_mask: u32,
     pub led_values: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for LedFeedbackCtl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("LedFeedbackCtl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(LedFeedbackCtl, "LedFeedbackCtl");
 impl TryParse for LedFeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -5387,12 +5157,7 @@ pub struct FeedbackCtlDataKeyboard {
     pub led_mask: u32,
     pub led_values: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackCtlDataKeyboard {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackCtlDataKeyboard").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackCtlDataKeyboard, "FeedbackCtlDataKeyboard");
 impl TryParse for FeedbackCtlDataKeyboard {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (key, remaining) = KeyCode::try_parse(remaining)?;
@@ -5457,12 +5222,7 @@ pub struct FeedbackCtlDataPointer {
     pub denom: i16,
     pub threshold: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackCtlDataPointer {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackCtlDataPointer").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackCtlDataPointer, "FeedbackCtlDataPointer");
 impl TryParse for FeedbackCtlDataPointer {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
@@ -5504,12 +5264,7 @@ impl Serialize for FeedbackCtlDataPointer {
 pub struct FeedbackCtlDataString {
     pub keysyms: Vec<xproto::Keysym>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackCtlDataString {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackCtlDataString").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackCtlDataString, "FeedbackCtlDataString");
 impl TryParse for FeedbackCtlDataString {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = remaining.get(2..).ok_or(ParseError::InsufficientData)?;
@@ -5555,12 +5310,7 @@ impl FeedbackCtlDataString {
 pub struct FeedbackCtlDataInteger {
     pub int_to_display: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackCtlDataInteger {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackCtlDataInteger").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackCtlDataInteger, "FeedbackCtlDataInteger");
 impl TryParse for FeedbackCtlDataInteger {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (int_to_display, remaining) = i32::try_parse(remaining)?;
@@ -5591,12 +5341,7 @@ pub struct FeedbackCtlDataLed {
     pub led_mask: u32,
     pub led_values: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackCtlDataLed {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackCtlDataLed").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackCtlDataLed, "FeedbackCtlDataLed");
 impl TryParse for FeedbackCtlDataLed {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (led_mask, remaining) = u32::try_parse(remaining)?;
@@ -5635,12 +5380,7 @@ pub struct FeedbackCtlDataBell {
     pub pitch: i16,
     pub duration: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackCtlDataBell {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackCtlDataBell").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackCtlDataBell, "FeedbackCtlDataBell");
 impl TryParse for FeedbackCtlDataBell {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (percent, remaining) = i8::try_parse(remaining)?;
@@ -5696,12 +5436,7 @@ pub enum FeedbackCtlData {
     /// will raise a panic.
     InvalidValue(u8),
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackCtlData {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackCtlData").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackCtlData, "FeedbackCtlData");
 impl FeedbackCtlData {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -5830,12 +5565,7 @@ pub struct FeedbackCtl {
     pub len: u16,
     pub data: FeedbackCtlData,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FeedbackCtl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FeedbackCtl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FeedbackCtl, "FeedbackCtl");
 impl TryParse for FeedbackCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -6095,12 +5825,7 @@ pub struct GetDeviceKeyMappingReply {
     pub keysyms_per_keycode: u8,
     pub keysyms: Vec<xproto::Keysym>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceKeyMappingReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceKeyMappingReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceKeyMappingReply, "GetDeviceKeyMappingReply");
 impl TryParse for GetDeviceKeyMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6320,12 +6045,7 @@ pub struct GetDeviceModifierMappingReply {
     pub length: u32,
     pub keymaps: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceModifierMappingReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceModifierMappingReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceModifierMappingReply, "GetDeviceModifierMappingReply");
 impl TryParse for GetDeviceModifierMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6474,12 +6194,7 @@ pub struct SetDeviceModifierMappingReply {
     pub length: u32,
     pub status: xproto::MappingStatus,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetDeviceModifierMappingReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDeviceModifierMappingReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDeviceModifierMappingReply, "SetDeviceModifierMappingReply");
 impl TryParse for SetDeviceModifierMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6627,12 +6342,7 @@ pub struct GetDeviceButtonMappingReply {
     pub length: u32,
     pub map: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceButtonMappingReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceButtonMappingReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceButtonMappingReply, "GetDeviceButtonMappingReply");
 impl TryParse for GetDeviceButtonMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6784,12 +6494,7 @@ pub struct SetDeviceButtonMappingReply {
     pub length: u32,
     pub status: xproto::MappingStatus,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetDeviceButtonMappingReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDeviceButtonMappingReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDeviceButtonMappingReply, "SetDeviceButtonMappingReply");
 impl TryParse for SetDeviceButtonMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6874,12 +6579,7 @@ pub struct KeyState {
     pub num_keys: u8,
     pub keys: [u8; 32],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KeyState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KeyState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KeyState, "KeyState");
 impl TryParse for KeyState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -6956,12 +6656,7 @@ pub struct ButtonState {
     pub num_buttons: u8,
     pub buttons: [u8; 32],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ButtonState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ButtonState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ButtonState, "ButtonState");
 impl TryParse for ButtonState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -7098,12 +6793,7 @@ pub struct ValuatorState {
     pub mode: ValuatorStateModeMask,
     pub valuators: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ValuatorState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ValuatorState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ValuatorState, "ValuatorState");
 impl TryParse for ValuatorState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -7157,12 +6847,7 @@ pub struct InputStateDataKey {
     pub num_keys: u8,
     pub keys: [u8; 32],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputStateDataKey {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputStateDataKey").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputStateDataKey, "InputStateDataKey");
 impl TryParse for InputStateDataKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_keys, remaining) = u8::try_parse(remaining)?;
@@ -7227,12 +6912,7 @@ pub struct InputStateDataButton {
     pub num_buttons: u8,
     pub buttons: [u8; 32],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputStateDataButton {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputStateDataButton").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputStateDataButton, "InputStateDataButton");
 impl TryParse for InputStateDataButton {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_buttons, remaining) = u8::try_parse(remaining)?;
@@ -7297,12 +6977,7 @@ pub struct InputStateDataValuator {
     pub mode: ValuatorStateModeMask,
     pub valuators: Vec<i32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputStateDataValuator {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputStateDataValuator").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputStateDataValuator, "InputStateDataValuator");
 impl TryParse for InputStateDataValuator {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_valuators, remaining) = u8::try_parse(remaining)?;
@@ -7360,12 +7035,7 @@ pub enum InputStateData {
     /// will raise a panic.
     InvalidValue(u8),
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputStateData {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputStateData").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputStateData, "InputStateData");
 impl InputStateData {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], class_id: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -7451,12 +7121,7 @@ pub struct InputState {
     pub len: u8,
     pub data: InputStateData,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InputState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InputState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InputState, "InputState");
 impl TryParse for InputState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (class_id, remaining) = u8::try_parse(remaining)?;
@@ -7554,12 +7219,7 @@ pub struct QueryDeviceStateReply {
     pub length: u32,
     pub classes: Vec<InputState>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryDeviceStateReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryDeviceStateReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryDeviceStateReply, "QueryDeviceStateReply");
 impl TryParse for QueryDeviceStateReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -7783,12 +7443,7 @@ pub struct SetDeviceValuatorsReply {
     pub length: u32,
     pub status: xproto::GrabStatus,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetDeviceValuatorsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDeviceValuatorsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDeviceValuatorsReply, "SetDeviceValuatorsReply");
 impl TryParse for SetDeviceValuatorsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -7933,12 +7588,7 @@ pub struct DeviceResolutionState {
     pub resolution_min: Vec<u32>,
     pub resolution_max: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceResolutionState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceResolutionState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceResolutionState, "DeviceResolutionState");
 impl TryParse for DeviceResolutionState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
@@ -8003,12 +7653,7 @@ pub struct DeviceAbsCalibState {
     pub rotation: u32,
     pub button_threshold: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceAbsCalibState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceAbsCalibState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceAbsCalibState, "DeviceAbsCalibState");
 impl TryParse for DeviceAbsCalibState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
@@ -8106,12 +7751,7 @@ pub struct DeviceAbsAreaState {
     pub screen: u32,
     pub following: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceAbsAreaState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceAbsAreaState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceAbsAreaState, "DeviceAbsAreaState");
 impl TryParse for DeviceAbsAreaState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
@@ -8191,12 +7831,7 @@ pub struct DeviceCoreState {
     pub status: u8,
     pub iscore: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceCoreState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceCoreState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceCoreState, "DeviceCoreState");
 impl TryParse for DeviceCoreState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
@@ -8245,12 +7880,7 @@ pub struct DeviceEnableState {
     pub len: u16,
     pub enable: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceEnableState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceEnableState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceEnableState, "DeviceEnableState");
 impl TryParse for DeviceEnableState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
@@ -8296,12 +7926,7 @@ pub struct DeviceStateDataResolution {
     pub resolution_min: Vec<u32>,
     pub resolution_max: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceStateDataResolution {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceStateDataResolution").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceStateDataResolution, "DeviceStateDataResolution");
 impl TryParse for DeviceStateDataResolution {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_valuators, remaining) = u32::try_parse(remaining)?;
@@ -8357,12 +7982,7 @@ pub struct DeviceStateDataAbsCalib {
     pub rotation: u32,
     pub button_threshold: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceStateDataAbsCalib {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceStateDataAbsCalib").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceStateDataAbsCalib, "DeviceStateDataAbsCalib");
 impl TryParse for DeviceStateDataAbsCalib {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (min_x, remaining) = i32::try_parse(remaining)?;
@@ -8442,12 +8062,7 @@ pub struct DeviceStateDataCore {
     pub status: u8,
     pub iscore: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceStateDataCore {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceStateDataCore").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceStateDataCore, "DeviceStateDataCore");
 impl TryParse for DeviceStateDataCore {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (status, remaining) = u8::try_parse(remaining)?;
@@ -8487,12 +8102,7 @@ pub struct DeviceStateDataAbsArea {
     pub screen: u32,
     pub following: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceStateDataAbsArea {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceStateDataAbsArea").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceStateDataAbsArea, "DeviceStateDataAbsArea");
 impl TryParse for DeviceStateDataAbsArea {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (offset_x, remaining) = u32::try_parse(remaining)?;
@@ -8570,12 +8180,7 @@ pub enum DeviceStateData {
     /// will raise a panic.
     InvalidValue(u16),
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceStateData {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceStateData").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceStateData, "DeviceStateData");
 impl DeviceStateData {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -8695,12 +8300,7 @@ pub struct DeviceState {
     pub len: u16,
     pub data: DeviceStateData,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceState {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceState").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceState, "DeviceState");
 impl TryParse for DeviceState {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
@@ -8804,12 +8404,7 @@ pub struct GetDeviceControlReply {
     pub status: u8,
     pub control: DeviceState,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceControlReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceControlReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceControlReply, "GetDeviceControlReply");
 impl TryParse for GetDeviceControlReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -8859,12 +8454,7 @@ pub struct DeviceResolutionCtl {
     pub first_valuator: u8,
     pub resolution_values: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceResolutionCtl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceResolutionCtl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceResolutionCtl, "DeviceResolutionCtl");
 impl TryParse for DeviceResolutionCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
@@ -8927,12 +8517,7 @@ pub struct DeviceAbsCalibCtl {
     pub rotation: u32,
     pub button_threshold: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceAbsCalibCtl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceAbsCalibCtl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceAbsCalibCtl, "DeviceAbsCalibCtl");
 impl TryParse for DeviceAbsCalibCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
@@ -9030,12 +8615,7 @@ pub struct DeviceAbsAreaCtrl {
     pub screen: i32,
     pub following: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceAbsAreaCtrl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceAbsAreaCtrl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceAbsAreaCtrl, "DeviceAbsAreaCtrl");
 impl TryParse for DeviceAbsAreaCtrl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
@@ -9114,12 +8694,7 @@ pub struct DeviceCoreCtrl {
     pub len: u16,
     pub status: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceCoreCtrl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceCoreCtrl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceCoreCtrl, "DeviceCoreCtrl");
 impl TryParse for DeviceCoreCtrl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
@@ -9165,12 +8740,7 @@ pub struct DeviceEnableCtrl {
     pub len: u16,
     pub enable: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceEnableCtrl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceEnableCtrl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceEnableCtrl, "DeviceEnableCtrl");
 impl TryParse for DeviceEnableCtrl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
@@ -9215,12 +8785,7 @@ pub struct DeviceCtlDataResolution {
     pub first_valuator: u8,
     pub resolution_values: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceCtlDataResolution {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceCtlDataResolution").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceCtlDataResolution, "DeviceCtlDataResolution");
 impl TryParse for DeviceCtlDataResolution {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (first_valuator, remaining) = u8::try_parse(remaining)?;
@@ -9275,12 +8840,7 @@ pub struct DeviceCtlDataAbsCalib {
     pub rotation: u32,
     pub button_threshold: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceCtlDataAbsCalib {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceCtlDataAbsCalib").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceCtlDataAbsCalib, "DeviceCtlDataAbsCalib");
 impl TryParse for DeviceCtlDataAbsCalib {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (min_x, remaining) = i32::try_parse(remaining)?;
@@ -9359,12 +8919,7 @@ impl Serialize for DeviceCtlDataAbsCalib {
 pub struct DeviceCtlDataCore {
     pub status: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceCtlDataCore {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceCtlDataCore").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceCtlDataCore, "DeviceCtlDataCore");
 impl TryParse for DeviceCtlDataCore {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (status, remaining) = u8::try_parse(remaining)?;
@@ -9401,12 +8956,7 @@ pub struct DeviceCtlDataAbsArea {
     pub screen: i32,
     pub following: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceCtlDataAbsArea {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceCtlDataAbsArea").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceCtlDataAbsArea, "DeviceCtlDataAbsArea");
 impl TryParse for DeviceCtlDataAbsArea {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (offset_x, remaining) = u32::try_parse(remaining)?;
@@ -9484,12 +9034,7 @@ pub enum DeviceCtlData {
     /// will raise a panic.
     InvalidValue(u16),
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceCtlData {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceCtlData").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceCtlData, "DeviceCtlData");
 impl DeviceCtlData {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], control_id: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -9609,12 +9154,7 @@ pub struct DeviceCtl {
     pub len: u16,
     pub data: DeviceCtlData,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceCtl {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceCtl").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceCtl, "DeviceCtl");
 impl TryParse for DeviceCtl {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (control_id, remaining) = u16::try_parse(remaining)?;
@@ -9724,12 +9264,7 @@ pub struct ChangeDeviceControlReply {
     pub length: u32,
     pub status: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeDeviceControlReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeDeviceControlReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeDeviceControlReply, "ChangeDeviceControlReply");
 impl TryParse for ChangeDeviceControlReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -9876,12 +9411,7 @@ pub struct ListDevicePropertiesReply {
     pub length: u32,
     pub atoms: Vec<xproto::Atom>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListDevicePropertiesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListDevicePropertiesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListDevicePropertiesReply, "ListDevicePropertiesReply");
 impl TryParse for ListDevicePropertiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10016,12 +9546,7 @@ pub enum ChangeDevicePropertyAux {
     /// will raise a panic.
     InvalidValue(u8),
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeDevicePropertyAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeDevicePropertyAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeDevicePropertyAux, "ChangeDevicePropertyAux");
 impl ChangeDevicePropertyAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -10423,12 +9948,7 @@ pub enum GetDevicePropertyItems {
     /// will raise a panic.
     InvalidValue(u8),
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDevicePropertyItems {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDevicePropertyItems").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDevicePropertyItems, "GetDevicePropertyItems");
 impl GetDevicePropertyItems {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -10545,12 +10065,7 @@ pub struct GetDevicePropertyReply {
     pub device_id: u8,
     pub items: GetDevicePropertyItems,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDevicePropertyReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDevicePropertyReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDevicePropertyReply, "GetDevicePropertyReply");
 impl TryParse for GetDevicePropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10680,12 +10195,7 @@ pub struct GroupInfo {
     pub locked: u8,
     pub effective: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GroupInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GroupInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GroupInfo, "GroupInfo");
 impl TryParse for GroupInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (base, remaining) = u8::try_parse(remaining)?;
@@ -10728,12 +10238,7 @@ pub struct ModifierInfo {
     pub locked: u32,
     pub effective: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ModifierInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ModifierInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ModifierInfo, "ModifierInfo");
 impl TryParse for ModifierInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (base, remaining) = u32::try_parse(remaining)?;
@@ -10867,12 +10372,7 @@ pub struct XIQueryPointerReply {
     pub group: GroupInfo,
     pub buttons: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIQueryPointerReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIQueryPointerReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIQueryPointerReply, "XIQueryPointerReply");
 impl TryParse for XIQueryPointerReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -11273,12 +10773,7 @@ pub struct AddMaster {
     pub enable: bool,
     pub name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AddMaster {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AddMaster").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AddMaster, "AddMaster");
 impl TryParse for AddMaster {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -11344,12 +10839,7 @@ pub struct RemoveMaster {
     pub return_pointer: DeviceId,
     pub return_keyboard: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RemoveMaster {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RemoveMaster").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RemoveMaster, "RemoveMaster");
 impl TryParse for RemoveMaster {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u16::try_parse(remaining)?;
@@ -11410,12 +10900,7 @@ pub struct AttachSlave {
     pub deviceid: DeviceId,
     pub master: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AttachSlave {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AttachSlave").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AttachSlave, "AttachSlave");
 impl TryParse for AttachSlave {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u16::try_parse(remaining)?;
@@ -11462,12 +10947,7 @@ pub struct DetachSlave {
     pub len: u16,
     pub deviceid: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DetachSlave {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DetachSlave").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DetachSlave, "DetachSlave");
 impl TryParse for DetachSlave {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u16::try_parse(remaining)?;
@@ -11513,12 +10993,7 @@ pub struct HierarchyChangeDataAddMaster {
     pub enable: bool,
     pub name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for HierarchyChangeDataAddMaster {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("HierarchyChangeDataAddMaster").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(HierarchyChangeDataAddMaster, "HierarchyChangeDataAddMaster");
 impl TryParse for HierarchyChangeDataAddMaster {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -11576,12 +11051,7 @@ pub struct HierarchyChangeDataRemoveMaster {
     pub return_pointer: DeviceId,
     pub return_keyboard: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for HierarchyChangeDataRemoveMaster {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("HierarchyChangeDataRemoveMaster").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(HierarchyChangeDataRemoveMaster, "HierarchyChangeDataRemoveMaster");
 impl TryParse for HierarchyChangeDataRemoveMaster {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -11628,12 +11098,7 @@ pub struct HierarchyChangeDataAttachSlave {
     pub deviceid: DeviceId,
     pub master: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for HierarchyChangeDataAttachSlave {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("HierarchyChangeDataAttachSlave").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(HierarchyChangeDataAttachSlave, "HierarchyChangeDataAttachSlave");
 impl TryParse for HierarchyChangeDataAttachSlave {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -11666,12 +11131,7 @@ impl Serialize for HierarchyChangeDataAttachSlave {
 pub struct HierarchyChangeDataDetachSlave {
     pub deviceid: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for HierarchyChangeDataDetachSlave {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("HierarchyChangeDataDetachSlave").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(HierarchyChangeDataDetachSlave, "HierarchyChangeDataDetachSlave");
 impl TryParse for HierarchyChangeDataDetachSlave {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -11715,12 +11175,7 @@ pub enum HierarchyChangeData {
     /// will raise a panic.
     InvalidValue(u16),
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for HierarchyChangeData {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("HierarchyChangeData").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(HierarchyChangeData, "HierarchyChangeData");
 impl HierarchyChangeData {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -11820,12 +11275,7 @@ pub struct HierarchyChange {
     pub len: u16,
     pub data: HierarchyChangeData,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for HierarchyChange {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("HierarchyChange").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(HierarchyChange, "HierarchyChange");
 impl TryParse for HierarchyChange {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u16::try_parse(remaining)?;
@@ -12066,12 +11516,7 @@ pub struct XIGetClientPointerReply {
     pub set: bool,
     pub deviceid: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIGetClientPointerReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIGetClientPointerReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIGetClientPointerReply, "XIGetClientPointerReply");
 impl TryParse for XIGetClientPointerReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -12253,12 +11698,7 @@ pub struct EventMask {
     pub deviceid: DeviceId,
     pub mask: Vec<XIEventMask>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EventMask {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EventMask").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EventMask, "EventMask");
 impl TryParse for EventMask {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -12467,12 +11907,7 @@ pub struct XIQueryVersionReply {
     pub major_version: u16,
     pub minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIQueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIQueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIQueryVersionReply, "XIQueryVersionReply");
 impl TryParse for XIQueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -12839,12 +12274,7 @@ pub struct ButtonClass {
     pub state: Vec<u32>,
     pub labels: Vec<xproto::Atom>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ButtonClass {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ButtonClass").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ButtonClass, "ButtonClass");
 impl TryParse for ButtonClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u16::try_parse(remaining)?;
@@ -12902,12 +12332,7 @@ pub struct KeyClass {
     pub sourceid: DeviceId,
     pub keys: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KeyClass {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KeyClass").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KeyClass, "KeyClass");
 impl TryParse for KeyClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u16::try_parse(remaining)?;
@@ -12965,12 +12390,7 @@ pub struct ScrollClass {
     pub flags: ScrollFlags,
     pub increment: Fp3232,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ScrollClass {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ScrollClass").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ScrollClass, "ScrollClass");
 impl TryParse for ScrollClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u16::try_parse(remaining)?;
@@ -13048,12 +12468,7 @@ pub struct TouchClass {
     pub mode: TouchMode,
     pub num_touches: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for TouchClass {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TouchClass").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(TouchClass, "TouchClass");
 impl TryParse for TouchClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u16::try_parse(remaining)?;
@@ -13105,12 +12520,7 @@ pub struct GestureClass {
     pub sourceid: DeviceId,
     pub num_touches: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GestureClass {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GestureClass").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GestureClass, "GestureClass");
 impl TryParse for GestureClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u16::try_parse(remaining)?;
@@ -13166,12 +12576,7 @@ pub struct ValuatorClass {
     pub resolution: u32,
     pub mode: ValuatorMode,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ValuatorClass {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ValuatorClass").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ValuatorClass, "ValuatorClass");
 impl TryParse for ValuatorClass {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u16::try_parse(remaining)?;
@@ -13273,12 +12678,7 @@ impl Serialize for ValuatorClass {
 pub struct DeviceClassDataKey {
     pub keys: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceClassDataKey {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceClassDataKey").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceClassDataKey, "DeviceClassDataKey");
 impl TryParse for DeviceClassDataKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_keys, remaining) = u16::try_parse(remaining)?;
@@ -13322,12 +12722,7 @@ pub struct DeviceClassDataButton {
     pub state: Vec<u32>,
     pub labels: Vec<xproto::Atom>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceClassDataButton {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceClassDataButton").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceClassDataButton, "DeviceClassDataButton");
 impl TryParse for DeviceClassDataButton {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_buttons, remaining) = u16::try_parse(remaining)?;
@@ -13379,12 +12774,7 @@ pub struct DeviceClassDataValuator {
     pub resolution: u32,
     pub mode: ValuatorMode,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceClassDataValuator {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceClassDataValuator").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceClassDataValuator, "DeviceClassDataValuator");
 impl TryParse for DeviceClassDataValuator {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (number, remaining) = u16::try_parse(remaining)?;
@@ -13472,12 +12862,7 @@ pub struct DeviceClassDataScroll {
     pub flags: ScrollFlags,
     pub increment: Fp3232,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceClassDataScroll {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceClassDataScroll").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceClassDataScroll, "DeviceClassDataScroll");
 impl TryParse for DeviceClassDataScroll {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (number, remaining) = u16::try_parse(remaining)?;
@@ -13535,12 +12920,7 @@ pub struct DeviceClassDataTouch {
     pub mode: TouchMode,
     pub num_touches: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceClassDataTouch {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceClassDataTouch").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceClassDataTouch, "DeviceClassDataTouch");
 impl TryParse for DeviceClassDataTouch {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (mode, remaining) = u8::try_parse(remaining)?;
@@ -13572,12 +12952,7 @@ impl Serialize for DeviceClassDataTouch {
 pub struct DeviceClassDataGesture {
     pub num_touches: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceClassDataGesture {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceClassDataGesture").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceClassDataGesture, "DeviceClassDataGesture");
 impl TryParse for DeviceClassDataGesture {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (num_touches, remaining) = u8::try_parse(remaining)?;
@@ -13621,12 +12996,7 @@ pub enum DeviceClassData {
     /// will raise a panic.
     InvalidValue(u16),
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceClassData {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceClassData").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceClassData, "DeviceClassData");
 impl DeviceClassData {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], type_: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -13755,12 +13125,7 @@ pub struct DeviceClass {
     pub sourceid: DeviceId,
     pub data: DeviceClassData,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceClass {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceClass").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceClass, "DeviceClass");
 impl TryParse for DeviceClass {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -13804,12 +13169,7 @@ pub struct XIDeviceInfo {
     pub name: Vec<u8>,
     pub classes: Vec<DeviceClass>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIDeviceInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIDeviceInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIDeviceInfo, "XIDeviceInfo");
 impl TryParse for XIDeviceInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -13955,12 +13315,7 @@ pub struct XIQueryDeviceReply {
     pub length: u32,
     pub infos: Vec<XIDeviceInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIQueryDeviceReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIQueryDeviceReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIQueryDeviceReply, "XIQueryDeviceReply");
 impl TryParse for XIQueryDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14166,12 +13521,7 @@ pub struct XIGetFocusReply {
     pub length: u32,
     pub focus: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIGetFocusReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIGetFocusReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIGetFocusReply, "XIGetFocusReply");
 impl TryParse for XIGetFocusReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14453,12 +13803,7 @@ pub struct XIGrabDeviceReply {
     pub length: u32,
     pub status: xproto::GrabStatus,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIGrabDeviceReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIGrabDeviceReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIGrabDeviceReply, "XIGrabDeviceReply");
 impl TryParse for XIGrabDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14948,12 +14293,7 @@ pub struct GrabModifierInfo {
     pub modifiers: u32,
     pub status: xproto::GrabStatus,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GrabModifierInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabModifierInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabModifierInfo, "GrabModifierInfo");
 impl TryParse for GrabModifierInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (modifiers, remaining) = u32::try_parse(remaining)?;
@@ -15153,12 +14493,7 @@ pub struct XIPassiveGrabDeviceReply {
     pub length: u32,
     pub modifiers: Vec<GrabModifierInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIPassiveGrabDeviceReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIPassiveGrabDeviceReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIPassiveGrabDeviceReply, "XIPassiveGrabDeviceReply");
 impl TryParse for XIPassiveGrabDeviceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -15393,12 +14728,7 @@ pub struct XIListPropertiesReply {
     pub length: u32,
     pub properties: Vec<xproto::Atom>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIListPropertiesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIListPropertiesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIListPropertiesReply, "XIListPropertiesReply");
 impl TryParse for XIListPropertiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -15472,12 +14802,7 @@ pub enum XIChangePropertyAux {
     /// will raise a panic.
     InvalidValue(u8),
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIChangePropertyAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIChangePropertyAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIChangePropertyAux, "XIChangePropertyAux");
 impl XIChangePropertyAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -15878,12 +15203,7 @@ pub enum XIGetPropertyItems {
     /// will raise a panic.
     InvalidValue(u8),
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIGetPropertyItems {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIGetPropertyItems").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIGetPropertyItems, "XIGetPropertyItems");
 impl XIGetPropertyItems {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], format: u8, num_items: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -15998,12 +15318,7 @@ pub struct XIGetPropertyReply {
     pub num_items: u32,
     pub items: XIGetPropertyItems,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIGetPropertyReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIGetPropertyReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIGetPropertyReply, "XIGetPropertyReply");
 impl TryParse for XIGetPropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -16121,12 +15436,7 @@ pub struct XIGetSelectedEventsReply {
     pub length: u32,
     pub masks: Vec<EventMask>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIGetSelectedEventsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIGetSelectedEventsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIGetSelectedEventsReply, "XIGetSelectedEventsReply");
 impl TryParse for XIGetSelectedEventsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -16191,12 +15501,7 @@ pub struct BarrierReleasePointerInfo {
     pub barrier: xfixes::Barrier,
     pub eventid: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BarrierReleasePointerInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BarrierReleasePointerInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BarrierReleasePointerInfo, "BarrierReleasePointerInfo");
 impl TryParse for BarrierReleasePointerInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -16324,12 +15629,7 @@ pub struct DeviceValuatorEvent {
     pub first_valuator: u8,
     pub valuators: [i32; 6],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceValuatorEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceValuatorEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceValuatorEvent, "DeviceValuatorEvent");
 impl TryParse for DeviceValuatorEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -16556,12 +15856,7 @@ pub struct DeviceKeyPressEvent {
     pub same_screen: bool,
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceKeyPressEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceKeyPressEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceKeyPressEvent, "DeviceKeyPressEvent");
 impl TryParse for DeviceKeyPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -16745,12 +16040,7 @@ pub struct DeviceFocusInEvent {
     pub mode: xproto::NotifyMode,
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceFocusInEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceFocusInEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceFocusInEvent, "DeviceFocusInEvent");
 impl TryParse for DeviceFocusInEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -16975,12 +16265,7 @@ pub struct DeviceStateNotifyEvent {
     pub keys: [u8; 4],
     pub valuators: [u32; 3],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceStateNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceStateNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceStateNotifyEvent, "DeviceStateNotifyEvent");
 impl TryParse for DeviceStateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -17143,12 +16428,7 @@ pub struct DeviceMappingNotifyEvent {
     pub count: u8,
     pub time: xproto::Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceMappingNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceMappingNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceMappingNotifyEvent, "DeviceMappingNotifyEvent");
 impl TryParse for DeviceMappingNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -17349,12 +16629,7 @@ pub struct ChangeDeviceNotifyEvent {
     pub time: xproto::Timestamp,
     pub request: ChangeDevice,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeDeviceNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeDeviceNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeDeviceNotifyEvent, "ChangeDeviceNotifyEvent");
 impl TryParse for ChangeDeviceNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -17485,12 +16760,7 @@ pub struct DeviceKeyStateNotifyEvent {
     pub sequence: u16,
     pub keys: [u8; 28],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceKeyStateNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceKeyStateNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceKeyStateNotifyEvent, "DeviceKeyStateNotifyEvent");
 impl TryParse for DeviceKeyStateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -17612,12 +16882,7 @@ pub struct DeviceButtonStateNotifyEvent {
     pub sequence: u16,
     pub buttons: [u8; 28],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceButtonStateNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceButtonStateNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceButtonStateNotifyEvent, "DeviceButtonStateNotifyEvent");
 impl TryParse for DeviceButtonStateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -17808,12 +17073,7 @@ pub struct DevicePresenceNotifyEvent {
     pub device_id: u8,
     pub control: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DevicePresenceNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DevicePresenceNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DevicePresenceNotifyEvent, "DevicePresenceNotifyEvent");
 impl TryParse for DevicePresenceNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -17952,12 +17212,7 @@ pub struct DevicePropertyNotifyEvent {
     pub property: xproto::Atom,
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DevicePropertyNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DevicePropertyNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DevicePropertyNotifyEvent, "DevicePropertyNotifyEvent");
 impl TryParse for DevicePropertyNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -18157,12 +17412,7 @@ pub struct DeviceChangedEvent {
     pub reason: ChangeReason,
     pub classes: Vec<DeviceClass>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceChangedEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceChangedEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceChangedEvent, "DeviceChangedEvent");
 impl TryParse for DeviceChangedEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -18301,12 +17551,7 @@ pub struct KeyPressEvent {
     pub valuator_mask: Vec<u32>,
     pub axisvalues: Vec<Fp3232>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KeyPressEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KeyPressEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KeyPressEvent, "KeyPressEvent");
 impl TryParse for KeyPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -18490,12 +17735,7 @@ pub struct ButtonPressEvent {
     pub valuator_mask: Vec<u32>,
     pub axisvalues: Vec<Fp3232>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ButtonPressEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ButtonPressEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ButtonPressEvent, "ButtonPressEvent");
 impl TryParse for ButtonPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -18775,12 +18015,7 @@ pub struct EnterEvent {
     pub group: GroupInfo,
     pub buttons: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EnterEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EnterEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EnterEvent, "EnterEvent");
 impl TryParse for EnterEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -18949,12 +18184,7 @@ pub struct HierarchyInfo {
     pub enabled: bool,
     pub flags: HierarchyMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for HierarchyInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("HierarchyInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(HierarchyInfo, "HierarchyInfo");
 impl TryParse for HierarchyInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (deviceid, remaining) = DeviceId::try_parse(remaining)?;
@@ -19019,12 +18249,7 @@ pub struct HierarchyEvent {
     pub flags: HierarchyMask,
     pub infos: Vec<HierarchyInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for HierarchyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("HierarchyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(HierarchyEvent, "HierarchyEvent");
 impl TryParse for HierarchyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -19163,12 +18388,7 @@ pub struct PropertyEvent {
     pub property: xproto::Atom,
     pub what: PropertyFlag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PropertyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PropertyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PropertyEvent, "PropertyEvent");
 impl TryParse for PropertyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -19272,12 +18492,7 @@ pub struct RawKeyPressEvent {
     pub axisvalues: Vec<Fp3232>,
     pub axisvalues_raw: Vec<Fp3232>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RawKeyPressEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RawKeyPressEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RawKeyPressEvent, "RawKeyPressEvent");
 impl TryParse for RawKeyPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -19373,12 +18588,7 @@ pub struct RawButtonPressEvent {
     pub axisvalues: Vec<Fp3232>,
     pub axisvalues_raw: Vec<Fp3232>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RawButtonPressEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RawButtonPressEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RawButtonPressEvent, "RawButtonPressEvent");
 impl TryParse for RawButtonPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -19535,12 +18745,7 @@ pub struct TouchBeginEvent {
     pub valuator_mask: Vec<u32>,
     pub axisvalues: Vec<Fp3232>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for TouchBeginEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TouchBeginEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(TouchBeginEvent, "TouchBeginEvent");
 impl TryParse for TouchBeginEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -19718,12 +18923,7 @@ pub struct TouchOwnershipEvent {
     pub sourceid: DeviceId,
     pub flags: TouchOwnershipFlags,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for TouchOwnershipEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TouchOwnershipEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(TouchOwnershipEvent, "TouchOwnershipEvent");
 impl TryParse for TouchOwnershipEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -19857,12 +19057,7 @@ pub struct RawTouchBeginEvent {
     pub axisvalues: Vec<Fp3232>,
     pub axisvalues_raw: Vec<Fp3232>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RawTouchBeginEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RawTouchBeginEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RawTouchBeginEvent, "RawTouchBeginEvent");
 impl TryParse for RawTouchBeginEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -20015,12 +19210,7 @@ pub struct BarrierHitEvent {
     pub dx: Fp3232,
     pub dy: Fp3232,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BarrierHitEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BarrierHitEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BarrierHitEvent, "BarrierHitEvent");
 impl TryParse for BarrierHitEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -20249,12 +19439,7 @@ pub struct GesturePinchBeginEvent {
     pub group: GroupInfo,
     pub flags: GesturePinchEventFlags,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GesturePinchBeginEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GesturePinchBeginEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GesturePinchBeginEvent, "GesturePinchBeginEvent");
 impl TryParse for GesturePinchBeginEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -20538,12 +19723,7 @@ pub struct GestureSwipeBeginEvent {
     pub group: GroupInfo,
     pub flags: GestureSwipeEventFlags,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GestureSwipeBeginEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GestureSwipeBeginEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GestureSwipeBeginEvent, "GestureSwipeBeginEvent");
 impl TryParse for GestureSwipeBeginEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -93,12 +93,7 @@ pub const GET_EXTENSION_VERSION_REQUEST: u8 = 1;
 pub struct GetExtensionVersionRequest<'input> {
     pub name: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for GetExtensionVersionRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetExtensionVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetExtensionVersionRequest<'_>, "GetExtensionVersionRequest");
 impl<'input> GetExtensionVersionRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -996,12 +991,7 @@ pub const LIST_INPUT_DEVICES_REQUEST: u8 = 2;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListInputDevicesRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListInputDevicesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListInputDevicesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListInputDevicesRequest, "ListInputDevicesRequest");
 impl ListInputDevicesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1167,12 +1157,7 @@ pub const OPEN_DEVICE_REQUEST: u8 = 3;
 pub struct OpenDeviceRequest {
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for OpenDeviceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OpenDeviceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OpenDeviceRequest, "OpenDeviceRequest");
 impl OpenDeviceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1302,12 +1287,7 @@ pub const CLOSE_DEVICE_REQUEST: u8 = 4;
 pub struct CloseDeviceRequest {
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CloseDeviceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CloseDeviceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CloseDeviceRequest, "CloseDeviceRequest");
 impl CloseDeviceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1365,12 +1345,7 @@ pub struct SetDeviceModeRequest {
     pub device_id: u8,
     pub mode: ValuatorMode,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetDeviceModeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDeviceModeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDeviceModeRequest, "SetDeviceModeRequest");
 impl SetDeviceModeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1518,12 +1493,7 @@ pub struct SelectExtensionEventRequest<'input> {
     pub window: xproto::Window,
     pub classes: Cow<'input, [EventClass]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SelectExtensionEventRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectExtensionEventRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectExtensionEventRequest<'_>, "SelectExtensionEventRequest");
 impl<'input> SelectExtensionEventRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1600,12 +1570,7 @@ pub const GET_SELECTED_EXTENSION_EVENTS_REQUEST: u8 = 7;
 pub struct GetSelectedExtensionEventsRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSelectedExtensionEventsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSelectedExtensionEventsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSelectedExtensionEventsRequest, "GetSelectedExtensionEventsRequest");
 impl GetSelectedExtensionEventsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1808,12 +1773,7 @@ pub struct ChangeDeviceDontPropagateListRequest<'input> {
     pub mode: PropagateMode,
     pub classes: Cow<'input, [EventClass]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeDeviceDontPropagateListRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeDeviceDontPropagateListRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeDeviceDontPropagateListRequest<'_>, "ChangeDeviceDontPropagateListRequest");
 impl<'input> ChangeDeviceDontPropagateListRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1895,12 +1855,7 @@ pub const GET_DEVICE_DONT_PROPAGATE_LIST_REQUEST: u8 = 9;
 pub struct GetDeviceDontPropagateListRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceDontPropagateListRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceDontPropagateListRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceDontPropagateListRequest, "GetDeviceDontPropagateListRequest");
 impl GetDeviceDontPropagateListRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2055,12 +2010,7 @@ pub struct GetDeviceMotionEventsRequest {
     pub stop: xproto::Timestamp,
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceMotionEventsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceMotionEventsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceMotionEventsRequest, "GetDeviceMotionEventsRequest");
 impl GetDeviceMotionEventsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2214,12 +2164,7 @@ pub const CHANGE_KEYBOARD_DEVICE_REQUEST: u8 = 11;
 pub struct ChangeKeyboardDeviceRequest {
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeKeyboardDeviceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeKeyboardDeviceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeKeyboardDeviceRequest, "ChangeKeyboardDeviceRequest");
 impl ChangeKeyboardDeviceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2364,12 +2309,7 @@ pub struct ChangePointerDeviceRequest {
     pub y_axis: u8,
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangePointerDeviceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangePointerDeviceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangePointerDeviceRequest, "ChangePointerDeviceRequest");
 impl ChangePointerDeviceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2524,12 +2464,7 @@ pub struct GrabDeviceRequest<'input> {
     pub device_id: u8,
     pub classes: Cow<'input, [EventClass]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for GrabDeviceRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabDeviceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabDeviceRequest<'_>, "GrabDeviceRequest");
 impl<'input> GrabDeviceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2723,12 +2658,7 @@ pub struct UngrabDeviceRequest {
     pub time: xproto::Timestamp,
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UngrabDeviceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UngrabDeviceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UngrabDeviceRequest, "UngrabDeviceRequest");
 impl UngrabDeviceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2857,12 +2787,7 @@ pub struct GrabDeviceKeyRequest<'input> {
     pub owner_events: bool,
     pub classes: Cow<'input, [EventClass]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for GrabDeviceKeyRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabDeviceKeyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabDeviceKeyRequest<'_>, "GrabDeviceKeyRequest");
 impl<'input> GrabDeviceKeyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2982,12 +2907,7 @@ pub struct UngrabDeviceKeyRequest {
     pub key: u8,
     pub grabbed_device: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UngrabDeviceKeyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UngrabDeviceKeyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UngrabDeviceKeyRequest, "UngrabDeviceKeyRequest");
 impl UngrabDeviceKeyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3072,12 +2992,7 @@ pub struct GrabDeviceButtonRequest<'input> {
     pub owner_events: bool,
     pub classes: Cow<'input, [EventClass]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for GrabDeviceButtonRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabDeviceButtonRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabDeviceButtonRequest<'_>, "GrabDeviceButtonRequest");
 impl<'input> GrabDeviceButtonRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3197,12 +3112,7 @@ pub struct UngrabDeviceButtonRequest {
     pub button: u8,
     pub grabbed_device: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UngrabDeviceButtonRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UngrabDeviceButtonRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UngrabDeviceButtonRequest, "UngrabDeviceButtonRequest");
 impl UngrabDeviceButtonRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3349,12 +3259,7 @@ pub struct AllowDeviceEventsRequest {
     pub mode: DeviceInputMode,
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AllowDeviceEventsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AllowDeviceEventsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AllowDeviceEventsRequest, "AllowDeviceEventsRequest");
 impl AllowDeviceEventsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3422,12 +3327,7 @@ pub const GET_DEVICE_FOCUS_REQUEST: u8 = 20;
 pub struct GetDeviceFocusRequest {
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceFocusRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceFocusRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceFocusRequest, "GetDeviceFocusRequest");
 impl GetDeviceFocusRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3581,12 +3481,7 @@ pub struct SetDeviceFocusRequest {
     pub revert_to: xproto::InputFocus,
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetDeviceFocusRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDeviceFocusRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDeviceFocusRequest, "SetDeviceFocusRequest");
 impl SetDeviceFocusRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -4650,12 +4545,7 @@ pub const GET_FEEDBACK_CONTROL_REQUEST: u8 = 22;
 pub struct GetFeedbackControlRequest {
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetFeedbackControlRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetFeedbackControlRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetFeedbackControlRequest, "GetFeedbackControlRequest");
 impl GetFeedbackControlRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5674,12 +5564,7 @@ pub struct ChangeFeedbackControlRequest {
     pub feedback_id: u8,
     pub feedback: FeedbackCtl,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeFeedbackControlRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeFeedbackControlRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeFeedbackControlRequest, "ChangeFeedbackControlRequest");
 impl ChangeFeedbackControlRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 3]> {
@@ -5755,12 +5640,7 @@ pub struct GetDeviceKeyMappingRequest {
     pub first_keycode: KeyCode,
     pub count: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceKeyMappingRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceKeyMappingRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceKeyMappingRequest, "GetDeviceKeyMappingRequest");
 impl GetDeviceKeyMappingRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -5894,12 +5774,7 @@ pub struct ChangeDeviceKeyMappingRequest<'input> {
     pub keycode_count: u8,
     pub keysyms: Cow<'input, [xproto::Keysym]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeDeviceKeyMappingRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeDeviceKeyMappingRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeDeviceKeyMappingRequest<'_>, "ChangeDeviceKeyMappingRequest");
 impl<'input> ChangeDeviceKeyMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -5981,12 +5856,7 @@ pub const GET_DEVICE_MODIFIER_MAPPING_REQUEST: u8 = 26;
 pub struct GetDeviceModifierMappingRequest {
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceModifierMappingRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceModifierMappingRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceModifierMappingRequest, "GetDeviceModifierMappingRequest");
 impl GetDeviceModifierMappingRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6114,12 +5984,7 @@ pub struct SetDeviceModifierMappingRequest<'input> {
     pub device_id: u8,
     pub keymaps: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetDeviceModifierMappingRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDeviceModifierMappingRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDeviceModifierMappingRequest<'_>, "SetDeviceModifierMappingRequest");
 impl<'input> SetDeviceModifierMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -6278,12 +6143,7 @@ pub const GET_DEVICE_BUTTON_MAPPING_REQUEST: u8 = 28;
 pub struct GetDeviceButtonMappingRequest {
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceButtonMappingRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceButtonMappingRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceButtonMappingRequest, "GetDeviceButtonMappingRequest");
 impl GetDeviceButtonMappingRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6415,12 +6275,7 @@ pub struct SetDeviceButtonMappingRequest<'input> {
     pub device_id: u8,
     pub map: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetDeviceButtonMappingRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDeviceButtonMappingRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDeviceButtonMappingRequest<'_>, "SetDeviceButtonMappingRequest");
 impl<'input> SetDeviceButtonMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -7155,12 +7010,7 @@ pub const QUERY_DEVICE_STATE_REQUEST: u8 = 30;
 pub struct QueryDeviceStateRequest {
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryDeviceStateRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryDeviceStateRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryDeviceStateRequest, "QueryDeviceStateRequest");
 impl QueryDeviceStateRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7287,12 +7137,7 @@ pub struct DeviceBellRequest {
     pub feedback_class: u8,
     pub percent: i8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceBellRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceBellRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceBellRequest, "DeviceBellRequest");
 impl DeviceBellRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7359,12 +7204,7 @@ pub struct SetDeviceValuatorsRequest<'input> {
     pub first_valuator: u8,
     pub valuators: Cow<'input, [i32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetDeviceValuatorsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDeviceValuatorsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDeviceValuatorsRequest<'_>, "SetDeviceValuatorsRequest");
 impl<'input> SetDeviceValuatorsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -8335,12 +8175,7 @@ pub struct GetDeviceControlRequest {
     pub control_id: DeviceControl,
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceControlRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceControlRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceControlRequest, "GetDeviceControlRequest");
 impl GetDeviceControlRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9190,12 +9025,7 @@ pub struct ChangeDeviceControlRequest {
     pub device_id: u8,
     pub control: DeviceCtl,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeDeviceControlRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeDeviceControlRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeDeviceControlRequest, "ChangeDeviceControlRequest");
 impl ChangeDeviceControlRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 3]> {
@@ -9347,12 +9177,7 @@ pub const LIST_DEVICE_PROPERTIES_REQUEST: u8 = 36;
 pub struct ListDevicePropertiesRequest {
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListDevicePropertiesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListDevicePropertiesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListDevicePropertiesRequest, "ListDevicePropertiesRequest");
 impl ListDevicePropertiesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9663,12 +9488,7 @@ pub struct ChangeDevicePropertyRequest<'input> {
     pub num_items: u32,
     pub items: Cow<'input, ChangeDevicePropertyAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeDevicePropertyRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeDevicePropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeDevicePropertyRequest<'_>, "ChangeDevicePropertyRequest");
 impl<'input> ChangeDevicePropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -9771,12 +9591,7 @@ pub struct DeleteDevicePropertyRequest {
     pub property: xproto::Atom,
     pub device_id: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeleteDevicePropertyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeleteDevicePropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeleteDevicePropertyRequest, "DeleteDevicePropertyRequest");
 impl DeleteDevicePropertyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9845,12 +9660,7 @@ pub struct GetDevicePropertyRequest {
     pub device_id: u8,
     pub delete: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDevicePropertyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDevicePropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDevicePropertyRequest, "GetDevicePropertyRequest");
 impl GetDevicePropertyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -10293,12 +10103,7 @@ pub struct XIQueryPointerRequest {
     pub window: xproto::Window,
     pub deviceid: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIQueryPointerRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIQueryPointerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIQueryPointerRequest, "XIQueryPointerRequest");
 impl XIQueryPointerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -10463,12 +10268,7 @@ pub struct XIWarpPointerRequest {
     pub dst_y: Fp1616,
     pub deviceid: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIWarpPointerRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIWarpPointerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIWarpPointerRequest, "XIWarpPointerRequest");
 impl XIWarpPointerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -10579,12 +10379,7 @@ pub struct XIChangeCursorRequest {
     pub cursor: xproto::Cursor,
     pub deviceid: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIChangeCursorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIChangeCursorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIChangeCursorRequest, "XIChangeCursorRequest");
 impl XIChangeCursorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11309,12 +11104,7 @@ pub const XI_CHANGE_HIERARCHY_REQUEST: u8 = 43;
 pub struct XIChangeHierarchyRequest<'input> {
     pub changes: Cow<'input, [HierarchyChange]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for XIChangeHierarchyRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIChangeHierarchyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIChangeHierarchyRequest<'_>, "XIChangeHierarchyRequest");
 impl<'input> XIChangeHierarchyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -11384,12 +11174,7 @@ pub struct XISetClientPointerRequest {
     pub window: xproto::Window,
     pub deviceid: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XISetClientPointerRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XISetClientPointerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XISetClientPointerRequest, "XISetClientPointerRequest");
 impl XISetClientPointerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11453,12 +11238,7 @@ pub const XI_GET_CLIENT_POINTER_REQUEST: u8 = 45;
 pub struct XIGetClientPointerRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIGetClientPointerRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIGetClientPointerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIGetClientPointerRequest, "XIGetClientPointerRequest");
 impl XIGetClientPointerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11758,12 +11538,7 @@ pub struct XISelectEventsRequest<'input> {
     pub window: xproto::Window,
     pub masks: Cow<'input, [EventMask]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for XISelectEventsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XISelectEventsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XISelectEventsRequest<'_>, "XISelectEventsRequest");
 impl<'input> XISelectEventsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -11841,12 +11616,7 @@ pub struct XIQueryVersionRequest {
     pub major_version: u16,
     pub minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIQueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIQueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIQueryVersionRequest, "XIQueryVersionRequest");
 impl XIQueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13252,12 +13022,7 @@ pub const XI_QUERY_DEVICE_REQUEST: u8 = 48;
 pub struct XIQueryDeviceRequest {
     pub deviceid: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIQueryDeviceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIQueryDeviceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIQueryDeviceRequest, "XIQueryDeviceRequest");
 impl XIQueryDeviceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13382,12 +13147,7 @@ pub struct XISetFocusRequest {
     pub time: xproto::Timestamp,
     pub deviceid: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XISetFocusRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XISetFocusRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XISetFocusRequest, "XISetFocusRequest");
 impl XISetFocusRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13458,12 +13218,7 @@ pub const XI_GET_FOCUS_REQUEST: u8 = 50;
 pub struct XIGetFocusRequest {
     pub deviceid: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIGetFocusRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIGetFocusRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIGetFocusRequest, "XIGetFocusRequest");
 impl XIGetFocusRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13681,12 +13436,7 @@ pub struct XIGrabDeviceRequest<'input> {
     pub owner_events: GrabOwner,
     pub mask: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for XIGrabDeviceRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIGrabDeviceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIGrabDeviceRequest<'_>, "XIGrabDeviceRequest");
 impl<'input> XIGrabDeviceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -13887,12 +13637,7 @@ pub struct XIUngrabDeviceRequest {
     pub time: xproto::Timestamp,
     pub deviceid: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIUngrabDeviceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIUngrabDeviceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIUngrabDeviceRequest, "XIUngrabDeviceRequest");
 impl XIUngrabDeviceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -14031,12 +13776,7 @@ pub struct XIAllowEventsRequest {
     pub touchid: u32,
     pub grab_window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIAllowEventsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIAllowEventsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIAllowEventsRequest, "XIAllowEventsRequest");
 impl XIAllowEventsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -14346,12 +14086,7 @@ pub struct XIPassiveGrabDeviceRequest<'input> {
     pub mask: Cow<'input, [u32]>,
     pub modifiers: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for XIPassiveGrabDeviceRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIPassiveGrabDeviceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIPassiveGrabDeviceRequest<'_>, "XIPassiveGrabDeviceRequest");
 impl<'input> XIPassiveGrabDeviceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 4]> {
@@ -14562,12 +14297,7 @@ pub struct XIPassiveUngrabDeviceRequest<'input> {
     pub grab_type: GrabType,
     pub modifiers: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for XIPassiveUngrabDeviceRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIPassiveUngrabDeviceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIPassiveUngrabDeviceRequest<'_>, "XIPassiveUngrabDeviceRequest");
 impl<'input> XIPassiveUngrabDeviceRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -14665,12 +14395,7 @@ pub const XI_LIST_PROPERTIES_REQUEST: u8 = 56;
 pub struct XIListPropertiesRequest {
     pub deviceid: DeviceId,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIListPropertiesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIListPropertiesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIListPropertiesRequest, "XIListPropertiesRequest");
 impl XIListPropertiesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -14919,12 +14644,7 @@ pub struct XIChangePropertyRequest<'input> {
     pub num_items: u32,
     pub items: Cow<'input, XIChangePropertyAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for XIChangePropertyRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIChangePropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIChangePropertyRequest<'_>, "XIChangePropertyRequest");
 impl<'input> XIChangePropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -15026,12 +14746,7 @@ pub struct XIDeletePropertyRequest {
     pub deviceid: DeviceId,
     pub property: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIDeletePropertyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIDeletePropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIDeletePropertyRequest, "XIDeletePropertyRequest");
 impl XIDeletePropertyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -15100,12 +14815,7 @@ pub struct XIGetPropertyRequest {
     pub offset: u32,
     pub len: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIGetPropertyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIGetPropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIGetPropertyRequest, "XIGetPropertyRequest");
 impl XIGetPropertyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -15374,12 +15084,7 @@ pub const XI_GET_SELECTED_EVENTS_REQUEST: u8 = 60;
 pub struct XIGetSelectedEventsRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for XIGetSelectedEventsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIGetSelectedEventsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIGetSelectedEventsRequest, "XIGetSelectedEventsRequest");
 impl XIGetSelectedEventsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -15550,12 +15255,7 @@ pub const XI_BARRIER_RELEASE_POINTER_REQUEST: u8 = 61;
 pub struct XIBarrierReleasePointerRequest<'input> {
     pub barriers: Cow<'input, [BarrierReleasePointerInfo]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for XIBarrierReleasePointerRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("XIBarrierReleasePointerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(XIBarrierReleasePointerRequest<'_>, "XIBarrierReleasePointerRequest");
 impl<'input> XIBarrierReleasePointerRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -20122,12 +19822,7 @@ pub struct SendExtensionEventRequest<'input> {
     pub events: Cow<'input, [EventForSend]>,
     pub classes: Cow<'input, [EventClass]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SendExtensionEventRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SendExtensionEventRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SendExtensionEventRequest<'_>, "SendExtensionEventRequest");
 impl<'input> SendExtensionEventRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 4]> {

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -5907,12 +5907,7 @@ pub struct UseExtensionRequest {
     pub wanted_major: u16,
     pub wanted_minor: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UseExtensionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UseExtensionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UseExtensionRequest, "UseExtensionRequest");
 impl UseExtensionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6719,12 +6714,7 @@ pub struct SelectEventsRequest<'input> {
     pub map: MapPart,
     pub details: Cow<'input, SelectEventsAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SelectEventsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsRequest<'_>, "SelectEventsRequest");
 impl<'input> SelectEventsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -6833,12 +6823,7 @@ pub struct BellRequest {
     pub name: xproto::Atom,
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BellRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BellRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BellRequest, "BellRequest");
 impl BellRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -6943,12 +6928,7 @@ pub const GET_STATE_REQUEST: u8 = 4;
 pub struct GetStateRequest {
     pub device_spec: DeviceSpec,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetStateRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetStateRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetStateRequest, "GetStateRequest");
 impl GetStateRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7163,12 +7143,7 @@ pub struct LatchLockStateRequest {
     pub latch_group: bool,
     pub group_latch: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for LatchLockStateRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("LatchLockStateRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(LatchLockStateRequest, "LatchLockStateRequest");
 impl LatchLockStateRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7259,12 +7234,7 @@ pub const GET_CONTROLS_REQUEST: u8 = 6;
 pub struct GetControlsRequest {
     pub device_spec: DeviceSpec,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetControlsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetControlsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetControlsRequest, "GetControlsRequest");
 impl GetControlsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -7608,12 +7578,7 @@ pub struct SetControlsRequest<'input> {
     pub access_x_timeout_options_values: AXOption,
     pub per_key_repeat: Cow<'input, [u8; 32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetControlsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetControlsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetControlsRequest<'_>, "SetControlsRequest");
 impl<'input> SetControlsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 2]> {
@@ -7885,12 +7850,7 @@ pub struct GetMapRequest {
     pub first_v_mod_map_key: xproto::Keycode,
     pub n_v_mod_map_keys: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMapRequest, "GetMapRequest");
 impl GetMapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8655,12 +8615,7 @@ pub struct SetMapRequest<'input> {
     pub virtual_mods: VMod,
     pub values: Cow<'input, SetMapAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetMapRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetMapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetMapRequest<'_>, "SetMapRequest");
 impl<'input> SetMapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -8862,12 +8817,7 @@ pub struct GetCompatMapRequest {
     pub first_si: u16,
     pub n_si: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCompatMapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCompatMapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCompatMapRequest, "GetCompatMapRequest");
 impl GetCompatMapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9029,12 +8979,7 @@ pub struct SetCompatMapRequest<'input> {
     pub si: Cow<'input, [SymInterpret]>,
     pub group_maps: Cow<'input, [ModDef]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetCompatMapRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetCompatMapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetCompatMapRequest<'_>, "SetCompatMapRequest");
 impl<'input> SetCompatMapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 4]> {
@@ -9139,12 +9084,7 @@ pub const GET_INDICATOR_STATE_REQUEST: u8 = 12;
 pub struct GetIndicatorStateRequest {
     pub device_spec: DeviceSpec,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetIndicatorStateRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetIndicatorStateRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetIndicatorStateRequest, "GetIndicatorStateRequest");
 impl GetIndicatorStateRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9287,12 +9227,7 @@ pub struct GetIndicatorMapRequest {
     pub device_spec: DeviceSpec,
     pub which: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetIndicatorMapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetIndicatorMapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetIndicatorMapRequest, "GetIndicatorMapRequest");
 impl GetIndicatorMapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9417,12 +9352,7 @@ pub struct SetIndicatorMapRequest<'input> {
     pub which: u32,
     pub maps: Cow<'input, [IndicatorMap]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetIndicatorMapRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetIndicatorMapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetIndicatorMapRequest<'_>, "SetIndicatorMapRequest");
 impl<'input> SetIndicatorMapRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -9504,12 +9434,7 @@ pub struct GetNamedIndicatorRequest {
     pub led_id: IDSpec,
     pub indicator: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetNamedIndicatorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetNamedIndicatorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetNamedIndicatorRequest, "GetNamedIndicatorRequest");
 impl GetNamedIndicatorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9743,12 +9668,7 @@ pub struct SetNamedIndicatorRequest {
     pub map_vmods: VMod,
     pub map_ctrls: BoolCtrl,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetNamedIndicatorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetNamedIndicatorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetNamedIndicatorRequest, "SetNamedIndicatorRequest");
 impl SetNamedIndicatorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9881,12 +9801,7 @@ pub struct GetNamesRequest {
     pub device_spec: DeviceSpec,
     pub which: NameDetail,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetNamesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetNamesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetNamesRequest, "GetNamesRequest");
 impl GetNamesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -10714,12 +10629,7 @@ pub struct SetNamesRequest<'input> {
     pub total_kt_level_names: u16,
     pub values: Cow<'input, SetNamesAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetNamesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetNamesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetNamesRequest<'_>, "SetNamesRequest");
 impl<'input> SetNamesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -10867,12 +10777,7 @@ pub struct PerClientFlagsRequest {
     pub auto_ctrls: BoolCtrl,
     pub auto_ctrls_values: BoolCtrl,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PerClientFlagsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PerClientFlagsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PerClientFlagsRequest, "PerClientFlagsRequest");
 impl PerClientFlagsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11071,12 +10976,7 @@ pub struct ListComponentsRequest {
     pub device_spec: DeviceSpec,
     pub max_names: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListComponentsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListComponentsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListComponentsRequest, "ListComponentsRequest");
 impl ListComponentsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11303,12 +11203,7 @@ pub struct GetKbdByNameRequest {
     pub want: GBNDetail,
     pub load: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKbdByNameRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKbdByNameRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKbdByNameRequest, "GetKbdByNameRequest");
 impl GetKbdByNameRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12457,12 +12352,7 @@ pub struct GetDeviceInfoRequest {
     pub led_class: LedClass,
     pub led_id: IDSpec,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceInfoRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceInfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceInfoRequest, "GetDeviceInfoRequest");
 impl GetDeviceInfoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12699,12 +12589,7 @@ pub struct SetDeviceInfoRequest<'input> {
     pub btn_actions: Cow<'input, [Action]>,
     pub leds: Cow<'input, [DeviceLedInfo]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetDeviceInfoRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDeviceInfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDeviceInfoRequest<'_>, "SetDeviceInfoRequest");
 impl<'input> SetDeviceInfoRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 4]> {
@@ -12801,12 +12686,7 @@ pub struct SetDebuggingFlagsRequest<'input> {
     pub ctrls: u32,
     pub message: Cow<'input, [String8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetDebuggingFlagsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDebuggingFlagsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDebuggingFlagsRequest<'_>, "SetDebuggingFlagsRequest");
 impl<'input> SetDebuggingFlagsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {

--- a/x11rb-protocol/src/protocol/xkb.rs
+++ b/x11rb-protocol/src/protocol/xkb.rs
@@ -1917,12 +1917,7 @@ pub struct IndicatorMap {
     pub vmods: VMod,
     pub ctrls: BoolCtrl,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IndicatorMap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IndicatorMap").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IndicatorMap, "IndicatorMap");
 impl TryParse for IndicatorMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (flags, remaining) = u8::try_parse(remaining)?;
@@ -2304,12 +2299,7 @@ pub struct ModDef {
     pub real_mods: xproto::ModMask,
     pub vmods: VMod,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ModDef {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ModDef").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ModDef, "ModDef");
 impl TryParse for ModDef {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (mask, remaining) = u8::try_parse(remaining)?;
@@ -2349,12 +2339,7 @@ impl Serialize for ModDef {
 pub struct KeyName {
     pub name: [u8; 4],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KeyName {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KeyName").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KeyName, "KeyName");
 impl TryParse for KeyName {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (name, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
@@ -2385,12 +2370,7 @@ pub struct KeyAlias {
     pub real: [u8; 4],
     pub alias: [u8; 4],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KeyAlias {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KeyAlias").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KeyAlias, "KeyAlias");
 impl TryParse for KeyAlias {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (real, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
@@ -2427,12 +2407,7 @@ pub struct CountedString16 {
     pub string: Vec<u8>,
     pub alignment_pad: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CountedString16 {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CountedString16").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CountedString16, "CountedString16");
 impl TryParse for CountedString16 {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (length, remaining) = u16::try_parse(remaining)?;
@@ -2485,12 +2460,7 @@ pub struct KTMapEntry {
     pub mods_mods: xproto::ModMask,
     pub mods_vmods: VMod,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KTMapEntry {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KTMapEntry").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KTMapEntry, "KTMapEntry");
 impl TryParse for KTMapEntry {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (active, remaining) = bool::try_parse(remaining)?;
@@ -2548,12 +2518,7 @@ pub struct KeyType {
     pub map: Vec<KTMapEntry>,
     pub preserve: Vec<ModDef>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KeyType {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KeyType").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KeyType, "KeyType");
 impl TryParse for KeyType {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (mods_mask, remaining) = u8::try_parse(remaining)?;
@@ -2619,12 +2584,7 @@ pub struct KeySymMap {
     pub width: u8,
     pub syms: Vec<xproto::Keysym>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KeySymMap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KeySymMap").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KeySymMap, "KeySymMap");
 impl TryParse for KeySymMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (kt_index, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
@@ -2676,12 +2636,7 @@ pub struct CommonBehavior {
     pub type_: u8,
     pub data: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CommonBehavior {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CommonBehavior").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CommonBehavior, "CommonBehavior");
 impl TryParse for CommonBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -2713,12 +2668,7 @@ impl Serialize for CommonBehavior {
 pub struct DefaultBehavior {
     pub type_: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DefaultBehavior {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DefaultBehavior").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DefaultBehavior, "DefaultBehavior");
 impl TryParse for DefaultBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -2752,12 +2702,7 @@ pub struct RadioGroupBehavior {
     pub type_: u8,
     pub group: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RadioGroupBehavior {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RadioGroupBehavior").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RadioGroupBehavior, "RadioGroupBehavior");
 impl TryParse for RadioGroupBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -2790,12 +2735,7 @@ pub struct OverlayBehavior {
     pub type_: u8,
     pub key: xproto::Keycode,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for OverlayBehavior {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OverlayBehavior").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OverlayBehavior, "OverlayBehavior");
 impl TryParse for OverlayBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -3054,12 +2994,7 @@ pub struct SetBehavior {
     pub keycode: xproto::Keycode,
     pub behavior: Behavior,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetBehavior {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetBehavior").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetBehavior, "SetBehavior");
 impl TryParse for SetBehavior {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
@@ -3096,12 +3031,7 @@ pub struct SetExplicit {
     pub keycode: xproto::Keycode,
     pub explicit: Explicit,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetExplicit {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetExplicit").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetExplicit, "SetExplicit");
 impl TryParse for SetExplicit {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
@@ -3135,12 +3065,7 @@ pub struct KeyModMap {
     pub keycode: xproto::Keycode,
     pub mods: xproto::ModMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KeyModMap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KeyModMap").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KeyModMap, "KeyModMap");
 impl TryParse for KeyModMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
@@ -3174,12 +3099,7 @@ pub struct KeyVModMap {
     pub keycode: xproto::Keycode,
     pub vmods: VMod,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KeyVModMap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KeyVModMap").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KeyVModMap, "KeyVModMap");
 impl TryParse for KeyVModMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (keycode, remaining) = xproto::Keycode::try_parse(remaining)?;
@@ -3218,12 +3138,7 @@ pub struct KTSetMapEntry {
     pub real_mods: xproto::ModMask,
     pub virtual_mods: VMod,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KTSetMapEntry {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KTSetMapEntry").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KTSetMapEntry, "KTSetMapEntry");
 impl TryParse for KTSetMapEntry {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (level, remaining) = u8::try_parse(remaining)?;
@@ -3268,12 +3183,7 @@ pub struct SetKeyType {
     pub entries: Vec<KTSetMapEntry>,
     pub preserve_entries: Vec<KTSetMapEntry>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetKeyType {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetKeyType").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetKeyType, "SetKeyType");
 impl TryParse for SetKeyType {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (mask, remaining) = u8::try_parse(remaining)?;
@@ -3339,12 +3249,7 @@ pub struct Outline {
     pub corner_radius: u8,
     pub points: Vec<xproto::Point>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Outline {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Outline").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Outline, "Outline");
 impl TryParse for Outline {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (n_points, remaining) = u8::try_parse(remaining)?;
@@ -3396,12 +3301,7 @@ pub struct Shape {
     pub approx_ndx: u8,
     pub outlines: Vec<Outline>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Shape {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Shape").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Shape, "Shape");
 impl TryParse for Shape {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (name, remaining) = xproto::Atom::try_parse(remaining)?;
@@ -3457,12 +3357,7 @@ pub struct Key {
     pub shape_ndx: u8,
     pub color_ndx: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Key {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Key").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Key, "Key");
 impl TryParse for Key {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (name, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
@@ -3506,12 +3401,7 @@ pub struct OverlayKey {
     pub over: [String8; 4],
     pub under: [String8; 4],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for OverlayKey {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OverlayKey").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OverlayKey, "OverlayKey");
 impl TryParse for OverlayKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (over, remaining) = crate::x11_utils::parse_u8_array::<4>(remaining)?;
@@ -3548,12 +3438,7 @@ pub struct OverlayRow {
     pub row_under: u8,
     pub keys: Vec<OverlayKey>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for OverlayRow {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OverlayRow").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OverlayRow, "OverlayRow");
 impl TryParse for OverlayRow {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (row_under, remaining) = u8::try_parse(remaining)?;
@@ -3603,12 +3488,7 @@ pub struct Overlay {
     pub name: xproto::Atom,
     pub rows: Vec<OverlayRow>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Overlay {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Overlay").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Overlay, "Overlay");
 impl TryParse for Overlay {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (name, remaining) = xproto::Atom::try_parse(remaining)?;
@@ -3660,12 +3540,7 @@ pub struct Row {
     pub vertical: bool,
     pub keys: Vec<Key>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Row {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Row").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Row, "Row");
 impl TryParse for Row {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (top, remaining) = i16::try_parse(remaining)?;
@@ -3784,12 +3659,7 @@ pub struct Listing {
     pub flags: u16,
     pub string: Vec<String8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Listing {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Listing").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Listing, "Listing");
 impl TryParse for Listing {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -3850,12 +3720,7 @@ pub struct DeviceLedInfo {
     pub names: Vec<xproto::Atom>,
     pub maps: Vec<IndicatorMap>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeviceLedInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeviceLedInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeviceLedInfo, "DeviceLedInfo");
 impl TryParse for DeviceLedInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (led_class, remaining) = LedClassSpec::try_parse(remaining)?;
@@ -4124,12 +3989,7 @@ impl core::fmt::Debug for SAType  {
 pub struct SANoAction {
     pub type_: SAType,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SANoAction {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SANoAction").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SANoAction, "SANoAction");
 impl TryParse for SANoAction {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -4172,12 +4032,7 @@ pub struct SASetMods {
     pub vmods_high: VModsHigh,
     pub vmods_low: VModsLow,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SASetMods {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SASetMods").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SASetMods, "SASetMods");
 impl TryParse for SASetMods {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -4241,12 +4096,7 @@ pub struct SASetGroup {
     pub flags: SA,
     pub group: i8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SASetGroup {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SASetGroup").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SASetGroup, "SASetGroup");
 impl TryParse for SASetGroup {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -4362,12 +4212,7 @@ pub struct SAMovePtr {
     pub y_high: i8,
     pub y_low: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SAMovePtr {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SAMovePtr").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SAMovePtr, "SAMovePtr");
 impl TryParse for SAMovePtr {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -4424,12 +4269,7 @@ pub struct SAPtrBtn {
     pub count: u8,
     pub button: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SAPtrBtn {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SAPtrBtn").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SAPtrBtn, "SAPtrBtn");
 impl TryParse for SAPtrBtn {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -4478,12 +4318,7 @@ pub struct SALockPtrBtn {
     pub flags: u8,
     pub button: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SALockPtrBtn {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SALockPtrBtn").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SALockPtrBtn, "SALockPtrBtn");
 impl TryParse for SALockPtrBtn {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -4592,12 +4427,7 @@ pub struct SASetPtrDflt {
     pub affect: SASetPtrDfltFlag,
     pub value: i8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SASetPtrDflt {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SASetPtrDflt").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SASetPtrDflt, "SASetPtrDflt");
 impl TryParse for SASetPtrDflt {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -4783,12 +4613,7 @@ pub struct SAIsoLock {
     pub vmods_high: VModsHigh,
     pub vmods_low: VModsLow,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SAIsoLock {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SAIsoLock").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SAIsoLock, "SAIsoLock");
 impl TryParse for SAIsoLock {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -4851,12 +4676,7 @@ impl Serialize for SAIsoLock {
 pub struct SATerminate {
     pub type_: SAType,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SATerminate {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SATerminate").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SATerminate, "SATerminate");
 impl TryParse for SATerminate {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -4956,12 +4776,7 @@ pub struct SASwitchScreen {
     pub flags: u8,
     pub new_screen: i8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SASwitchScreen {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SASwitchScreen").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SASwitchScreen, "SASwitchScreen");
 impl TryParse for SASwitchScreen {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -5145,12 +4960,7 @@ pub struct SASetControls {
     pub bool_ctrls_high: BoolCtrlsHigh,
     pub bool_ctrls_low: BoolCtrlsLow,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SASetControls {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SASetControls").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SASetControls, "SASetControls");
 impl TryParse for SASetControls {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -5264,12 +5074,7 @@ pub struct SAActionMessage {
     pub flags: ActionMessageFlag,
     pub message: [u8; 6],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SAActionMessage {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SAActionMessage").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SAActionMessage, "SAActionMessage");
 impl TryParse for SAActionMessage {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -5318,12 +5123,7 @@ pub struct SARedirectKey {
     pub vmods_high: VModsHigh,
     pub vmods_low: VModsLow,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SARedirectKey {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SARedirectKey").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SARedirectKey, "SARedirectKey");
 impl TryParse for SARedirectKey {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -5390,12 +5190,7 @@ pub struct SADeviceBtn {
     pub button: u8,
     pub device: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SADeviceBtn {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SADeviceBtn").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SADeviceBtn, "SADeviceBtn");
 impl TryParse for SADeviceBtn {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -5508,12 +5303,7 @@ pub struct SALockDeviceBtn {
     pub button: u8,
     pub device: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SALockDeviceBtn {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SALockDeviceBtn").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SALockDeviceBtn, "SALockDeviceBtn");
 impl TryParse for SALockDeviceBtn {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -5637,12 +5427,7 @@ pub struct SADeviceValuator {
     pub val2index: u8,
     pub val2value: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SADeviceValuator {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SADeviceValuator").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SADeviceValuator, "SADeviceValuator");
 impl TryParse for SADeviceValuator {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -5702,12 +5487,7 @@ pub struct SIAction {
     pub type_: SAType,
     pub data: [u8; 7],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SIAction {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SIAction").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SIAction, "SIAction");
 impl TryParse for SIAction {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (type_, remaining) = u8::try_parse(remaining)?;
@@ -5750,12 +5530,7 @@ pub struct SymInterpret {
     pub flags: u8,
     pub action: SIAction,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SymInterpret {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SymInterpret").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SymInterpret, "SymInterpret");
 impl TryParse for SymInterpret {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (sym, remaining) = xproto::Keysym::try_parse(remaining)?;
@@ -6199,12 +5974,7 @@ pub struct UseExtensionReply {
     pub server_major: u16,
     pub server_minor: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UseExtensionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UseExtensionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UseExtensionReply, "UseExtensionReply");
 impl TryParse for UseExtensionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6289,12 +6059,7 @@ pub struct SelectEventsAuxNewKeyboardNotify {
     pub affect_new_keyboard: NKNDetail,
     pub new_keyboard_details: NKNDetail,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectEventsAuxNewKeyboardNotify {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsAuxNewKeyboardNotify").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsAuxNewKeyboardNotify, "SelectEventsAuxNewKeyboardNotify");
 impl TryParse for SelectEventsAuxNewKeyboardNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_new_keyboard, remaining) = u16::try_parse(remaining)?;
@@ -6330,12 +6095,7 @@ pub struct SelectEventsAuxStateNotify {
     pub affect_state: StatePart,
     pub state_details: StatePart,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectEventsAuxStateNotify {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsAuxStateNotify").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsAuxStateNotify, "SelectEventsAuxStateNotify");
 impl TryParse for SelectEventsAuxStateNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_state, remaining) = u16::try_parse(remaining)?;
@@ -6371,12 +6131,7 @@ pub struct SelectEventsAuxControlsNotify {
     pub affect_ctrls: Control,
     pub ctrl_details: Control,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectEventsAuxControlsNotify {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsAuxControlsNotify").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsAuxControlsNotify, "SelectEventsAuxControlsNotify");
 impl TryParse for SelectEventsAuxControlsNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_ctrls, remaining) = u32::try_parse(remaining)?;
@@ -6416,12 +6171,7 @@ pub struct SelectEventsAuxIndicatorStateNotify {
     pub affect_indicator_state: u32,
     pub indicator_state_details: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectEventsAuxIndicatorStateNotify {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsAuxIndicatorStateNotify").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsAuxIndicatorStateNotify, "SelectEventsAuxIndicatorStateNotify");
 impl TryParse for SelectEventsAuxIndicatorStateNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_indicator_state, remaining) = u32::try_parse(remaining)?;
@@ -6459,12 +6209,7 @@ pub struct SelectEventsAuxIndicatorMapNotify {
     pub affect_indicator_map: u32,
     pub indicator_map_details: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectEventsAuxIndicatorMapNotify {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsAuxIndicatorMapNotify").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsAuxIndicatorMapNotify, "SelectEventsAuxIndicatorMapNotify");
 impl TryParse for SelectEventsAuxIndicatorMapNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_indicator_map, remaining) = u32::try_parse(remaining)?;
@@ -6502,12 +6247,7 @@ pub struct SelectEventsAuxNamesNotify {
     pub affect_names: NameDetail,
     pub names_details: NameDetail,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectEventsAuxNamesNotify {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsAuxNamesNotify").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsAuxNamesNotify, "SelectEventsAuxNamesNotify");
 impl TryParse for SelectEventsAuxNamesNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_names, remaining) = u16::try_parse(remaining)?;
@@ -6543,12 +6283,7 @@ pub struct SelectEventsAuxCompatMapNotify {
     pub affect_compat: CMDetail,
     pub compat_details: CMDetail,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectEventsAuxCompatMapNotify {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsAuxCompatMapNotify").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsAuxCompatMapNotify, "SelectEventsAuxCompatMapNotify");
 impl TryParse for SelectEventsAuxCompatMapNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_compat, remaining) = u8::try_parse(remaining)?;
@@ -6582,12 +6317,7 @@ pub struct SelectEventsAuxBellNotify {
     pub affect_bell: u8,
     pub bell_details: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectEventsAuxBellNotify {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsAuxBellNotify").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsAuxBellNotify, "SelectEventsAuxBellNotify");
 impl TryParse for SelectEventsAuxBellNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_bell, remaining) = u8::try_parse(remaining)?;
@@ -6619,12 +6349,7 @@ pub struct SelectEventsAuxActionMessage {
     pub affect_msg_details: u8,
     pub msg_details: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectEventsAuxActionMessage {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsAuxActionMessage").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsAuxActionMessage, "SelectEventsAuxActionMessage");
 impl TryParse for SelectEventsAuxActionMessage {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_msg_details, remaining) = u8::try_parse(remaining)?;
@@ -6656,12 +6381,7 @@ pub struct SelectEventsAuxAccessXNotify {
     pub affect_access_x: AXNDetail,
     pub access_x_details: AXNDetail,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectEventsAuxAccessXNotify {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsAuxAccessXNotify").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsAuxAccessXNotify, "SelectEventsAuxAccessXNotify");
 impl TryParse for SelectEventsAuxAccessXNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_access_x, remaining) = u16::try_parse(remaining)?;
@@ -6697,12 +6417,7 @@ pub struct SelectEventsAuxExtensionDeviceNotify {
     pub affect_ext_dev: XIFeature,
     pub extdev_details: XIFeature,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectEventsAuxExtensionDeviceNotify {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsAuxExtensionDeviceNotify").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsAuxExtensionDeviceNotify, "SelectEventsAuxExtensionDeviceNotify");
 impl TryParse for SelectEventsAuxExtensionDeviceNotify {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (affect_ext_dev, remaining) = u16::try_parse(remaining)?;
@@ -6748,12 +6463,7 @@ pub struct SelectEventsAux {
     pub access_x_notify: Option<SelectEventsAuxAccessXNotify>,
     pub extension_device_notify: Option<SelectEventsAuxExtensionDeviceNotify>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectEventsAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectEventsAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectEventsAux, "SelectEventsAux");
 impl SelectEventsAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], affect_which: u16, clear: u16, select_all: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -7310,12 +7020,7 @@ pub struct GetStateReply {
     pub compat_lookup_mods: xproto::ModMask,
     pub ptr_btn_state: xproto::KeyButMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetStateReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetStateReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetStateReply, "GetStateReply");
 impl TryParse for GetStateReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -7643,12 +7348,7 @@ pub struct GetControlsReply {
     pub enabled_controls: BoolCtrl,
     pub per_key_repeat: [u8; 32],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetControlsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetControlsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetControlsReply, "GetControlsReply");
 impl TryParse for GetControlsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -8321,12 +8021,7 @@ pub struct GetMapMapKeyActions {
     pub acts_rtrn_count: Vec<u8>,
     pub acts_rtrn_acts: Vec<Action>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMapMapKeyActions {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMapMapKeyActions").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMapMapKeyActions, "GetMapMapKeyActions");
 impl GetMapMapKeyActions {
     pub fn try_parse(remaining: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -8369,12 +8064,7 @@ pub struct GetMapMap {
     pub modmap_rtrn: Option<Vec<KeyModMap>>,
     pub vmodmap_rtrn: Option<Vec<KeyVModMap>>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMapMap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMapMap").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMapMap, "GetMapMap");
 impl GetMapMap {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -8581,12 +8271,7 @@ pub struct GetMapReply {
     pub virtual_mods: VMod,
     pub map: GetMapMap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMapReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMapReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMapReply, "GetMapReply");
 impl TryParse for GetMapReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -8686,12 +8371,7 @@ pub struct SetMapAuxKeyActions {
     pub actions_count: Vec<u8>,
     pub actions: Vec<Action>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetMapAuxKeyActions {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetMapAuxKeyActions").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetMapAuxKeyActions, "SetMapAuxKeyActions");
 impl SetMapAuxKeyActions {
     pub fn try_parse(remaining: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -8735,12 +8415,7 @@ pub struct SetMapAux {
     pub modmap: Option<Vec<KeyModMap>>,
     pub vmodmap: Option<Vec<KeyVModMap>>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetMapAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetMapAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetMapAux, "SetMapAux");
 impl SetMapAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -9271,12 +8946,7 @@ pub struct GetCompatMapReply {
     pub si_rtrn: Vec<SymInterpret>,
     pub group_rtrn: Vec<ModDef>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetCompatMapReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetCompatMapReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetCompatMapReply, "GetCompatMapReply");
 impl TryParse for GetCompatMapReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -9533,12 +9203,7 @@ pub struct GetIndicatorStateReply {
     pub length: u32,
     pub state: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetIndicatorStateReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetIndicatorStateReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetIndicatorStateReply, "GetIndicatorStateReply");
 impl TryParse for GetIndicatorStateReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -9696,12 +9361,7 @@ pub struct GetIndicatorMapReply {
     pub n_indicators: u8,
     pub maps: Vec<IndicatorMap>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetIndicatorMapReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetIndicatorMapReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetIndicatorMapReply, "GetIndicatorMapReply");
 impl TryParse for GetIndicatorMapReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -9939,12 +9599,7 @@ pub struct GetNamedIndicatorReply {
     pub map_ctrls: BoolCtrl,
     pub supported: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetNamedIndicatorReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetNamedIndicatorReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetNamedIndicatorReply, "GetNamedIndicatorReply");
 impl TryParse for GetNamedIndicatorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10296,12 +9951,7 @@ pub struct GetNamesValueListKTLevelNames {
     pub n_levels_per_type: Vec<u8>,
     pub kt_level_names: Vec<xproto::Atom>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetNamesValueListKTLevelNames {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetNamesValueListKTLevelNames").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetNamesValueListKTLevelNames, "GetNamesValueListKTLevelNames");
 impl GetNamesValueListKTLevelNames {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -10350,12 +10000,7 @@ pub struct GetNamesValueList {
     pub key_aliases: Option<Vec<KeyAlias>>,
     pub radio_group_names: Option<Vec<xproto::Atom>>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetNamesValueList {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetNamesValueList").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetNamesValueList, "GetNamesValueList");
 impl GetNamesValueList {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -10605,12 +10250,7 @@ pub struct GetNamesReply {
     pub n_kt_levels: u16,
     pub value_list: GetNamesValueList,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetNamesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetNamesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetNamesReply, "GetNamesReply");
 impl TryParse for GetNamesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10683,12 +10323,7 @@ pub struct SetNamesAuxKTLevelNames {
     pub n_levels_per_type: Vec<u8>,
     pub kt_level_names: Vec<xproto::Atom>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetNamesAuxKTLevelNames {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetNamesAuxKTLevelNames").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetNamesAuxKTLevelNames, "SetNamesAuxKTLevelNames");
 impl SetNamesAuxKTLevelNames {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -10738,12 +10373,7 @@ pub struct SetNamesAux {
     pub key_aliases: Option<Vec<KeyAlias>>,
     pub radio_group_names: Option<Vec<xproto::Atom>>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetNamesAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetNamesAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetNamesAux, "SetNamesAux");
 impl SetNamesAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -11344,12 +10974,7 @@ pub struct PerClientFlagsReply {
     pub auto_ctrls: BoolCtrl,
     pub auto_ctrls_values: BoolCtrl,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PerClientFlagsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PerClientFlagsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PerClientFlagsReply, "PerClientFlagsReply");
 impl TryParse for PerClientFlagsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -11518,12 +11143,7 @@ pub struct ListComponentsReply {
     pub symbols: Vec<Listing>,
     pub geometries: Vec<Listing>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListComponentsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListComponentsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListComponentsReply, "ListComponentsReply");
 impl TryParse for ListComponentsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -11760,12 +11380,7 @@ pub struct GetKbdByNameRepliesTypesMapKeyActions {
     pub acts_rtrn_count: Vec<u8>,
     pub acts_rtrn_acts: Vec<Action>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKbdByNameRepliesTypesMapKeyActions {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKbdByNameRepliesTypesMapKeyActions").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKbdByNameRepliesTypesMapKeyActions, "GetKbdByNameRepliesTypesMapKeyActions");
 impl GetKbdByNameRepliesTypesMapKeyActions {
     pub fn try_parse(remaining: &[u8], n_key_actions: u8, total_actions: u16) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -11808,12 +11423,7 @@ pub struct GetKbdByNameRepliesTypesMap {
     pub modmap_rtrn: Option<Vec<KeyModMap>>,
     pub vmodmap_rtrn: Option<Vec<KeyVModMap>>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKbdByNameRepliesTypesMap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKbdByNameRepliesTypesMap").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKbdByNameRepliesTypesMap, "GetKbdByNameRepliesTypesMap");
 impl GetKbdByNameRepliesTypesMap {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], present: u16, n_types: u8, n_key_syms: u8, n_key_actions: u8, total_actions: u16, total_key_behaviors: u8, virtual_mods: u16, total_key_explicit: u8, total_mod_map_keys: u8, total_v_mod_map_keys: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -12021,12 +11631,7 @@ pub struct GetKbdByNameRepliesTypes {
     pub virtual_mods: VMod,
     pub map: GetKbdByNameRepliesTypesMap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKbdByNameRepliesTypes {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKbdByNameRepliesTypes").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKbdByNameRepliesTypes, "GetKbdByNameRepliesTypes");
 impl TryParse for GetKbdByNameRepliesTypes {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (getmap_type, remaining) = u8::try_parse(remaining)?;
@@ -12124,12 +11729,7 @@ pub struct GetKbdByNameRepliesCompatMap {
     pub si_rtrn: Vec<SymInterpret>,
     pub group_rtrn: Vec<ModDef>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKbdByNameRepliesCompatMap {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKbdByNameRepliesCompatMap").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKbdByNameRepliesCompatMap, "GetKbdByNameRepliesCompatMap");
 impl TryParse for GetKbdByNameRepliesCompatMap {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (compatmap_type, remaining) = u8::try_parse(remaining)?;
@@ -12201,12 +11801,7 @@ pub struct GetKbdByNameRepliesIndicatorMaps {
     pub real_indicators: u32,
     pub maps: Vec<IndicatorMap>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKbdByNameRepliesIndicatorMaps {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKbdByNameRepliesIndicatorMaps").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKbdByNameRepliesIndicatorMaps, "GetKbdByNameRepliesIndicatorMaps");
 impl TryParse for GetKbdByNameRepliesIndicatorMaps {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (indicatormap_type, remaining) = u8::try_parse(remaining)?;
@@ -12265,12 +11860,7 @@ pub struct GetKbdByNameRepliesKeyNamesValueListKTLevelNames {
     pub n_levels_per_type: Vec<u8>,
     pub kt_level_names: Vec<xproto::Atom>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKbdByNameRepliesKeyNamesValueListKTLevelNames {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKbdByNameRepliesKeyNamesValueListKTLevelNames").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKbdByNameRepliesKeyNamesValueListKTLevelNames, "GetKbdByNameRepliesKeyNamesValueListKTLevelNames");
 impl GetKbdByNameRepliesKeyNamesValueListKTLevelNames {
     pub fn try_parse(remaining: &[u8], n_types: u8) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -12319,12 +11909,7 @@ pub struct GetKbdByNameRepliesKeyNamesValueList {
     pub key_aliases: Option<Vec<KeyAlias>>,
     pub radio_group_names: Option<Vec<xproto::Atom>>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKbdByNameRepliesKeyNamesValueList {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKbdByNameRepliesKeyNamesValueList").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKbdByNameRepliesKeyNamesValueList, "GetKbdByNameRepliesKeyNamesValueList");
 impl GetKbdByNameRepliesKeyNamesValueList {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], which: u32, n_types: u8, indicators: u32, virtual_mods: u16, group_names: u8, n_keys: u8, n_key_aliases: u8, n_radio_groups: u8) -> Result<(Self, &[u8]), ParseError> {
@@ -12575,12 +12160,7 @@ pub struct GetKbdByNameRepliesKeyNames {
     pub n_kt_levels: u16,
     pub value_list: GetKbdByNameRepliesKeyNamesValueList,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKbdByNameRepliesKeyNames {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKbdByNameRepliesKeyNames").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKbdByNameRepliesKeyNames, "GetKbdByNameRepliesKeyNames");
 impl TryParse for GetKbdByNameRepliesKeyNames {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (keyname_type, remaining) = u8::try_parse(remaining)?;
@@ -12659,12 +12239,7 @@ pub struct GetKbdByNameRepliesGeometry {
     pub label_color_ndx: u8,
     pub label_font: CountedString16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKbdByNameRepliesGeometry {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKbdByNameRepliesGeometry").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKbdByNameRepliesGeometry, "GetKbdByNameRepliesGeometry");
 impl TryParse for GetKbdByNameRepliesGeometry {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (geometry_type, remaining) = u8::try_parse(remaining)?;
@@ -12728,12 +12303,7 @@ pub struct GetKbdByNameReplies {
     pub key_names: Option<GetKbdByNameRepliesKeyNames>,
     pub geometry: Option<GetKbdByNameRepliesGeometry>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKbdByNameReplies {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKbdByNameReplies").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKbdByNameReplies, "GetKbdByNameReplies");
 impl GetKbdByNameReplies {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], reported: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -12820,12 +12390,7 @@ pub struct GetKbdByNameReply {
     pub reported: GBNDetail,
     pub replies: GetKbdByNameReplies,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKbdByNameReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKbdByNameReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKbdByNameReply, "GetKbdByNameReply");
 impl TryParse for GetKbdByNameReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -12997,12 +12562,7 @@ pub struct GetDeviceInfoReply {
     pub btn_actions: Vec<Action>,
     pub leds: Vec<DeviceLedInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceInfoReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceInfoReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceInfoReply, "GetDeviceInfoReply");
 impl TryParse for GetDeviceInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -13350,12 +12910,7 @@ pub struct SetDebuggingFlagsReply {
     pub supported_flags: u32,
     pub supported_ctrls: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetDebuggingFlagsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDebuggingFlagsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDebuggingFlagsReply, "SetDebuggingFlagsReply");
 impl TryParse for SetDebuggingFlagsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -13458,12 +13013,7 @@ pub struct NewKeyboardNotifyEvent {
     pub request_minor: u8,
     pub changed: NKNDetail,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for NewKeyboardNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("NewKeyboardNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(NewKeyboardNotifyEvent, "NewKeyboardNotifyEvent");
 impl TryParse for NewKeyboardNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -13646,12 +13196,7 @@ pub struct MapNotifyEvent {
     pub n_v_mod_map_keys: u8,
     pub virtual_mods: VMod,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MapNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MapNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MapNotifyEvent, "MapNotifyEvent");
 impl TryParse for MapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -13879,12 +13424,7 @@ pub struct StateNotifyEvent {
     pub request_major: u8,
     pub request_minor: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for StateNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("StateNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(StateNotifyEvent, "StateNotifyEvent");
 impl TryParse for StateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14110,12 +13650,7 @@ pub struct ControlsNotifyEvent {
     pub request_major: u8,
     pub request_minor: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ControlsNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ControlsNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ControlsNotifyEvent, "ControlsNotifyEvent");
 impl TryParse for ControlsNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14285,12 +13820,7 @@ pub struct IndicatorStateNotifyEvent {
     pub state: u32,
     pub state_changed: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IndicatorStateNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IndicatorStateNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IndicatorStateNotifyEvent, "IndicatorStateNotifyEvent");
 impl TryParse for IndicatorStateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14433,12 +13963,7 @@ pub struct IndicatorMapNotifyEvent {
     pub state: u32,
     pub map_changed: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for IndicatorMapNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("IndicatorMapNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(IndicatorMapNotifyEvent, "IndicatorMapNotifyEvent");
 impl TryParse for IndicatorMapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14591,12 +14116,7 @@ pub struct NamesNotifyEvent {
     pub n_keys: u8,
     pub changed_indicators: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for NamesNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("NamesNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(NamesNotifyEvent, "NamesNotifyEvent");
 impl TryParse for NamesNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14786,12 +14306,7 @@ pub struct CompatMapNotifyEvent {
     pub n_si: u16,
     pub n_total_si: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CompatMapNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CompatMapNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CompatMapNotifyEvent, "CompatMapNotifyEvent");
 impl TryParse for CompatMapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14947,12 +14462,7 @@ pub struct BellNotifyEvent {
     pub window: xproto::Window,
     pub event_only: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BellNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BellNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BellNotifyEvent, "BellNotifyEvent");
 impl TryParse for BellNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -15122,12 +14632,7 @@ pub struct ActionMessageEvent {
     pub group: Group,
     pub message: [String8; 8],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ActionMessageEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ActionMessageEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ActionMessageEvent, "ActionMessageEvent");
 impl TryParse for ActionMessageEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -15286,12 +14791,7 @@ pub struct AccessXNotifyEvent {
     pub slow_keys_delay: u16,
     pub debounce_delay: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AccessXNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AccessXNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AccessXNotifyEvent, "AccessXNotifyEvent");
 impl TryParse for AccessXNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -15448,12 +14948,7 @@ pub struct ExtensionDeviceNotifyEvent {
     pub supported: XIFeature,
     pub unsupported: XIFeature,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ExtensionDeviceNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ExtensionDeviceNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ExtensionDeviceNotifyEvent, "ExtensionDeviceNotifyEvent");
 impl TryParse for ExtensionDeviceNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xprint.rs
+++ b/x11rb-protocol/src/protocol/xprint.rs
@@ -45,12 +45,7 @@ pub struct Printer {
     pub name: Vec<String8>,
     pub description: Vec<String8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Printer {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Printer").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Printer, "Printer");
 impl TryParse for Printer {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -452,12 +447,7 @@ pub struct PrintQueryVersionReply {
     pub major_version: u16,
     pub minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintQueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintQueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintQueryVersionReply, "PrintQueryVersionReply");
 impl TryParse for PrintQueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -611,12 +601,7 @@ pub struct PrintGetPrinterListReply {
     pub length: u32,
     pub printers: Vec<Printer>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetPrinterListReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetPrinterListReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetPrinterListReply, "PrintGetPrinterListReply");
 impl TryParse for PrintGetPrinterListReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -946,12 +931,7 @@ pub struct PrintGetContextReply {
     pub length: u32,
     pub context: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetContextReply, "PrintGetContextReply");
 impl TryParse for PrintGetContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1125,12 +1105,7 @@ pub struct PrintGetScreenOfContextReply {
     pub length: u32,
     pub root: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetScreenOfContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetScreenOfContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetScreenOfContextReply, "PrintGetScreenOfContextReply");
 impl TryParse for PrintGetScreenOfContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1619,12 +1594,7 @@ pub struct PrintGetDocumentDataReply {
     pub finished_flag: u32,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetDocumentDataReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetDocumentDataReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetDocumentDataReply, "PrintGetDocumentDataReply");
 impl TryParse for PrintGetDocumentDataReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1949,12 +1919,7 @@ pub struct PrintInputSelectedReply {
     pub event_mask: u32,
     pub all_events_mask: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintInputSelectedReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintInputSelectedReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintInputSelectedReply, "PrintInputSelectedReply");
 impl TryParse for PrintInputSelectedReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2092,12 +2057,7 @@ pub struct PrintGetAttributesReply {
     pub length: u32,
     pub attributes: Vec<String8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetAttributesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetAttributesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetAttributesReply, "PrintGetAttributesReply");
 impl TryParse for PrintGetAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2255,12 +2215,7 @@ pub struct PrintGetOneAttributesReply {
     pub length: u32,
     pub value: Vec<String8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetOneAttributesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetOneAttributesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetOneAttributesReply, "PrintGetOneAttributesReply");
 impl TryParse for PrintGetOneAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2491,12 +2446,7 @@ pub struct PrintGetPageDimensionsReply {
     pub reproducible_width: u16,
     pub reproducible_height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetPageDimensionsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetPageDimensionsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetPageDimensionsReply, "PrintGetPageDimensionsReply");
 impl TryParse for PrintGetPageDimensionsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2632,12 +2582,7 @@ pub struct PrintQueryScreensReply {
     pub length: u32,
     pub roots: Vec<xproto::Window>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintQueryScreensReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintQueryScreensReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintQueryScreensReply, "PrintQueryScreensReply");
 impl TryParse for PrintQueryScreensReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2773,12 +2718,7 @@ pub struct PrintSetImageResolutionReply {
     pub length: u32,
     pub previous_resolutions: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintSetImageResolutionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintSetImageResolutionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintSetImageResolutionReply, "PrintSetImageResolutionReply");
 impl TryParse for PrintSetImageResolutionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2899,12 +2839,7 @@ pub struct PrintGetImageResolutionReply {
     pub length: u32,
     pub image_resolution: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetImageResolutionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetImageResolutionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetImageResolutionReply, "PrintGetImageResolutionReply");
 impl TryParse for PrintGetImageResolutionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2966,12 +2901,7 @@ pub struct NotifyEvent {
     pub context: Pcontext,
     pub cancel: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for NotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("NotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(NotifyEvent, "NotifyEvent");
 impl TryParse for NotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3077,12 +3007,7 @@ pub struct AttributNotifyEvent {
     pub sequence: u16,
     pub context: Pcontext,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AttributNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AttributNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AttributNotifyEvent, "AttributNotifyEvent");
 impl TryParse for AttributNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xprint.rs
+++ b/x11rb-protocol/src/protocol/xprint.rs
@@ -391,12 +391,7 @@ pub const PRINT_QUERY_VERSION_REQUEST: u8 = 0;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintQueryVersionRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintQueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintQueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintQueryVersionRequest, "PrintQueryVersionRequest");
 impl PrintQueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -511,12 +506,7 @@ pub struct PrintGetPrinterListRequest<'input> {
     pub printer_name: Cow<'input, [String8]>,
     pub locale: Cow<'input, [String8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PrintGetPrinterListRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetPrinterListRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetPrinterListRequest<'_>, "PrintGetPrinterListRequest");
 impl<'input> PrintGetPrinterListRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 5]> {
@@ -664,12 +654,7 @@ pub const PRINT_REHASH_PRINTER_LIST_REQUEST: u8 = 20;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintRehashPrinterListRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintRehashPrinterListRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintRehashPrinterListRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintRehashPrinterListRequest, "PrintRehashPrinterListRequest");
 impl PrintRehashPrinterListRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -720,12 +705,7 @@ pub struct CreateContextRequest<'input> {
     pub printer_name: Cow<'input, [String8]>,
     pub locale: Cow<'input, [String8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateContextRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateContextRequest<'_>, "CreateContextRequest");
 impl<'input> CreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 5]> {
@@ -817,12 +797,7 @@ pub const PRINT_SET_CONTEXT_REQUEST: u8 = 3;
 pub struct PrintSetContextRequest {
     pub context: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintSetContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintSetContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintSetContextRequest, "PrintSetContextRequest");
 impl PrintSetContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -876,12 +851,7 @@ pub const PRINT_GET_CONTEXT_REQUEST: u8 = 4;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetContextRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetContextRequest, "PrintGetContextRequest");
 impl PrintGetContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -991,12 +961,7 @@ pub const PRINT_DESTROY_CONTEXT_REQUEST: u8 = 5;
 pub struct PrintDestroyContextRequest {
     pub context: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintDestroyContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintDestroyContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintDestroyContextRequest, "PrintDestroyContextRequest");
 impl PrintDestroyContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1050,12 +1015,7 @@ pub const PRINT_GET_SCREEN_OF_CONTEXT_REQUEST: u8 = 6;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintGetScreenOfContextRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetScreenOfContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetScreenOfContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetScreenOfContextRequest, "PrintGetScreenOfContextRequest");
 impl PrintGetScreenOfContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1165,12 +1125,7 @@ pub const PRINT_START_JOB_REQUEST: u8 = 7;
 pub struct PrintStartJobRequest {
     pub output_mode: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintStartJobRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintStartJobRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintStartJobRequest, "PrintStartJobRequest");
 impl PrintStartJobRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1226,12 +1181,7 @@ pub const PRINT_END_JOB_REQUEST: u8 = 8;
 pub struct PrintEndJobRequest {
     pub cancel: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintEndJobRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintEndJobRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintEndJobRequest, "PrintEndJobRequest");
 impl PrintEndJobRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1287,12 +1237,7 @@ pub const PRINT_START_DOC_REQUEST: u8 = 9;
 pub struct PrintStartDocRequest {
     pub driver_mode: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintStartDocRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintStartDocRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintStartDocRequest, "PrintStartDocRequest");
 impl PrintStartDocRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1348,12 +1293,7 @@ pub const PRINT_END_DOC_REQUEST: u8 = 10;
 pub struct PrintEndDocRequest {
     pub cancel: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintEndDocRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintEndDocRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintEndDocRequest, "PrintEndDocRequest");
 impl PrintEndDocRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1412,12 +1352,7 @@ pub struct PrintPutDocumentDataRequest<'input> {
     pub doc_format: Cow<'input, [String8]>,
     pub options: Cow<'input, [String8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PrintPutDocumentDataRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintPutDocumentDataRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintPutDocumentDataRequest<'_>, "PrintPutDocumentDataRequest");
 impl<'input> PrintPutDocumentDataRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 7]> {
@@ -1523,12 +1458,7 @@ pub struct PrintGetDocumentDataRequest {
     pub context: Pcontext,
     pub max_bytes: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetDocumentDataRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetDocumentDataRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetDocumentDataRequest, "PrintGetDocumentDataRequest");
 impl PrintGetDocumentDataRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1664,12 +1594,7 @@ pub const PRINT_START_PAGE_REQUEST: u8 = 13;
 pub struct PrintStartPageRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintStartPageRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintStartPageRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintStartPageRequest, "PrintStartPageRequest");
 impl PrintStartPageRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1725,12 +1650,7 @@ pub const PRINT_END_PAGE_REQUEST: u8 = 14;
 pub struct PrintEndPageRequest {
     pub cancel: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintEndPageRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintEndPageRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintEndPageRequest, "PrintEndPageRequest");
 impl PrintEndPageRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1788,12 +1708,7 @@ pub struct PrintSelectInputRequest {
     pub context: Pcontext,
     pub event_mask: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintSelectInputRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintSelectInputRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintSelectInputRequest, "PrintSelectInputRequest");
 impl PrintSelectInputRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1856,12 +1771,7 @@ pub const PRINT_INPUT_SELECTED_REQUEST: u8 = 16;
 pub struct PrintInputSelectedRequest {
     pub context: Pcontext,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintInputSelectedRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintInputSelectedRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintInputSelectedRequest, "PrintInputSelectedRequest");
 impl PrintInputSelectedRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1987,12 +1897,7 @@ pub struct PrintGetAttributesRequest {
     pub context: Pcontext,
     pub pool: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetAttributesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetAttributesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetAttributesRequest, "PrintGetAttributesRequest");
 impl PrintGetAttributesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2125,12 +2030,7 @@ pub struct PrintGetOneAttributesRequest<'input> {
     pub pool: u8,
     pub name: Cow<'input, [String8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PrintGetOneAttributesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetOneAttributesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetOneAttributesRequest<'_>, "PrintGetOneAttributesRequest");
 impl<'input> PrintGetOneAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2285,12 +2185,7 @@ pub struct PrintSetAttributesRequest<'input> {
     pub rule: u8,
     pub attributes: Cow<'input, [String8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PrintSetAttributesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintSetAttributesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintSetAttributesRequest<'_>, "PrintSetAttributesRequest");
 impl<'input> PrintSetAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2379,12 +2274,7 @@ pub const PRINT_GET_PAGE_DIMENSIONS_REQUEST: u8 = 21;
 pub struct PrintGetPageDimensionsRequest {
     pub context: Pcontext,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetPageDimensionsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetPageDimensionsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetPageDimensionsRequest, "PrintGetPageDimensionsRequest");
 impl PrintGetPageDimensionsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2527,12 +2417,7 @@ pub const PRINT_QUERY_SCREENS_REQUEST: u8 = 22;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PrintQueryScreensRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintQueryScreensRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintQueryScreensRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintQueryScreensRequest, "PrintQueryScreensRequest");
 impl PrintQueryScreensRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2648,12 +2533,7 @@ pub struct PrintSetImageResolutionRequest {
     pub context: Pcontext,
     pub image_resolution: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintSetImageResolutionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintSetImageResolutionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintSetImageResolutionRequest, "PrintSetImageResolutionRequest");
 impl PrintSetImageResolutionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2777,12 +2657,7 @@ pub const PRINT_GET_IMAGE_RESOLUTION_REQUEST: u8 = 24;
 pub struct PrintGetImageResolutionRequest {
     pub context: Pcontext,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PrintGetImageResolutionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PrintGetImageResolutionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PrintGetImageResolutionRequest, "PrintGetImageResolutionRequest");
 impl PrintGetImageResolutionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -7275,12 +7275,7 @@ pub struct CreateWindowRequest<'input> {
     pub visual: Visualid,
     pub value_list: Cow<'input, CreateWindowAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateWindowRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateWindowRequest<'_>, "CreateWindowRequest");
 impl<'input> CreateWindowRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -7796,12 +7791,7 @@ pub struct ChangeWindowAttributesRequest<'input> {
     pub window: Window,
     pub value_list: Cow<'input, ChangeWindowAttributesAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeWindowAttributesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeWindowAttributesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeWindowAttributesRequest<'_>, "ChangeWindowAttributesRequest");
 impl<'input> ChangeWindowAttributesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -7953,12 +7943,7 @@ pub const GET_WINDOW_ATTRIBUTES_REQUEST: u8 = 3;
 pub struct GetWindowAttributesRequest {
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetWindowAttributesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetWindowAttributesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetWindowAttributesRequest, "GetWindowAttributesRequest");
 impl GetWindowAttributesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8212,12 +8197,7 @@ pub const DESTROY_WINDOW_REQUEST: u8 = 4;
 pub struct DestroyWindowRequest {
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyWindowRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyWindowRequest, "DestroyWindowRequest");
 impl DestroyWindowRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8276,12 +8256,7 @@ pub const DESTROY_SUBWINDOWS_REQUEST: u8 = 5;
 pub struct DestroySubwindowsRequest {
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroySubwindowsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroySubwindowsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroySubwindowsRequest, "DestroySubwindowsRequest");
 impl DestroySubwindowsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8422,12 +8397,7 @@ pub struct ChangeSaveSetRequest {
     pub mode: SetMode,
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeSaveSetRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeSaveSetRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeSaveSetRequest, "ChangeSaveSetRequest");
 impl ChangeSaveSetRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8524,12 +8494,7 @@ pub struct ReparentWindowRequest {
     pub x: i16,
     pub y: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ReparentWindowRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ReparentWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ReparentWindowRequest, "ReparentWindowRequest");
 impl ReparentWindowRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8640,12 +8605,7 @@ pub const MAP_WINDOW_REQUEST: u8 = 8;
 pub struct MapWindowRequest {
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MapWindowRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MapWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MapWindowRequest, "MapWindowRequest");
 impl MapWindowRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8704,12 +8664,7 @@ pub const MAP_SUBWINDOWS_REQUEST: u8 = 9;
 pub struct MapSubwindowsRequest {
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MapSubwindowsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MapSubwindowsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MapSubwindowsRequest, "MapSubwindowsRequest");
 impl MapSubwindowsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8789,12 +8744,7 @@ pub const UNMAP_WINDOW_REQUEST: u8 = 10;
 pub struct UnmapWindowRequest {
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UnmapWindowRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UnmapWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UnmapWindowRequest, "UnmapWindowRequest");
 impl UnmapWindowRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -8853,12 +8803,7 @@ pub const UNMAP_SUBWINDOWS_REQUEST: u8 = 11;
 pub struct UnmapSubwindowsRequest {
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UnmapSubwindowsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UnmapSubwindowsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UnmapSubwindowsRequest, "UnmapSubwindowsRequest");
 impl UnmapSubwindowsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9305,12 +9250,7 @@ pub struct ConfigureWindowRequest<'input> {
     pub window: Window,
     pub value_list: Cow<'input, ConfigureWindowAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ConfigureWindowRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ConfigureWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ConfigureWindowRequest<'_>, "ConfigureWindowRequest");
 impl<'input> ConfigureWindowRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -9467,12 +9407,7 @@ pub struct CirculateWindowRequest {
     pub direction: Circulate,
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CirculateWindowRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CirculateWindowRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CirculateWindowRequest, "CirculateWindowRequest");
 impl CirculateWindowRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9570,12 +9505,7 @@ pub const GET_GEOMETRY_REQUEST: u8 = 14;
 pub struct GetGeometryRequest {
     pub drawable: Drawable,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetGeometryRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetGeometryRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetGeometryRequest, "GetGeometryRequest");
 impl GetGeometryRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9781,12 +9711,7 @@ pub const QUERY_TREE_REQUEST: u8 = 15;
 pub struct QueryTreeRequest {
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryTreeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryTreeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryTreeRequest, "QueryTreeRequest");
 impl QueryTreeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -9966,12 +9891,7 @@ pub struct InternAtomRequest<'input> {
     pub only_if_exists: bool,
     pub name: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for InternAtomRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InternAtomRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InternAtomRequest<'_>, "InternAtomRequest");
 impl<'input> InternAtomRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -10106,12 +10026,7 @@ pub const GET_ATOM_NAME_REQUEST: u8 = 17;
 pub struct GetAtomNameRequest {
     pub atom: Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetAtomNameRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetAtomNameRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetAtomNameRequest, "GetAtomNameRequest");
 impl GetAtomNameRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -10364,12 +10279,7 @@ pub struct ChangePropertyRequest<'input> {
     pub data_len: u32,
     pub data: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangePropertyRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangePropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangePropertyRequest<'_>, "ChangePropertyRequest");
 impl<'input> ChangePropertyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -10479,12 +10389,7 @@ pub struct DeletePropertyRequest {
     pub window: Window,
     pub property: Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DeletePropertyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DeletePropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DeletePropertyRequest, "DeletePropertyRequest");
 impl DeletePropertyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -10680,12 +10585,7 @@ pub struct GetPropertyRequest {
     pub long_offset: u32,
     pub long_length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPropertyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPropertyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPropertyRequest, "GetPropertyRequest");
 impl GetPropertyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11001,12 +10901,7 @@ pub const LIST_PROPERTIES_REQUEST: u8 = 21;
 pub struct ListPropertiesRequest {
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListPropertiesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListPropertiesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListPropertiesRequest, "ListPropertiesRequest");
 impl ListPropertiesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11162,12 +11057,7 @@ pub struct SetSelectionOwnerRequest {
     pub selection: Atom,
     pub time: Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetSelectionOwnerRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetSelectionOwnerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetSelectionOwnerRequest, "SetSelectionOwnerRequest");
 impl SetSelectionOwnerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11257,12 +11147,7 @@ pub const GET_SELECTION_OWNER_REQUEST: u8 = 23;
 pub struct GetSelectionOwnerRequest {
     pub selection: Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSelectionOwnerRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSelectionOwnerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSelectionOwnerRequest, "GetSelectionOwnerRequest");
 impl GetSelectionOwnerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11389,12 +11274,7 @@ pub struct ConvertSelectionRequest {
     pub property: Atom,
     pub time: Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ConvertSelectionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ConvertSelectionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ConvertSelectionRequest, "ConvertSelectionRequest");
 impl ConvertSelectionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -11628,12 +11508,7 @@ pub struct SendEventRequest<'input> {
     pub event_mask: EventMask,
     pub event: Cow<'input, [u8; 32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SendEventRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SendEventRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SendEventRequest<'_>, "SendEventRequest");
 impl<'input> SendEventRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 2]> {
@@ -11979,12 +11854,7 @@ pub struct GrabPointerRequest {
     pub cursor: Cursor,
     pub time: Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GrabPointerRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabPointerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabPointerRequest, "GrabPointerRequest");
 impl GrabPointerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12161,12 +12031,7 @@ pub const UNGRAB_POINTER_REQUEST: u8 = 27;
 pub struct UngrabPointerRequest {
     pub time: Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UngrabPointerRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UngrabPointerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UngrabPointerRequest, "UngrabPointerRequest");
 impl UngrabPointerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12375,12 +12240,7 @@ pub struct GrabButtonRequest {
     pub button: ButtonIndex,
     pub modifiers: ModMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GrabButtonRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabButtonRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabButtonRequest, "GrabButtonRequest");
 impl GrabButtonRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12486,12 +12346,7 @@ pub struct UngrabButtonRequest {
     pub grab_window: Window,
     pub modifiers: ModMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UngrabButtonRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UngrabButtonRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UngrabButtonRequest, "UngrabButtonRequest");
 impl UngrabButtonRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12564,12 +12419,7 @@ pub struct ChangeActivePointerGrabRequest {
     pub time: Timestamp,
     pub event_mask: EventMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeActivePointerGrabRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeActivePointerGrabRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeActivePointerGrabRequest, "ChangeActivePointerGrabRequest");
 impl ChangeActivePointerGrabRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12710,12 +12560,7 @@ pub struct GrabKeyboardRequest {
     pub pointer_mode: GrabMode,
     pub keyboard_mode: GrabMode,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GrabKeyboardRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabKeyboardRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabKeyboardRequest, "GrabKeyboardRequest");
 impl GrabKeyboardRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -12852,12 +12697,7 @@ pub const UNGRAB_KEYBOARD_REQUEST: u8 = 32;
 pub struct UngrabKeyboardRequest {
     pub time: Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UngrabKeyboardRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UngrabKeyboardRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UngrabKeyboardRequest, "UngrabKeyboardRequest");
 impl UngrabKeyboardRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13037,12 +12877,7 @@ pub struct GrabKeyRequest {
     pub pointer_mode: GrabMode,
     pub keyboard_mode: GrabMode,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GrabKeyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabKeyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabKeyRequest, "GrabKeyRequest");
 impl GrabKeyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13154,12 +12989,7 @@ pub struct UngrabKeyRequest {
     pub grab_window: Window,
     pub modifiers: ModMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UngrabKeyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UngrabKeyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UngrabKeyRequest, "UngrabKeyRequest");
 impl UngrabKeyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13378,12 +13208,7 @@ pub struct AllowEventsRequest {
     pub mode: Allow,
     pub time: Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AllowEventsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AllowEventsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AllowEventsRequest, "AllowEventsRequest");
 impl AllowEventsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13443,12 +13268,7 @@ pub const GRAB_SERVER_REQUEST: u8 = 36;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GrabServerRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GrabServerRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabServerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabServerRequest, "GrabServerRequest");
 impl GrabServerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13498,12 +13318,7 @@ pub const UNGRAB_SERVER_REQUEST: u8 = 37;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UngrabServerRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UngrabServerRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UngrabServerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UngrabServerRequest, "UngrabServerRequest");
 impl UngrabServerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13568,12 +13383,7 @@ pub const QUERY_POINTER_REQUEST: u8 = 38;
 pub struct QueryPointerRequest {
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryPointerRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryPointerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryPointerRequest, "QueryPointerRequest");
 impl QueryPointerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13802,12 +13612,7 @@ pub struct GetMotionEventsRequest {
     pub start: Timestamp,
     pub stop: Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMotionEventsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMotionEventsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMotionEventsRequest, "GetMotionEventsRequest");
 impl GetMotionEventsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -13949,12 +13754,7 @@ pub struct TranslateCoordinatesRequest {
     pub src_x: i16,
     pub src_y: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for TranslateCoordinatesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TranslateCoordinatesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(TranslateCoordinatesRequest, "TranslateCoordinatesRequest");
 impl TranslateCoordinatesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -14144,12 +13944,7 @@ pub struct WarpPointerRequest {
     pub dst_x: i16,
     pub dst_y: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for WarpPointerRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("WarpPointerRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(WarpPointerRequest, "WarpPointerRequest");
 impl WarpPointerRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -14354,12 +14149,7 @@ pub struct SetInputFocusRequest {
     pub focus: Window,
     pub time: Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetInputFocusRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetInputFocusRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetInputFocusRequest, "SetInputFocusRequest");
 impl SetInputFocusRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -14426,12 +14216,7 @@ pub const GET_INPUT_FOCUS_REQUEST: u8 = 43;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetInputFocusRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetInputFocusRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetInputFocusRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetInputFocusRequest, "GetInputFocusRequest");
 impl GetInputFocusRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -14545,12 +14330,7 @@ pub const QUERY_KEYMAP_REQUEST: u8 = 44;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryKeymapRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryKeymapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryKeymapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryKeymapRequest, "QueryKeymapRequest");
 impl QueryKeymapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -14710,12 +14490,7 @@ pub struct OpenFontRequest<'input> {
     pub fid: Font,
     pub name: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for OpenFontRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("OpenFontRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(OpenFontRequest<'_>, "OpenFontRequest");
 impl<'input> OpenFontRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -14794,12 +14569,7 @@ pub const CLOSE_FONT_REQUEST: u8 = 46;
 pub struct CloseFontRequest {
     pub font: Font,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CloseFontRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CloseFontRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CloseFontRequest, "CloseFontRequest");
 impl CloseFontRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -15022,12 +14792,7 @@ pub const QUERY_FONT_REQUEST: u8 = 47;
 pub struct QueryFontRequest {
     pub font: Fontable,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryFontRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryFontRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryFontRequest, "QueryFontRequest");
 impl QueryFontRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -15253,12 +15018,7 @@ pub struct QueryTextExtentsRequest<'input> {
     pub font: Fontable,
     pub string: Cow<'input, [Char2b]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for QueryTextExtentsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryTextExtentsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryTextExtentsRequest<'_>, "QueryTextExtentsRequest");
 impl<'input> QueryTextExtentsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -15508,12 +15268,7 @@ pub struct ListFontsRequest<'input> {
     pub max_names: u16,
     pub pattern: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ListFontsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListFontsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListFontsRequest<'_>, "ListFontsRequest");
 impl<'input> ListFontsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -15668,12 +15423,7 @@ pub struct ListFontsWithInfoRequest<'input> {
     pub max_names: u16,
     pub pattern: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ListFontsWithInfoRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListFontsWithInfoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListFontsWithInfoRequest<'_>, "ListFontsWithInfoRequest");
 impl<'input> ListFontsWithInfoRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -15884,12 +15634,7 @@ pub const SET_FONT_PATH_REQUEST: u8 = 51;
 pub struct SetFontPathRequest<'input> {
     pub font: Cow<'input, [Str]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetFontPathRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetFontPathRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetFontPathRequest<'_>, "SetFontPathRequest");
 impl<'input> SetFontPathRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -15959,12 +15704,7 @@ pub const GET_FONT_PATH_REQUEST: u8 = 52;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetFontPathRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetFontPathRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetFontPathRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetFontPathRequest, "GetFontPathRequest");
 impl GetFontPathRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -16109,12 +15849,7 @@ pub struct CreatePixmapRequest {
     pub width: u16,
     pub height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreatePixmapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreatePixmapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreatePixmapRequest, "CreatePixmapRequest");
 impl CreatePixmapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -16204,12 +15939,7 @@ pub const FREE_PIXMAP_REQUEST: u8 = 54;
 pub struct FreePixmapRequest {
     pub pixmap: Pixmap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FreePixmapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FreePixmapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FreePixmapRequest, "FreePixmapRequest");
 impl FreePixmapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -17432,12 +17162,7 @@ pub struct CreateGCRequest<'input> {
     pub drawable: Drawable,
     pub value_list: Cow<'input, CreateGCAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for CreateGCRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateGCRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateGCRequest<'_>, "CreateGCRequest");
 impl<'input> CreateGCRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -18100,12 +17825,7 @@ pub struct ChangeGCRequest<'input> {
     pub gc: Gcontext,
     pub value_list: Cow<'input, ChangeGCAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeGCRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeGCRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeGCRequest<'_>, "ChangeGCRequest");
 impl<'input> ChangeGCRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -18186,12 +17906,7 @@ pub struct CopyGCRequest {
     pub dst_gc: Gcontext,
     pub value_mask: GC,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CopyGCRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CopyGCRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CopyGCRequest, "CopyGCRequest");
 impl CopyGCRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -18267,12 +17982,7 @@ pub struct SetDashesRequest<'input> {
     pub dash_offset: u16,
     pub dashes: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetDashesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDashesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDashesRequest<'_>, "SetDashesRequest");
 impl<'input> SetDashesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -18421,12 +18131,7 @@ pub struct SetClipRectanglesRequest<'input> {
     pub clip_y_origin: i16,
     pub rectangles: Cow<'input, [Rectangle]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetClipRectanglesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetClipRectanglesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetClipRectanglesRequest<'_>, "SetClipRectanglesRequest");
 impl<'input> SetClipRectanglesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -18532,12 +18237,7 @@ pub const FREE_GC_REQUEST: u8 = 60;
 pub struct FreeGCRequest {
     pub gc: Gcontext,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FreeGCRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FreeGCRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FreeGCRequest, "FreeGCRequest");
 impl FreeGCRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -18601,12 +18301,7 @@ pub struct ClearAreaRequest {
     pub width: u16,
     pub height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ClearAreaRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ClearAreaRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ClearAreaRequest, "ClearAreaRequest");
 impl ClearAreaRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -18716,12 +18411,7 @@ pub struct CopyAreaRequest {
     pub width: u16,
     pub height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CopyAreaRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CopyAreaRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CopyAreaRequest, "CopyAreaRequest");
 impl CopyAreaRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -18833,12 +18523,7 @@ pub struct CopyPlaneRequest {
     pub height: u16,
     pub bit_plane: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CopyPlaneRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CopyPlaneRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CopyPlaneRequest, "CopyPlaneRequest");
 impl CopyPlaneRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -19014,12 +18699,7 @@ pub struct PolyPointRequest<'input> {
     pub gc: Gcontext,
     pub points: Cow<'input, [Point]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PolyPointRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PolyPointRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PolyPointRequest<'_>, "PolyPointRequest");
 impl<'input> PolyPointRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -19152,12 +18832,7 @@ pub struct PolyLineRequest<'input> {
     pub gc: Gcontext,
     pub points: Cow<'input, [Point]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PolyLineRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PolyLineRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PolyLineRequest<'_>, "PolyLineRequest");
 impl<'input> PolyLineRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -19323,12 +18998,7 @@ pub struct PolySegmentRequest<'input> {
     pub gc: Gcontext,
     pub segments: Cow<'input, [Segment]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PolySegmentRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PolySegmentRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PolySegmentRequest<'_>, "PolySegmentRequest");
 impl<'input> PolySegmentRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -19417,12 +19087,7 @@ pub struct PolyRectangleRequest<'input> {
     pub gc: Gcontext,
     pub rectangles: Cow<'input, [Rectangle]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PolyRectangleRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PolyRectangleRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PolyRectangleRequest<'_>, "PolyRectangleRequest");
 impl<'input> PolyRectangleRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -19511,12 +19176,7 @@ pub struct PolyArcRequest<'input> {
     pub gc: Gcontext,
     pub arcs: Cow<'input, [Arc]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PolyArcRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PolyArcRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PolyArcRequest<'_>, "PolyArcRequest");
 impl<'input> PolyArcRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -19668,12 +19328,7 @@ pub struct FillPolyRequest<'input> {
     pub coordinate_mode: CoordMode,
     pub points: Cow<'input, [Point]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for FillPolyRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FillPolyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FillPolyRequest<'_>, "FillPolyRequest");
 impl<'input> FillPolyRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -19802,12 +19457,7 @@ pub struct PolyFillRectangleRequest<'input> {
     pub gc: Gcontext,
     pub rectangles: Cow<'input, [Rectangle]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PolyFillRectangleRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PolyFillRectangleRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PolyFillRectangleRequest<'_>, "PolyFillRectangleRequest");
 impl<'input> PolyFillRectangleRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -19896,12 +19546,7 @@ pub struct PolyFillArcRequest<'input> {
     pub gc: Gcontext,
     pub arcs: Cow<'input, [Arc]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PolyFillArcRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PolyFillArcRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PolyFillArcRequest<'_>, "PolyFillArcRequest");
 impl<'input> PolyFillArcRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -20058,12 +19703,7 @@ pub struct PutImageRequest<'input> {
     pub depth: u8,
     pub data: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PutImageRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PutImageRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PutImageRequest<'_>, "PutImageRequest");
 impl<'input> PutImageRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -20189,12 +19829,7 @@ pub struct GetImageRequest {
     pub height: u16,
     pub plane_mask: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetImageRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetImageRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetImageRequest, "GetImageRequest");
 impl GetImageRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -20357,12 +19992,7 @@ pub struct PolyText8Request<'input> {
     pub y: i16,
     pub items: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PolyText8Request<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PolyText8Request").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PolyText8Request<'_>, "PolyText8Request");
 impl<'input> PolyText8Request<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -20457,12 +20087,7 @@ pub struct PolyText16Request<'input> {
     pub y: i16,
     pub items: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PolyText16Request<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PolyText16Request").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PolyText16Request<'_>, "PolyText16Request");
 impl<'input> PolyText16Request<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -20589,12 +20214,7 @@ pub struct ImageText8Request<'input> {
     pub y: i16,
     pub string: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ImageText8Request<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ImageText8Request").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ImageText8Request<'_>, "ImageText8Request");
 impl<'input> ImageText8Request<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -20724,12 +20344,7 @@ pub struct ImageText16Request<'input> {
     pub y: i16,
     pub string: Cow<'input, [Char2b]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ImageText16Request<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ImageText16Request").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ImageText16Request<'_>, "ImageText16Request");
 impl<'input> ImageText16Request<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -20885,12 +20500,7 @@ pub struct CreateColormapRequest {
     pub window: Window,
     pub visual: Visualid,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateColormapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateColormapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateColormapRequest, "CreateColormapRequest");
 impl CreateColormapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -20966,12 +20576,7 @@ pub const FREE_COLORMAP_REQUEST: u8 = 79;
 pub struct FreeColormapRequest {
     pub cmap: Colormap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FreeColormapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FreeColormapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FreeColormapRequest, "FreeColormapRequest");
 impl FreeColormapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -21031,12 +20636,7 @@ pub struct CopyColormapAndFreeRequest {
     pub mid: Colormap,
     pub src_cmap: Colormap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CopyColormapAndFreeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CopyColormapAndFreeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CopyColormapAndFreeRequest, "CopyColormapAndFreeRequest");
 impl CopyColormapAndFreeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -21102,12 +20702,7 @@ pub const INSTALL_COLORMAP_REQUEST: u8 = 81;
 pub struct InstallColormapRequest {
     pub cmap: Colormap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InstallColormapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InstallColormapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InstallColormapRequest, "InstallColormapRequest");
 impl InstallColormapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -21166,12 +20761,7 @@ pub const UNINSTALL_COLORMAP_REQUEST: u8 = 82;
 pub struct UninstallColormapRequest {
     pub cmap: Colormap,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UninstallColormapRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UninstallColormapRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UninstallColormapRequest, "UninstallColormapRequest");
 impl UninstallColormapRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -21230,12 +20820,7 @@ pub const LIST_INSTALLED_COLORMAPS_REQUEST: u8 = 83;
 pub struct ListInstalledColormapsRequest {
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListInstalledColormapsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListInstalledColormapsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListInstalledColormapsRequest, "ListInstalledColormapsRequest");
 impl ListInstalledColormapsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -21381,12 +20966,7 @@ pub struct AllocColorRequest {
     pub green: u16,
     pub blue: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AllocColorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AllocColorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AllocColorRequest, "AllocColorRequest");
 impl AllocColorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -21547,12 +21127,7 @@ pub struct AllocNamedColorRequest<'input> {
     pub cmap: Colormap,
     pub name: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for AllocNamedColorRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AllocNamedColorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AllocNamedColorRequest<'_>, "AllocNamedColorRequest");
 impl<'input> AllocNamedColorRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -21731,12 +21306,7 @@ pub struct AllocColorCellsRequest {
     pub colors: u16,
     pub planes: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AllocColorCellsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AllocColorCellsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AllocColorCellsRequest, "AllocColorCellsRequest");
 impl AllocColorCellsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -21897,12 +21467,7 @@ pub struct AllocColorPlanesRequest {
     pub greens: u16,
     pub blues: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AllocColorPlanesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AllocColorPlanesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AllocColorPlanesRequest, "AllocColorPlanesRequest");
 impl AllocColorPlanesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -22062,12 +21627,7 @@ pub struct FreeColorsRequest<'input> {
     pub plane_mask: u32,
     pub pixels: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for FreeColorsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FreeColorsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FreeColorsRequest<'_>, "FreeColorsRequest");
 impl<'input> FreeColorsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -22275,12 +21835,7 @@ pub struct StoreColorsRequest<'input> {
     pub cmap: Colormap,
     pub items: Cow<'input, [Coloritem]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for StoreColorsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("StoreColorsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(StoreColorsRequest<'_>, "StoreColorsRequest");
 impl<'input> StoreColorsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -22362,12 +21917,7 @@ pub struct StoreNamedColorRequest<'input> {
     pub pixel: u32,
     pub name: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for StoreNamedColorRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("StoreNamedColorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(StoreNamedColorRequest<'_>, "StoreNamedColorRequest");
 impl<'input> StoreNamedColorRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -22504,12 +22054,7 @@ pub struct QueryColorsRequest<'input> {
     pub cmap: Colormap,
     pub pixels: Cow<'input, [u32]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for QueryColorsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryColorsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryColorsRequest<'_>, "QueryColorsRequest");
 impl<'input> QueryColorsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -22655,12 +22200,7 @@ pub struct LookupColorRequest<'input> {
     pub cmap: Colormap,
     pub name: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for LookupColorRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("LookupColorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(LookupColorRequest<'_>, "LookupColorRequest");
 impl<'input> LookupColorRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -22895,12 +22435,7 @@ pub struct CreateCursorRequest {
     pub x: u16,
     pub y: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateCursorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateCursorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateCursorRequest, "CreateCursorRequest");
 impl CreateCursorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -23113,12 +22648,7 @@ pub struct CreateGlyphCursorRequest {
     pub back_green: u16,
     pub back_blue: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateGlyphCursorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateGlyphCursorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateGlyphCursorRequest, "CreateGlyphCursorRequest");
 impl CreateGlyphCursorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -23243,12 +22773,7 @@ pub const FREE_CURSOR_REQUEST: u8 = 95;
 pub struct FreeCursorRequest {
     pub cursor: Cursor,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FreeCursorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FreeCursorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FreeCursorRequest, "FreeCursorRequest");
 impl FreeCursorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -23313,12 +22838,7 @@ pub struct RecolorCursorRequest {
     pub back_green: u16,
     pub back_blue: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for RecolorCursorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RecolorCursorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RecolorCursorRequest, "RecolorCursorRequest");
 impl RecolorCursorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -23471,12 +22991,7 @@ pub struct QueryBestSizeRequest {
     pub width: u16,
     pub height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryBestSizeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryBestSizeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryBestSizeRequest, "QueryBestSizeRequest");
 impl QueryBestSizeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -23634,12 +23149,7 @@ pub const QUERY_EXTENSION_REQUEST: u8 = 98;
 pub struct QueryExtensionRequest<'input> {
     pub name: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for QueryExtensionRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryExtensionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryExtensionRequest<'_>, "QueryExtensionRequest");
 impl<'input> QueryExtensionRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -23787,12 +23297,7 @@ pub const LIST_EXTENSIONS_REQUEST: u8 = 99;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListExtensionsRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListExtensionsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListExtensionsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListExtensionsRequest, "ListExtensionsRequest");
 impl ListExtensionsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -23911,12 +23416,7 @@ pub struct ChangeKeyboardMappingRequest<'input> {
     pub keysyms_per_keycode: u8,
     pub keysyms: Cow<'input, [Keysym]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeKeyboardMappingRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeKeyboardMappingRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeKeyboardMappingRequest<'_>, "ChangeKeyboardMappingRequest");
 impl<'input> ChangeKeyboardMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -23998,12 +23498,7 @@ pub struct GetKeyboardMappingRequest {
     pub first_keycode: Keycode,
     pub count: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKeyboardMappingRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKeyboardMappingRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKeyboardMappingRequest, "GetKeyboardMappingRequest");
 impl GetKeyboardMappingRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -24495,12 +23990,7 @@ pub const CHANGE_KEYBOARD_CONTROL_REQUEST: u8 = 102;
 pub struct ChangeKeyboardControlRequest<'input> {
     pub value_list: Cow<'input, ChangeKeyboardControlAux>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeKeyboardControlRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeKeyboardControlRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeKeyboardControlRequest<'_>, "ChangeKeyboardControlRequest");
 impl<'input> ChangeKeyboardControlRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -24569,12 +24059,7 @@ pub const GET_KEYBOARD_CONTROL_REQUEST: u8 = 103;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetKeyboardControlRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKeyboardControlRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKeyboardControlRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKeyboardControlRequest, "GetKeyboardControlRequest");
 impl GetKeyboardControlRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -24751,12 +24236,7 @@ pub const BELL_REQUEST: u8 = 104;
 pub struct BellRequest {
     pub percent: i8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for BellRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("BellRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(BellRequest, "BellRequest");
 impl BellRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -24814,12 +24294,7 @@ pub struct ChangePointerControlRequest {
     pub do_acceleration: bool,
     pub do_threshold: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangePointerControlRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangePointerControlRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangePointerControlRequest, "ChangePointerControlRequest");
 impl ChangePointerControlRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -24892,12 +24367,7 @@ pub const GET_POINTER_CONTROL_REQUEST: u8 = 106;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPointerControlRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPointerControlRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPointerControlRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPointerControlRequest, "GetPointerControlRequest");
 impl GetPointerControlRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -25165,12 +24635,7 @@ pub struct SetScreenSaverRequest {
     pub prefer_blanking: Blanking,
     pub allow_exposures: Exposures,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetScreenSaverRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetScreenSaverRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetScreenSaverRequest, "SetScreenSaverRequest");
 impl SetScreenSaverRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -25242,12 +24707,7 @@ pub const GET_SCREEN_SAVER_REQUEST: u8 = 108;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetScreenSaverRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenSaverRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenSaverRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenSaverRequest, "GetScreenSaverRequest");
 impl GetScreenSaverRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -25522,12 +24982,7 @@ pub struct ChangeHostsRequest<'input> {
     pub family: Family,
     pub address: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for ChangeHostsRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeHostsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeHostsRequest<'_>, "ChangeHostsRequest");
 impl<'input> ChangeHostsRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -25663,12 +25118,7 @@ pub const LIST_HOSTS_REQUEST: u8 = 110;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListHostsRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListHostsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListHostsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListHostsRequest, "ListHostsRequest");
 impl ListHostsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -25847,12 +25297,7 @@ pub const SET_ACCESS_CONTROL_REQUEST: u8 = 111;
 pub struct SetAccessControlRequest {
     pub mode: AccessControl,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetAccessControlRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetAccessControlRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetAccessControlRequest, "SetAccessControlRequest");
 impl SetAccessControlRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -25968,12 +25413,7 @@ pub const SET_CLOSE_DOWN_MODE_REQUEST: u8 = 112;
 pub struct SetCloseDownModeRequest {
     pub mode: CloseDown,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetCloseDownModeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetCloseDownModeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetCloseDownModeRequest, "SetCloseDownModeRequest");
 impl SetCloseDownModeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -26104,12 +25544,7 @@ pub const KILL_CLIENT_REQUEST: u8 = 113;
 pub struct KillClientRequest {
     pub resource: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KillClientRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KillClientRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KillClientRequest, "KillClientRequest");
 impl KillClientRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -26170,12 +25605,7 @@ pub struct RotatePropertiesRequest<'input> {
     pub delta: i16,
     pub atoms: Cow<'input, [Atom]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for RotatePropertiesRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("RotatePropertiesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(RotatePropertiesRequest<'_>, "RotatePropertiesRequest");
 impl<'input> RotatePropertiesRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -26317,12 +25747,7 @@ pub const FORCE_SCREEN_SAVER_REQUEST: u8 = 115;
 pub struct ForceScreenSaverRequest {
     pub mode: ScreenSaver,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ForceScreenSaverRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ForceScreenSaverRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ForceScreenSaverRequest, "ForceScreenSaverRequest");
 impl ForceScreenSaverRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -26438,12 +25863,7 @@ pub const SET_POINTER_MAPPING_REQUEST: u8 = 116;
 pub struct SetPointerMappingRequest<'input> {
     pub map: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetPointerMappingRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetPointerMappingRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetPointerMappingRequest<'_>, "SetPointerMappingRequest");
 impl<'input> SetPointerMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -26562,12 +25982,7 @@ pub const GET_POINTER_MAPPING_REQUEST: u8 = 117;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPointerMappingRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPointerMappingRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPointerMappingRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPointerMappingRequest, "GetPointerMappingRequest");
 impl GetPointerMappingRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -26755,12 +26170,7 @@ pub const SET_MODIFIER_MAPPING_REQUEST: u8 = 118;
 pub struct SetModifierMappingRequest<'input> {
     pub keycodes: Cow<'input, [Keycode]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetModifierMappingRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetModifierMappingRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetModifierMappingRequest<'_>, "SetModifierMappingRequest");
 impl<'input> SetModifierMappingRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -26880,12 +26290,7 @@ pub const GET_MODIFIER_MAPPING_REQUEST: u8 = 119;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetModifierMappingRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetModifierMappingRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetModifierMappingRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetModifierMappingRequest, "GetModifierMappingRequest");
 impl GetModifierMappingRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -27002,12 +26407,7 @@ pub const NO_OPERATION_REQUEST: u8 = 127;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NoOperationRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for NoOperationRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("NoOperationRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(NoOperationRequest, "NoOperationRequest");
 impl NoOperationRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -35,12 +35,7 @@ pub struct Char2b {
     pub byte1: u8,
     pub byte2: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Char2b {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Char2b").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Char2b, "Char2b");
 impl TryParse for Char2b {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (byte1, remaining) = u8::try_parse(remaining)?;
@@ -105,12 +100,7 @@ pub struct Point {
     pub x: i16,
     pub y: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Point {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Point").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Point, "Point");
 impl TryParse for Point {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (x, remaining) = i16::try_parse(remaining)?;
@@ -147,12 +137,7 @@ pub struct Rectangle {
     pub width: u16,
     pub height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Rectangle {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Rectangle").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Rectangle, "Rectangle");
 impl TryParse for Rectangle {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (x, remaining) = i16::try_parse(remaining)?;
@@ -201,12 +186,7 @@ pub struct Arc {
     pub angle1: i16,
     pub angle2: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Arc {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Arc").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Arc, "Arc");
 impl TryParse for Arc {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (x, remaining) = i16::try_parse(remaining)?;
@@ -262,12 +242,7 @@ pub struct Format {
     pub bits_per_pixel: u8,
     pub scanline_pad: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Format {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Format").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Format, "Format");
 impl TryParse for Format {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (depth, remaining) = u8::try_parse(remaining)?;
@@ -383,12 +358,7 @@ pub struct Visualtype {
     pub green_mask: u32,
     pub blue_mask: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Visualtype {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Visualtype").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Visualtype, "Visualtype");
 impl TryParse for Visualtype {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (visual_id, remaining) = Visualid::try_parse(remaining)?;
@@ -461,12 +431,7 @@ pub struct Depth {
     pub depth: u8,
     pub visuals: Vec<Visualtype>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Depth {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Depth").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Depth, "Depth");
 impl TryParse for Depth {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (depth, remaining) = u8::try_parse(remaining)?;
@@ -677,12 +642,7 @@ pub struct Screen {
     pub root_depth: u8,
     pub allowed_depths: Vec<Depth>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Screen {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Screen").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Screen, "Screen");
 impl TryParse for Screen {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (root, remaining) = Window::try_parse(remaining)?;
@@ -763,12 +723,7 @@ pub struct SetupRequest {
     pub authorization_protocol_name: Vec<u8>,
     pub authorization_protocol_data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetupRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetupRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetupRequest, "SetupRequest");
 impl TryParse for SetupRequest {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -858,12 +813,7 @@ pub struct SetupFailed {
     pub length: u16,
     pub reason: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetupFailed {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetupFailed").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetupFailed, "SetupFailed");
 impl TryParse for SetupFailed {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (status, remaining) = u8::try_parse(remaining)?;
@@ -918,12 +868,7 @@ pub struct SetupAuthenticate {
     pub status: u8,
     pub reason: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetupAuthenticate {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetupAuthenticate").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetupAuthenticate, "SetupAuthenticate");
 impl TryParse for SetupAuthenticate {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (status, remaining) = u8::try_parse(remaining)?;
@@ -1051,12 +996,7 @@ pub struct Setup {
     pub pixmap_formats: Vec<Format>,
     pub roots: Vec<Screen>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Setup {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Setup").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Setup, "Setup");
 impl TryParse for Setup {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -1419,12 +1359,7 @@ pub struct KeyPressEvent {
     pub state: KeyButMask,
     pub same_screen: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KeyPressEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KeyPressEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KeyPressEvent, "KeyPressEvent");
 impl TryParse for KeyPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1686,12 +1621,7 @@ pub struct ButtonPressEvent {
     pub state: KeyButMask,
     pub same_screen: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ButtonPressEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ButtonPressEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ButtonPressEvent, "ButtonPressEvent");
 impl TryParse for ButtonPressEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1950,12 +1880,7 @@ pub struct MotionNotifyEvent {
     pub state: KeyButMask,
     pub same_screen: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MotionNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MotionNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MotionNotifyEvent, "MotionNotifyEvent");
 impl TryParse for MotionNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2278,12 +2203,7 @@ pub struct EnterNotifyEvent {
     pub mode: NotifyMode,
     pub same_screen_focus: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EnterNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EnterNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EnterNotifyEvent, "EnterNotifyEvent");
 impl TryParse for EnterNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2463,12 +2383,7 @@ pub struct FocusInEvent {
     pub event: Window,
     pub mode: NotifyMode,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FocusInEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FocusInEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FocusInEvent, "FocusInEvent");
 impl TryParse for FocusInEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2583,12 +2498,7 @@ pub struct KeymapNotifyEvent {
     pub response_type: u8,
     pub keys: [u8; 31],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for KeymapNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("KeymapNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(KeymapNotifyEvent, "KeymapNotifyEvent");
 impl TryParse for KeymapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2721,12 +2631,7 @@ pub struct ExposeEvent {
     pub height: u16,
     pub count: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ExposeEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ExposeEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ExposeEvent, "ExposeEvent");
 impl TryParse for ExposeEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2865,12 +2770,7 @@ pub struct GraphicsExposureEvent {
     pub count: u16,
     pub major_opcode: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GraphicsExposureEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GraphicsExposureEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GraphicsExposureEvent, "GraphicsExposureEvent");
 impl TryParse for GraphicsExposureEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3016,12 +2916,7 @@ pub struct NoExposureEvent {
     pub minor_opcode: u16,
     pub major_opcode: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for NoExposureEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("NoExposureEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(NoExposureEvent, "NoExposureEvent");
 impl TryParse for NoExposureEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3195,12 +3090,7 @@ pub struct VisibilityNotifyEvent {
     pub window: Window,
     pub state: Visibility,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for VisibilityNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("VisibilityNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(VisibilityNotifyEvent, "VisibilityNotifyEvent");
 impl TryParse for VisibilityNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3316,12 +3206,7 @@ pub struct CreateNotifyEvent {
     pub border_width: u16,
     pub override_redirect: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateNotifyEvent, "CreateNotifyEvent");
 impl TryParse for CreateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3477,12 +3362,7 @@ pub struct DestroyNotifyEvent {
     pub event: Window,
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyNotifyEvent, "DestroyNotifyEvent");
 impl TryParse for DestroyNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3603,12 +3483,7 @@ pub struct UnmapNotifyEvent {
     pub window: Window,
     pub from_configure: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UnmapNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UnmapNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UnmapNotifyEvent, "UnmapNotifyEvent");
 impl TryParse for UnmapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3738,12 +3613,7 @@ pub struct MapNotifyEvent {
     pub window: Window,
     pub override_redirect: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MapNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MapNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MapNotifyEvent, "MapNotifyEvent");
 impl TryParse for MapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3870,12 +3740,7 @@ pub struct MapRequestEvent {
     pub parent: Window,
     pub window: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MapRequestEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MapRequestEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MapRequestEvent, "MapRequestEvent");
 impl TryParse for MapRequestEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3986,12 +3851,7 @@ pub struct ReparentNotifyEvent {
     pub y: i16,
     pub override_redirect: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ReparentNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ReparentNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ReparentNotifyEvent, "ReparentNotifyEvent");
 impl TryParse for ReparentNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4157,12 +4017,7 @@ pub struct ConfigureNotifyEvent {
     pub border_width: u16,
     pub override_redirect: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ConfigureNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ConfigureNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ConfigureNotifyEvent, "ConfigureNotifyEvent");
 impl TryParse for ConfigureNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4323,12 +4178,7 @@ pub struct ConfigureRequestEvent {
     pub border_width: u16,
     pub value_mask: ConfigWindow,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ConfigureRequestEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ConfigureRequestEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ConfigureRequestEvent, "ConfigureRequestEvent");
 impl TryParse for ConfigureRequestEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4485,12 +4335,7 @@ pub struct GravityNotifyEvent {
     pub x: i16,
     pub y: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GravityNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GravityNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GravityNotifyEvent, "GravityNotifyEvent");
 impl TryParse for GravityNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4610,12 +4455,7 @@ pub struct ResizeRequestEvent {
     pub width: u16,
     pub height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ResizeRequestEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ResizeRequestEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ResizeRequestEvent, "ResizeRequestEvent");
 impl TryParse for ResizeRequestEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -4802,12 +4642,7 @@ pub struct CirculateNotifyEvent {
     pub window: Window,
     pub place: Place,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CirculateNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CirculateNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CirculateNotifyEvent, "CirculateNotifyEvent");
 impl TryParse for CirculateNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5008,12 +4843,7 @@ pub struct PropertyNotifyEvent {
     pub time: Timestamp,
     pub state: Property,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PropertyNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PropertyNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PropertyNotifyEvent, "PropertyNotifyEvent");
 impl TryParse for PropertyNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5140,12 +4970,7 @@ pub struct SelectionClearEvent {
     pub owner: Window,
     pub selection: Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectionClearEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectionClearEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectionClearEvent, "SelectionClearEvent");
 impl TryParse for SelectionClearEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5516,12 +5341,7 @@ pub struct SelectionRequestEvent {
     pub target: Atom,
     pub property: Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectionRequestEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectionRequestEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectionRequestEvent, "SelectionRequestEvent");
 impl TryParse for SelectionRequestEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5663,12 +5483,7 @@ pub struct SelectionNotifyEvent {
     pub target: Atom,
     pub property: Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectionNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectionNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectionNotifyEvent, "SelectionNotifyEvent");
 impl TryParse for SelectionNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -5934,12 +5749,7 @@ pub struct ColormapNotifyEvent {
     pub new: bool,
     pub state: ColormapState,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ColormapNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ColormapNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ColormapNotifyEvent, "ColormapNotifyEvent");
 impl TryParse for ColormapNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6235,12 +6045,7 @@ pub struct ClientMessageEvent {
     pub type_: Atom,
     pub data: ClientMessageData,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ClientMessageEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ClientMessageEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ClientMessageEvent, "ClientMessageEvent");
 impl TryParse for ClientMessageEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6461,12 +6266,7 @@ pub struct MappingNotifyEvent {
     pub first_keycode: Keycode,
     pub count: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for MappingNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MappingNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(MappingNotifyEvent, "MappingNotifyEvent");
 impl TryParse for MappingNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -6584,12 +6384,7 @@ pub struct GeGenericEvent {
     pub length: u32,
     pub event_type: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GeGenericEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GeGenericEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GeGenericEvent, "GeGenericEvent");
 impl TryParse for GeGenericEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -7069,12 +6864,7 @@ pub struct CreateWindowAux {
     pub colormap: Option<Colormap>,
     pub cursor: Option<Cursor>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateWindowAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateWindowAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateWindowAux, "CreateWindowAux");
 impl CreateWindowAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -7638,12 +7428,7 @@ pub struct ChangeWindowAttributesAux {
     pub colormap: Option<Colormap>,
     pub cursor: Option<Cursor>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeWindowAttributesAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeWindowAttributesAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeWindowAttributesAux, "ChangeWindowAttributesAux");
 impl ChangeWindowAttributesAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -8263,12 +8048,7 @@ pub struct GetWindowAttributesReply {
     pub your_event_mask: EventMask,
     pub do_not_propagate_mask: EventMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetWindowAttributesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetWindowAttributesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetWindowAttributesReply, "GetWindowAttributesReply");
 impl TryParse for GetWindowAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -9259,12 +9039,7 @@ pub struct ConfigureWindowAux {
     pub sibling: Option<Window>,
     pub stack_mode: Option<StackMode>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ConfigureWindowAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ConfigureWindowAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ConfigureWindowAux, "ConfigureWindowAux");
 impl ConfigureWindowAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u16) -> Result<(Self, &[u8]), ParseError> {
@@ -9879,12 +9654,7 @@ pub struct GetGeometryReply {
     pub height: u16,
     pub border_width: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetGeometryReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetGeometryReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetGeometryReply, "GetGeometryReply");
 impl TryParse for GetGeometryReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10082,12 +9852,7 @@ pub struct QueryTreeReply {
     pub parent: Window,
     pub children: Vec<Window>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryTreeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryTreeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryTreeReply, "QueryTreeReply");
 impl TryParse for QueryTreeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10281,12 +10046,7 @@ pub struct InternAtomReply {
     pub length: u32,
     pub atom: Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for InternAtomReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("InternAtomReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(InternAtomReply, "InternAtomReply");
 impl TryParse for InternAtomReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -10411,12 +10171,7 @@ pub struct GetAtomNameReply {
     pub length: u32,
     pub name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetAtomNameReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetAtomNameReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetAtomNameReply, "GetAtomNameReply");
 impl TryParse for GetAtomNameReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -11191,12 +10946,7 @@ pub struct GetPropertyReply {
     pub value_len: u32,
     pub value: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPropertyReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPropertyReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPropertyReply, "GetPropertyReply");
 impl TryParse for GetPropertyReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -11316,12 +11066,7 @@ pub struct ListPropertiesReply {
     pub length: u32,
     pub atoms: Vec<Atom>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListPropertiesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListPropertiesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListPropertiesReply, "ListPropertiesReply");
 impl TryParse for ListPropertiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -11580,12 +11325,7 @@ pub struct GetSelectionOwnerReply {
     pub length: u32,
     pub owner: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSelectionOwnerReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSelectionOwnerReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSelectionOwnerReply, "GetSelectionOwnerReply");
 impl TryParse for GetSelectionOwnerReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -12343,12 +12083,7 @@ pub struct GrabPointerReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GrabPointerReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabPointerReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabPointerReply, "GrabPointerReply");
 impl TryParse for GrabPointerReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -13062,12 +12797,7 @@ pub struct GrabKeyboardReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GrabKeyboardReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabKeyboardReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabKeyboardReply, "GrabKeyboardReply");
 impl TryParse for GrabKeyboardReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -13929,12 +13659,7 @@ pub struct QueryPointerReply {
     pub win_y: i16,
     pub mask: KeyButMask,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryPointerReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryPointerReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryPointerReply, "QueryPointerReply");
 impl TryParse for QueryPointerReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14032,12 +13757,7 @@ pub struct Timecoord {
     pub x: i16,
     pub y: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Timecoord {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Timecoord").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Timecoord, "Timecoord");
 impl TryParse for Timecoord {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (time, remaining) = Timestamp::try_parse(remaining)?;
@@ -14161,12 +13881,7 @@ pub struct GetMotionEventsReply {
     pub length: u32,
     pub events: Vec<Timecoord>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetMotionEventsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetMotionEventsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetMotionEventsReply, "GetMotionEventsReply");
 impl TryParse for GetMotionEventsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14319,12 +14034,7 @@ pub struct TranslateCoordinatesReply {
     pub dst_x: i16,
     pub dst_y: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for TranslateCoordinatesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("TranslateCoordinatesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(TranslateCoordinatesReply, "TranslateCoordinatesReply");
 impl TryParse for TranslateCoordinatesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14775,12 +14485,7 @@ pub struct GetInputFocusReply {
     pub length: u32,
     pub focus: Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetInputFocusReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetInputFocusReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetInputFocusReply, "GetInputFocusReply");
 impl TryParse for GetInputFocusReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -14898,12 +14603,7 @@ pub struct QueryKeymapReply {
     pub length: u32,
     pub keys: [u8; 32],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryKeymapReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryKeymapReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryKeymapReply, "QueryKeymapReply");
 impl TryParse for QueryKeymapReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -15216,12 +14916,7 @@ pub struct Fontprop {
     pub name: Atom,
     pub value: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Fontprop {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Fontprop").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Fontprop, "Fontprop");
 impl TryParse for Fontprop {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (name, remaining) = Atom::try_parse(remaining)?;
@@ -15264,12 +14959,7 @@ pub struct Charinfo {
     pub descent: i16,
     pub attributes: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Charinfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Charinfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Charinfo, "Charinfo");
 impl TryParse for Charinfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (left_side_bearing, remaining) = i16::try_parse(remaining)?;
@@ -15420,12 +15110,7 @@ pub struct QueryFontReply {
     pub properties: Vec<Fontprop>,
     pub char_infos: Vec<Charinfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryFontReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryFontReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryFontReply, "QueryFontReply");
 impl TryParse for QueryFontReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -15669,12 +15354,7 @@ pub struct QueryTextExtentsReply {
     pub overall_left: i32,
     pub overall_right: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryTextExtentsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryTextExtentsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryTextExtentsReply, "QueryTextExtentsReply");
 impl TryParse for QueryTextExtentsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -15768,12 +15448,7 @@ impl Serialize for QueryTextExtentsReply {
 pub struct Str {
     pub name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Str {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Str").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Str, "Str");
 impl TryParse for Str {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (name_len, remaining) = u8::try_parse(remaining)?;
@@ -15915,12 +15590,7 @@ pub struct ListFontsReply {
     pub length: u32,
     pub names: Vec<Str>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListFontsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListFontsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListFontsReply, "ListFontsReply");
 impl TryParse for ListFontsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -16105,12 +15775,7 @@ pub struct ListFontsWithInfoReply {
     pub properties: Vec<Fontprop>,
     pub name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListFontsWithInfoReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListFontsWithInfoReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListFontsWithInfoReply, "ListFontsWithInfoReply");
 impl TryParse for ListFontsWithInfoReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -16352,12 +16017,7 @@ pub struct GetFontPathReply {
     pub length: u32,
     pub path: Vec<Str>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetFontPathReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetFontPathReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetFontPathReply, "GetFontPathReply");
 impl TryParse for GetFontPathReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -17237,12 +16897,7 @@ pub struct CreateGCAux {
     pub dashes: Option<u32>,
     pub arc_mode: Option<ArcMode>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateGCAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateGCAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateGCAux, "CreateGCAux");
 impl CreateGCAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -17890,12 +17545,7 @@ pub struct ChangeGCAux {
     pub dashes: Option<u32>,
     pub arc_mode: Option<ArcMode>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeGCAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeGCAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeGCAux, "ChangeGCAux");
 impl ChangeGCAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -19599,12 +19249,7 @@ pub struct Segment {
     pub x2: i16,
     pub y2: i16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Segment {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Segment").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Segment, "Segment");
 impl TryParse for Segment {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (x1, remaining) = i16::try_parse(remaining)?;
@@ -20640,12 +20285,7 @@ pub struct GetImageReply {
     pub visual: Visualid,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetImageReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetImageReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetImageReply, "GetImageReply");
 impl TryParse for GetImageReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -21655,12 +21295,7 @@ pub struct ListInstalledColormapsReply {
     pub length: u32,
     pub cmaps: Vec<Colormap>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListInstalledColormapsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListInstalledColormapsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListInstalledColormapsReply, "ListInstalledColormapsReply");
 impl TryParse for ListInstalledColormapsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -21832,12 +21467,7 @@ pub struct AllocColorReply {
     pub blue: u16,
     pub pixel: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AllocColorReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AllocColorReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AllocColorReply, "AllocColorReply");
 impl TryParse for AllocColorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -22008,12 +21638,7 @@ pub struct AllocNamedColorReply {
     pub visual_green: u16,
     pub visual_blue: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AllocNamedColorReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AllocNamedColorReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AllocNamedColorReply, "AllocNamedColorReply");
 impl TryParse for AllocNamedColorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -22184,12 +21809,7 @@ pub struct AllocColorCellsReply {
     pub pixels: Vec<u32>,
     pub masks: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AllocColorCellsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AllocColorCellsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AllocColorCellsReply, "AllocColorCellsReply");
 impl TryParse for AllocColorCellsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -22367,12 +21987,7 @@ pub struct AllocColorPlanesReply {
     pub blue_mask: u32,
     pub pixels: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AllocColorPlanesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AllocColorPlanesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AllocColorPlanesReply, "AllocColorPlanesReply");
 impl TryParse for AllocColorPlanesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -22603,12 +22218,7 @@ pub struct Coloritem {
     pub blue: u16,
     pub flags: ColorFlag,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Coloritem {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Coloritem").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Coloritem, "Coloritem");
 impl TryParse for Coloritem {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (pixel, remaining) = u32::try_parse(remaining)?;
@@ -22848,12 +22458,7 @@ pub struct Rgb {
     pub green: u16,
     pub blue: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Rgb {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Rgb").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Rgb, "Rgb");
 impl TryParse for Rgb {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (red, remaining) = u16::try_parse(remaining)?;
@@ -22984,12 +22589,7 @@ pub struct QueryColorsReply {
     pub length: u32,
     pub colors: Vec<Rgb>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryColorsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryColorsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryColorsReply, "QueryColorsReply");
 impl TryParse for QueryColorsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -23145,12 +22745,7 @@ pub struct LookupColorReply {
     pub visual_green: u16,
     pub visual_blue: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for LookupColorReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("LookupColorReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(LookupColorReply, "LookupColorReply");
 impl TryParse for LookupColorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -23955,12 +23550,7 @@ pub struct QueryBestSizeReply {
     pub width: u16,
     pub height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryBestSizeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryBestSizeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryBestSizeReply, "QueryBestSizeReply");
 impl TryParse for QueryBestSizeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -24130,12 +23720,7 @@ pub struct QueryExtensionReply {
     pub first_event: u8,
     pub first_error: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryExtensionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryExtensionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryExtensionReply, "QueryExtensionReply");
 impl TryParse for QueryExtensionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -24260,12 +23845,7 @@ pub struct ListExtensionsReply {
     pub length: u32,
     pub names: Vec<Str>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListExtensionsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListExtensionsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListExtensionsReply, "ListExtensionsReply");
 impl TryParse for ListExtensionsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -24486,12 +24066,7 @@ pub struct GetKeyboardMappingReply {
     pub sequence: u16,
     pub keysyms: Vec<Keysym>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKeyboardMappingReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKeyboardMappingReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKeyboardMappingReply, "GetKeyboardMappingReply");
 impl TryParse for GetKeyboardMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -24716,12 +24291,7 @@ pub struct ChangeKeyboardControlAux {
     pub key: Option<Keycode32>,
     pub auto_repeat_mode: Option<AutoRepeatMode>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ChangeKeyboardControlAux {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ChangeKeyboardControlAux").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ChangeKeyboardControlAux, "ChangeKeyboardControlAux");
 impl ChangeKeyboardControlAux {
     #[cfg_attr(not(feature = "request-parsing"), allow(dead_code))]
     fn try_parse(value: &[u8], value_mask: u32) -> Result<(Self, &[u8]), ParseError> {
@@ -25063,12 +24633,7 @@ pub struct GetKeyboardControlReply {
     pub bell_duration: u16,
     pub auto_repeats: [u8; 32],
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetKeyboardControlReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetKeyboardControlReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetKeyboardControlReply, "GetKeyboardControlReply");
 impl TryParse for GetKeyboardControlReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -25387,12 +24952,7 @@ pub struct GetPointerControlReply {
     pub acceleration_denominator: u16,
     pub threshold: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPointerControlReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPointerControlReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPointerControlReply, "GetPointerControlReply");
 impl TryParse for GetPointerControlReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -25743,12 +25303,7 @@ pub struct GetScreenSaverReply {
     pub prefer_blanking: Blanking,
     pub allow_exposures: Exposures,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetScreenSaverReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetScreenSaverReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetScreenSaverReply, "GetScreenSaverReply");
 impl TryParse for GetScreenSaverReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -26051,12 +25606,7 @@ pub struct Host {
     pub family: Family,
     pub address: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Host {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Host").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Host, "Host");
 impl TryParse for Host {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -26172,12 +25722,7 @@ pub struct ListHostsReply {
     pub length: u32,
     pub hosts: Vec<Host>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListHostsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListHostsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListHostsReply, "ListHostsReply");
 impl TryParse for ListHostsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -26964,12 +26509,7 @@ pub struct SetPointerMappingReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetPointerMappingReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetPointerMappingReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetPointerMappingReply, "SetPointerMappingReply");
 impl TryParse for SetPointerMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -27080,12 +26620,7 @@ pub struct GetPointerMappingReply {
     pub length: u32,
     pub map: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPointerMappingReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPointerMappingReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPointerMappingReply, "GetPointerMappingReply");
 impl TryParse for GetPointerMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -27292,12 +26827,7 @@ pub struct SetModifierMappingReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetModifierMappingReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetModifierMappingReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetModifierMappingReply, "SetModifierMappingReply");
 impl TryParse for SetModifierMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -27408,12 +26938,7 @@ pub struct GetModifierMappingReply {
     pub length: u32,
     pub keycodes: Vec<Keycode>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetModifierMappingReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetModifierMappingReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetModifierMappingReply, "GetModifierMappingReply");
 impl TryParse for GetModifierMappingReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xselinux.rs
+++ b/x11rb-protocol/src/protocol/xselinux.rs
@@ -45,12 +45,7 @@ pub struct QueryVersionRequest {
     pub client_major: u8,
     pub client_minor: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -174,12 +169,7 @@ pub const SET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 1;
 pub struct SetDeviceCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetDeviceCreateContextRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDeviceCreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDeviceCreateContextRequest<'_>, "SetDeviceCreateContextRequest");
 impl<'input> SetDeviceCreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -244,12 +234,7 @@ pub const GET_DEVICE_CREATE_CONTEXT_REQUEST: u8 = 2;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetDeviceCreateContextRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceCreateContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceCreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceCreateContextRequest, "GetDeviceCreateContextRequest");
 impl GetDeviceCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -366,12 +351,7 @@ pub struct SetDeviceContextRequest<'input> {
     pub device: u32,
     pub context: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetDeviceContextRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetDeviceContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetDeviceContextRequest<'_>, "SetDeviceContextRequest");
 impl<'input> SetDeviceContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -446,12 +426,7 @@ pub const GET_DEVICE_CONTEXT_REQUEST: u8 = 4;
 pub struct GetDeviceContextRequest {
     pub device: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceContextRequest, "GetDeviceContextRequest");
 impl GetDeviceContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -574,12 +549,7 @@ pub const SET_WINDOW_CREATE_CONTEXT_REQUEST: u8 = 5;
 pub struct SetWindowCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetWindowCreateContextRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetWindowCreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetWindowCreateContextRequest<'_>, "SetWindowCreateContextRequest");
 impl<'input> SetWindowCreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -644,12 +614,7 @@ pub const GET_WINDOW_CREATE_CONTEXT_REQUEST: u8 = 6;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetWindowCreateContextRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetWindowCreateContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetWindowCreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetWindowCreateContextRequest, "GetWindowCreateContextRequest");
 impl GetWindowCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -765,12 +730,7 @@ pub const GET_WINDOW_CONTEXT_REQUEST: u8 = 7;
 pub struct GetWindowContextRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetWindowContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetWindowContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetWindowContextRequest, "GetWindowContextRequest");
 impl GetWindowContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -973,12 +933,7 @@ pub const SET_PROPERTY_CREATE_CONTEXT_REQUEST: u8 = 8;
 pub struct SetPropertyCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetPropertyCreateContextRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetPropertyCreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetPropertyCreateContextRequest<'_>, "SetPropertyCreateContextRequest");
 impl<'input> SetPropertyCreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1043,12 +998,7 @@ pub const GET_PROPERTY_CREATE_CONTEXT_REQUEST: u8 = 9;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyCreateContextRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPropertyCreateContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPropertyCreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPropertyCreateContextRequest, "GetPropertyCreateContextRequest");
 impl GetPropertyCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1164,12 +1114,7 @@ pub const SET_PROPERTY_USE_CONTEXT_REQUEST: u8 = 10;
 pub struct SetPropertyUseContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetPropertyUseContextRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetPropertyUseContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetPropertyUseContextRequest<'_>, "SetPropertyUseContextRequest");
 impl<'input> SetPropertyUseContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1234,12 +1179,7 @@ pub const GET_PROPERTY_USE_CONTEXT_REQUEST: u8 = 11;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetPropertyUseContextRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPropertyUseContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPropertyUseContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPropertyUseContextRequest, "GetPropertyUseContextRequest");
 impl GetPropertyUseContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1356,12 +1296,7 @@ pub struct GetPropertyContextRequest {
     pub window: xproto::Window,
     pub property: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPropertyContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPropertyContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPropertyContextRequest, "GetPropertyContextRequest");
 impl GetPropertyContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1492,12 +1427,7 @@ pub struct GetPropertyDataContextRequest {
     pub window: xproto::Window,
     pub property: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPropertyDataContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPropertyDataContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPropertyDataContextRequest, "GetPropertyDataContextRequest");
 impl GetPropertyDataContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1627,12 +1557,7 @@ pub const LIST_PROPERTIES_REQUEST: u8 = 14;
 pub struct ListPropertiesRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListPropertiesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListPropertiesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListPropertiesRequest, "ListPropertiesRequest");
 impl ListPropertiesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1754,12 +1679,7 @@ pub const SET_SELECTION_CREATE_CONTEXT_REQUEST: u8 = 15;
 pub struct SetSelectionCreateContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetSelectionCreateContextRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetSelectionCreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetSelectionCreateContextRequest<'_>, "SetSelectionCreateContextRequest");
 impl<'input> SetSelectionCreateContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -1824,12 +1744,7 @@ pub const GET_SELECTION_CREATE_CONTEXT_REQUEST: u8 = 16;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionCreateContextRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSelectionCreateContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSelectionCreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSelectionCreateContextRequest, "GetSelectionCreateContextRequest");
 impl GetSelectionCreateContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1945,12 +1860,7 @@ pub const SET_SELECTION_USE_CONTEXT_REQUEST: u8 = 17;
 pub struct SetSelectionUseContextRequest<'input> {
     pub context: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for SetSelectionUseContextRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetSelectionUseContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetSelectionUseContextRequest<'_>, "SetSelectionUseContextRequest");
 impl<'input> SetSelectionUseContextRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -2015,12 +1925,7 @@ pub const GET_SELECTION_USE_CONTEXT_REQUEST: u8 = 18;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct GetSelectionUseContextRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSelectionUseContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSelectionUseContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSelectionUseContextRequest, "GetSelectionUseContextRequest");
 impl GetSelectionUseContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2136,12 +2041,7 @@ pub const GET_SELECTION_CONTEXT_REQUEST: u8 = 19;
 pub struct GetSelectionContextRequest {
     pub selection: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSelectionContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSelectionContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSelectionContextRequest, "GetSelectionContextRequest");
 impl GetSelectionContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2264,12 +2164,7 @@ pub const GET_SELECTION_DATA_CONTEXT_REQUEST: u8 = 20;
 pub struct GetSelectionDataContextRequest {
     pub selection: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSelectionDataContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSelectionDataContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSelectionDataContextRequest, "GetSelectionDataContextRequest");
 impl GetSelectionDataContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2390,12 +2285,7 @@ pub const LIST_SELECTIONS_REQUEST: u8 = 21;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ListSelectionsRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListSelectionsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListSelectionsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListSelectionsRequest, "ListSelectionsRequest");
 impl ListSelectionsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2510,12 +2400,7 @@ pub const GET_CLIENT_CONTEXT_REQUEST: u8 = 22;
 pub struct GetClientContextRequest {
     pub resource: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetClientContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetClientContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetClientContextRequest, "GetClientContextRequest");
 impl GetClientContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xselinux.rs
+++ b/x11rb-protocol/src/protocol/xselinux.rs
@@ -111,12 +111,7 @@ pub struct QueryVersionReply {
     pub server_major: u16,
     pub server_minor: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -304,12 +299,7 @@ pub struct GetDeviceCreateContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceCreateContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceCreateContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceCreateContextReply, "GetDeviceCreateContextReply");
 impl TryParse for GetDeviceCreateContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -518,12 +508,7 @@ pub struct GetDeviceContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetDeviceContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetDeviceContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetDeviceContextReply, "GetDeviceContextReply");
 impl TryParse for GetDeviceContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -714,12 +699,7 @@ pub struct GetWindowCreateContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetWindowCreateContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetWindowCreateContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetWindowCreateContextReply, "GetWindowCreateContextReply");
 impl TryParse for GetWindowCreateContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -847,12 +827,7 @@ pub struct GetWindowContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetWindowContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetWindowContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetWindowContextReply, "GetWindowContextReply");
 impl TryParse for GetWindowContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -918,12 +893,7 @@ pub struct ListItem {
     pub object_context: Vec<u8>,
     pub data_context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListItem {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListItem").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListItem, "ListItem");
 impl TryParse for ListItem {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -1128,12 +1098,7 @@ pub struct GetPropertyCreateContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPropertyCreateContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPropertyCreateContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPropertyCreateContextReply, "GetPropertyCreateContextReply");
 impl TryParse for GetPropertyCreateContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1324,12 +1289,7 @@ pub struct GetPropertyUseContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPropertyUseContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPropertyUseContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPropertyUseContextReply, "GetPropertyUseContextReply");
 impl TryParse for GetPropertyUseContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1465,12 +1425,7 @@ pub struct GetPropertyContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPropertyContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPropertyContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPropertyContextReply, "GetPropertyContextReply");
 impl TryParse for GetPropertyContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1606,12 +1561,7 @@ pub struct GetPropertyDataContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPropertyDataContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPropertyDataContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPropertyDataContextReply, "GetPropertyDataContextReply");
 impl TryParse for GetPropertyDataContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1739,12 +1689,7 @@ pub struct ListPropertiesReply {
     pub length: u32,
     pub properties: Vec<ListItem>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListPropertiesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListPropertiesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListPropertiesReply, "ListPropertiesReply");
 impl TryParse for ListPropertiesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1934,12 +1879,7 @@ pub struct GetSelectionCreateContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSelectionCreateContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSelectionCreateContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSelectionCreateContextReply, "GetSelectionCreateContextReply");
 impl TryParse for GetSelectionCreateContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2130,12 +2070,7 @@ pub struct GetSelectionUseContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSelectionUseContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSelectionUseContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSelectionUseContextReply, "GetSelectionUseContextReply");
 impl TryParse for GetSelectionUseContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2263,12 +2198,7 @@ pub struct GetSelectionContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSelectionContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSelectionContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSelectionContextReply, "GetSelectionContextReply");
 impl TryParse for GetSelectionContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2396,12 +2326,7 @@ pub struct GetSelectionDataContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetSelectionDataContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetSelectionDataContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetSelectionDataContextReply, "GetSelectionDataContextReply");
 impl TryParse for GetSelectionDataContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2520,12 +2445,7 @@ pub struct ListSelectionsReply {
     pub length: u32,
     pub selections: Vec<ListItem>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListSelectionsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListSelectionsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListSelectionsReply, "ListSelectionsReply");
 impl TryParse for ListSelectionsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2652,12 +2572,7 @@ pub struct GetClientContextReply {
     pub length: u32,
     pub context: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetClientContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetClientContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetClientContextReply, "GetClientContextReply");
 impl TryParse for GetClientContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xtest.rs
+++ b/x11rb-protocol/src/protocol/xtest.rs
@@ -112,12 +112,7 @@ pub struct GetVersionReply {
     pub length: u32,
     pub minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetVersionReply, "GetVersionReply");
 impl TryParse for GetVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -317,12 +312,7 @@ pub struct CompareCursorReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CompareCursorReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CompareCursorReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CompareCursorReply, "CompareCursorReply");
 impl TryParse for CompareCursorReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xtest.rs
+++ b/x11rb-protocol/src/protocol/xtest.rs
@@ -45,12 +45,7 @@ pub struct GetVersionRequest {
     pub major_version: u8,
     pub minor_version: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetVersionRequest, "GetVersionRequest");
 impl GetVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -243,12 +238,7 @@ pub struct CompareCursorRequest {
     pub window: xproto::Window,
     pub cursor: xproto::Cursor,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CompareCursorRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CompareCursorRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CompareCursorRequest, "CompareCursorRequest");
 impl CompareCursorRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -372,12 +362,7 @@ pub struct FakeInputRequest {
     pub root_y: i16,
     pub deviceid: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for FakeInputRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("FakeInputRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(FakeInputRequest, "FakeInputRequest");
 impl FakeInputRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -482,12 +467,7 @@ pub const GRAB_CONTROL_REQUEST: u8 = 3;
 pub struct GrabControlRequest {
     pub impervious: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GrabControlRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabControlRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabControlRequest, "GrabControlRequest");
 impl GrabControlRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -1345,12 +1345,7 @@ pub const QUERY_EXTENSION_REQUEST: u8 = 0;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryExtensionRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryExtensionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryExtensionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryExtensionRequest, "QueryExtensionRequest");
 impl QueryExtensionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1464,12 +1459,7 @@ pub const QUERY_ADAPTORS_REQUEST: u8 = 1;
 pub struct QueryAdaptorsRequest {
     pub window: xproto::Window,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryAdaptorsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryAdaptorsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryAdaptorsRequest, "QueryAdaptorsRequest");
 impl QueryAdaptorsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1591,12 +1581,7 @@ pub const QUERY_ENCODINGS_REQUEST: u8 = 2;
 pub struct QueryEncodingsRequest {
     pub port: Port,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryEncodingsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryEncodingsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryEncodingsRequest, "QueryEncodingsRequest");
 impl QueryEncodingsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1719,12 +1704,7 @@ pub struct GrabPortRequest {
     pub port: Port,
     pub time: xproto::Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GrabPortRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabPortRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabPortRequest, "GrabPortRequest");
 impl GrabPortRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1844,12 +1824,7 @@ pub struct UngrabPortRequest {
     pub port: Port,
     pub time: xproto::Timestamp,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for UngrabPortRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("UngrabPortRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(UngrabPortRequest, "UngrabPortRequest");
 impl UngrabPortRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1922,12 +1897,7 @@ pub struct PutVideoRequest {
     pub drw_w: u16,
     pub drw_h: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PutVideoRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PutVideoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PutVideoRequest, "PutVideoRequest");
 impl PutVideoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2047,12 +2017,7 @@ pub struct PutStillRequest {
     pub drw_w: u16,
     pub drw_h: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PutStillRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PutStillRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PutStillRequest, "PutStillRequest");
 impl PutStillRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2172,12 +2137,7 @@ pub struct GetVideoRequest {
     pub drw_w: u16,
     pub drw_h: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetVideoRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetVideoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetVideoRequest, "GetVideoRequest");
 impl GetVideoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2297,12 +2257,7 @@ pub struct GetStillRequest {
     pub drw_w: u16,
     pub drw_h: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetStillRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetStillRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetStillRequest, "GetStillRequest");
 impl GetStillRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2413,12 +2368,7 @@ pub struct StopVideoRequest {
     pub port: Port,
     pub drawable: xproto::Drawable,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for StopVideoRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("StopVideoRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(StopVideoRequest, "StopVideoRequest");
 impl StopVideoRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2482,12 +2432,7 @@ pub struct SelectVideoNotifyRequest {
     pub drawable: xproto::Drawable,
     pub onoff: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectVideoNotifyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectVideoNotifyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectVideoNotifyRequest, "SelectVideoNotifyRequest");
 impl SelectVideoNotifyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2552,12 +2497,7 @@ pub struct SelectPortNotifyRequest {
     pub port: Port,
     pub onoff: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SelectPortNotifyRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SelectPortNotifyRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SelectPortNotifyRequest, "SelectPortNotifyRequest");
 impl SelectPortNotifyRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2626,12 +2566,7 @@ pub struct QueryBestSizeRequest {
     pub drw_h: u16,
     pub motion: bool,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryBestSizeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryBestSizeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryBestSizeRequest, "QueryBestSizeRequest");
 impl QueryBestSizeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2782,12 +2717,7 @@ pub struct SetPortAttributeRequest {
     pub attribute: xproto::Atom,
     pub value: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SetPortAttributeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SetPortAttributeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SetPortAttributeRequest, "SetPortAttributeRequest");
 impl SetPortAttributeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2858,12 +2788,7 @@ pub struct GetPortAttributeRequest {
     pub port: Port,
     pub attribute: xproto::Atom,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPortAttributeRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPortAttributeRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPortAttributeRequest, "GetPortAttributeRequest");
 impl GetPortAttributeRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -2987,12 +2912,7 @@ pub const QUERY_PORT_ATTRIBUTES_REQUEST: u8 = 15;
 pub struct QueryPortAttributesRequest {
     pub port: Port,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryPortAttributesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryPortAttributesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryPortAttributesRequest, "QueryPortAttributesRequest");
 impl QueryPortAttributesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3117,12 +3037,7 @@ pub const LIST_IMAGE_FORMATS_REQUEST: u8 = 16;
 pub struct ListImageFormatsRequest {
     pub port: Port,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListImageFormatsRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListImageFormatsRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListImageFormatsRequest, "ListImageFormatsRequest");
 impl ListImageFormatsRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3247,12 +3162,7 @@ pub struct QueryImageAttributesRequest {
     pub width: u16,
     pub height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryImageAttributesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryImageAttributesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryImageAttributesRequest, "QueryImageAttributesRequest");
 impl QueryImageAttributesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -3418,12 +3328,7 @@ pub struct PutImageRequest<'input> {
     pub height: u16,
     pub data: Cow<'input, [u8]>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl<'input> core::fmt::Debug for PutImageRequest<'input> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PutImageRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PutImageRequest<'_>, "PutImageRequest");
 impl<'input> PutImageRequest<'input> {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'input, [u8]>; 3]> {
@@ -3591,12 +3496,7 @@ pub struct ShmPutImageRequest {
     pub height: u16,
     pub send_event: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ShmPutImageRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ShmPutImageRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ShmPutImageRequest, "ShmPutImageRequest");
 impl ShmPutImageRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xv.rs
+++ b/x11rb-protocol/src/protocol/xv.rs
@@ -472,12 +472,7 @@ pub struct Rational {
     pub numerator: i32,
     pub denominator: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Rational {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Rational").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Rational, "Rational");
 impl TryParse for Rational {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (numerator, remaining) = i32::try_parse(remaining)?;
@@ -516,12 +511,7 @@ pub struct Format {
     pub visual: xproto::Visualid,
     pub depth: u8,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Format {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Format").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Format, "Format");
 impl TryParse for Format {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (visual, remaining) = xproto::Visualid::try_parse(remaining)?;
@@ -565,12 +555,7 @@ pub struct AdaptorInfo {
     pub name: Vec<u8>,
     pub formats: Vec<Format>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AdaptorInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AdaptorInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AdaptorInfo, "AdaptorInfo");
 impl TryParse for AdaptorInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -653,12 +638,7 @@ pub struct EncodingInfo {
     pub rate: Rational,
     pub name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for EncodingInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("EncodingInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(EncodingInfo, "EncodingInfo");
 impl TryParse for EncodingInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -725,12 +705,7 @@ pub struct Image {
     pub offsets: Vec<u32>,
     pub data: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for Image {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Image").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(Image, "Image");
 impl TryParse for Image {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (id, remaining) = u32::try_parse(remaining)?;
@@ -806,12 +781,7 @@ pub struct AttributeInfo {
     pub max: i32,
     pub name: Vec<u8>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for AttributeInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("AttributeInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(AttributeInfo, "AttributeInfo");
 impl TryParse for AttributeInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let value = remaining;
@@ -891,12 +861,7 @@ pub struct ImageFormatInfo {
     pub vcomp_order: [u8; 32],
     pub vscanline_order: ScanlineOrder,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ImageFormatInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ImageFormatInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ImageFormatInfo, "ImageFormatInfo");
 impl TryParse for ImageFormatInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (id, remaining) = u32::try_parse(remaining)?;
@@ -1142,12 +1107,7 @@ pub struct VideoNotifyEvent {
     pub drawable: xproto::Drawable,
     pub port: Port,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for VideoNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("VideoNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(VideoNotifyEvent, "VideoNotifyEvent");
 impl TryParse for VideoNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1267,12 +1227,7 @@ pub struct PortNotifyEvent {
     pub attribute: xproto::Atom,
     pub value: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for PortNotifyEvent {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("PortNotifyEvent").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(PortNotifyEvent, "PortNotifyEvent");
 impl TryParse for PortNotifyEvent {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1446,12 +1401,7 @@ pub struct QueryExtensionReply {
     pub major: u16,
     pub minor: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryExtensionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryExtensionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryExtensionReply, "QueryExtensionReply");
 impl TryParse for QueryExtensionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1576,12 +1526,7 @@ pub struct QueryAdaptorsReply {
     pub length: u32,
     pub info: Vec<AdaptorInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryAdaptorsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryAdaptorsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryAdaptorsReply, "QueryAdaptorsReply");
 impl TryParse for QueryAdaptorsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1708,12 +1653,7 @@ pub struct QueryEncodingsReply {
     pub length: u32,
     pub info: Vec<EncodingInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryEncodingsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryEncodingsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryEncodingsReply, "QueryEncodingsReply");
 impl TryParse for QueryEncodingsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1848,12 +1788,7 @@ pub struct GrabPortReply {
     pub sequence: u16,
     pub length: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GrabPortReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GrabPortReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GrabPortReply, "GrabPortReply");
 impl TryParse for GrabPortReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2782,12 +2717,7 @@ pub struct QueryBestSizeReply {
     pub actual_width: u16,
     pub actual_height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryBestSizeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryBestSizeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryBestSizeReply, "QueryBestSizeReply");
 impl TryParse for QueryBestSizeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -2997,12 +2927,7 @@ pub struct GetPortAttributeReply {
     pub length: u32,
     pub value: i32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for GetPortAttributeReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GetPortAttributeReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(GetPortAttributeReply, "GetPortAttributeReply");
 impl TryParse for GetPortAttributeReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3125,12 +3050,7 @@ pub struct QueryPortAttributesReply {
     pub text_size: u32,
     pub attributes: Vec<AttributeInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryPortAttributesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryPortAttributesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryPortAttributesReply, "QueryPortAttributesReply");
 impl TryParse for QueryPortAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3259,12 +3179,7 @@ pub struct ListImageFormatsReply {
     pub length: u32,
     pub format: Vec<ImageFormatInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListImageFormatsReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListImageFormatsReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListImageFormatsReply, "ListImageFormatsReply");
 impl TryParse for ListImageFormatsReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -3415,12 +3330,7 @@ pub struct QueryImageAttributesReply {
     pub pitches: Vec<u32>,
     pub offsets: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryImageAttributesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryImageAttributesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryImageAttributesReply, "QueryImageAttributesReply");
 impl TryParse for QueryImageAttributesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/protocol/xvmc.rs
+++ b/x11rb-protocol/src/protocol/xvmc.rs
@@ -131,12 +131,7 @@ pub const QUERY_VERSION_REQUEST: u8 = 0;
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct QueryVersionRequest;
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionRequest, "QueryVersionRequest");
 impl QueryVersionRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -254,12 +249,7 @@ pub const LIST_SURFACE_TYPES_REQUEST: u8 = 1;
 pub struct ListSurfaceTypesRequest {
     pub port_id: xv::Port,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListSurfaceTypesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListSurfaceTypesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListSurfaceTypesRequest, "ListSurfaceTypesRequest");
 impl ListSurfaceTypesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -386,12 +376,7 @@ pub struct CreateContextRequest {
     pub height: u16,
     pub flags: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateContextRequest, "CreateContextRequest");
 impl CreateContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -550,12 +535,7 @@ pub const DESTROY_CONTEXT_REQUEST: u8 = 3;
 pub struct DestroyContextRequest {
     pub context_id: Context,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroyContextRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroyContextRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroyContextRequest, "DestroyContextRequest");
 impl DestroyContextRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -612,12 +592,7 @@ pub struct CreateSurfaceRequest {
     pub surface_id: Surface,
     pub context_id: Context,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateSurfaceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateSurfaceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateSurfaceRequest, "CreateSurfaceRequest");
 impl CreateSurfaceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -743,12 +718,7 @@ pub const DESTROY_SURFACE_REQUEST: u8 = 5;
 pub struct DestroySurfaceRequest {
     pub surface_id: Surface,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroySurfaceRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroySurfaceRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroySurfaceRequest, "DestroySurfaceRequest");
 impl DestroySurfaceRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -808,12 +778,7 @@ pub struct CreateSubpictureRequest {
     pub width: u16,
     pub height: u16,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateSubpictureRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateSubpictureRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateSubpictureRequest, "CreateSubpictureRequest");
 impl CreateSubpictureRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -971,12 +936,7 @@ pub const DESTROY_SUBPICTURE_REQUEST: u8 = 7;
 pub struct DestroySubpictureRequest {
     pub subpicture_id: Subpicture,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for DestroySubpictureRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("DestroySubpictureRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(DestroySubpictureRequest, "DestroySubpictureRequest");
 impl DestroySubpictureRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {
@@ -1033,12 +993,7 @@ pub struct ListSubpictureTypesRequest {
     pub port_id: xv::Port,
     pub surface_id: Surface,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListSubpictureTypesRequest {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListSubpictureTypesRequest").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListSubpictureTypesRequest, "ListSubpictureTypesRequest");
 impl ListSubpictureTypesRequest {
     /// Serialize this request into bytes for the provided connection
     pub fn serialize(self, major_opcode: u8) -> BufWithFds<[Cow<'static, [u8]>; 1]> {

--- a/x11rb-protocol/src/protocol/xvmc.rs
+++ b/x11rb-protocol/src/protocol/xvmc.rs
@@ -56,12 +56,7 @@ pub struct SurfaceInfo {
     pub mc_type: u32,
     pub flags: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for SurfaceInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("SurfaceInfo").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(SurfaceInfo, "SurfaceInfo");
 impl TryParse for SurfaceInfo {
     fn try_parse(remaining: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let (id, remaining) = Surface::try_parse(remaining)?;
@@ -192,12 +187,7 @@ pub struct QueryVersionReply {
     pub major: u32,
     pub minor: u32,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for QueryVersionReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("QueryVersionReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(QueryVersionReply, "QueryVersionReply");
 impl TryParse for QueryVersionReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -326,12 +316,7 @@ pub struct ListSurfaceTypesReply {
     pub length: u32,
     pub surfaces: Vec<SurfaceInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListSurfaceTypesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListSurfaceTypesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListSurfaceTypesReply, "ListSurfaceTypesReply");
 impl TryParse for ListSurfaceTypesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -496,12 +481,7 @@ pub struct CreateContextReply {
     pub flags_return: u32,
     pub priv_data: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateContextReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateContextReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateContextReply, "CreateContextReply");
 impl TryParse for CreateContextReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -700,12 +680,7 @@ pub struct CreateSurfaceReply {
     pub sequence: u16,
     pub priv_data: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateSurfaceReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateSurfaceReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateSurfaceReply, "CreateSurfaceReply");
 impl TryParse for CreateSurfaceReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -923,12 +898,7 @@ pub struct CreateSubpictureReply {
     pub component_order: [u8; 4],
     pub priv_data: Vec<u32>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for CreateSubpictureReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CreateSubpictureReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(CreateSubpictureReply, "CreateSubpictureReply");
 impl TryParse for CreateSubpictureReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;
@@ -1132,12 +1102,7 @@ pub struct ListSubpictureTypesReply {
     pub length: u32,
     pub types: Vec<xv::ImageFormatInfo>,
 }
-#[cfg(not(feature = "extra-traits"))]
-impl core::fmt::Debug for ListSubpictureTypesReply {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("ListSubpictureTypesReply").finish_non_exhaustive()
-    }
-}
+impl_debug_if_no_extra_traits!(ListSubpictureTypesReply, "ListSubpictureTypesReply");
 impl TryParse for ListSubpictureTypesReply {
     fn try_parse(initial_value: &[u8]) -> Result<(Self, &[u8]), ParseError> {
         let remaining = initial_value;

--- a/x11rb-protocol/src/x11_utils.rs
+++ b/x11rb-protocol/src/x11_utils.rs
@@ -688,6 +688,17 @@ macro_rules! bitmask_binop {
     };
 }
 
+macro_rules! impl_debug_if_no_extra_traits {
+    ($type:ty, $name:literal) => {
+        #[cfg(not(feature = "extra-traits"))]
+        impl core::fmt::Debug for $type {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                f.debug_struct($name).finish_non_exhaustive()
+            }
+        }
+    };
+}
+
 /// Wrapper around TryInto that produces a ParseError.
 ///
 /// This trait shortens `x.try_into().or(Err(ParseError::ConversionFailed))` to `x.try_to_usize()`.


### PR DESCRIPTION
I doubt that this does anything for compile time, but it uses a macro to shorten some code.
```
 35 files changed, 1379 insertions(+), 8156 deletions(-)
```