### PR TITLE
Update to async-io 2

### DIFF
--- a/x11rb-async/Cargo.toml
+++ b/x11rb-async/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["xcb", "X11", "async"]
 
 [dependencies]
-async-io = "1.13.0"
+async-io = "2.3"
 async-lock = "3.3"
 blocking = "1.5"
 event-listener = "5.0"


### PR DESCRIPTION
With version 2, there is an API break. async-io switched from AsRawFd to AsFd, in order to implement I/O safety. Also, some previously safe method was marked as unsafe.

In this commit, I am just following these API changes.