### PR TITLE
Really fix dl-libxcb feature on OpenBSD

### DIFF
--- a/x11rb/src/xcb_ffi/raw_ffi/ffi.rs
+++ b/x11rb/src/xcb_ffi/raw_ffi/ffi.rs
@@ -34,12 +34,20 @@ pub(crate) mod libxcb_library {
             // TODO: Names for non-unix platforms
             #[cfg(not(unix))]
             compile_error!("dl-libxcb feature is not supported on non-unix");
-            #[cfg(all(unix, not(any(target_os = "openbsd", target_os = "netbsd"))))]
+
+            #[cfg(all(unix, target_os = "linux"))]
             const LIB_NAME: &str = "libxcb.so.1";
-            // libtool turns -version-info differently into SONAMES on Open and NetBSD.
+
+            // libtool turns -version-info differently into SONAMES on NetBSD.
             // Also, the library is apparently not in the default search path, hence use a full path.
-            #[cfg(any(target_os = "openbsd", target_os = "netbsd"))]
+            #[cfg(all(unix, target_os = "netbsd"))]
             const LIB_NAME: &str = "/usr/X11R7/lib/libxcb.so.2";
+
+            // If we do not know anything, just assume libxcb.so and hope for the best.
+            // This is actually the right thing to do on OpenBSD since the dynamic linker then does
+            // some magic to find the right SONAME.
+            #[cfg(all(unix, not(any(target_os = "linux", target_os = "netbsd"))))]
+            const LIB_NAME: &str = "libxcb.so";
 
             let library = libloading::Library::new(LIB_NAME)
                 .map_err(|e| LibxcbLoadError::OpenLibError(LIB_NAME.into(), e.to_string()))?;


### PR DESCRIPTION
In commit 53de935c I fixed the dl-libxcb feature not finding libxcb.so on NetBSD and just assumed that this also fixes things on OpenBSD since I found some similarities. However, it turns out that OpenBSD ignores libtool's SONAME handling and just rolls its own.

However, we do not really have to care much. Here, loading "libxcb.so" does the right thing. Not because there is actually a file with this name, but since the dynamic linker does some magic when it gets a request to load a library without providing version information. Thus, this commit changes the code to just load "libxcb.so" on OpenBSD.

With that, I got thinking. On untested systems, we do not really know which SONAME to use. And we now have evidence that somehow just letting the OS do some magic is the best option. Thus, this commit changes the code to load "libxcb.so" on all systems except for Linux (where this would e.g. require libxcb1-dev to be installed on Debian) and NetBSD (where we have a working version that I do not want to break).

Fixes: https://github.com/psychon/x11rb/issues/895