### PR TITLE
Add remove() to bitmask_binop!

### DIFF
--- a/x11rb-protocol/src/x11_utils.rs
+++ b/x11rb-protocol/src/x11_utils.rs
@@ -680,6 +680,14 @@ macro_rules! bitmask_binop {
                 (<$u>::from(self) & flag) != 0
             }
 
+            /// Remove some flags.
+            ///
+            /// All bits that are set in the given flags are removed from the `self` instance, if
+            /// they are present.
+            pub fn remove(self, flags: impl Into<$u>) -> Self {
+                Self::from(self.bits() & !flags.into())
+            }
+
             /// Returns the internal value of the object.
             pub fn bits(self) -> $u {
                 self.0

--- a/x11rb-protocol/tests/enum_tests.rs
+++ b/x11rb-protocol/tests/enum_tests.rs
@@ -105,3 +105,28 @@ fn test_intersects() {
     assert!(!mask.intersects(16u32));
     assert!(mask.intersects(20u32));
 }
+
+#[test]
+fn test_remove() {
+    let no_event = EventMask::NO_EVENT;
+    let key_press = EventMask::KEY_PRESS;
+    let button_press = EventMask::BUTTON_PRESS;
+    let exposure = EventMask::EXPOSURE;
+    let key_and_button_press = key_press | button_press;
+
+    assert_eq!(no_event, key_press.remove(key_press));
+    assert_eq!(key_press, key_press.remove(no_event));
+    assert_eq!(key_press, key_press.remove(button_press));
+    assert_eq!(key_press, key_and_button_press.remove(button_press));
+    assert_eq!(key_press, key_and_button_press.remove(button_press));
+    assert_eq!(key_and_button_press, key_and_button_press.remove(exposure));
+
+    assert_eq!(no_event, key_press.remove(1u32));
+    assert_eq!(key_press, key_press.remove(0u32));
+    assert_eq!(key_press, key_press.remove(4u32));
+    assert_eq!(key_press, key_and_button_press.remove(4u32));
+    assert_eq!(
+        key_and_button_press,
+        key_and_button_press.remove(1u32 << 15)
+    );
+}


### PR DESCRIPTION
In this commit, I am adding a new function remove() to the bitmask_binop! macro. This function removes some set bits from the self instance.