### PR TITLE
Remove extra-traits from x11rb-protocol default

### DIFF
--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 criterion = "0.5"
 
 [features]
-default = ["extra-traits", "std"]
+default = ["std"]
 std = []
 
 # Enable extra traits for the X11 types

--- a/x11rb-protocol/src/connect.rs
+++ b/x11rb-protocol/src/connect.rs
@@ -263,6 +263,7 @@ impl TryFrom<Connect> for Setup {
 }
 
 #[cfg(test)]
+#[cfg(feature = "extra-traits")]
 mod tests {
     use super::Connect;
     use crate::errors::ConnectError;

--- a/x11rb-protocol/tests/request_parsing_tests.rs
+++ b/x11rb-protocol/tests/request_parsing_tests.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "request-parsing")]
+#![cfg(feature = "extra-traits")]
 
 use std::borrow::Cow;
 


### PR DESCRIPTION
This feature enables lots of extra trait implementations that are not helping compile times much. Thus, it makes sense to not enable this by default, but instead have everyone who needs this explicitly enable it.

To make this actually work, some tests needed to be disabled that depend on these extra traits.
