### PR TITLE
Add some floating-point conversion helpers to Fp1616 and Fp3232 in xinput

### DIFF
--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -411,6 +411,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             None,
             out,
         );
+        special_cases::handle_struct(struct_def, out);
 
         outln!(out, "");
     }
@@ -925,6 +926,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             rust_new_name,
             self.type_to_rust_type(type_alias_def.old_name.get_resolved()),
         );
+        special_cases::handle_type_alias(type_alias_def, out);
         outln!(out, "");
     }
 

--- a/generator/src/generator/special_cases.rs
+++ b/generator/src/generator/special_cases.rs
@@ -180,3 +180,54 @@ pub(super) fn handle_event(
         outln!(out, "}}");
     }
 }
+
+pub(super) fn handle_struct(struct_def: &xcbdefs::StructDef, out: &mut Output) {
+    let ns = struct_def.namespace.upgrade().unwrap();
+    if struct_def.name == "FP3232" && ns.header == "xinput" {
+        outln!(out, "impl Fp3232 {{");
+        out.indented(|out| {
+            outln!(out, "/// Convert to a floating point number.");
+            outln!(out, "///");
+            outln!(
+                out,
+                "/// A [Fp3232] contains a 32 bits integer part and another 32 bits for a"
+            );
+            outln!(
+                out,
+                "/// fractional component. This function converts this representation to a f64."
+            );
+            outln!(out, "pub fn as_f64(&self) -> f64 {{");
+            out.indented(|out| {
+                outln!(
+                    out,
+                    "(self.integral as f64) + (self.frac as f64) / ((1u64 << 32) as f64)"
+                );
+            });
+            outln!(out, "}}");
+        });
+        outln!(out, "}}");
+    }
+}
+
+pub(super) fn handle_type_alias(type_alias: &xcbdefs::TypeAliasDef, out: &mut Output) {
+    let ns = type_alias.namespace.upgrade().unwrap();
+    if type_alias.new_name == "FP1616" && ns.header == "xinput" {
+        // This is a free function since Fp1616 is just a type alias for i32.
+        outln!(out, "/// Convert a [Fp1616] to a floating point number.");
+        outln!(out, "///");
+        outln!(
+            out,
+            "/// A [Fp1616] is a 32 bit integer where the upper 16 bits represent an integer"
+        );
+        outln!(
+            out,
+            "/// component and the lower 16 bits are a fractional part. This function"
+        );
+        outln!(out, "/// converts this representation to a f32.");
+        outln!(out, "pub fn fp1616_as_f32(input: Fp1616) -> f32 {{");
+        out.indented(|out| {
+            outln!(out, "(input as f32) / ((1u32 << 16) as f32)");
+        });
+        outln!(out, "}}");
+    }
+}

