### PR TITLE
Enable some more lints

### DIFF
--- a/x11rb-async/src/blocking.rs
+++ b/x11rb-async/src/blocking.rs
@@ -37,6 +37,7 @@ use x11rb_protocol::DiscardMode;
 /// The [`blocking`] threadpool is used to handle all requests.
 ///
 /// [`blocking`]: https://docs.rs/blocking
+#[derive(Debug)]
 pub struct BlockingConnection<C> {
     inner: Arc<C>,
 }

--- a/x11rb-async/src/cookie.rs
+++ b/x11rb-async/src/cookie.rs
@@ -21,6 +21,7 @@ use std::task::{Context, Poll};
 use crate::protocol::record::EnableContextReply;
 
 /// A cookie for a request without a reply.
+#[derive(Debug)]
 pub struct VoidCookie<'conn, C: RequestConnection + ?Sized> {
     conn: &'conn C,
     sequence: SequenceNumber,
@@ -75,6 +76,7 @@ impl<'conn, C: RequestConnection + ?Sized> Drop for VoidCookie<'conn, C> {
 }
 
 /// Helper for cookies that hold a reply.
+#[derive(Debug)]
 struct RawCookie<'a, C: RequestConnection + ?Sized> {
     conn: &'a C,
     sequence: SequenceNumber,
@@ -103,6 +105,7 @@ impl<'a, C: RequestConnection + ?Sized> Drop for RawCookie<'a, C> {
 }
 
 /// A cookie for a request that has a reply.
+#[derive(Debug)]
 pub struct Cookie<'conn, C: RequestConnection + ?Sized, R> {
     raw: RawCookie<'conn, C>,
     capture: PhantomData<R>,
@@ -173,6 +176,7 @@ impl<'conn, C: Connection + ?Sized, R: TryParse> Cookie<'conn, C, R> {
 }
 
 /// A cookie for a request that has a reply containing file descriptors.
+#[derive(Debug)]
 pub struct CookieWithFds<'conn, C: RequestConnection + ?Sized, R> {
     raw: RawCookie<'conn, C>,
     capture: PhantomData<R>,
@@ -233,6 +237,14 @@ macro_rules! multiple_reply_cookie {
 
             // Current wait future we're polling.
             wait: Option<Pin<Box<dyn Future<Output = Result<C::Buf, ReplyError>> + Send + 'conn>>>,
+        }
+
+        impl<'conn, C: RequestConnection + std::fmt::Debug + ?Sized> std::fmt::Debug for $name<'conn, C> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_struct(stringify!($name))
+                    .field("raw", &self.raw)
+                    .finish_non_exhaustive()
+            }
         }
 
         impl<'conn, C: RequestConnection + ?Sized> $name<'conn, C> {

--- a/x11rb-async/src/lib.rs
+++ b/x11rb-async/src/lib.rs
@@ -52,13 +52,19 @@
     clippy::cast_lossless,
     clippy::needless_pass_by_value,
 )]
+// A list of lints that are only #![deny] and not the stronger #![forbid]. Each one has a comment
+// explaining why it gets the weaker treatment.
+#![deny(
+    // Not everything in x11rb::protocol has doc comments
+    missing_docs,
+)]
 #![cfg_attr(not(feature = "allow-unsafe-code"), forbid(unsafe_code))]
 
 // -- Public Modules --
 
 pub mod blocking;
 pub mod connection;
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, missing_docs)]
 #[rustfmt::skip]
 pub mod protocol;
 pub mod rust_connection;
@@ -76,5 +82,6 @@ mod cookie;
 pub use cookie::{Cookie, CookieWithFds, VoidCookie};
 
 pub mod utils {
+    //! Utility functions that are not specific to X11.
     pub use x11rb::utils::RawFdContainer;
 }

--- a/x11rb-async/src/lib.rs
+++ b/x11rb-async/src/lib.rs
@@ -45,6 +45,7 @@
     missing_copy_implementations,
     missing_debug_implementations,
     rustdoc::private_doc_tests,
+    rust_2018_idioms,
     //single_use_lifetimes,
     trivial_casts,
     trivial_numeric_casts,

--- a/x11rb-async/src/lib.rs
+++ b/x11rb-async/src/lib.rs
@@ -41,6 +41,19 @@
 //! * `extra-traits`: Implement extra traits for X11 types. This improves the output of the `Debug`
 //!   impl and adds `PartialEq`, `Eq`, `PartialOrd`, `Ord`, and `Hash` where possible.
 
