### PR TITLE
Update dependencies

### DIFF
--- a/x11rb-async/Cargo.toml
+++ b/x11rb-async/Cargo.toml
@@ -16,10 +16,10 @@ keywords = ["xcb", "X11", "async"]
 
 [dependencies]
 async-io = "1.13.0"
-async-lock = "2.8.0"
-blocking = "1.3.0"
-event-listener = "2.5.3"
-futures-lite = "1"
+async-lock = "3.3"
+blocking = "1.5"
+event-listener = "5.0"
+futures-lite = "2.2"
 tracing = { version = "0.1.33", default-features = false }
 x11rb = { version = "0.13.0", path = "../x11rb", default-features = false }
 x11rb-protocol = { version = "0.13.0", default-features = false, features = ["std"], path = "../x11rb-protocol" }
@@ -96,7 +96,7 @@ allow-unsafe-code = ["x11rb/allow-unsafe-code"]
 all-features = true
 
 [dev-dependencies]
-async-executor = "1.5.0"
+async-executor = "1.8"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [target.'cfg(unix)'.dev-dependencies.rustix]

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["xcb", "X11"]
 x11rb-protocol = { version = "0.13.0", default-features = false, features = ["std"], path = "../x11rb-protocol" }
 libc = { version = "0.2", optional = true }
 libloading = { version = "0.8.0", optional = true }
-once_cell = { version = "1.17", optional = true }
+once_cell = { version = "1.19", optional = true }
 as-raw-xcb-connection = { version = "1.0", optional = true }
 tracing = { version = "0.1", optional = true, default-features = false }
 rustix = { version = "0.38", default-features = false, features = ["std", "event", "fs", "net", "system"] }
@@ -28,7 +28,7 @@ gethostname = "0.4"
 
 [dev-dependencies]
 gethostname = "0.4"
-polling = "3.3.1"
+polling = "3.4"
 tracing-subscriber = "0.3"
 
 [features]

--- a/xcbgen-rs/Cargo.toml
+++ b/xcbgen-rs/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-once_cell = "1.17.0"
+once_cell = "1.19.0"
 roxmltree = "0.19.0"

--- a/xtrace-example/Cargo.toml
+++ b/xtrace-example/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-smol = "1.3"
+smol = "2.0"
 
 [dependencies.x11rb-protocol]
 path = "../x11rb-protocol"


### PR DESCRIPTION
This updates all dependencies to their latest version. Exceptions are cairo-rs, which has a higher MSRV than we do, and async-io, which has a breaking API change in version 2.