### PR TITLE
Try to make extract-generated-code-doc more readable

### DIFF
--- a/extract-generated-code-doc/src/main.rs
+++ b/extract-generated-code-doc/src/main.rs
@@ -11,6 +11,7 @@
 
 use std::io::Error as IoError;
 use std::path::Path;
+use std::process::ExitCode;
 
 pub mod doc;
 
@@ -72,7 +73,7 @@ fn load_sections(path: &Path) -> Result<Sections, IoError> {
     )?))
 }
 
-fn main2() -> Result<u8, IoError> {
+fn main() -> Result<ExitCode, IoError> {
     let args: Vec<_> = std::env::args_os().collect();
     if args.len() != 4 {
         eprintln!("USAGE:");
@@ -80,7 +81,7 @@ fn main2() -> Result<u8, IoError> {
             "    {} <OUTPUT_FILE> <PROTO_XPROTO_FILE> <X11RB_XPROTO_FILE>",
             args[0].to_string_lossy()
         );
-        return Ok(1);
+        return Ok(ExitCode::FAILURE);
     }
     let output_file = Path::new(&args[1]);
     let proto_xproto = load_sections(Path::new(&args[2]))?;
@@ -89,9 +90,5 @@ fn main2() -> Result<u8, IoError> {
     let output = doc::generate(&proto_xproto, &x11rb_xproto);
     std::fs::write(output_file, output)?;
 
-    Ok(0)
-}
-
-fn main() -> Result<(), IoError> {
-    std::process::exit(i32::from(main2()?));
+    Ok(ExitCode::SUCCESS)
 }

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -10,6 +10,7 @@
 #![forbid(unsafe_code)]
 
 use std::path::{Path, PathBuf};
+use std::process::ExitCode;
 
 mod generator;
 
@@ -112,7 +113,7 @@ fn replace_file_if_different(file_path: &Path, data: &[u8]) -> Result<(), Error>
     Ok(())
 }
 
-fn main2() -> Result<u8, Error> {
+fn main() -> Result<ExitCode, Error> {
     let args: Vec<_> = std::env::args_os().collect();
     if args.len() != 5 {
         eprintln!("USAGE:");
@@ -120,7 +121,7 @@ fn main2() -> Result<u8, Error> {
             "    {} <INPUT_DIR> <PROTO_OUTPUT_DIR> <X11RB_OUTPUT_DIR> <ASYNC_OUTPUT_DIR>",
             args[0].to_string_lossy()
         );
-        return Ok(1);
+        return Ok(ExitCode::FAILURE);
     }
     let input_dir_path = Path::new(&args[1]);
     let proto_output_dir_path = Path::new(&args[2]);
@@ -154,10 +155,5 @@ fn main2() -> Result<u8, Error> {
     }
     println!("Code generated successfully");
 
-    Ok(0)
-}
-
-fn main() {
-    let exit_code = main2().unwrap();
-    std::process::exit(i32::from(exit_code));
+    Ok(ExitCode::SUCCESS)
 }


### PR DESCRIPTION
@eduardosm Here is my attempt at improving readability of this code. Dunno if it is much better.

The second commit is an unrelated thing I noticed is now available / possible. It replaces explicit calls to `exit()` with returns from `main`.