+#![forbid(
+    missing_copy_implementations,
+    rustdoc::private_doc_tests,
+    //single_use_lifetimes,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused_import_braces,
+    unused_must_use,
+    clippy::cast_lossless,
+    clippy::needless_pass_by_value,
+)]
+#![cfg_attr(not(feature = "allow-unsafe-code"), forbid(unsafe_code))]
+
 // -- Public Modules --
 
 pub mod blocking;

--- a/x11rb-async/src/lib.rs
+++ b/x11rb-async/src/lib.rs
@@ -43,6 +43,7 @@
 
 #![forbid(
     missing_copy_implementations,
+    missing_debug_implementations,
     rustdoc::private_doc_tests,
     //single_use_lifetimes,
     trivial_casts,

--- a/x11rb-async/src/lib.rs
+++ b/x11rb-async/src/lib.rs
@@ -49,6 +49,7 @@
     //single_use_lifetimes,
     trivial_casts,
     trivial_numeric_casts,
+    unreachable_pub,
     unused_import_braces,
     unused_must_use,
     unused_results,

--- a/x11rb-async/src/lib.rs
+++ b/x11rb-async/src/lib.rs
@@ -55,6 +55,8 @@
 // A list of lints that are only #![deny] and not the stronger #![forbid]. Each one has a comment
 // explaining why it gets the weaker treatment.
 #![deny(
+    // #[derive] generates an #[allow] for this
+    unused_qualifications,
     // Not everything in x11rb::protocol has doc comments
     missing_docs,
 )]

--- a/x11rb-async/src/lib.rs
+++ b/x11rb-async/src/lib.rs
@@ -49,6 +49,7 @@
     trivial_numeric_casts,
     unused_import_braces,
     unused_must_use,
+    unused_results,
     clippy::cast_lossless,
     clippy::needless_pass_by_value,
 )]

--- a/x11rb-async/src/rust_connection/extensions.rs
+++ b/x11rb-async/src/rust_connection/extensions.rs
@@ -43,7 +43,7 @@ impl Extensions {
             let cookie = crate::protocol::xproto::query_extension(conn, name.as_bytes()).await?;
 
             // Add the extension to the cache.
-            entry.insert(ExtensionState::Loading(cookie.sequence_number()));
+            let _entry = entry.insert(ExtensionState::Loading(cookie.sequence_number()));
 
             std::mem::forget(cookie);
         }

--- a/x11rb-async/src/rust_connection/mod.rs
+++ b/x11rb-async/src/rust_connection/mod.rs
@@ -322,8 +322,6 @@ impl<S: Stream + Send + Sync> RustConnection<S> {
                 .send_request(ReplyFdKind::ReplyWithoutFDs)
                 .expect("This request should not be blocked by syncs");
             inner.discard_reply(seq, DiscardMode::DiscardReplyAndError);
-
-            seq
         };
 
         // Write the entire packet.
@@ -589,7 +587,8 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
 
     fn prefetch_maximum_request_bytes(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
-            self.prefetch_len_impl()
+            let _guard = self
+                .prefetch_len_impl()
                 .await
                 .expect("Failed to prefetch maximum request bytes");
         })

--- a/x11rb-async/src/rust_connection/mod.rs
+++ b/x11rb-async/src/rust_connection/mod.rs
@@ -414,7 +414,7 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
         &'this self,
         bufs: &'bufs [io::IoSlice<'sl>],
         fds: Vec<RawFdContainer>,
-    ) -> Fut<'future, crate::Cookie<'this, Self, R>, ConnectionError>
+    ) -> Fut<'future, Cookie<'this, Self, R>, ConnectionError>
     where
         'this: 'future,
         'bufs: 'future,
@@ -435,7 +435,7 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
         &'this self,
         bufs: &'bufs [io::IoSlice<'sl>],
         fds: Vec<RawFdContainer>,
-    ) -> Fut<'future, crate::CookieWithFds<'this, Self, R>, ConnectionError>
+    ) -> Fut<'future, CookieWithFds<'this, Self, R>, ConnectionError>
     where
         'this: 'future,
         'bufs: 'future,
@@ -456,7 +456,7 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
         &'this self,
         bufs: &'bufs [io::IoSlice<'sl>],
         fds: Vec<RawFdContainer>,
