### PR TITLE
Add impl of `std::ops::Not` to `bitmask_binop`

### DIFF
--- a/x11rb-protocol/src/x11_utils.rs
+++ b/x11rb-protocol/src/x11_utils.rs
@@ -593,8 +593,7 @@ impl<T: Serialize> Serialize for [T] {
     }
 }
 
-// This macro is used by the generated code to implement e.g. `std::ops::BitOr` and
-// `std::ops::BitOrAssign`.
+/// This macro is used by the generated code to implement logical operations on bitmasks.
 macro_rules! bitmask_binop {
     ($t:ty, $u:ty) => {
         impl core::ops::BitOr for $t {
@@ -661,6 +660,12 @@ macro_rules! bitmask_binop {
         impl core::ops::BitAndAssign<$u> for $t {
             fn bitand_assign(&mut self, other: $u) {
                 self.0 &= other
+            }
+        }
+        impl core::ops::Not for $t {
+            type Output = $t;
+            fn not(self) -> Self::Output {
+                Self::from(!<$u>::from(self))
             }
         }
         impl $t {

--- a/x11rb-protocol/tests/enum_tests.rs
+++ b/x11rb-protocol/tests/enum_tests.rs
@@ -63,6 +63,22 @@ fn test_bit_and() {
 }
 
 #[test]
+fn test_not() {
+    assert_eq!(
+        EventMask::NO_EVENT,
+        !EventMask::from(u32::MAX)
+    );
+    assert_eq!(
+        !EventMask::KEY_PRESS,
+        EventMask::from(!EventMask::KEY_PRESS.bits())
+    );
+    assert_eq!(
+        EventMask::KEY_PRESS,
+        !(!EventMask::KEY_PRESS)
+    );
+}
+
+#[test]
 fn test_contains() {
     let mask = EventMask::KEY_PRESS;
     assert!(mask.contains(EventMask::KEY_PRESS));

--- a/x11rb-protocol/tests/enum_tests.rs
+++ b/x11rb-protocol/tests/enum_tests.rs
@@ -64,18 +64,12 @@ fn test_bit_and() {
 
 #[test]
 fn test_not() {
-    assert_eq!(
-        EventMask::NO_EVENT,
-        !EventMask::from(u32::MAX)
-    );
+    assert_eq!(EventMask::NO_EVENT, !EventMask::from(u32::MAX));
     assert_eq!(
         !EventMask::KEY_PRESS,
         EventMask::from(!EventMask::KEY_PRESS.bits())
     );
-    assert_eq!(
-        EventMask::KEY_PRESS,
-        !(!EventMask::KEY_PRESS)
-    );
+    assert_eq!(EventMask::KEY_PRESS, !(!EventMask::KEY_PRESS));
 }
 
 #[test]


### PR DESCRIPTION
I noticed bitmasks (e.g. `EventMask`) was missing the`!` operator, which can be useful for manipulating this kind of data structure.