--- a/generator/src/generator/special_cases.rs
+++ b/generator/src/generator/special_cases.rs
@@ -200,7 +200,7 @@ pub(super) fn handle_struct(struct_def: &xcbdefs::StructDef, out: &mut Output) {
             out.indented(|out| {
                 outln!(
                     out,
-                    "(self.integral as f64) + (self.frac as f64) / ((1u64 << 32) as f64)"
+                    "(self.integral as f64) + (self.frac as f64) / 2f64.powi(32)"
                 );
             });
             outln!(out, "}}");
@@ -222,7 +222,7 @@ pub(super) fn handle_struct(struct_def: &xcbdefs::StructDef, out: &mut Output) {
             outln!(out, "/// `-1^31` is unspecified.");
             outln!(out, "pub fn from_f64(input: f64) -> Self {{");
             out.indented(|out| {
-                outln!(out, "let scaled = input * ((1u64 << 32) as f64);");
+                outln!(out, "let scaled = input * 2f64.powi(32);");
                 outln!(out, "let converted = scaled as i64;");
                 outln!(out, "let integral = converted >> 32;");
                 outln!(out, "let frac = converted - (integral << 32);");
@@ -264,7 +264,7 @@ pub(super) fn handle_type_alias(type_alias: &xcbdefs::TypeAliasDef, out: &mut Ou
         outln!(out, "/// converts this representation to a f32.");
         outln!(out, "pub fn fp1616_as_f32(input: Fp1616) -> f32 {{");
         out.indented(|out| {
-            outln!(out, "(input as f32) / ((1u32 << 16) as f32)");
+            outln!(out, "(input as f32) / 2f32.powi(16)");
         });
         outln!(out, "}}");
 
@@ -281,7 +281,7 @@ pub(super) fn handle_type_alias(type_alias: &xcbdefs::TypeAliasDef, out: &mut Ou
         outln!(out, "/// converts this representation to a f32.");
         outln!(out, "pub fn f32_as_fp1616(input: f32) -> Fp1616 {{");
         out.indented(|out| {
-            outln!(out, "(input * ((1u32 << 16) as f32)) as _");
+            outln!(out, "(input * 2f32.powi(16)) as _");
         });
         outln!(out, "}}");
     }

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -51,7 +51,7 @@ pub type Fp1616 = i32;
 /// component and the lower 16 bits are a fractional part. This function
 /// converts this representation to a f32.
 pub fn fp1616_as_f32(input: Fp1616) -> f32 {
-    (input as f32) / ((1u32 << 16) as f32)
+    (input as f32) / 2f32.powi(16)
 }
 /// Convert a floating point number to a [Fp1616].
 ///
@@ -59,7 +59,7 @@ pub fn fp1616_as_f32(input: Fp1616) -> f32 {
 /// component and the lower 16 bits are a fractional part. This function
 /// converts this representation to a f32.
 pub fn f32_as_fp1616(input: f32) -> Fp1616 {
-    (input * ((1u32 << 16) as f32)) as _
+    (input * 2f32.powi(16)) as _
 }
 
 #[derive(Clone, Copy, Default)]
@@ -106,7 +106,7 @@ impl Fp3232 {
     /// A [Fp3232] contains a 32 bits integer part and another 32 bits for a
     /// fractional component. This function converts this representation to a f64.
     pub fn as_f64(&self) -> f64 {
-        (self.integral as f64) + (self.frac as f64) / ((1u64 << 32) as f64)
+        (self.integral as f64) + (self.frac as f64) / 2f64.powi(32)
     }
     /// Convert from a floating point number.
     ///
@@ -116,7 +116,7 @@ impl Fp3232 {
     /// The behaviour for values greater or equal to `1^31` or less or equal to
     /// `-1^31` is unspecified.
     pub fn from_f64(input: f64) -> Self {
-        let scaled = input * ((1u64 << 32) as f64);
+        let scaled = input * 2f64.powi(32);
         let converted = scaled as i64;
         let integral = converted >> 32;
         let frac = converted - (integral << 32);

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -45,6 +45,14 @@ pub type KeyCode = u8;
 pub type DeviceId = u16;
 
 pub type Fp1616 = i32;
+/// Convert a [Fp1616] to a floating point number.
+///
+/// A [Fp1616] is a 32 bit integer where the upper 16 bits represent an integer
+/// component and the lower 16 bits are a fractional part. This function
+/// converts this representation to a f32.
+pub fn fp1616_as_f32(input: Fp1616) -> f32 {
+    (input as f32) / ((1u32 << 16) as f32)
+}
 
 #[derive(Clone, Copy, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
@@ -82,6 +90,15 @@ impl Serialize for Fp3232 {
         bytes.reserve(8);
         self.integral.serialize_into(bytes);
         self.frac.serialize_into(bytes);
+    }
+}
+impl Fp3232 {
+    /// Convert to a floating point number.
+    ///
+    /// A [Fp3232] contains a 32 bits integer part and another 32 bits for a
+    /// fractional component. This function converts this representation to a f64.
+    pub fn as_f64(&self) -> f64 {
+        (self.integral as f64) + (self.frac as f64) / ((1u64 << 32) as f64)
     }
 }
 

--- a/x11rb-protocol/src/protocol/xinput.rs
+++ b/x11rb-protocol/src/protocol/xinput.rs
@@ -53,6 +53,14 @@ pub type Fp1616 = i32;
 pub fn fp1616_as_f32(input: Fp1616) -> f32 {
     (input as f32) / ((1u32 << 16) as f32)
 }
+/// Convert a floating point number to a [Fp1616].
+///
+/// A [Fp1616] is a 32 bit integer where the upper 16 bits represent an integer
+/// component and the lower 16 bits are a fractional part. This function
+/// converts this representation to a f32.
+pub fn f32_as_fp1616(input: f32) -> Fp1616 {
+    (input * ((1u32 << 16) as f32)) as _
+}
 
 #[derive(Clone, Copy, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
@@ -99,6 +107,28 @@ impl Fp3232 {
     /// fractional component. This function converts this representation to a f64.
     pub fn as_f64(&self) -> f64 {
         (self.integral as f64) + (self.frac as f64) / ((1u64 << 32) as f64)
+    }
+    /// Convert from a floating point number.
+    ///
+    /// A [Fp3232] contains a 32 bits integer part and another 32 bits for a
+    /// fractional component. This function converts a f64 to this representation.
+    ///
+    /// The behaviour for values greater or equal to `1^31` or less or equal to
+    /// `-1^31` is unspecified.
+    pub fn from_f64(input: f64) -> Self {
+        let scaled = input * ((1u64 << 32) as f64);
+        let converted = scaled as i64;
+        let integral = converted >> 32;
+        let frac = converted - (integral << 32);
+        let integral = if frac >= 0 {
+            integral
+        } else {
+            integral - 1
+        };
+        let frac = converted - (integral << 32);
+        let integral = i32::try_from(integral).unwrap();
+        let frac = u32::try_from(frac).unwrap();
+        Self { integral, frac }
     }
 }
 

--- a/x11rb-protocol/tests/helper_tests.rs
+++ b/x11rb-protocol/tests/helper_tests.rs
@@ -1,0 +1,60 @@
+#[cfg(feature = "xinput")]
+#[test]
+fn test_fp1616() {
+    use x11rb_protocol::protocol::xinput::fp1616_as_f32;
+
+    let tests = [
+        (0, 0.),
+        (1 << 16, 1.),
+        (-1 << 16, -1.),
+        (1 << 15, 0.5),
+        (-1 << 15, -0.5),
+        (3 << 15, 1.5),
+        (-3 << 15, -1.5),
+        (i32::MAX, 2f32.powi(15)),
+        (i32::MIN, -2f32.powi(15)),
+    ];
+
+    for (input, output) in tests {
+        assert_eq!(
+            output,
+            fp1616_as_f32(input),
+            "Expected fp1616_as_f32({input}) to be {output}"
+        );
+    }
+}
+
+#[cfg(feature = "xinput")]
+#[test]
+fn test_fp3232() {
+    use x11rb_protocol::protocol::xinput::Fp3232;
+
+    let tests = [
+        (0i64, 0.),
+        (1 << 32, 1.),
+        (-1 << 32, -1.),
+        (1 << 31, 0.5),
+        (-1 << 31, -0.5),
+        (3 << 31, 1.5),
+        (-3 << 31, -1.5),
+        // The following actually tests a rounding error since the result should be slightly less
+        // than 2^31.
+        (i64::MAX, 2f64.powi(31)),
+        (i64::MIN, -2f64.powi(31)),
+        // The largest number below 1
+        ((1 << 32) - 1, 1f64 - (1f64 / ((1u64 << 32) as f64))),
+        (-(1 << 32) + 1, -1f64 + (1f64 / ((1u64 << 32) as f64))),
+    ];
+
+    for (input, output) in tests {
+        let bytes = input.to_be_bytes();
+        let integral = i32::from_be_bytes(bytes[..4].try_into().unwrap());
+        let frac = u32::from_be_bytes(bytes[4..].try_into().unwrap());
+        let obj = Fp3232 { integral, frac };
+        assert_eq!(
+            output,
+            obj.as_f64(),
+            "Expected Fp3232 {{ {input} }} == Fp3232 {{ integral: {integral}, frac: {frac} }}.as_f64() to be {output}"
+        );
+    }
+}


### PR DESCRIPTION
These were requested in https://github.com/rust-windowing/winit/pull/3252

After an afternoon of rounding errors, I am giving up for now.