-    ) -> Fut<'future, crate::VoidCookie<'this, Self>, ConnectionError>
+    ) -> Fut<'future, VoidCookie<'this, Self>, ConnectionError>
     where
         'this: 'future,
         'bufs: 'future,
@@ -473,7 +473,7 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
         &self,
         sequence: SequenceNumber,
         _kind: x11rb::connection::RequestKind,
-        mode: x11rb_protocol::DiscardMode,
+        mode: DiscardMode,
     ) {
         tracing::debug!(
             "Discarding reply to request {} in mode {:?}",
@@ -542,8 +542,7 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
     fn wait_for_reply_with_fds_raw(
         &self,
         sequence: SequenceNumber,
-    ) -> Fut<'_, ReplyOrError<x11rb::connection::BufWithFds<Self::Buf>, Self::Buf>, ConnectionError>
-    {
+    ) -> Fut<'_, ReplyOrError<BufWithFds<Self::Buf>, Self::Buf>, ConnectionError> {
         Box::pin(
             self.wait_for_reply_with_fds_impl(sequence)
                 .instrument(tracing::info_span!("wait_for_reply_with_fds_raw", sequence)),
@@ -588,9 +587,7 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
         )
     }
 
-    fn prefetch_maximum_request_bytes(
-        &self,
-    ) -> Pin<Box<dyn futures_lite::Future<Output = ()> + Send + '_>> {
+    fn prefetch_maximum_request_bytes(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async move {
             self.prefetch_len_impl()
                 .await
@@ -598,9 +595,7 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
         })
     }
 
-    fn maximum_request_bytes(
-        &self,
-    ) -> Pin<Box<dyn futures_lite::Future<Output = usize> + Send + '_>> {
+    fn maximum_request_bytes(&self) -> Pin<Box<dyn Future<Output = usize> + Send + '_>> {
         Box::pin(
             async move {
                 let mut mrl = self
@@ -645,7 +640,7 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
         )
     }
 
-    fn parse_error(&self, error: &[u8]) -> Result<x11rb::x11_utils::X11Error, ParseError> {
+    fn parse_error(&self, error: &[u8]) -> Result<X11Error, ParseError> {
         let extensions = future::block_on(self.extensions.read());
         X11Error::try_parse(error, &*extensions)
     }

--- a/x11rb-async/src/rust_connection/nb_connect.rs
+++ b/x11rb-async/src/rust_connection/nb_connect.rs
@@ -133,8 +133,8 @@ async fn resolve_host(host: &str) -> io::Result<impl Stream<Item = IpAddr>> {
             cx: &mut std::task::Context<'_>,
         ) -> std::task::Poll<Option<Self::Item>> {
             match self.get_mut() {
-                Either::Left(a) => a.poll_next(cx),
-                Either::Right(b) => b.poll_next(cx),
+                Left(a) => a.poll_next(cx),
+                Right(b) => b.poll_next(cx),
             }
         }
     }

--- a/x11rb-async/src/rust_connection/shared_state.rs
+++ b/x11rb-async/src/rust_connection/shared_state.rs
@@ -115,7 +115,7 @@ impl<S: Stream> SharedState<S> {
 
                 if packet_count > 0 {
                     // Notify any listeners that there is new data.
-                    self.new_input.notify_additional(std::usize::MAX);
+                    let _num_notified = self.new_input.notify_additional(std::usize::MAX);
                 } else {
                     // Wait for more data.
                     self.stream.readable().await?;
@@ -223,6 +223,6 @@ impl<S> Drop for BreakOnDrop<S> {
         self.0.driver_dropped.store(true, Ordering::SeqCst);
 
         // Wake up everyone that might be waiting
-        self.0.new_input.notify_additional(std::usize::MAX);
+        let _num_notified = self.0.new_input.notify_additional(std::usize::MAX);
     }
 }

--- a/x11rb-async/src/rust_connection/stream.rs
+++ b/x11rb-async/src/rust_connection/stream.rs
@@ -42,6 +42,7 @@ impl<S: for<'a> StreamBase<'a>> Stream for S {}
 pub type DefaultStream = StreamAdaptor<X11rbDefaultStream>;
 
 /// An adaptor that implements a `Stream` for a type that implements `X11rbStream`.
+#[derive(Debug)]
 pub struct StreamAdaptor<S> {
     inner: Async<S>,
 }

--- a/x11rb-async/src/rust_connection/stream.rs
+++ b/x11rb-async/src/rust_connection/stream.rs
@@ -63,7 +63,7 @@ impl<S> Unpin for Readable<'_, S> {}
 impl<S> Future for Readable<'_, S> {
     type Output = io::Result<()>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Pin::new(&mut self.0).poll(cx)
     }
 }
