### PR TITLE
Fix some new clippy warnings

### DIFF
--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -51,6 +51,13 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> Vec<Generated> {
             "#![allow(clippy::needless_borrow, clippy::needless_lifetimes)]"
         );
     }
+    outln!(main_proto_out, "// clippy::unnecessary_fallible_conversion is new in 1.75. TODO: Remove once our MSRV is high enough.");
+    outln!(main_proto_out, "#![allow(unknown_lints)]");
+    outln!(main_proto_out, "// We use TryFrom in places where From could be used, but fixing this would make the code generator more complicated");
+    outln!(
+        main_proto_out,
+        "#![allow(clippy::unnecessary_fallible_conversion)]"
+    );
     outln!(main_proto_out, "");
     outln!(main_proto_out, "use alloc::borrow::Cow;");
     outln!(main_proto_out, "use alloc::string::String;");

--- a/generator/src/generator/namespace/request.rs
+++ b/generator/src/generator/namespace/request.rs
@@ -994,7 +994,7 @@ fn emit_request_struct(
             let fields = request_def.fields.borrow();
             let mut seen_complete_header = false;
             let mut is_first_body_field = true;
-            for (_, field) in fields.iter().enumerate() {
+            for field in fields.iter() {
                 match field.name() {
                     // These are all in the header. Ignore them.
                     Some("major_opcode") | Some("minor_opcode") => continue,

--- a/x11rb-async/src/rust_connection/mod.rs
+++ b/x11rb-async/src/rust_connection/mod.rs
@@ -618,8 +618,7 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
                             None => {
                                 // Not available.
                                 return usize::from(self.setup().maximum_request_length)
-                                    .checked_mul(4)
-                                    .unwrap_or(std::usize::MAX);
+                                    .saturating_mul(4);
                             }
                         };
 

--- a/x11rb-async/src/rust_connection/mod.rs
+++ b/x11rb-async/src/rust_connection/mod.rs
@@ -617,12 +617,8 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
                             Some(cookie) => cookie,
                             None => {
                                 // Not available.
-                                return self
-                                    .setup()
-                                    .maximum_request_length
-                                    .try_into()
-                                    .ok()
-                                    .and_then(|x: usize| x.checked_mul(4))
+                                return usize::from(self.setup().maximum_request_length)
+                                    .checked_mul(4)
                                     .unwrap_or(std::usize::MAX);
                             }
                         };

--- a/x11rb-protocol/src/protocol/mod.rs
+++ b/x11rb-protocol/src/protocol/mod.rs
@@ -10,6 +10,10 @@
 #![allow(clippy::upper_case_acronyms)]
 // This is not easy to fix, so ignore it.
 #![allow(clippy::needless_borrow, clippy::needless_lifetimes)]
+// clippy::unnecessary_fallible_conversion is new in 1.75. TODO: Remove once our MSRV is high enough.
+#![allow(unknown_lints)]
+// We use TryFrom in places where From could be used, but fixing this would make the code generator more complicated
+#![allow(clippy::unnecessary_fallible_conversion)]
 
 use alloc::borrow::Cow;
 use alloc::string::String;


### PR DESCRIPTION
There is a new clippy beta and thus we get new warnings. This PR tries to deal with them. Most of them were dealt with using `#[allow]` (in the generated code).