### PR TITLE
Update the changelog for the next release

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,3 +1,25 @@
+# Version 0.13.1 (2024-XX-XX)
+
+New features:
+* Add an `xkbcommon-example` to showcase use of x11rb together with the
+  xkbcommon crate.
+* Update from xcb-proto 1.15.2 to 1.17.0. This brings support for PRESENT 1.4
+  and DRI3 1.4 and fixes some typos in the documentation.
+
+Fixes:
+* Macro hygiene: `atom_manager!` macro now uses`::std` when referring to std
+  items.
+
+Breaking changes:
+* Optimise `atom_manager!` implementation. This changes the contents of the
+  generated `Cookie` struct, but there should be no reasons to access these
+  directly.
+* Remove some unreachable public API from x11rb-async's `StreamAdaptor`.
+
+Minor changes:
+* Fix new compiler warnings and enable more lints.
+* Update dependencies.
+
 # Version 0.13.0 (2023-12-09)
 
 New features:


### PR DESCRIPTION
Arguably, 39be1861642ccb9856e1e1191f5bf5769cd4f169 is a breaking change since we cannot prevent access to the fields of the `...Cookie` struct that is generated by `atom_manager!` invocations and these fields actually appeared in the docs. However, I can come up with zero reasons why anyone would mess with these fields directly and would like to pretend that this is not a breaking change. I documented it as one anyway.

Complaints?

Edit: Ref: https://github.com/psychon/x11rb/issues/925