### PR TITLE
Really silence unnecessary_fallible_conversions lint

### DIFF
--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -51,12 +51,12 @@ pub(crate) fn generate(module: &xcbgen::defs::Module) -> Vec<Generated> {
             "#![allow(clippy::needless_borrow, clippy::needless_lifetimes)]"
         );
     }
-    outln!(main_proto_out, "// clippy::unnecessary_fallible_conversion is new in 1.75. TODO: Remove once our MSRV is high enough.");
+    outln!(main_proto_out, "// clippy::unnecessary_fallible_conversions is new in 1.75. TODO: Remove once our MSRV is high enough.");
     outln!(main_proto_out, "#![allow(unknown_lints)]");
     outln!(main_proto_out, "// We use TryFrom in places where From could be used, but fixing this would make the code generator more complicated");
     outln!(
         main_proto_out,
-        "#![allow(clippy::unnecessary_fallible_conversion)]"
+        "#![allow(clippy::unnecessary_fallible_conversions)]"
     );
     outln!(main_proto_out, "");
     outln!(main_proto_out, "use alloc::borrow::Cow;");

--- a/x11rb-protocol/src/protocol/mod.rs
+++ b/x11rb-protocol/src/protocol/mod.rs
@@ -10,10 +10,10 @@
 #![allow(clippy::upper_case_acronyms)]
 // This is not easy to fix, so ignore it.
 #![allow(clippy::needless_borrow, clippy::needless_lifetimes)]
-// clippy::unnecessary_fallible_conversion is new in 1.75. TODO: Remove once our MSRV is high enough.
+// clippy::unnecessary_fallible_conversions is new in 1.75. TODO: Remove once our MSRV is high enough.
 #![allow(unknown_lints)]
 // We use TryFrom in places where From could be used, but fixing this would make the code generator more complicated
-#![allow(clippy::unnecessary_fallible_conversion)]
+#![allow(clippy::unnecessary_fallible_conversions)]
 
 use alloc::borrow::Cow;
 use alloc::string::String;


### PR DESCRIPTION
Turns out I had a typo in commit 0933817efb7fa and forgot the trailing "s" in the name of the lint. This was not due to another change in the same commit: The addition of `#![allow(unknown_lints)]`