@@ -77,7 +77,7 @@ impl<S> Unpin for Writable<'_, S> {}
 impl<S> Future for Writable<'_, S> {
     type Output = io::Result<()>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Pin::new(&mut self.0).poll(cx)
     }
 }

--- a/x11rb-async/src/rust_connection/write_buffer.rs
+++ b/x11rb-async/src/rust_connection/write_buffer.rs
@@ -43,7 +43,7 @@ impl WriteBuffer {
     /// considered corrupted. This mechanism exists to catch futures being dropped without being
     /// polled to completion. In this situation we cannot be sure how many bytes were already
     /// written to the stream, so the complete connection is now broken.
-    pub async fn lock(&self) -> Result<WriteBufferGuard<'_>, ConnectionError> {
+    pub(super) async fn lock(&self) -> Result<WriteBufferGuard<'_>, ConnectionError> {
         let mut lock = self.0.lock().await;
         if std::mem::replace(&mut lock.corrupted, true) {
             return Err(ConnectionError::IoError(io::Error::new(
@@ -58,7 +58,7 @@ impl WriteBuffer {
 
 impl WriteBufferGuard<'_> {
     /// Unlock this guard.
-    pub fn unlock(mut self) {
+    pub(super) fn unlock(mut self) {
         self.0.corrupted = false;
     }
 }
@@ -79,7 +79,7 @@ impl std::ops::DerefMut for WriteBufferGuard<'_> {
 
 impl WriteBufferInner {
     /// Flush the write buffer.
-    pub async fn flush<'b, S: StreamBase<'b>>(
+    pub(super) async fn flush<'b, S: StreamBase<'b>>(
         &mut self,
         stream: &'b S,
     ) -> Result<(), ConnectionError> {
@@ -130,7 +130,7 @@ impl WriteBufferInner {
     }
 
     /// Write a set of buffers to the stream.
-    pub async fn write_all_vectored<'b, S: StreamBase<'b>>(
+    pub(super) async fn write_all_vectored<'b, S: StreamBase<'b>>(
         &mut self,
         stream: &'b S,
         mut bufs: &[io::IoSlice<'_>],

--- a/x11rb-protocol/src/lib.rs
+++ b/x11rb-protocol/src/lib.rs
@@ -50,6 +50,7 @@
     unreachable_pub,
     unsafe_code,
     unused_import_braces,
+    unused_must_use,
     unused_results,
     clippy::cast_lossless,
     clippy::needless_pass_by_value,

--- a/x11rb/src/lib.rs
+++ b/x11rb/src/lib.rs
@@ -130,6 +130,7 @@
     trivial_numeric_casts,
     unreachable_pub,
     unused_import_braces,
+    unused_must_use,
     unused_results,
     clippy::cast_lossless,
     clippy::needless_pass_by_value,

--- a/xcbgen-rs/src/defs/fields.rs
+++ b/xcbgen-rs/src/defs/fields.rs
@@ -96,7 +96,7 @@ impl FieldDef {
 }
 
 /// A `<pad>` field.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct PadField {
     /// The kind and size of padding
     pub kind: PadKind,
@@ -377,7 +377,7 @@ pub enum FieldValueSet {
 }
 
 /// The kind of padding a `<pad>` can represent.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub enum PadKind {
     /// A fixed size padding of the given size (`bytes` attribute).
     Bytes(u16),

--- a/xcbgen-rs/src/defs/top_level.rs
+++ b/xcbgen-rs/src/defs/top_level.rs
@@ -475,7 +475,7 @@ pub struct EnumItem {
 }
 
 /// The value of an enum item
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum EnumValue {
     /// A `<value>`.
     Value(u32),

--- a/xcbgen-rs/src/lib.rs
+++ b/xcbgen-rs/src/lib.rs
@@ -13,7 +13,13 @@
     unreachable_pub,
     unused_import_braces,
     unused_must_use,
-    unused_qualifications
+    unused_qualifications,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    rustdoc::private_doc_tests,
+    single_use_lifetimes,
+    clippy::cast_lossless,
+    clippy::needless_pass_by_value
 )]
 #![forbid(unsafe_code)]
 

--- a/xcbgen-rs/src/parser.rs
+++ b/xcbgen-rs/src/parser.rs
@@ -12,7 +12,7 @@ use once_cell::unsync::OnceCell;
 use crate::defs;
 
 /// An error that occurred while parsing an error.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum ParseError {
     /// The XML tree is in some way malformed.
     ///
@@ -51,6 +51,7 @@ pub enum ParseError {
 /// A `Parser` that adds namespaces to a module.
 ///
 /// One instance of this struct can be used to parse multiple namespaces, one after another.
+#[derive(Debug)]
 pub struct Parser {
     module: Rc<defs::Module>,
 }

--- a/xcbgen-rs/src/resolver/nesting_checker.rs
+++ b/xcbgen-rs/src/resolver/nesting_checker.rs
@@ -51,8 +51,8 @@ impl NestingChecker {
 
     fn check_type_def(&mut self, type_def: &defs::TypeDef) -> Result<(), ResolveError> {
         match type_def {
-            defs::TypeDef::Struct(struct_def) => self.check_struct(&struct_def.clone()),
-            defs::TypeDef::Union(union_def) => self.check_union(&union_def.clone()),
+            defs::TypeDef::Struct(struct_def) => self.check_struct(struct_def),
+            defs::TypeDef::Union(union_def) => self.check_union(union_def),
             _ => Ok(()),
         }
     }

--- a/xcbgen-rs/src/resolver/nesting_checker.rs
+++ b/xcbgen-rs/src/resolver/nesting_checker.rs
@@ -51,15 +51,15 @@ impl NestingChecker {
 
     fn check_type_def(&mut self, type_def: &defs::TypeDef) -> Result<(), ResolveError> {
         match type_def {
-            defs::TypeDef::Struct(struct_def) => self.check_struct(struct_def.clone()),
-            defs::TypeDef::Union(union_def) => self.check_union(union_def.clone()),
+            defs::TypeDef::Struct(struct_def) => self.check_struct(&struct_def.clone()),
+            defs::TypeDef::Union(union_def) => self.check_union(&union_def.clone()),
             _ => Ok(()),
         }
     }
 
-    fn check_struct(&mut self, struct_def: Rc<defs::StructDef>) -> Result<(), ResolveError> {
+    fn check_struct(&mut self, struct_def: &Rc<defs::StructDef>) -> Result<(), ResolveError> {
         self.push(NestingStackItem::Struct(struct_def.clone()))?;
-        let struct_def_ptr: *const defs::StructDef = &*struct_def;
+        let struct_def_ptr: *const defs::StructDef = &**struct_def;
         if self.checked.insert(struct_def_ptr as usize) {
             // Not checked yet
             for field in struct_def.fields.borrow().iter() {
@@ -70,9 +70,9 @@ impl NestingChecker {
         Ok(())
     }
 
-    fn check_union(&mut self, union_def: Rc<defs::UnionDef>) -> Result<(), ResolveError> {
+    fn check_union(&mut self, union_def: &Rc<defs::UnionDef>) -> Result<(), ResolveError> {
         self.push(NestingStackItem::Union(union_def.clone()))?;
-        let union_def_ptr: *const defs::UnionDef = &*union_def;
+        let union_def_ptr: *const defs::UnionDef = &**union_def;
         if self.checked.insert(union_def_ptr as usize) {
             // Not checked yet
             for field in union_def.fields.iter() {
@@ -115,8 +115,8 @@ impl NestingChecker {
 
     fn check_type_ref(&mut self, type_: &defs::TypeRef) -> Result<(), ResolveError> {
         match type_ {
-            defs::TypeRef::Struct(struct_def) => self.check_struct(struct_def.upgrade().unwrap()),
-            defs::TypeRef::Union(union_def) => self.check_union(union_def.upgrade().unwrap()),
+            defs::TypeRef::Struct(struct_def) => self.check_struct(&struct_def.upgrade().unwrap()),
+            defs::TypeRef::Union(union_def) => self.check_union(&union_def.upgrade().unwrap()),
             defs::TypeRef::Alias(type_alias_def) => {
                 let type_alias_def = type_alias_def.upgrade().unwrap();
                 self.check_type_ref(type_alias_def.old_name.get_resolved())


### PR DESCRIPTION
I noticed that we have several versions of the "`#![forbid]` all the things" dance at the beginning of modules. The worst thing is that x11rb-async did not actually forbid unsafe code by default. This PR does some linting.