### PR TITLE
Fix unused_qualifications warnings on Windows and exclude extract-generated-code-doc and generator from clippy's MSRV check

### DIFF
--- a/extract-generated-code-doc/src/main.rs
+++ b/extract-generated-code-doc/src/main.rs
@@ -7,6 +7,8 @@
     unused_qualifications
 )]
 #![forbid(unsafe_code)]
+// This crate is not shipped to users and does not follow our MSRV
+#![allow(clippy::incompatible_msrv)]
 
 use std::io::Error as IoError;
 use std::path::Path;

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -1142,12 +1142,14 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             outln!(out, "///");
             for error in doc.errors.iter() {
                 let text = format!(
-                    "* `{}` - {}",
+                    "`{}` - {}",
                     error.type_,
                     error.doc.as_deref().unwrap_or("").trim(),
                 );
+                let mut prefix_char = '*';
                 for line in text.split('\n') {
-                    outln!(out, "/// {}", line.trim_end());
+                    outln!(out, "/// {} {}", prefix_char, line.trim_end());
+                    prefix_char = ' ';
                 }
             }
         }

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -1115,13 +1115,16 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                     continue;
                 }
                 let text = format!(
-                    " * `{}` - {}",
+                    "`{}` - {}",
                     field.name,
                     field.doc.as_deref().unwrap_or("").trim(),
                 );
+                let mut prefix_char = '*';
                 // Prevent rustdoc interpreting many leading spaces as code examples (?)
                 for line in text.trim().split('\n') {
                     let line = line.trim();
+                    let line = format!("{} {}", prefix_char, line);
+                    prefix_char = ' ';
                     if line.trim().is_empty() {
                         outln!(out, "///");
                     } else {

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -7,6 +7,8 @@
     unused_qualifications
 )]
 #![forbid(unsafe_code)]
+// This crate is not shipped to users and does not follow our MSRV
+#![allow(clippy::incompatible_msrv)]
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;

--- a/x11rb-async/src/lib.rs
+++ b/x11rb-async/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! Additionally, the following flags exist:
 //! * `allow-unsafe-code`: Enable the same feature in x11rb and implement
-//! [`blocking::BlockingConnection`] for [`x11rb::xcb_ffi::XCBConnection`]
+//!   [`blocking::BlockingConnection`] for [`x11rb::xcb_ffi::XCBConnection`]
 //! * `extra-traits`: Implement extra traits for X11 types. This improves the output of the `Debug`
 //!   impl and adds `PartialEq`, `Eq`, `PartialOrd`, `Ord`, and `Hash` where possible.
 

--- a/x11rb-async/src/protocol/composite.rs
+++ b/x11rb-async/src/protocol/composite.rs
@@ -73,8 +73,8 @@ where
 ///
 /// * `window` - The root of the hierarchy to redirect to off-screen storage.
 /// * `update` - Whether contents are automatically mirrored to the parent window.  If one client
-/// already specifies an update type of Manual, any attempt by another to specify a
-/// mode of Manual so will result in an Access error.
+///   already specifies an update type of Manual, any attempt by another to specify a
+///   mode of Manual so will result in an Access error.
 pub async fn redirect_window<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -99,8 +99,8 @@ where
 ///
 /// * `window` - The root of the hierarchy to redirect to off-screen storage.
 /// * `update` - Whether contents are automatically mirrored to the parent window.  If one client
-/// already specifies an update type of Manual, any attempt by another to specify a
-/// mode of Manual so will result in an Access error.
+///   already specifies an update type of Manual, any attempt by another to specify a
+///   mode of Manual so will result in an Access error.
 pub async fn redirect_subwindows<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -122,9 +122,9 @@ where
 /// # Fields
 ///
 /// * `window` - The window to terminate redirection of.  Must be redirected by the
-/// current client, or a Value error results.
+///   current client, or a Value error results.
 /// * `update` - The update type passed to RedirectWindows.  If this does not match the
-/// previously requested update type, a Value error results.
+///   previously requested update type, a Value error results.
 pub async fn unredirect_window<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -145,10 +145,10 @@ where
 /// # Fields
 ///
 /// * `window` - The window to terminate redirection of.  Must have previously been
-/// selected for sub-redirection by the current client, or a Value error
-/// results.
+///   selected for sub-redirection by the current client, or a Value error
+///   results.
 /// * `update` - The update type passed to RedirectSubWindows.  If this does not match
-/// the previously requested update type, a Value error results.
+///   the previously requested update type, a Value error results.
 pub async fn unredirect_subwindows<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -240,8 +240,8 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `window` - The root of the hierarchy to redirect to off-screen storage.
     /// * `update` - Whether contents are automatically mirrored to the parent window.  If one client
-    /// already specifies an update type of Manual, any attempt by another to specify a
-    /// mode of Manual so will result in an Access error.
+    ///   already specifies an update type of Manual, any attempt by another to specify a
+    ///   mode of Manual so will result in an Access error.
     fn composite_redirect_window(&self, window: xproto::Window, update: Redirect) -> Pin<Box<dyn Future<Output = Result<VoidCookie<'_, Self>, ConnectionError>> + Send + '_>>
     {
         Box::pin(redirect_window(self, window, update))
@@ -257,8 +257,8 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `window` - The root of the hierarchy to redirect to off-screen storage.
     /// * `update` - Whether contents are automatically mirrored to the parent window.  If one client
-    /// already specifies an update type of Manual, any attempt by another to specify a
-    /// mode of Manual so will result in an Access error.
+    ///   already specifies an update type of Manual, any attempt by another to specify a
+    ///   mode of Manual so will result in an Access error.
     fn composite_redirect_subwindows(&self, window: xproto::Window, update: Redirect) -> Pin<Box<dyn Future<Output = Result<VoidCookie<'_, Self>, ConnectionError>> + Send + '_>>
     {
         Box::pin(redirect_subwindows(self, window, update))
@@ -271,9 +271,9 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `window` - The window to terminate redirection of.  Must be redirected by the
-    /// current client, or a Value error results.
+    ///   current client, or a Value error results.
     /// * `update` - The update type passed to RedirectWindows.  If this does not match the
-    /// previously requested update type, a Value error results.
+    ///   previously requested update type, a Value error results.
     fn composite_unredirect_window(&self, window: xproto::Window, update: Redirect) -> Pin<Box<dyn Future<Output = Result<VoidCookie<'_, Self>, ConnectionError>> + Send + '_>>
     {
         Box::pin(unredirect_window(self, window, update))
@@ -285,10 +285,10 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `window` - The window to terminate redirection of.  Must have previously been
-    /// selected for sub-redirection by the current client, or a Value error
-    /// results.
+    ///   selected for sub-redirection by the current client, or a Value error
+    ///   results.
     /// * `update` - The update type passed to RedirectSubWindows.  If this does not match
-    /// the previously requested update type, a Value error results.
+    ///   the previously requested update type, a Value error results.
     fn composite_unredirect_subwindows(&self, window: xproto::Window, update: Redirect) -> Pin<Box<dyn Future<Output = Result<VoidCookie<'_, Self>, ConnectionError>> + Send + '_>>
     {
         Box::pin(unredirect_subwindows(self, window, update))

--- a/x11rb-async/src/protocol/damage.rs
+++ b/x11rb-async/src/protocol/damage.rs
@@ -91,7 +91,7 @@ where
 /// # Fields
 ///
 /// * `damage` - The ID with which you will refer to the new Damage object, created by
-/// `xcb_generate_id`.
+///   `xcb_generate_id`.
 /// * `drawable` - The ID of the drawable to be monitored.
 /// * `level` - The level of detail to be provided in Damage events.
 pub async fn create<Conn>(conn: &Conn, damage: Damage, drawable: xproto::Drawable, level: ReportLevel) -> Result<VoidCookie<'_, Conn>, ConnectionError>
@@ -223,7 +223,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `damage` - The ID with which you will refer to the new Damage object, created by
-    /// `xcb_generate_id`.
+    ///   `xcb_generate_id`.
     /// * `drawable` - The ID of the drawable to be monitored.
     /// * `level` - The level of detail to be provided in Damage events.
     fn damage_create(&self, damage: Damage, drawable: xproto::Drawable, level: ReportLevel) -> Pin<Box<dyn Future<Output = Result<VoidCookie<'_, Self>, ConnectionError>> + Send + '_>>

--- a/x11rb-async/src/protocol/shm.rs
+++ b/x11rb-async/src/protocol/shm.rs
@@ -112,21 +112,21 @@ where
 /// * `src_x` - The source X coordinate of the sub-image to copy.
 /// * `src_y` - The source Y coordinate of the sub-image to copy.
 /// * `src_width` - The width, in source image coordinates, of the data to copy from the source.
-/// The X server will use this to determine the amount of data to copy.  The amount
-/// of the destination image that is overwritten is determined automatically.
+///   The X server will use this to determine the amount of data to copy.  The amount
+///   of the destination image that is overwritten is determined automatically.
 /// * `src_height` - The height, in source image coordinates, of the data to copy from the source.
-/// The X server will use this to determine the amount of data to copy.  The amount
-/// of the destination image that is overwritten is determined automatically.
+///   The X server will use this to determine the amount of data to copy.  The amount
+///   of the destination image that is overwritten is determined automatically.
 /// * `dst_x` - The X coordinate on the destination drawable to copy to.
 /// * `dst_y` - The Y coordinate on the destination drawable to copy to.
 /// * `depth` - The depth to use.
 /// * `format` - The format of the image being drawn.  If it is XYBitmap, depth must be 1, or a
-/// "BadMatch" error results.  The foreground pixel in the GC determines the source
-/// for the one bits in the image, and the background pixel determines the source
-/// for the zero bits.  For XYPixmap and ZPixmap, the depth must match the depth of
-/// the drawable, or a "BadMatch" error results.
+///   "BadMatch" error results.  The foreground pixel in the GC determines the source
+///   for the one bits in the image, and the background pixel determines the source
+///   for the zero bits.  For XYPixmap and ZPixmap, the depth must match the depth of
+///   the drawable, or a "BadMatch" error results.
 /// * `send_event` - True if the server should send an XCB_SHM_COMPLETION event when the blit
-/// completes.
+///   completes.
 /// * `offset` - The offset that the source image starts at.
 pub async fn put_image<Conn>(conn: &Conn, drawable: xproto::Drawable, gc: xproto::Gcontext, total_width: u16, total_height: u16, src_x: u16, src_y: u16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16, depth: u8, format: u8, send_event: bool, shmseg: Seg, offset: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -329,21 +329,21 @@ pub trait ConnectionExt: RequestConnection {
     /// * `src_x` - The source X coordinate of the sub-image to copy.
     /// * `src_y` - The source Y coordinate of the sub-image to copy.
     /// * `src_width` - The width, in source image coordinates, of the data to copy from the source.
-    /// The X server will use this to determine the amount of data to copy.  The amount
-    /// of the destination image that is overwritten is determined automatically.
+    ///   The X server will use this to determine the amount of data to copy.  The amount
+    ///   of the destination image that is overwritten is determined automatically.
     /// * `src_height` - The height, in source image coordinates, of the data to copy from the source.
-    /// The X server will use this to determine the amount of data to copy.  The amount
-    /// of the destination image that is overwritten is determined automatically.
+    ///   The X server will use this to determine the amount of data to copy.  The amount
+    ///   of the destination image that is overwritten is determined automatically.
     /// * `dst_x` - The X coordinate on the destination drawable to copy to.
     /// * `dst_y` - The Y coordinate on the destination drawable to copy to.
     /// * `depth` - The depth to use.
     /// * `format` - The format of the image being drawn.  If it is XYBitmap, depth must be 1, or a
-    /// "BadMatch" error results.  The foreground pixel in the GC determines the source
-    /// for the one bits in the image, and the background pixel determines the source
-    /// for the zero bits.  For XYPixmap and ZPixmap, the depth must match the depth of
-    /// the drawable, or a "BadMatch" error results.
+    ///   "BadMatch" error results.  The foreground pixel in the GC determines the source
+    ///   for the one bits in the image, and the background pixel determines the source
+    ///   for the zero bits.  For XYPixmap and ZPixmap, the depth must match the depth of
+    ///   the drawable, or a "BadMatch" error results.
     /// * `send_event` - True if the server should send an XCB_SHM_COMPLETION event when the blit
-    /// completes.
+    ///   completes.
     /// * `offset` - The offset that the source image starts at.
     fn shm_put_image(&self, drawable: xproto::Drawable, gc: xproto::Gcontext, total_width: u16, total_height: u16, src_x: u16, src_y: u16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16, depth: u8, format: u8, send_event: bool, shmseg: Seg, offset: u32) -> Pin<Box<dyn Future<Output = Result<VoidCookie<'_, Self>, ConnectionError>> + Send + '_>>
     {

--- a/x11rb-async/src/protocol/xproto.rs
+++ b/x11rb-async/src/protocol/xproto.rs
@@ -53,20 +53,20 @@ pub use x11rb_protocol::protocol::xproto::*;
 /// # Fields
 ///
 /// * `wid` - The ID with which you will refer to the new window, created by
-/// `xcb_generate_id`.
+///   `xcb_generate_id`.
 /// * `depth` - Specifies the new window's depth (TODO: what unit?).
 ///
-/// The special value `XCB_COPY_FROM_PARENT` means the depth is taken from the
-/// `parent` window.
+///   The special value `XCB_COPY_FROM_PARENT` means the depth is taken from the
+///   `parent` window.
 /// * `visual` - Specifies the id for the new window's visual.
 ///
-/// The special value `XCB_COPY_FROM_PARENT` means the visual is taken from the
-/// `parent` window.
+///   The special value `XCB_COPY_FROM_PARENT` means the visual is taken from the
+///   `parent` window.
 /// * `class` -
 /// * `parent` - The parent window of the new window.
 /// * `border_width` - TODO:
 ///
-/// Must be zero if the `class` is `InputOnly` or a `xcb_match_error_t` occurs.
+///   Must be zero if the `class` is `InputOnly` or a `xcb_match_error_t` occurs.
 /// * `x` - The X coordinate of the new window.
 /// * `y` - The Y coordinate of the new window.
 /// * `width` - The width of the new window.
@@ -118,8 +118,8 @@ where
 /// * `window` - The window to change.
 /// * `value_mask` -
 /// * `value_list` - Values for each of the attributes specified in the bitmask `value_mask`. The
-/// order has to correspond to the order of possible `value_mask` bits. See the
-/// example.
+///   order has to correspond to the order of possible `value_mask` bits. See the
+///   example.
 ///
 /// # Errors
 ///
@@ -408,7 +408,7 @@ where
 /// * `window` - The window to configure.
 /// * `value_mask` - Bitmask of attributes to change.
 /// * `value_list` - New values, corresponding to the attributes in value_mask. The order has to
-/// correspond to the order of possible `value_mask` bits. See the example.
+///   correspond to the order of possible `value_mask` bits. See the example.
 ///
 /// # Errors
 ///
@@ -673,8 +673,8 @@ where
 /// * `property` - The property you want to change (an atom).
 /// * `type` - The type of the property you want to change (an atom).
 /// * `format` - Specifies whether the data should be viewed as a list of 8-bit, 16-bit or
-/// 32-bit quantities. Possible values are 8, 16 and 32. This information allows
-/// the X server to correctly perform byte-swap operations as necessary.
+///   32-bit quantities. Possible values are 8, 16 and 32. This information allows
+///   the X server to correctly perform byte-swap operations as necessary.
 /// * `data_len` - Specifies the number of elements (see `format`).
 /// * `data` - The property data.
 ///
@@ -762,13 +762,13 @@ where
 ///
 /// * `window` - The window whose property you want to get.
 /// * `delete` - Whether the property should actually be deleted. For deleting a property, the
-/// specified `type` has to match the actual property type.
+///   specified `type` has to match the actual property type.
 /// * `property` - The property you want to get (an atom).
 /// * `type` - The type of the property you want to get (an atom).
 /// * `long_offset` - Specifies the offset (in 32-bit multiples) in the specified property where the
-/// data is to be retrieved.
+///   data is to be retrieved.
 /// * `long_length` - Specifies how many 32-bit multiples of data should be retrieved (e.g. if you
-/// set `long_length` to 4, you will receive 16 bytes of data).
+///   set `long_length` to 4, you will receive 16 bytes of data).
 ///
 /// # Errors
 ///
@@ -858,15 +858,15 @@ where
 /// * `selection` - The selection.
 /// * `owner` - The new owner of the selection.
 ///
-/// The special value `XCB_NONE` means that the selection will have no owner.
+///   The special value `XCB_NONE` means that the selection will have no owner.
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The selection will not be changed if `time` is earlier than the current
-/// last-change time of the `selection` or is later than the current X server time.
-/// Otherwise, the last-change time is set to the specified time.
+///   The selection will not be changed if `time` is earlier than the current
+///   last-change time of the `selection` or is later than the current X server time.
+///   Otherwise, the last-change time is set to the specified time.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 ///
 /// # Errors
 ///
@@ -955,23 +955,23 @@ where
 /// # Fields
 ///
 /// * `destination` - The window to send this event to. Every client which selects any event within
-/// `event_mask` on `destination` will get the event.
+///   `event_mask` on `destination` will get the event.
 ///
-/// The special value `XCB_SEND_EVENT_DEST_POINTER_WINDOW` refers to the window
-/// that contains the mouse pointer.
+///   The special value `XCB_SEND_EVENT_DEST_POINTER_WINDOW` refers to the window
+///   that contains the mouse pointer.
 ///
-/// The special value `XCB_SEND_EVENT_DEST_ITEM_FOCUS` refers to the window which
-/// has the keyboard focus.
+///   The special value `XCB_SEND_EVENT_DEST_ITEM_FOCUS` refers to the window which
+///   has the keyboard focus.
 /// * `event_mask` - Event_mask for determining which clients should receive the specified event.
-/// See `destination` and `propagate`.
+///   See `destination` and `propagate`.
 /// * `propagate` - If `propagate` is true and no clients have selected any event on `destination`,
-/// the destination is replaced with the closest ancestor of `destination` for
-/// which some client has selected a type in `event_mask` and for which no
-/// intervening window has that type in its do-not-propagate-mask. If no such
-/// window exists or if the window is an ancestor of the focus window and
-/// `InputFocus` was originally specified as the destination, the event is not sent
-/// to any clients. Otherwise, the event is reported to every client selecting on
-/// the final destination any of the types specified in `event_mask`.
+///   the destination is replaced with the closest ancestor of `destination` for
+///   which some client has selected a type in `event_mask` and for which no
+///   intervening window has that type in its do-not-propagate-mask. If no such
+///   window exists or if the window is an ancestor of the focus window and
+///   `InputFocus` was originally specified as the destination, the event is not sent
+///   to any clients. Otherwise, the event is reported to every client selecting on
+///   the final destination any of the types specified in `event_mask`.
 /// * `event` - The event to send to the specified `destination`.
 ///
 /// # Errors
@@ -1042,27 +1042,27 @@ where
 ///
 /// * `event_mask` - Specifies which pointer events are reported to the client.
 ///
-/// TODO: which values?
+///   TODO: which values?
 /// * `confine_to` - Specifies the window to confine the pointer in (the user will not be able to
-/// move the pointer out of that window).
+///   move the pointer out of that window).
 ///
-/// The special value `XCB_NONE` means don't confine the pointer.
+///   The special value `XCB_NONE` means don't confine the pointer.
 /// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
-/// cursor.
+///   cursor.
 /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-/// reported to the `grab_window`.
+///   reported to the `grab_window`.
 /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
 /// * `time` - The time argument allows you to avoid certain circumstances that come up if
-/// applications take a long time to respond or if there are long network delays.
-/// Consider a situation where you have two applications, both of which normally
-/// grab the pointer when clicked on. If both applications specify the timestamp
-/// from the event, the second application may wake up faster and successfully grab
-/// the pointer before the first application. The first application then will get
-/// an indication that the other application grabbed the pointer before its request
-/// was processed.
+///   applications take a long time to respond or if there are long network delays.
+///   Consider a situation where you have two applications, both of which normally
+///   grab the pointer when clicked on. If both applications specify the timestamp
+///   from the event, the second application may wake up faster and successfully grab
+///   the pointer before the first application. The first application then will get
+///   an indication that the other application grabbed the pointer before its request
+///   was processed.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 /// * `pointer_mode` -
 /// * `keyboard_mode` -
 ///
@@ -1142,8 +1142,8 @@ where
 ///
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The pointer will not be released if `time` is earlier than the
-/// last-pointer-grab time or later than the current X server time.
+///   The pointer will not be released if `time` is earlier than the
+///   last-pointer-grab time or later than the current X server time.
 /// * `name_len` - Length (in bytes) of `name`.
 /// * `name` - A pattern describing an X core font.
 ///
@@ -1208,21 +1208,21 @@ where
 /// # Fields
 ///
 /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-/// reported to the `grab_window`.
+///   reported to the `grab_window`.
 /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
 /// * `event_mask` - Specifies which pointer events are reported to the client.
 ///
-/// TODO: which values?
+///   TODO: which values?
 /// * `confine_to` - Specifies the window to confine the pointer in (the user will not be able to
-/// move the pointer out of that window).
+///   move the pointer out of that window).
 ///
-/// The special value `XCB_NONE` means don't confine the pointer.
+///   The special value `XCB_NONE` means don't confine the pointer.
 /// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
-/// cursor.
+///   cursor.
 /// * `modifiers` - The modifiers to grab.
 ///
-/// Using the special value `XCB_MOD_MASK_ANY` means grab the pointer with all
-/// possible modifier combinations.
+///   Using the special value `XCB_MOD_MASK_ANY` means grab the pointer with all
+///   possible modifier combinations.
 /// * `pointer_mode` -
 /// * `keyboard_mode` -
 /// * `button` -
@@ -1306,12 +1306,12 @@ where
 /// # Fields
 ///
 /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-/// reported to the `grab_window`.
+///   reported to the `grab_window`.
 /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 /// * `pointer_mode` -
 /// * `keyboard_mode` -
 ///
@@ -1420,15 +1420,15 @@ where
 /// # Fields
 ///
 /// * `owner_events` - If 1, the `grab_window` will still get the key events. If 0, events are not
-/// reported to the `grab_window`.
+///   reported to the `grab_window`.
 /// * `grab_window` - Specifies the window on which the key should be grabbed.
 /// * `key` - The keycode of the key to grab.
 ///
-/// The special value `XCB_GRAB_ANY` means grab any key.
+///   The special value `XCB_GRAB_ANY` means grab any key.
 /// * `modifiers` - The modifiers to grab.
 ///
-/// Using the special value `XCB_MOD_MASK_ANY` means grab the key with all
-/// possible modifier combinations.
+///   Using the special value `XCB_MOD_MASK_ANY` means grab the key with all
+///   possible modifier combinations.
 /// * `pointer_mode` -
 /// * `keyboard_mode` -
 ///
@@ -1471,12 +1471,12 @@ where
 ///
 /// * `key` - The keycode of the specified key combination.
 ///
-/// Using the special value `XCB_GRAB_ANY` means releasing all possible key codes.
+///   Using the special value `XCB_GRAB_ANY` means releasing all possible key codes.
 /// * `grab_window` - The window on which the grabbed key combination will be released.
 /// * `modifiers` - The modifiers of the specified key combination.
 ///
-/// Using the special value `XCB_MOD_MASK_ANY` means releasing the key combination
-/// with every possible modifier combination.
+///   Using the special value `XCB_MOD_MASK_ANY` means releasing the key combination
+///   with every possible modifier combination.
 ///
 /// # Errors
 ///
@@ -1515,8 +1515,8 @@ where
 /// * `mode` -
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 ///
 /// # Errors
 ///
@@ -1564,7 +1564,7 @@ where
 /// # Fields
 ///
 /// * `window` - A window to check if the pointer is on the same screen as `window` (see the
-/// `same_screen` field in the reply).
+///   `same_screen` field in the reply).
 ///
 /// # Errors
 ///
@@ -1631,13 +1631,13 @@ where
 /// # Fields
 ///
 /// * `src_window` - If `src_window` is not `XCB_NONE` (TODO), the move will only take place if the
-/// pointer is inside `src_window` and within the rectangle specified by (`src_x`,
-/// `src_y`, `src_width`, `src_height`). The rectangle coordinates are relative to
-/// `src_window`.
+///   pointer is inside `src_window` and within the rectangle specified by (`src_x`,
+///   `src_y`, `src_width`, `src_height`). The rectangle coordinates are relative to
+///   `src_window`.
 /// * `dst_window` - If `dst_window` is not `XCB_NONE` (TODO), the pointer will be moved to the
-/// offsets (`dst_x`, `dst_y`) relative to `dst_window`. If `dst_window` is
-/// `XCB_NONE` (TODO), the pointer will be moved by the offsets (`dst_x`, `dst_y`)
-/// relative to the current position of the pointer.
+///   offsets (`dst_x`, `dst_y`) relative to `dst_window`. If `dst_window` is
+///   `XCB_NONE` (TODO), the pointer will be moved by the offsets (`dst_x`, `dst_y`)
+///   relative to the current position of the pointer.
 ///
 /// # Errors
 ///
@@ -1680,19 +1680,19 @@ where
 /// # Fields
 ///
 /// * `focus` - The window to focus. All keyboard events will be reported to this window. The
-/// window must be viewable (TODO), or a `xcb_match_error_t` occurs (TODO).
+///   window must be viewable (TODO), or a `xcb_match_error_t` occurs (TODO).
 ///
-/// If `focus` is `XCB_NONE` (TODO), all keyboard events are
-/// discarded until a new focus window is set.
+///   If `focus` is `XCB_NONE` (TODO), all keyboard events are
+///   discarded until a new focus window is set.
 ///
-/// If `focus` is `XCB_POINTER_ROOT` (TODO), focus is on the root window of the
-/// screen on which the pointer is on currently.
+///   If `focus` is `XCB_POINTER_ROOT` (TODO), focus is on the root window of the
+///   screen on which the pointer is on currently.
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 /// * `revert_to` - Specifies what happens when the `focus` window becomes unviewable (if `focus`
-/// is neither `XCB_NONE` nor `XCB_POINTER_ROOT`).
+///   is neither `XCB_NONE` nor `XCB_POINTER_ROOT`).
 ///
 /// # Errors
 ///
@@ -1862,9 +1862,9 @@ where
 /// * `pattern_len` - The length (in bytes) of `pattern`.
 /// * `pattern` - A font pattern, for example "-misc-fixed-*".
 ///
-/// The asterisk (*) is a wildcard for any number of characters. The question mark
-/// (?) is a wildcard for a single character. Use of uppercase or lowercase does
-/// not matter.
+///   The asterisk (*) is a wildcard for any number of characters. The question mark
+///   (?) is a wildcard for a single character. Use of uppercase or lowercase does
+///   not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
 pub async fn list_fonts<'c, 'input, Conn>(conn: &'c Conn, max_names: u16, pattern: &'input [u8]) -> Result<Cookie<'c, Conn, ListFontsReply>, ConnectionError>
 where
@@ -1888,9 +1888,9 @@ where
 /// * `pattern_len` - The length (in bytes) of `pattern`.
 /// * `pattern` - A font pattern, for example "-misc-fixed-*".
 ///
-/// The asterisk (*) is a wildcard for any number of characters. The question mark
-/// (?) is a wildcard for a single character. Use of uppercase or lowercase does
-/// not matter.
+///   The asterisk (*) is a wildcard for any number of characters. The question mark
+///   (?) is a wildcard for a single character. Use of uppercase or lowercase does
+///   not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
 pub async fn list_fonts_with_info<'c, 'input, Conn>(conn: &'c Conn, max_names: u16, pattern: &'input [u8]) -> Result<ListFontsWithInfoCookie<'c, Conn>, ConnectionError>
 where
@@ -1936,7 +1936,7 @@ where
 ///
 /// * `depth` - TODO
 /// * `pid` - The ID with which you will refer to the new pixmap, created by
-/// `xcb_generate_id`.
+///   `xcb_generate_id`.
 /// * `drawable` - Drawable to get the screen from.
 /// * `width` - The width of the new pixmap.
 /// * `height` - The height of the new pixmap.
@@ -1998,7 +1998,7 @@ where
 /// # Fields
 ///
 /// * `cid` - The ID with which you will refer to the graphics context, created by
-/// `xcb_generate_id`.
+///   `xcb_generate_id`.
 /// * `drawable` - Drawable to get the root/depth from.
 ///
 /// # Errors
@@ -2036,8 +2036,8 @@ where
 /// * `gc` - The graphics context to change.
 /// * `value_mask` -
 /// * `value_list` - Values for each of the components specified in the bitmask `value_mask`. The
-/// order has to correspond to the order of possible `value_mask` bits. See the
-/// example.
+///   order has to correspond to the order of possible `value_mask` bits. See the
+///   example.
 ///
 /// # Errors
 ///
@@ -2317,7 +2317,7 @@ where
 /// * `drawable` - A drawable (Window or Pixmap) to draw on.
 /// * `gc` - The graphics context to use.
 ///
-/// TODO: document which attributes of a gc are used
+///   TODO: document which attributes of a gc are used
 /// * `segments_len` - The number of `xcb_segment_t` structures in `segments`.
 /// * `segments` - An array of `xcb_segment_t` structures.
 ///
@@ -2395,12 +2395,12 @@ where
 /// * `drawable` - The drawable (Window or Pixmap) to draw on.
 /// * `gc` - The graphics context to use.
 ///
-/// The following graphics context components are used: function, plane-mask,
-/// fill-style, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+///   The following graphics context components are used: function, plane-mask,
+///   fill-style, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
 ///
-/// The following graphics context mode-dependent components are used:
-/// foreground, background, tile, stipple, tile-stipple-x-origin, and
-/// tile-stipple-y-origin.
+///   The following graphics context mode-dependent components are used:
+///   foreground, background, tile, stipple, tile-stipple-x-origin, and
+///   tile-stipple-y-origin.
 /// * `rectangles_len` - The number of `xcb_rectangle_t` structures in `rectangles`.
 /// * `rectangles` - The rectangles to fill.
 ///
@@ -2523,15 +2523,15 @@ where
 ///
 /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
 /// * `string_len` - The length of the `string`. Note that this parameter limited by 255 due to
-/// using 8 bits!
+///   using 8 bits!
 /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
-/// type of `string_len`.
+///   type of `string_len`.
 /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
 /// * `y` - The y coordinate of the first character, relative to the origin of `drawable`.
 /// * `gc` - The graphics context to use.
 ///
-/// The following graphics context components are used: plane-mask, foreground,
-/// background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+///   The following graphics context components are used: plane-mask, foreground,
+///   background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
 ///
 /// # Errors
 ///
@@ -2573,16 +2573,16 @@ where
 ///
 /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
 /// * `string_len` - The length of the `string` in characters. Note that this parameter limited by
-/// 255 due to using 8 bits!
+///   255 due to using 8 bits!
 /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
-/// type of `string_len`. Every character uses 2 bytes (hence the 16 in this
-/// request's name).
+///   type of `string_len`. Every character uses 2 bytes (hence the 16 in this
+///   request's name).
 /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
 /// * `y` - The y coordinate of the first character, relative to the origin of `drawable`.
 /// * `gc` - The graphics context to use.
 ///
-/// The following graphics context components are used: plane-mask, foreground,
-/// background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+///   The following graphics context components are used: plane-mask, foreground,
+///   background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
 ///
 /// # Errors
 ///
@@ -2874,8 +2874,8 @@ where
 /// * `mask_font` - In which font to look for the mask glyph.
 /// * `source_char` - The glyph of `source_font` to use.
 /// * `mask_char` - The glyph of `mask_font` to use as a mask: Pixels which are set to 1 define
-/// which source pixels are displayed. All pixels which are set to 0 are not
-/// displayed.
+///   which source pixels are displayed. All pixels which are set to 0 are not
+///   displayed.
 /// * `fore_red` - The red value of the foreground color.
 /// * `fore_green` - The green value of the foreground color.
 /// * `fore_blue` - The blue value of the foreground color.
@@ -2985,7 +2985,7 @@ where
 ///
 /// * `name_len` - The length of `name` in bytes.
 /// * `name` - The name of the extension to query, for example "RANDR". This is case
-/// sensitive!
+///   sensitive!
 ///
 /// # See
 ///
@@ -3181,10 +3181,10 @@ where
 /// # Fields
 ///
 /// * `resource` - Any resource belonging to the client (for example a Window), used to identify
-/// the client connection.
+///   the client connection.
 ///
-/// The special value of `XCB_KILL_ALL_TEMPORARY`, the resources of all clients
-/// that have terminated in `RetainTemporary` (TODO) are destroyed.
+///   The special value of `XCB_KILL_ALL_TEMPORARY`, the resources of all clients
+///   that have terminated in `RetainTemporary` (TODO) are destroyed.
 ///
 /// # Errors
 ///
@@ -3309,20 +3309,20 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `wid` - The ID with which you will refer to the new window, created by
-    /// `xcb_generate_id`.
+    ///   `xcb_generate_id`.
     /// * `depth` - Specifies the new window's depth (TODO: what unit?).
     ///
-    /// The special value `XCB_COPY_FROM_PARENT` means the depth is taken from the
-    /// `parent` window.
+    ///   The special value `XCB_COPY_FROM_PARENT` means the depth is taken from the
+    ///   `parent` window.
     /// * `visual` - Specifies the id for the new window's visual.
     ///
-    /// The special value `XCB_COPY_FROM_PARENT` means the visual is taken from the
-    /// `parent` window.
+    ///   The special value `XCB_COPY_FROM_PARENT` means the visual is taken from the
+    ///   `parent` window.
     /// * `class` -
     /// * `parent` - The parent window of the new window.
     /// * `border_width` - TODO:
     ///
-    /// Must be zero if the `class` is `InputOnly` or a `xcb_match_error_t` occurs.
+    ///   Must be zero if the `class` is `InputOnly` or a `xcb_match_error_t` occurs.
     /// * `x` - The X coordinate of the new window.
     /// * `y` - The Y coordinate of the new window.
     /// * `width` - The width of the new window.
@@ -3359,8 +3359,8 @@ pub trait ConnectionExt: RequestConnection {
     /// * `window` - The window to change.
     /// * `value_mask` -
     /// * `value_list` - Values for each of the attributes specified in the bitmask `value_mask`. The
-    /// order has to correspond to the order of possible `value_mask` bits. See the
-    /// example.
+    ///   order has to correspond to the order of possible `value_mask` bits. See the
+    ///   example.
     ///
     /// # Errors
     ///
@@ -3567,7 +3567,7 @@ pub trait ConnectionExt: RequestConnection {
     /// * `window` - The window to configure.
     /// * `value_mask` - Bitmask of attributes to change.
     /// * `value_list` - New values, corresponding to the attributes in value_mask. The order has to
-    /// correspond to the order of possible `value_mask` bits. See the example.
+    ///   correspond to the order of possible `value_mask` bits. See the example.
     ///
     /// # Errors
     ///
@@ -3787,8 +3787,8 @@ pub trait ConnectionExt: RequestConnection {
     /// * `property` - The property you want to change (an atom).
     /// * `type` - The type of the property you want to change (an atom).
     /// * `format` - Specifies whether the data should be viewed as a list of 8-bit, 16-bit or
-    /// 32-bit quantities. Possible values are 8, 16 and 32. This information allows
-    /// the X server to correctly perform byte-swap operations as necessary.
+    ///   32-bit quantities. Possible values are 8, 16 and 32. This information allows
+    ///   the X server to correctly perform byte-swap operations as necessary.
     /// * `data_len` - Specifies the number of elements (see `format`).
     /// * `data` - The property data.
     ///
@@ -3854,13 +3854,13 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `window` - The window whose property you want to get.
     /// * `delete` - Whether the property should actually be deleted. For deleting a property, the
-    /// specified `type` has to match the actual property type.
+    ///   specified `type` has to match the actual property type.
     /// * `property` - The property you want to get (an atom).
     /// * `type` - The type of the property you want to get (an atom).
     /// * `long_offset` - Specifies the offset (in 32-bit multiples) in the specified property where the
-    /// data is to be retrieved.
+    ///   data is to be retrieved.
     /// * `long_length` - Specifies how many 32-bit multiples of data should be retrieved (e.g. if you
-    /// set `long_length` to 4, you will receive 16 bytes of data).
+    ///   set `long_length` to 4, you will receive 16 bytes of data).
     ///
     /// # Errors
     ///
@@ -3928,15 +3928,15 @@ pub trait ConnectionExt: RequestConnection {
     /// * `selection` - The selection.
     /// * `owner` - The new owner of the selection.
     ///
-    /// The special value `XCB_NONE` means that the selection will have no owner.
+    ///   The special value `XCB_NONE` means that the selection will have no owner.
     /// * `time` - Timestamp to avoid race conditions when running X over the network.
     ///
-    /// The selection will not be changed if `time` is earlier than the current
-    /// last-change time of the `selection` or is later than the current X server time.
-    /// Otherwise, the last-change time is set to the specified time.
+    ///   The selection will not be changed if `time` is earlier than the current
+    ///   last-change time of the `selection` or is later than the current X server time.
+    ///   Otherwise, the last-change time is set to the specified time.
     ///
-    /// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-    /// time.
+    ///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+    ///   time.
     ///
     /// # Errors
     ///
@@ -3993,23 +3993,23 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `destination` - The window to send this event to. Every client which selects any event within
-    /// `event_mask` on `destination` will get the event.
+    ///   `event_mask` on `destination` will get the event.
     ///
-    /// The special value `XCB_SEND_EVENT_DEST_POINTER_WINDOW` refers to the window
-    /// that contains the mouse pointer.
+    ///   The special value `XCB_SEND_EVENT_DEST_POINTER_WINDOW` refers to the window
+    ///   that contains the mouse pointer.
     ///
-    /// The special value `XCB_SEND_EVENT_DEST_ITEM_FOCUS` refers to the window which
-    /// has the keyboard focus.
+    ///   The special value `XCB_SEND_EVENT_DEST_ITEM_FOCUS` refers to the window which
+    ///   has the keyboard focus.
     /// * `event_mask` - Event_mask for determining which clients should receive the specified event.
-    /// See `destination` and `propagate`.
+    ///   See `destination` and `propagate`.
     /// * `propagate` - If `propagate` is true and no clients have selected any event on `destination`,
-    /// the destination is replaced with the closest ancestor of `destination` for
-    /// which some client has selected a type in `event_mask` and for which no
-    /// intervening window has that type in its do-not-propagate-mask. If no such
-    /// window exists or if the window is an ancestor of the focus window and
-    /// `InputFocus` was originally specified as the destination, the event is not sent
-    /// to any clients. Otherwise, the event is reported to every client selecting on
-    /// the final destination any of the types specified in `event_mask`.
+    ///   the destination is replaced with the closest ancestor of `destination` for
+    ///   which some client has selected a type in `event_mask` and for which no
+    ///   intervening window has that type in its do-not-propagate-mask. If no such
+    ///   window exists or if the window is an ancestor of the focus window and
+    ///   `InputFocus` was originally specified as the destination, the event is not sent
+    ///   to any clients. Otherwise, the event is reported to every client selecting on
+    ///   the final destination any of the types specified in `event_mask`.
     /// * `event` - The event to send to the specified `destination`.
     ///
     /// # Errors
@@ -4068,27 +4068,27 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `event_mask` - Specifies which pointer events are reported to the client.
     ///
-    /// TODO: which values?
+    ///   TODO: which values?
     /// * `confine_to` - Specifies the window to confine the pointer in (the user will not be able to
-    /// move the pointer out of that window).
+    ///   move the pointer out of that window).
     ///
-    /// The special value `XCB_NONE` means don't confine the pointer.
+    ///   The special value `XCB_NONE` means don't confine the pointer.
     /// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
-    /// cursor.
+    ///   cursor.
     /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-    /// reported to the `grab_window`.
+    ///   reported to the `grab_window`.
     /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
     /// * `time` - The time argument allows you to avoid certain circumstances that come up if
-    /// applications take a long time to respond or if there are long network delays.
-    /// Consider a situation where you have two applications, both of which normally
-    /// grab the pointer when clicked on. If both applications specify the timestamp
-    /// from the event, the second application may wake up faster and successfully grab
-    /// the pointer before the first application. The first application then will get
-    /// an indication that the other application grabbed the pointer before its request
-    /// was processed.
+    ///   applications take a long time to respond or if there are long network delays.
+    ///   Consider a situation where you have two applications, both of which normally
+    ///   grab the pointer when clicked on. If both applications specify the timestamp
+    ///   from the event, the second application may wake up faster and successfully grab
+    ///   the pointer before the first application. The first application then will get
+    ///   an indication that the other application grabbed the pointer before its request
+    ///   was processed.
     ///
-    /// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-    /// time.
+    ///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+    ///   time.
     /// * `pointer_mode` -
     /// * `keyboard_mode` -
     ///
@@ -4151,8 +4151,8 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `time` - Timestamp to avoid race conditions when running X over the network.
     ///
-    /// The pointer will not be released if `time` is earlier than the
-    /// last-pointer-grab time or later than the current X server time.
+    ///   The pointer will not be released if `time` is earlier than the
+    ///   last-pointer-grab time or later than the current X server time.
     /// * `name_len` - Length (in bytes) of `name`.
     /// * `name` - A pattern describing an X core font.
     ///
@@ -4209,21 +4209,21 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-    /// reported to the `grab_window`.
+    ///   reported to the `grab_window`.
     /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
     /// * `event_mask` - Specifies which pointer events are reported to the client.
     ///
-    /// TODO: which values?
+    ///   TODO: which values?
     /// * `confine_to` - Specifies the window to confine the pointer in (the user will not be able to
-    /// move the pointer out of that window).
+    ///   move the pointer out of that window).
     ///
-    /// The special value `XCB_NONE` means don't confine the pointer.
+    ///   The special value `XCB_NONE` means don't confine the pointer.
     /// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
-    /// cursor.
+    ///   cursor.
     /// * `modifiers` - The modifiers to grab.
     ///
-    /// Using the special value `XCB_MOD_MASK_ANY` means grab the pointer with all
-    /// possible modifier combinations.
+    ///   Using the special value `XCB_MOD_MASK_ANY` means grab the pointer with all
+    ///   possible modifier combinations.
     /// * `pointer_mode` -
     /// * `keyboard_mode` -
     /// * `button` -
@@ -4269,12 +4269,12 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-    /// reported to the `grab_window`.
+    ///   reported to the `grab_window`.
     /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
     /// * `time` - Timestamp to avoid race conditions when running X over the network.
     ///
-    /// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-    /// time.
+    ///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+    ///   time.
     /// * `pointer_mode` -
     /// * `keyboard_mode` -
     ///
@@ -4363,15 +4363,15 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `owner_events` - If 1, the `grab_window` will still get the key events. If 0, events are not
-    /// reported to the `grab_window`.
+    ///   reported to the `grab_window`.
     /// * `grab_window` - Specifies the window on which the key should be grabbed.
     /// * `key` - The keycode of the key to grab.
     ///
-    /// The special value `XCB_GRAB_ANY` means grab any key.
+    ///   The special value `XCB_GRAB_ANY` means grab any key.
     /// * `modifiers` - The modifiers to grab.
     ///
-    /// Using the special value `XCB_MOD_MASK_ANY` means grab the key with all
-    /// possible modifier combinations.
+    ///   Using the special value `XCB_MOD_MASK_ANY` means grab the key with all
+    ///   possible modifier combinations.
     /// * `pointer_mode` -
     /// * `keyboard_mode` -
     ///
@@ -4401,12 +4401,12 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `key` - The keycode of the specified key combination.
     ///
-    /// Using the special value `XCB_GRAB_ANY` means releasing all possible key codes.
+    ///   Using the special value `XCB_GRAB_ANY` means releasing all possible key codes.
     /// * `grab_window` - The window on which the grabbed key combination will be released.
     /// * `modifiers` - The modifiers of the specified key combination.
     ///
-    /// Using the special value `XCB_MOD_MASK_ANY` means releasing the key combination
-    /// with every possible modifier combination.
+    ///   Using the special value `XCB_MOD_MASK_ANY` means releasing the key combination
+    ///   with every possible modifier combination.
     ///
     /// # Errors
     ///
@@ -4435,8 +4435,8 @@ pub trait ConnectionExt: RequestConnection {
     /// * `mode` -
     /// * `time` - Timestamp to avoid race conditions when running X over the network.
     ///
-    /// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-    /// time.
+    ///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+    ///   time.
     ///
     /// # Errors
     ///
@@ -4463,7 +4463,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `window` - A window to check if the pointer is on the same screen as `window` (see the
-    /// `same_screen` field in the reply).
+    ///   `same_screen` field in the reply).
     ///
     /// # Errors
     ///
@@ -4500,13 +4500,13 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `src_window` - If `src_window` is not `XCB_NONE` (TODO), the move will only take place if the
-    /// pointer is inside `src_window` and within the rectangle specified by (`src_x`,
-    /// `src_y`, `src_width`, `src_height`). The rectangle coordinates are relative to
-    /// `src_window`.
+    ///   pointer is inside `src_window` and within the rectangle specified by (`src_x`,
+    ///   `src_y`, `src_width`, `src_height`). The rectangle coordinates are relative to
+    ///   `src_window`.
     /// * `dst_window` - If `dst_window` is not `XCB_NONE` (TODO), the pointer will be moved to the
-    /// offsets (`dst_x`, `dst_y`) relative to `dst_window`. If `dst_window` is
-    /// `XCB_NONE` (TODO), the pointer will be moved by the offsets (`dst_x`, `dst_y`)
-    /// relative to the current position of the pointer.
+    ///   offsets (`dst_x`, `dst_y`) relative to `dst_window`. If `dst_window` is
+    ///   `XCB_NONE` (TODO), the pointer will be moved by the offsets (`dst_x`, `dst_y`)
+    ///   relative to the current position of the pointer.
     ///
     /// # Errors
     ///
@@ -4533,19 +4533,19 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `focus` - The window to focus. All keyboard events will be reported to this window. The
-    /// window must be viewable (TODO), or a `xcb_match_error_t` occurs (TODO).
+    ///   window must be viewable (TODO), or a `xcb_match_error_t` occurs (TODO).
     ///
-    /// If `focus` is `XCB_NONE` (TODO), all keyboard events are
-    /// discarded until a new focus window is set.
+    ///   If `focus` is `XCB_NONE` (TODO), all keyboard events are
+    ///   discarded until a new focus window is set.
     ///
-    /// If `focus` is `XCB_POINTER_ROOT` (TODO), focus is on the root window of the
-    /// screen on which the pointer is on currently.
+    ///   If `focus` is `XCB_POINTER_ROOT` (TODO), focus is on the root window of the
+    ///   screen on which the pointer is on currently.
     /// * `time` - Timestamp to avoid race conditions when running X over the network.
     ///
-    /// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-    /// time.
+    ///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+    ///   time.
     /// * `revert_to` - Specifies what happens when the `focus` window becomes unviewable (if `focus`
-    /// is neither `XCB_NONE` nor `XCB_POINTER_ROOT`).
+    ///   is neither `XCB_NONE` nor `XCB_POINTER_ROOT`).
     ///
     /// # Errors
     ///
@@ -4664,9 +4664,9 @@ pub trait ConnectionExt: RequestConnection {
     /// * `pattern_len` - The length (in bytes) of `pattern`.
     /// * `pattern` - A font pattern, for example "-misc-fixed-*".
     ///
-    /// The asterisk (*) is a wildcard for any number of characters. The question mark
-    /// (?) is a wildcard for a single character. Use of uppercase or lowercase does
-    /// not matter.
+    ///   The asterisk (*) is a wildcard for any number of characters. The question mark
+    ///   (?) is a wildcard for a single character. Use of uppercase or lowercase does
+    ///   not matter.
     /// * `max_names` - The maximum number of fonts to be returned.
     fn list_fonts<'c, 'input, 'future>(&'c self, max_names: u16, pattern: &'input [u8]) -> Pin<Box<dyn Future<Output = Result<Cookie<'c, Self, ListFontsReply>, ConnectionError>> + Send + 'future>>
     where
@@ -4684,9 +4684,9 @@ pub trait ConnectionExt: RequestConnection {
     /// * `pattern_len` - The length (in bytes) of `pattern`.
     /// * `pattern` - A font pattern, for example "-misc-fixed-*".
     ///
-    /// The asterisk (*) is a wildcard for any number of characters. The question mark
-    /// (?) is a wildcard for a single character. Use of uppercase or lowercase does
-    /// not matter.
+    ///   The asterisk (*) is a wildcard for any number of characters. The question mark
+    ///   (?) is a wildcard for a single character. Use of uppercase or lowercase does
+    ///   not matter.
     /// * `max_names` - The maximum number of fonts to be returned.
     fn list_fonts_with_info<'c, 'input, 'future>(&'c self, max_names: u16, pattern: &'input [u8]) -> Pin<Box<dyn Future<Output = Result<ListFontsWithInfoCookie<'c, Self>, ConnectionError>> + Send + 'future>>
     where
@@ -4715,7 +4715,7 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `depth` - TODO
     /// * `pid` - The ID with which you will refer to the new pixmap, created by
-    /// `xcb_generate_id`.
+    ///   `xcb_generate_id`.
     /// * `drawable` - Drawable to get the screen from.
     /// * `width` - The width of the new pixmap.
     /// * `height` - The height of the new pixmap.
@@ -4757,7 +4757,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `cid` - The ID with which you will refer to the graphics context, created by
-    /// `xcb_generate_id`.
+    ///   `xcb_generate_id`.
     /// * `drawable` - Drawable to get the root/depth from.
     ///
     /// # Errors
@@ -4788,8 +4788,8 @@ pub trait ConnectionExt: RequestConnection {
     /// * `gc` - The graphics context to change.
     /// * `value_mask` -
     /// * `value_list` - Values for each of the components specified in the bitmask `value_mask`. The
-    /// order has to correspond to the order of possible `value_mask` bits. See the
-    /// example.
+    ///   order has to correspond to the order of possible `value_mask` bits. See the
+    ///   example.
     ///
     /// # Errors
     ///
@@ -4967,7 +4967,7 @@ pub trait ConnectionExt: RequestConnection {
     /// * `drawable` - A drawable (Window or Pixmap) to draw on.
     /// * `gc` - The graphics context to use.
     ///
-    /// TODO: document which attributes of a gc are used
+    ///   TODO: document which attributes of a gc are used
     /// * `segments_len` - The number of `xcb_segment_t` structures in `segments`.
     /// * `segments` - An array of `xcb_segment_t` structures.
     ///
@@ -5015,12 +5015,12 @@ pub trait ConnectionExt: RequestConnection {
     /// * `drawable` - The drawable (Window or Pixmap) to draw on.
     /// * `gc` - The graphics context to use.
     ///
-    /// The following graphics context components are used: function, plane-mask,
-    /// fill-style, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+    ///   The following graphics context components are used: function, plane-mask,
+    ///   fill-style, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
     ///
-    /// The following graphics context mode-dependent components are used:
-    /// foreground, background, tile, stipple, tile-stipple-x-origin, and
-    /// tile-stipple-y-origin.
+    ///   The following graphics context mode-dependent components are used:
+    ///   foreground, background, tile, stipple, tile-stipple-x-origin, and
+    ///   tile-stipple-y-origin.
     /// * `rectangles_len` - The number of `xcb_rectangle_t` structures in `rectangles`.
     /// * `rectangles` - The rectangles to fill.
     ///
@@ -5083,15 +5083,15 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
     /// * `string_len` - The length of the `string`. Note that this parameter limited by 255 due to
-    /// using 8 bits!
+    ///   using 8 bits!
     /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
-    /// type of `string_len`.
+    ///   type of `string_len`.
     /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
     /// * `y` - The y coordinate of the first character, relative to the origin of `drawable`.
     /// * `gc` - The graphics context to use.
     ///
-    /// The following graphics context components are used: plane-mask, foreground,
-    /// background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+    ///   The following graphics context components are used: plane-mask, foreground,
+    ///   background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
     ///
     /// # Errors
     ///
@@ -5124,16 +5124,16 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
     /// * `string_len` - The length of the `string` in characters. Note that this parameter limited by
-    /// 255 due to using 8 bits!
+    ///   255 due to using 8 bits!
     /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
-    /// type of `string_len`. Every character uses 2 bytes (hence the 16 in this
-    /// request's name).
+    ///   type of `string_len`. Every character uses 2 bytes (hence the 16 in this
+    ///   request's name).
     /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
     /// * `y` - The y coordinate of the first character, relative to the origin of `drawable`.
     /// * `gc` - The graphics context to use.
     ///
-    /// The following graphics context components are used: plane-mask, foreground,
-    /// background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+    ///   The following graphics context components are used: plane-mask, foreground,
+    ///   background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
     ///
     /// # Errors
     ///
@@ -5272,8 +5272,8 @@ pub trait ConnectionExt: RequestConnection {
     /// * `mask_font` - In which font to look for the mask glyph.
     /// * `source_char` - The glyph of `source_font` to use.
     /// * `mask_char` - The glyph of `mask_font` to use as a mask: Pixels which are set to 1 define
-    /// which source pixels are displayed. All pixels which are set to 0 are not
-    /// displayed.
+    ///   which source pixels are displayed. All pixels which are set to 0 are not
+    ///   displayed.
     /// * `fore_red` - The red value of the foreground color.
     /// * `fore_green` - The green value of the foreground color.
     /// * `fore_blue` - The blue value of the foreground color.
@@ -5332,7 +5332,7 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `name_len` - The length of `name` in bytes.
     /// * `name` - The name of the extension to query, for example "RANDR". This is case
-    /// sensitive!
+    ///   sensitive!
     ///
     /// # See
     ///
@@ -5417,10 +5417,10 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `resource` - Any resource belonging to the client (for example a Window), used to identify
-    /// the client connection.
+    ///   the client connection.
     ///
-    /// The special value of `XCB_KILL_ALL_TEMPORARY`, the resources of all clients
-    /// that have terminated in `RetainTemporary` (TODO) are destroyed.
+    ///   The special value of `XCB_KILL_ALL_TEMPORARY`, the resources of all clients
+    ///   that have terminated in `RetainTemporary` (TODO) are destroyed.
     ///
     /// # Errors
     ///

--- a/x11rb-async/src/protocol/xproto.rs
+++ b/x11rb-async/src/protocol/xproto.rs
@@ -228,7 +228,7 @@ where
 /// # Errors
 ///
 /// * `Match` - You created the specified window. This does not make sense, you can only add
-/// windows created by other clients to your save set.
+///   windows created by other clients to your save set.
 /// * `Value` - You specified an invalid mode.
 /// * `Window` - The specified window does not exist.
 ///
@@ -267,12 +267,12 @@ where
 /// # Errors
 ///
 /// * `Match` - The new parent window is not on the same screen as the old parent window.
-/// 
-/// The new parent window is the specified window or an inferior of the specified window.
-/// 
-/// The new parent is InputOnly and the window is not.
-/// 
-/// The specified window has a ParentRelative background and the new parent window is not the same depth as the specified window.
+///   
+///   The new parent window is the specified window or an inferior of the specified window.
+///   
+///   The new parent is InputOnly and the window is not.
+///   
+///   The specified window has a ParentRelative background and the new parent window is not the same depth as the specified window.
 /// * `Window` - The specified window does not exist.
 ///
 /// # See
@@ -413,7 +413,7 @@ where
 /// # Errors
 ///
 /// * `Match` - You specified a Sibling without also specifying StackMode or the window is not
-/// actually a Sibling.
+///   actually a Sibling.
 /// * `Window` - The specified window does not exist. TODO: any other reason?
 /// * `Value` - TODO: reasons?
 ///
@@ -775,8 +775,8 @@ where
 /// * `Window` - The specified `window` does not exist.
 /// * `Atom` - `property` or `type` do not refer to a valid atom.
 /// * `Value` - The specified `long_offset` is beyond the actual property length (e.g. the
-/// property has a length of 3 bytes and you are setting `long_offset` to 1,
-/// resulting in a byte offset of 4).
+///   property has a length of 3 bytes and you are setting `long_offset` to 1,
+///   resulting in a byte offset of 4).
 ///
 /// # See
 ///
@@ -1230,7 +1230,7 @@ where
 /// # Errors
 ///
 /// * `Access` - Another client has already issued a GrabButton with the same button/key
-/// combination on the same window.
+///   combination on the same window.
 /// * `Value` - TODO: reasons?
 /// * `Cursor` - The specified `cursor` does not exist.
 /// * `Window` - The specified `window` does not exist.
@@ -1435,9 +1435,9 @@ where
 /// # Errors
 ///
 /// * `Access` - Another client has already issued a GrabKey with the same button/key
-/// combination on the same window.
+///   combination on the same window.
 /// * `Value` - The key is not `XCB_GRAB_ANY` and not in the range specified by `min_keycode`
-/// and `max_keycode` in the connection setup.
+///   and `max_keycode` in the connection setup.
 /// * `Window` - The specified `window` does not exist.
 ///
 /// # See
@@ -3439,7 +3439,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Match` - You created the specified window. This does not make sense, you can only add
-    /// windows created by other clients to your save set.
+    ///   windows created by other clients to your save set.
     /// * `Value` - You specified an invalid mode.
     /// * `Window` - The specified window does not exist.
     ///
@@ -3469,12 +3469,12 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Match` - The new parent window is not on the same screen as the old parent window.
-    /// 
-    /// The new parent window is the specified window or an inferior of the specified window.
-    /// 
-    /// The new parent is InputOnly and the window is not.
-    /// 
-    /// The specified window has a ParentRelative background and the new parent window is not the same depth as the specified window.
+    ///   
+    ///   The new parent window is the specified window or an inferior of the specified window.
+    ///   
+    ///   The new parent is InputOnly and the window is not.
+    ///   
+    ///   The specified window has a ParentRelative background and the new parent window is not the same depth as the specified window.
     /// * `Window` - The specified window does not exist.
     ///
     /// # See
@@ -3572,7 +3572,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Match` - You specified a Sibling without also specifying StackMode or the window is not
-    /// actually a Sibling.
+    ///   actually a Sibling.
     /// * `Window` - The specified window does not exist. TODO: any other reason?
     /// * `Value` - TODO: reasons?
     ///
@@ -3867,8 +3867,8 @@ pub trait ConnectionExt: RequestConnection {
     /// * `Window` - The specified `window` does not exist.
     /// * `Atom` - `property` or `type` do not refer to a valid atom.
     /// * `Value` - The specified `long_offset` is beyond the actual property length (e.g. the
-    /// property has a length of 3 bytes and you are setting `long_offset` to 1,
-    /// resulting in a byte offset of 4).
+    ///   property has a length of 3 bytes and you are setting `long_offset` to 1,
+    ///   resulting in a byte offset of 4).
     ///
     /// # See
     ///
@@ -4231,7 +4231,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Access` - Another client has already issued a GrabButton with the same button/key
-    /// combination on the same window.
+    ///   combination on the same window.
     /// * `Value` - TODO: reasons?
     /// * `Cursor` - The specified `cursor` does not exist.
     /// * `Window` - The specified `window` does not exist.
@@ -4378,9 +4378,9 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Access` - Another client has already issued a GrabKey with the same button/key
-    /// combination on the same window.
+    ///   combination on the same window.
     /// * `Value` - The key is not `XCB_GRAB_ANY` and not in the range specified by `min_keycode`
-    /// and `max_keycode` in the connection setup.
+    ///   and `max_keycode` in the connection setup.
     /// * `Window` - The specified `window` does not exist.
     ///
     /// # See

--- a/x11rb-async/src/rust_connection/mod.rs
+++ b/x11rb-async/src/rust_connection/mod.rs
@@ -627,7 +627,7 @@ impl<S: Stream + Send + Sync> RequestConnection for RustConnection<S> {
                             .try_into()
                             .ok()
                             .and_then(|x: usize| x.checked_mul(4))
-                            .unwrap_or(std::usize::MAX);
+                            .unwrap_or(usize::MAX);
 
                         *mrl = MaxRequestBytes::Known(total);
                         tracing::debug!("Maximum request length is {} bytes", total);

--- a/x11rb-async/src/rust_connection/shared_state.rs
+++ b/x11rb-async/src/rust_connection/shared_state.rs
@@ -115,7 +115,7 @@ impl<S: Stream> SharedState<S> {
 
                 if packet_count > 0 {
                     // Notify any listeners that there is new data.
-                    let _num_notified = self.new_input.notify_additional(std::usize::MAX);
+                    let _num_notified = self.new_input.notify_additional(usize::MAX);
                 } else {
                     // Wait for more data.
                     self.stream.readable().await?;
@@ -223,6 +223,6 @@ impl<S> Drop for BreakOnDrop<S> {
         self.0.driver_dropped.store(true, Ordering::SeqCst);
 
         // Wake up everyone that might be waiting
-        let _num_notified = self.0.new_input.notify_additional(std::usize::MAX);
+        let _num_notified = self.0.new_input.notify_additional(usize::MAX);
     }
 }

--- a/x11rb-protocol/src/connection/mod.rs
+++ b/x11rb-protocol/src/connection/mod.rs
@@ -99,7 +99,7 @@ impl Connection {
             ReplyFdKind::ReplyWithoutFDs => true,
             ReplyFdKind::ReplyWithFDs => true,
         };
-        if self.next_reply_expected + SequenceNumber::from(u16::max_value()) - 1
+        if self.next_reply_expected + SequenceNumber::from(u16::MAX) - 1
             <= self.last_sequence_written
             && !has_response
         {
@@ -164,10 +164,10 @@ impl Connection {
         let number = u16::from_ne_bytes([buffer[2], buffer[3]]);
 
         // ...and use our state to reconstruct the high bytes
-        let high_bytes = self.last_sequence_read & !SequenceNumber::from(u16::max_value());
+        let high_bytes = self.last_sequence_read & !SequenceNumber::from(u16::MAX);
         let mut full_number = SequenceNumber::from(number) | high_bytes;
         if full_number < self.last_sequence_read {
-            full_number += SequenceNumber::from(u16::max_value()) + 1;
+            full_number += SequenceNumber::from(u16::MAX) + 1;
         }
 
         // Update our state

--- a/x11rb-protocol/src/protocol/composite.rs
+++ b/x11rb-protocol/src/protocol/composite.rs
@@ -281,8 +281,8 @@ pub const REDIRECT_WINDOW_REQUEST: u8 = 1;
 ///
 /// * `window` - The root of the hierarchy to redirect to off-screen storage.
 /// * `update` - Whether contents are automatically mirrored to the parent window.  If one client
-/// already specifies an update type of Manual, any attempt by another to specify a
-/// mode of Manual so will result in an Access error.
+///   already specifies an update type of Manual, any attempt by another to specify a
+///   mode of Manual so will result in an Access error.
 #[derive(Clone, Copy, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -360,8 +360,8 @@ pub const REDIRECT_SUBWINDOWS_REQUEST: u8 = 2;
 ///
 /// * `window` - The root of the hierarchy to redirect to off-screen storage.
 /// * `update` - Whether contents are automatically mirrored to the parent window.  If one client
-/// already specifies an update type of Manual, any attempt by another to specify a
-/// mode of Manual so will result in an Access error.
+///   already specifies an update type of Manual, any attempt by another to specify a
+///   mode of Manual so will result in an Access error.
 #[derive(Clone, Copy, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -436,9 +436,9 @@ pub const UNREDIRECT_WINDOW_REQUEST: u8 = 3;
 /// # Fields
 ///
 /// * `window` - The window to terminate redirection of.  Must be redirected by the
-/// current client, or a Value error results.
+///   current client, or a Value error results.
 /// * `update` - The update type passed to RedirectWindows.  If this does not match the
-/// previously requested update type, a Value error results.
+///   previously requested update type, a Value error results.
 #[derive(Clone, Copy, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -512,10 +512,10 @@ pub const UNREDIRECT_SUBWINDOWS_REQUEST: u8 = 4;
 /// # Fields
 ///
 /// * `window` - The window to terminate redirection of.  Must have previously been
-/// selected for sub-redirection by the current client, or a Value error
-/// results.
+///   selected for sub-redirection by the current client, or a Value error
+///   results.
 /// * `update` - The update type passed to RedirectSubWindows.  If this does not match
-/// the previously requested update type, a Value error results.
+///   the previously requested update type, a Value error results.
 #[derive(Clone, Copy, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/x11rb-protocol/src/protocol/damage.rs
+++ b/x11rb-protocol/src/protocol/damage.rs
@@ -308,7 +308,7 @@ pub const CREATE_REQUEST: u8 = 1;
 /// # Fields
 ///
 /// * `damage` - The ID with which you will refer to the new Damage object, created by
-/// `xcb_generate_id`.
+///   `xcb_generate_id`.
 /// * `drawable` - The ID of the drawable to be monitored.
 /// * `level` - The level of detail to be provided in Damage events.
 #[derive(Clone, Copy, Default)]
@@ -608,8 +608,8 @@ pub const NOTIFY_EVENT: u8 = 0;
 /// # Fields
 ///
 /// * `level` - The level of the damage being reported.
-/// If the 0x80 bit is set, indicates there are subsequent Damage events
-/// being delivered immediately as part of a larger Damage region.
+///   If the 0x80 bit is set, indicates there are subsequent Damage events
+///   being delivered immediately as part of a larger Damage region.
 /// * `drawable` - The drawable for which damage is being reported.
 /// * `damage` - The Damage object being used to track the damage.
 /// * `timestamp` - Time when the event was generated (in milliseconds).

--- a/x11rb-protocol/src/protocol/shm.rs
+++ b/x11rb-protocol/src/protocol/shm.rs
@@ -50,7 +50,7 @@ pub const COMPLETION_EVENT: u8 = 0;
 /// * `drawable` - The drawable used in the XCB_SHM_PUT_IMAGE request.
 /// * `minor_event` - The minor opcode used in the request.  Always XCB_SHM_PUT_IMAGE.
 /// * `major_event` - The major opcode used in the request.  Always the opcode of the MIT-SHM
-/// extension.
+///   extension.
 /// * `shmseg` - The shared memory segment used in the request.
 /// * `offset` - The offset in the shared memory segment used in the request.
 #[derive(Clone, Copy, Default)]
@@ -523,21 +523,21 @@ pub const PUT_IMAGE_REQUEST: u8 = 3;
 /// * `src_x` - The source X coordinate of the sub-image to copy.
 /// * `src_y` - The source Y coordinate of the sub-image to copy.
 /// * `src_width` - The width, in source image coordinates, of the data to copy from the source.
-/// The X server will use this to determine the amount of data to copy.  The amount
-/// of the destination image that is overwritten is determined automatically.
+///   The X server will use this to determine the amount of data to copy.  The amount
+///   of the destination image that is overwritten is determined automatically.
 /// * `src_height` - The height, in source image coordinates, of the data to copy from the source.
-/// The X server will use this to determine the amount of data to copy.  The amount
-/// of the destination image that is overwritten is determined automatically.
+///   The X server will use this to determine the amount of data to copy.  The amount
+///   of the destination image that is overwritten is determined automatically.
 /// * `dst_x` - The X coordinate on the destination drawable to copy to.
 /// * `dst_y` - The Y coordinate on the destination drawable to copy to.
 /// * `depth` - The depth to use.
 /// * `format` - The format of the image being drawn.  If it is XYBitmap, depth must be 1, or a
-/// "BadMatch" error results.  The foreground pixel in the GC determines the source
-/// for the one bits in the image, and the background pixel determines the source
-/// for the zero bits.  For XYPixmap and ZPixmap, the depth must match the depth of
-/// the drawable, or a "BadMatch" error results.
+///   "BadMatch" error results.  The foreground pixel in the GC determines the source
+///   for the one bits in the image, and the background pixel determines the source
+///   for the zero bits.  For XYPixmap and ZPixmap, the depth must match the depth of
+///   the drawable, or a "BadMatch" error results.
 /// * `send_event` - True if the server should send an XCB_SHM_COMPLETION event when the blit
-/// completes.
+///   completes.
 /// * `offset` - The offset that the source image starts at.
 #[derive(Clone, Copy, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]

--- a/x11rb-protocol/src/protocol/xfixes.rs
+++ b/x11rb-protocol/src/protocol/xfixes.rs
@@ -3513,11 +3513,11 @@ impl crate::x11_utils::VoidRequest for DeletePointerBarrierRequest {
 /// # Fields
 ///
 /// * `Default` - The default behavior for regular clients: the X11 server won't terminate as long
-/// as such clients are still connected, and should this client disconnect, the
-/// server will continue running so long as other clients (that have not set
-/// XFixesClientDisconnectFlagTerminate) are connected.
+///   as such clients are still connected, and should this client disconnect, the
+///   server will continue running so long as other clients (that have not set
+///   XFixesClientDisconnectFlagTerminate) are connected.
 /// * `Terminate` - Indicates to the X11 server that it can ignore the client and terminate itself
-/// even though the client is still connected to the X11 server.
+///   even though the client is still connected to the X11 server.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientDisconnectFlags(u32);

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -8383,7 +8383,7 @@ pub const CHANGE_SAVE_SET_REQUEST: u8 = 6;
 /// # Errors
 ///
 /// * `Match` - You created the specified window. This does not make sense, you can only add
-/// windows created by other clients to your save set.
+///   windows created by other clients to your save set.
 /// * `Value` - You specified an invalid mode.
 /// * `Window` - The specified window does not exist.
 ///
@@ -8472,12 +8472,12 @@ pub const REPARENT_WINDOW_REQUEST: u8 = 7;
 /// # Errors
 ///
 /// * `Match` - The new parent window is not on the same screen as the old parent window.
-/// 
-/// The new parent window is the specified window or an inferior of the specified window.
-/// 
-/// The new parent is InputOnly and the window is not.
-/// 
-/// The specified window has a ParentRelative background and the new parent window is not the same depth as the specified window.
+///   
+///   The new parent window is the specified window or an inferior of the specified window.
+///   
+///   The new parent is InputOnly and the window is not.
+///   
+///   The specified window has a ParentRelative background and the new parent window is not the same depth as the specified window.
 /// * `Window` - The specified window does not exist.
 ///
 /// # See
@@ -9207,7 +9207,7 @@ pub const CONFIGURE_WINDOW_REQUEST: u8 = 12;
 /// # Errors
 ///
 /// * `Match` - You specified a Sibling without also specifying StackMode or the window is not
-/// actually a Sibling.
+///   actually a Sibling.
 /// * `Window` - The specified window does not exist. TODO: any other reason?
 /// * `Value` - TODO: reasons?
 ///
@@ -10536,8 +10536,8 @@ pub const GET_PROPERTY_REQUEST: u8 = 20;
 /// * `Window` - The specified `window` does not exist.
 /// * `Atom` - `property` or `type` do not refer to a valid atom.
 /// * `Value` - The specified `long_offset` is beyond the actual property length (e.g. the
-/// property has a length of 3 bytes and you are setting `long_offset` to 1,
-/// resulting in a byte offset of 4).
+///   property has a length of 3 bytes and you are setting `long_offset` to 1,
+///   resulting in a byte offset of 4).
 ///
 /// # See
 ///
@@ -12222,7 +12222,7 @@ pub const GRAB_BUTTON_REQUEST: u8 = 28;
 /// # Errors
 ///
 /// * `Access` - Another client has already issued a GrabButton with the same button/key
-/// combination on the same window.
+///   combination on the same window.
 /// * `Value` - TODO: reasons?
 /// * `Cursor` - The specified `cursor` does not exist.
 /// * `Window` - The specified `window` does not exist.
@@ -12858,9 +12858,9 @@ pub const GRAB_KEY_REQUEST: u8 = 33;
 /// # Errors
 ///
 /// * `Access` - Another client has already issued a GrabKey with the same button/key
-/// combination on the same window.
+///   combination on the same window.
 /// * `Value` - The key is not `XCB_GRAB_ANY` and not in the range specified by `min_keycode`
-/// and `max_keycode` in the connection setup.
+///   and `max_keycode` in the connection setup.
 /// * `Window` - The specified `window` does not exist.
 ///
 /// # See

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -1322,20 +1322,20 @@ pub const KEY_PRESS_EVENT: u8 = 2;
 /// # Fields
 ///
 /// * `detail` - The keycode (a number representing a physical key on the keyboard) of the key
-/// which was pressed.
+///   which was pressed.
 /// * `time` - Time when the event was generated (in milliseconds).
 /// * `root` - The root window of `child`.
 /// * `same_screen` - Whether the `event` window is on the same screen as the `root` window.
 /// * `event_x` - If `same_screen` is true, this is the X coordinate relative to the `event`
-/// window's origin. Otherwise, `event_x` will be set to zero.
+///   window's origin. Otherwise, `event_x` will be set to zero.
 /// * `event_y` - If `same_screen` is true, this is the Y coordinate relative to the `event`
-/// window's origin. Otherwise, `event_y` will be set to zero.
+///   window's origin. Otherwise, `event_y` will be set to zero.
 /// * `root_x` - The X coordinate of the pointer relative to the `root` window at the time of
-/// the event.
+///   the event.
 /// * `root_y` - The Y coordinate of the pointer relative to the `root` window at the time of
-/// the event.
+///   the event.
 /// * `state` - The logical state of the pointer buttons and modifier keys just prior to the
-/// event.
+///   event.
 ///
 /// # See
 ///
@@ -1584,20 +1584,20 @@ pub const BUTTON_PRESS_EVENT: u8 = 4;
 /// # Fields
 ///
 /// * `detail` - The keycode (a number representing a physical key on the keyboard) of the key
-/// which was pressed.
+///   which was pressed.
 /// * `time` - Time when the event was generated (in milliseconds).
 /// * `root` - The root window of `child`.
 /// * `same_screen` - Whether the `event` window is on the same screen as the `root` window.
 /// * `event_x` - If `same_screen` is true, this is the X coordinate relative to the `event`
-/// window's origin. Otherwise, `event_x` will be set to zero.
+///   window's origin. Otherwise, `event_x` will be set to zero.
 /// * `event_y` - If `same_screen` is true, this is the Y coordinate relative to the `event`
-/// window's origin. Otherwise, `event_y` will be set to zero.
+///   window's origin. Otherwise, `event_y` will be set to zero.
 /// * `root_x` - The X coordinate of the pointer relative to the `root` window at the time of
-/// the event.
+///   the event.
 /// * `root_y` - The Y coordinate of the pointer relative to the `root` window at the time of
-/// the event.
+///   the event.
 /// * `state` - The logical state of the pointer buttons and modifier keys just prior to the
-/// event.
+///   event.
 ///
 /// # See
 ///
@@ -1843,20 +1843,20 @@ pub const MOTION_NOTIFY_EVENT: u8 = 6;
 /// # Fields
 ///
 /// * `detail` - The keycode (a number representing a physical key on the keyboard) of the key
-/// which was pressed.
+///   which was pressed.
 /// * `time` - Time when the event was generated (in milliseconds).
 /// * `root` - The root window of `child`.
 /// * `same_screen` - Whether the `event` window is on the same screen as the `root` window.
 /// * `event_x` - If `same_screen` is true, this is the X coordinate relative to the `event`
-/// window's origin. Otherwise, `event_x` will be set to zero.
+///   window's origin. Otherwise, `event_x` will be set to zero.
 /// * `event_y` - If `same_screen` is true, this is the Y coordinate relative to the `event`
-/// window's origin. Otherwise, `event_y` will be set to zero.
+///   window's origin. Otherwise, `event_y` will be set to zero.
 /// * `root_x` - The X coordinate of the pointer relative to the `root` window at the time of
-/// the event.
+///   the event.
 /// * `root_y` - The Y coordinate of the pointer relative to the `root` window at the time of
-/// the event.
+///   the event.
 /// * `state` - The logical state of the pointer buttons and modifier keys just prior to the
-/// event.
+///   event.
 ///
 /// # See
 ///
@@ -2175,14 +2175,14 @@ pub const ENTER_NOTIFY_EVENT: u8 = 7;
 ///
 /// * `event` - The window on which the event was generated.
 /// * `child` - If the `event` window has subwindows and the final pointer position is in one
-/// of them, then `child` is set to that subwindow, `XCB_WINDOW_NONE` otherwise.
+///   of them, then `child` is set to that subwindow, `XCB_WINDOW_NONE` otherwise.
 /// * `root` - The root window for the final cursor position.
 /// * `root_x` - The pointer X coordinate relative to `root`'s origin at the time of the event.
 /// * `root_y` - The pointer Y coordinate relative to `root`'s origin at the time of the event.
 /// * `event_x` - If `event` is on the same screen as `root`, this is the pointer X coordinate
-/// relative to the event window's origin.
+///   relative to the event window's origin.
 /// * `event_y` - If `event` is on the same screen as `root`, this is the pointer Y coordinate
-/// relative to the event window's origin.
+///   relative to the event window's origin.
 /// * `mode` -
 #[derive(Clone, Copy, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
@@ -2370,7 +2370,7 @@ pub const FOCUS_IN_EVENT: u8 = 9;
 /// # Fields
 ///
 /// * `event` - The window on which the focus event was generated. This is the window used by
-/// the X server to report the event.
+///   the X server to report the event.
 /// * `detail` -
 /// * `mode` -
 #[derive(Clone, Copy, Default)]
@@ -2609,15 +2609,15 @@ pub const EXPOSE_EVENT: u8 = 12;
 ///
 /// * `window` - The exposed (damaged) window.
 /// * `x` - The X coordinate of the left-upper corner of the exposed rectangle, relative to
-/// the `window`'s origin.
+///   the `window`'s origin.
 /// * `y` - The Y coordinate of the left-upper corner of the exposed rectangle, relative to
-/// the `window`'s origin.
+///   the `window`'s origin.
 /// * `width` - The width of the exposed rectangle.
 /// * `height` - The height of the exposed rectangle.
 /// * `count` - The amount of `Expose` events following this one. Simple applications that do
-/// not want to optimize redisplay by distinguishing between subareas of its window
-/// can just ignore all Expose events with nonzero counts and perform full
-/// redisplays on events with zero counts.
+///   not want to optimize redisplay by distinguishing between subareas of its window
+///   can just ignore all Expose events with nonzero counts and perform full
+///   redisplays on events with zero counts.
 #[derive(Clone, Copy, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -3347,7 +3347,7 @@ pub const DESTROY_NOTIFY_EVENT: u8 = 17;
 /// # Fields
 ///
 /// * `event` - The reconfigured window or its parent, depending on whether `StructureNotify`
-/// or `SubstructureNotify` was selected.
+///   or `SubstructureNotify` was selected.
 /// * `window` - The window that is destroyed.
 ///
 /// # See
@@ -3465,10 +3465,10 @@ pub const UNMAP_NOTIFY_EVENT: u8 = 18;
 /// # Fields
 ///
 /// * `event` - The reconfigured window or its parent, depending on whether `StructureNotify`
-/// or `SubstructureNotify` was selected.
+///   or `SubstructureNotify` was selected.
 /// * `window` - The window that was unmapped.
 /// * `from_configure` - Set to 1 if the event was generated as a result of a resizing of the window's
-/// parent when `window` had a win_gravity of `UnmapGravity`.
+///   parent when `window` had a win_gravity of `UnmapGravity`.
 ///
 /// # See
 ///
@@ -3596,7 +3596,7 @@ pub const MAP_NOTIFY_EVENT: u8 = 19;
 /// # Fields
 ///
 /// * `event` - The window which was mapped or its parent, depending on whether
-/// `StructureNotify` or `SubstructureNotify` was selected.
+///   `StructureNotify` or `SubstructureNotify` was selected.
 /// * `window` - The window that was mapped.
 /// * `override_redirect` - Window managers should ignore this window if `override_redirect` is 1.
 ///
@@ -3984,15 +3984,15 @@ pub const CONFIGURE_NOTIFY_EVENT: u8 = 22;
 /// # Fields
 ///
 /// * `event` - The reconfigured window or its parent, depending on whether `StructureNotify`
-/// or `SubstructureNotify` was selected.
+///   or `SubstructureNotify` was selected.
 /// * `window` - The window whose size, position, border, and/or stacking order was changed.
 /// * `above_sibling` - If `XCB_NONE`, the `window` is on the bottom of the stack with respect to
-/// sibling windows. However, if set to a sibling window, the `window` is placed on
-/// top of this sibling window.
+///   sibling windows. However, if set to a sibling window, the `window` is placed on
+///   top of this sibling window.
 /// * `x` - The X coordinate of the upper-left outside corner of `window`, relative to the
-/// parent window's origin.
+///   parent window's origin.
 /// * `y` - The Y coordinate of the upper-left outside corner of `window`, relative to the
-/// parent window's origin.
+///   parent window's origin.
 /// * `width` - The inside width of `window`, not including the border.
 /// * `height` - The inside height of `window`, not including the border.
 /// * `border_width` - The border width of `window`.
@@ -4625,7 +4625,7 @@ pub const CIRCULATE_NOTIFY_EVENT: u8 = 26;
 /// # Fields
 ///
 /// * `event` - Either the restacked window or its parent, depending on whether
-/// `StructureNotify` or `SubstructureNotify` was selected.
+///   `StructureNotify` or `SubstructureNotify` was selected.
 /// * `window` - The restacked window.
 /// * `place` -
 ///
@@ -5731,7 +5731,7 @@ pub const COLORMAP_NOTIFY_EVENT: u8 = 32;
 ///
 /// * `window` - The window whose associated colormap is changed, installed or uninstalled.
 /// * `colormap` - The colormap which is changed, installed or uninstalled. This is `XCB_NONE`
-/// when the colormap is changed by a call to `FreeColormap`.
+///   when the colormap is changed by a call to `FreeColormap`.
 /// * `_new` - Indicates whether the colormap was changed (1) or installed/uninstalled (0).
 /// * `state` -
 ///
@@ -6028,7 +6028,7 @@ pub const CLIENT_MESSAGE_EVENT: u8 = 33;
 ///
 /// * `format` - Specifies how to interpret `data`. Can be either 8, 16 or 32.
 /// * `type` - An atom which indicates how the data should be interpreted by the receiving
-/// client.
+///   client.
 /// * `data` - The data itself (20 bytes max).
 ///
 /// # See
@@ -6564,73 +6564,73 @@ impl core::fmt::Debug for WindowClass  {
 /// # Fields
 ///
 /// * `BackPixmap` - Overrides the default background-pixmap. The background pixmap and window must
-/// have the same root and same depth. Any size pixmap can be used, although some
-/// sizes may be faster than others.
+///   have the same root and same depth. Any size pixmap can be used, although some
+///   sizes may be faster than others.
 ///
-/// If `XCB_BACK_PIXMAP_NONE` is specified, the window has no defined background.
-/// The server may fill the contents with the previous screen contents or with
-/// contents of its own choosing.
+///   If `XCB_BACK_PIXMAP_NONE` is specified, the window has no defined background.
+///   The server may fill the contents with the previous screen contents or with
+///   contents of its own choosing.
 ///
-/// If `XCB_BACK_PIXMAP_PARENT_RELATIVE` is specified, the parent's background is
-/// used, but the window must have the same depth as the parent (or a Match error
-/// results).   The parent's background is tracked, and the current version is
-/// used each time the window background is required.
+///   If `XCB_BACK_PIXMAP_PARENT_RELATIVE` is specified, the parent's background is
+///   used, but the window must have the same depth as the parent (or a Match error
+///   results).   The parent's background is tracked, and the current version is
+///   used each time the window background is required.
 /// * `BackPixel` - Overrides `BackPixmap`. A pixmap of undefined size filled with the specified
-/// background pixel is used for the background. Range-checking is not performed,
-/// the background pixel is truncated to the appropriate number of bits.
+///   background pixel is used for the background. Range-checking is not performed,
+///   the background pixel is truncated to the appropriate number of bits.
 /// * `BorderPixmap` - Overrides the default border-pixmap. The border pixmap and window must have the
-/// same root and the same depth. Any size pixmap can be used, although some sizes
-/// may be faster than others.
+///   same root and the same depth. Any size pixmap can be used, although some sizes
+///   may be faster than others.
 ///
-/// The special value `XCB_COPY_FROM_PARENT` means the parent's border pixmap is
-/// copied (subsequent changes to the parent's border attribute do not affect the
-/// child), but the window must have the same depth as the parent.
+///   The special value `XCB_COPY_FROM_PARENT` means the parent's border pixmap is
+///   copied (subsequent changes to the parent's border attribute do not affect the
+///   child), but the window must have the same depth as the parent.
 /// * `BorderPixel` - Overrides `BorderPixmap`. A pixmap of undefined size filled with the specified
-/// border pixel is used for the border. Range checking is not performed on the
-/// border-pixel value, it is truncated to the appropriate number of bits.
+///   border pixel is used for the border. Range checking is not performed on the
+///   border-pixel value, it is truncated to the appropriate number of bits.
 /// * `BitGravity` - Defines which region of the window should be retained if the window is resized.
 /// * `WinGravity` - Defines how the window should be repositioned if the parent is resized (see
-/// `ConfigureWindow`).
+///   `ConfigureWindow`).
 /// * `BackingStore` - A backing-store of `WhenMapped` advises the server that maintaining contents of
-/// obscured regions when the window is mapped would be beneficial. A backing-store
-/// of `Always` advises the server that maintaining contents even when the window
-/// is unmapped would be beneficial. In this case, the server may generate an
-/// exposure event when the window is created. A value of `NotUseful` advises the
-/// server that maintaining contents is unnecessary, although a server may still
-/// choose to maintain contents while the window is mapped. Note that if the server
-/// maintains contents, then the server should maintain complete contents not just
-/// the region within the parent boundaries, even if the window is larger than its
-/// parent. While the server maintains contents, exposure events will not normally
-/// be generated, but the server may stop maintaining contents at any time.
+///   obscured regions when the window is mapped would be beneficial. A backing-store
+///   of `Always` advises the server that maintaining contents even when the window
+///   is unmapped would be beneficial. In this case, the server may generate an
+///   exposure event when the window is created. A value of `NotUseful` advises the
+///   server that maintaining contents is unnecessary, although a server may still
+///   choose to maintain contents while the window is mapped. Note that if the server
+///   maintains contents, then the server should maintain complete contents not just
+///   the region within the parent boundaries, even if the window is larger than its
+///   parent. While the server maintains contents, exposure events will not normally
+///   be generated, but the server may stop maintaining contents at any time.
 /// * `BackingPlanes` - The backing-planes indicates (with bits set to 1) which bit planes of the
-/// window hold dynamic data that must be preserved in backing-stores and during
-/// save-unders.
+///   window hold dynamic data that must be preserved in backing-stores and during
+///   save-unders.
 /// * `BackingPixel` - The backing-pixel specifies what value to use in planes not covered by
-/// backing-planes. The server is free to save only the specified bit planes in the
-/// backing-store or save-under and regenerate the remaining planes with the
-/// specified pixel value. Any bits beyond the specified depth of the window in
-/// these values are simply ignored.
+///   backing-planes. The server is free to save only the specified bit planes in the
+///   backing-store or save-under and regenerate the remaining planes with the
+///   specified pixel value. Any bits beyond the specified depth of the window in
+///   these values are simply ignored.
 /// * `OverrideRedirect` - The override-redirect specifies whether map and configure requests on this
-/// window should override a SubstructureRedirect on the parent, typically to
-/// inform a window manager not to tamper with the window.
+///   window should override a SubstructureRedirect on the parent, typically to
+///   inform a window manager not to tamper with the window.
 /// * `SaveUnder` - If 1, the server is advised that when this window is mapped, saving the
-/// contents of windows it obscures would be beneficial.
+///   contents of windows it obscures would be beneficial.
 /// * `EventMask` - The event-mask defines which events the client is interested in for this window
-/// (or for some event types, inferiors of the window).
+///   (or for some event types, inferiors of the window).
 /// * `DontPropagate` - The do-not-propagate-mask defines which events should not be propagated to
-/// ancestor windows when no client has the event type selected in this window.
+///   ancestor windows when no client has the event type selected in this window.
 /// * `Colormap` - The colormap specifies the colormap that best reflects the true colors of the window. Servers
-/// capable of supporting multiple hardware colormaps may use this information, and window man-
-/// agers may use it for InstallColormap requests. The colormap must have the same visual type
-/// and root as the window (or a Match error results). If CopyFromParent is specified, the parent's
-/// colormap is copied (subsequent changes to the parent's colormap attribute do not affect the child).
-/// However, the window must have the same visual type as the parent (or a Match error results),
-/// and the parent must not have a colormap of None (or a Match error results). For an explanation
-/// of None, see FreeColormap request. The colormap is copied by sharing the colormap object
-/// between the child and the parent, not by making a complete copy of the colormap contents.
+///   capable of supporting multiple hardware colormaps may use this information, and window man-
+///   agers may use it for InstallColormap requests. The colormap must have the same visual type
+///   and root as the window (or a Match error results). If CopyFromParent is specified, the parent's
+///   colormap is copied (subsequent changes to the parent's colormap attribute do not affect the child).
+///   However, the window must have the same visual type as the parent (or a Match error results),
+///   and the parent must not have a colormap of None (or a Match error results). For an explanation
+///   of None, see FreeColormap request. The colormap is copied by sharing the colormap object
+///   between the child and the parent, not by making a complete copy of the colormap contents.
 /// * `Cursor` - If a cursor is specified, it will be used whenever the pointer is in the window. If None is speci-
-/// fied, the parent's cursor will be used when the pointer is in the window, and any change in the
-/// parent's cursor will cause an immediate change in the displayed cursor.
+///   fied, the parent's cursor will be used when the pointer is in the window, and any change in the
+///   parent's cursor will cause an immediate change in the displayed cursor.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CW(u32);
@@ -7225,20 +7225,20 @@ pub const CREATE_WINDOW_REQUEST: u8 = 1;
 /// # Fields
 ///
 /// * `wid` - The ID with which you will refer to the new window, created by
-/// `xcb_generate_id`.
+///   `xcb_generate_id`.
 /// * `depth` - Specifies the new window's depth (TODO: what unit?).
 ///
-/// The special value `XCB_COPY_FROM_PARENT` means the depth is taken from the
-/// `parent` window.
+///   The special value `XCB_COPY_FROM_PARENT` means the depth is taken from the
+///   `parent` window.
 /// * `visual` - Specifies the id for the new window's visual.
 ///
-/// The special value `XCB_COPY_FROM_PARENT` means the visual is taken from the
-/// `parent` window.
+///   The special value `XCB_COPY_FROM_PARENT` means the visual is taken from the
+///   `parent` window.
 /// * `class` -
 /// * `parent` - The parent window of the new window.
 /// * `border_width` - TODO:
 ///
-/// Must be zero if the `class` is `InputOnly` or a `xcb_match_error_t` occurs.
+///   Must be zero if the `class` is `InputOnly` or a `xcb_match_error_t` occurs.
 /// * `x` - The X coordinate of the new window.
 /// * `y` - The Y coordinate of the new window.
 /// * `width` - The width of the new window.
@@ -7772,8 +7772,8 @@ pub const CHANGE_WINDOW_ATTRIBUTES_REQUEST: u8 = 2;
 ///
 /// * `window` - The window to change.
 /// * `value_list` - Values for each of the attributes specified in the bitmask `value_mask`. The
-/// order has to correspond to the order of possible `value_mask` bits. See the
-/// example.
+///   order has to correspond to the order of possible `value_mask` bits. See the
+///   example.
 ///
 /// # Errors
 ///
@@ -9202,7 +9202,7 @@ pub const CONFIGURE_WINDOW_REQUEST: u8 = 12;
 ///
 /// * `window` - The window to configure.
 /// * `value_list` - New values, corresponding to the attributes in value_mask. The order has to
-/// correspond to the order of possible `value_mask` bits. See the example.
+///   correspond to the order of possible `value_mask` bits. See the example.
 ///
 /// # Errors
 ///
@@ -9561,11 +9561,11 @@ impl crate::x11_utils::ReplyRequest for GetGeometryRequest {
 ///
 /// * `root` - Root window of the screen containing `drawable`.
 /// * `x` - The X coordinate of `drawable`. If `drawable` is a window, the coordinate
-/// specifies the upper-left outer corner relative to its parent's origin. If
-/// `drawable` is a pixmap, the X coordinate is always 0.
+///   specifies the upper-left outer corner relative to its parent's origin. If
+///   `drawable` is a pixmap, the X coordinate is always 0.
 /// * `y` - The Y coordinate of `drawable`. If `drawable` is a window, the coordinate
-/// specifies the upper-left outer corner relative to its parent's origin. If
-/// `drawable` is a pixmap, the Y coordinate is always 0.
+///   specifies the upper-left outer corner relative to its parent's origin. If
+///   `drawable` is a pixmap, the Y coordinate is always 0.
 /// * `width` - The width of `drawable`.
 /// * `height` - The height of `drawable`.
 /// * `border_width` - The border width (in pixels).
@@ -10148,11 +10148,11 @@ impl GetAtomNameReply {
 ///
 /// * `Replace` - Discard the previous property value and store the new data.
 /// * `Prepend` - Insert the new data before the beginning of existing data. The `format` must
-/// match existing property value. If the property is undefined, it is treated as
-/// defined with the correct type and format with zero-length data.
+///   match existing property value. If the property is undefined, it is treated as
+///   defined with the correct type and format with zero-length data.
 /// * `Append` - Insert the new data after the beginning of existing data. The `format` must
-/// match existing property value. If the property is undefined, it is treated as
-/// defined with the correct type and format with zero-length data.
+///   match existing property value. If the property is undefined, it is treated as
+///   defined with the correct type and format with zero-length data.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PropMode(u8);
@@ -10230,8 +10230,8 @@ pub const CHANGE_PROPERTY_REQUEST: u8 = 18;
 /// * `property` - The property you want to change (an atom).
 /// * `type` - The type of the property you want to change (an atom).
 /// * `format` - Specifies whether the data should be viewed as a list of 8-bit, 16-bit or
-/// 32-bit quantities. Possible values are 8, 16 and 32. This information allows
-/// the X server to correctly perform byte-swap operations as necessary.
+///   32-bit quantities. Possible values are 8, 16 and 32. This information allows
+///   the X server to correctly perform byte-swap operations as necessary.
 /// * `data_len` - Specifies the number of elements (see `format`).
 /// * `data` - The property data.
 ///
@@ -10523,13 +10523,13 @@ pub const GET_PROPERTY_REQUEST: u8 = 20;
 ///
 /// * `window` - The window whose property you want to get.
 /// * `delete` - Whether the property should actually be deleted. For deleting a property, the
-/// specified `type` has to match the actual property type.
+///   specified `type` has to match the actual property type.
 /// * `property` - The property you want to get (an atom).
 /// * `type` - The type of the property you want to get (an atom).
 /// * `long_offset` - Specifies the offset (in 32-bit multiples) in the specified property where the
-/// data is to be retrieved.
+///   data is to be retrieved.
 /// * `long_length` - Specifies how many 32-bit multiples of data should be retrieved (e.g. if you
-/// set `long_length` to 4, you will receive 16 bytes of data).
+///   set `long_length` to 4, you will receive 16 bytes of data).
 ///
 /// # Errors
 ///
@@ -10827,13 +10827,13 @@ impl GetPropertyReply {
 /// # Fields
 ///
 /// * `format` - Specifies whether the data should be viewed as a list of 8-bit, 16-bit, or
-/// 32-bit quantities. Possible values are 8, 16, and 32. This information allows
-/// the X server to correctly perform byte-swap operations as necessary.
+///   32-bit quantities. Possible values are 8, 16, and 32. This information allows
+///   the X server to correctly perform byte-swap operations as necessary.
 /// * `type` - The actual type of the property (an atom).
 /// * `bytes_after` - The number of bytes remaining to be read in the property if a partial read was
-/// performed.
+///   performed.
 /// * `value_len` - The length of value. You should use the corresponding accessor instead of this
-/// field.
+///   field.
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -11032,15 +11032,15 @@ pub const SET_SELECTION_OWNER_REQUEST: u8 = 22;
 /// * `selection` - The selection.
 /// * `owner` - The new owner of the selection.
 ///
-/// The special value `XCB_NONE` means that the selection will have no owner.
+///   The special value `XCB_NONE` means that the selection will have no owner.
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The selection will not be changed if `time` is earlier than the current
-/// last-change time of the `selection` or is later than the current X server time.
-/// Otherwise, the last-change time is set to the specified time.
+///   The selection will not be changed if `time` is earlier than the current
+///   last-change time of the `selection` or is later than the current X server time.
+///   Otherwise, the last-change time is set to the specified time.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 ///
 /// # Errors
 ///
@@ -11439,23 +11439,23 @@ pub const SEND_EVENT_REQUEST: u8 = 25;
 /// # Fields
 ///
 /// * `destination` - The window to send this event to. Every client which selects any event within
-/// `event_mask` on `destination` will get the event.
+///   `event_mask` on `destination` will get the event.
 ///
-/// The special value `XCB_SEND_EVENT_DEST_POINTER_WINDOW` refers to the window
-/// that contains the mouse pointer.
+///   The special value `XCB_SEND_EVENT_DEST_POINTER_WINDOW` refers to the window
+///   that contains the mouse pointer.
 ///
-/// The special value `XCB_SEND_EVENT_DEST_ITEM_FOCUS` refers to the window which
-/// has the keyboard focus.
+///   The special value `XCB_SEND_EVENT_DEST_ITEM_FOCUS` refers to the window which
+///   has the keyboard focus.
 /// * `event_mask` - Event_mask for determining which clients should receive the specified event.
-/// See `destination` and `propagate`.
+///   See `destination` and `propagate`.
 /// * `propagate` - If `propagate` is true and no clients have selected any event on `destination`,
-/// the destination is replaced with the closest ancestor of `destination` for
-/// which some client has selected a type in `event_mask` and for which no
-/// intervening window has that type in its do-not-propagate-mask. If no such
-/// window exists or if the window is an ancestor of the focus window and
-/// `InputFocus` was originally specified as the destination, the event is not sent
-/// to any clients. Otherwise, the event is reported to every client selecting on
-/// the final destination any of the types specified in `event_mask`.
+///   the destination is replaced with the closest ancestor of `destination` for
+///   which some client has selected a type in `event_mask` and for which no
+///   intervening window has that type in its do-not-propagate-mask. If no such
+///   window exists or if the window is an ancestor of the focus window and
+///   `InputFocus` was originally specified as the destination, the event is not sent
+///   to any clients. Otherwise, the event is reported to every client selecting on
+///   the final destination any of the types specified in `event_mask`.
 /// * `event` - The event to send to the specified `destination`.
 ///
 /// # Errors
@@ -11584,8 +11584,8 @@ impl<'input> crate::x11_utils::VoidRequest for SendEventRequest<'input> {
 /// # Fields
 ///
 /// * `Sync` - The state of the keyboard appears to freeze: No further keyboard events are
-/// generated by the server until the grabbing client issues a releasing
-/// `AllowEvents` request or until the keyboard grab is released.
+///   generated by the server until the grabbing client issues a releasing
+///   `AllowEvents` request or until the keyboard grab is released.
 /// * `Async` - Keyboard event processing continues normally.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -11778,27 +11778,27 @@ pub const GRAB_POINTER_REQUEST: u8 = 26;
 ///
 /// * `event_mask` - Specifies which pointer events are reported to the client.
 ///
-/// TODO: which values?
+///   TODO: which values?
 /// * `confine_to` - Specifies the window to confine the pointer in (the user will not be able to
-/// move the pointer out of that window).
+///   move the pointer out of that window).
 ///
-/// The special value `XCB_NONE` means don't confine the pointer.
+///   The special value `XCB_NONE` means don't confine the pointer.
 /// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
-/// cursor.
+///   cursor.
 /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-/// reported to the `grab_window`.
+///   reported to the `grab_window`.
 /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
 /// * `time` - The time argument allows you to avoid certain circumstances that come up if
-/// applications take a long time to respond or if there are long network delays.
-/// Consider a situation where you have two applications, both of which normally
-/// grab the pointer when clicked on. If both applications specify the timestamp
-/// from the event, the second application may wake up faster and successfully grab
-/// the pointer before the first application. The first application then will get
-/// an indication that the other application grabbed the pointer before its request
-/// was processed.
+///   applications take a long time to respond or if there are long network delays.
+///   Consider a situation where you have two applications, both of which normally
+///   grab the pointer when clicked on. If both applications specify the timestamp
+///   from the event, the second application may wake up faster and successfully grab
+///   the pointer before the first application. The first application then will get
+///   an indication that the other application grabbed the pointer before its request
+///   was processed.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 /// * `pointer_mode` -
 /// * `keyboard_mode` -
 ///
@@ -12014,8 +12014,8 @@ pub const UNGRAB_POINTER_REQUEST: u8 = 27;
 ///
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The pointer will not be released if `time` is earlier than the
-/// last-pointer-grab time or later than the current X server time.
+///   The pointer will not be released if `time` is earlier than the
+///   last-pointer-grab time or later than the current X server time.
 /// * `name_len` - Length (in bytes) of `name`.
 /// * `name` - A pattern describing an X core font.
 ///
@@ -12200,21 +12200,21 @@ pub const GRAB_BUTTON_REQUEST: u8 = 28;
 /// # Fields
 ///
 /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-/// reported to the `grab_window`.
+///   reported to the `grab_window`.
 /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
 /// * `event_mask` - Specifies which pointer events are reported to the client.
 ///
-/// TODO: which values?
+///   TODO: which values?
 /// * `confine_to` - Specifies the window to confine the pointer in (the user will not be able to
-/// move the pointer out of that window).
+///   move the pointer out of that window).
 ///
-/// The special value `XCB_NONE` means don't confine the pointer.
+///   The special value `XCB_NONE` means don't confine the pointer.
 /// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
-/// cursor.
+///   cursor.
 /// * `modifiers` - The modifiers to grab.
 ///
-/// Using the special value `XCB_MOD_MASK_ANY` means grab the pointer with all
-/// possible modifier combinations.
+///   Using the special value `XCB_MOD_MASK_ANY` means grab the pointer with all
+///   possible modifier combinations.
 /// * `pointer_mode` -
 /// * `keyboard_mode` -
 /// * `button` -
@@ -12504,12 +12504,12 @@ pub const GRAB_KEYBOARD_REQUEST: u8 = 31;
 /// # Fields
 ///
 /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-/// reported to the `grab_window`.
+///   reported to the `grab_window`.
 /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 /// * `pointer_mode` -
 /// * `keyboard_mode` -
 ///
@@ -12843,15 +12843,15 @@ pub const GRAB_KEY_REQUEST: u8 = 33;
 /// # Fields
 ///
 /// * `owner_events` - If 1, the `grab_window` will still get the key events. If 0, events are not
-/// reported to the `grab_window`.
+///   reported to the `grab_window`.
 /// * `grab_window` - Specifies the window on which the key should be grabbed.
 /// * `key` - The keycode of the key to grab.
 ///
-/// The special value `XCB_GRAB_ANY` means grab any key.
+///   The special value `XCB_GRAB_ANY` means grab any key.
 /// * `modifiers` - The modifiers to grab.
 ///
-/// Using the special value `XCB_MOD_MASK_ANY` means grab the key with all
-/// possible modifier combinations.
+///   Using the special value `XCB_MOD_MASK_ANY` means grab the key with all
+///   possible modifier combinations.
 /// * `pointer_mode` -
 /// * `keyboard_mode` -
 ///
@@ -12965,12 +12965,12 @@ pub const UNGRAB_KEY_REQUEST: u8 = 34;
 ///
 /// * `key` - The keycode of the specified key combination.
 ///
-/// Using the special value `XCB_GRAB_ANY` means releasing all possible key codes.
+///   Using the special value `XCB_GRAB_ANY` means releasing all possible key codes.
 /// * `grab_window` - The window on which the grabbed key combination will be released.
 /// * `modifiers` - The modifiers of the specified key combination.
 ///
-/// Using the special value `XCB_MOD_MASK_ANY` means releasing the key combination
-/// with every possible modifier combination.
+///   Using the special value `XCB_MOD_MASK_ANY` means releasing the key combination
+///   with every possible modifier combination.
 ///
 /// # Errors
 ///
@@ -13054,62 +13054,62 @@ impl crate::x11_utils::VoidRequest for UngrabKeyRequest {
 /// # Fields
 ///
 /// * `AsyncPointer` - For AsyncPointer, if the pointer is frozen by the client, pointer event
-/// processing continues normally. If the pointer is frozen twice by the client on
-/// behalf of two separate grabs, AsyncPointer thaws for both. AsyncPointer has no
-/// effect if the pointer is not frozen by the client, but the pointer need not be
-/// grabbed by the client.
+///   processing continues normally. If the pointer is frozen twice by the client on
+///   behalf of two separate grabs, AsyncPointer thaws for both. AsyncPointer has no
+///   effect if the pointer is not frozen by the client, but the pointer need not be
+///   grabbed by the client.
 ///
-/// TODO: rewrite this in more understandable terms.
+///   TODO: rewrite this in more understandable terms.
 /// * `SyncPointer` - For SyncPointer, if the pointer is frozen and actively grabbed by the client,
-/// pointer event processing continues normally until the next ButtonPress or
-/// ButtonRelease event is reported to the client, at which time the pointer again
-/// appears to freeze. However, if the reported event causes the pointer grab to be
-/// released, then the pointer does not freeze. SyncPointer has no effect if the
-/// pointer is not frozen by the client or if the pointer is not grabbed by the
-/// client.
+///   pointer event processing continues normally until the next ButtonPress or
+///   ButtonRelease event is reported to the client, at which time the pointer again
+///   appears to freeze. However, if the reported event causes the pointer grab to be
+///   released, then the pointer does not freeze. SyncPointer has no effect if the
+///   pointer is not frozen by the client or if the pointer is not grabbed by the
+///   client.
 /// * `ReplayPointer` - For ReplayPointer, if the pointer is actively grabbed by the client and is
-/// frozen as the result of an event having been sent to the client (either from
-/// the activation of a GrabButton or from a previous AllowEvents with mode
-/// SyncPointer but not from a GrabPointer), then the pointer grab is released and
-/// that event is completely reprocessed, this time ignoring any passive grabs at
-/// or above (towards the root) the grab-window of the grab just released. The
-/// request has no effect if the pointer is not grabbed by the client or if the
-/// pointer is not frozen as the result of an event.
+///   frozen as the result of an event having been sent to the client (either from
+///   the activation of a GrabButton or from a previous AllowEvents with mode
+///   SyncPointer but not from a GrabPointer), then the pointer grab is released and
+///   that event is completely reprocessed, this time ignoring any passive grabs at
+///   or above (towards the root) the grab-window of the grab just released. The
+///   request has no effect if the pointer is not grabbed by the client or if the
+///   pointer is not frozen as the result of an event.
 /// * `AsyncKeyboard` - For AsyncKeyboard, if the keyboard is frozen by the client, keyboard event
-/// processing continues normally. If the keyboard is frozen twice by the client on
-/// behalf of two separate grabs, AsyncKeyboard thaws for both. AsyncKeyboard has
-/// no effect if the keyboard is not frozen by the client, but the keyboard need
-/// not be grabbed by the client.
+///   processing continues normally. If the keyboard is frozen twice by the client on
+///   behalf of two separate grabs, AsyncKeyboard thaws for both. AsyncKeyboard has
+///   no effect if the keyboard is not frozen by the client, but the keyboard need
+///   not be grabbed by the client.
 /// * `SyncKeyboard` - For SyncKeyboard, if the keyboard is frozen and actively grabbed by the client,
-/// keyboard event processing continues normally until the next KeyPress or
-/// KeyRelease event is reported to the client, at which time the keyboard again
-/// appears to freeze. However, if the reported event causes the keyboard grab to
-/// be released, then the keyboard does not freeze. SyncKeyboard has no effect if
-/// the keyboard is not frozen by the client or if the keyboard is not grabbed by
-/// the client.
+///   keyboard event processing continues normally until the next KeyPress or
+///   KeyRelease event is reported to the client, at which time the keyboard again
+///   appears to freeze. However, if the reported event causes the keyboard grab to
+///   be released, then the keyboard does not freeze. SyncKeyboard has no effect if
+///   the keyboard is not frozen by the client or if the keyboard is not grabbed by
+///   the client.
 /// * `ReplayKeyboard` - For ReplayKeyboard, if the keyboard is actively grabbed by the client and is
-/// frozen as the result of an event having been sent to the client (either from
-/// the activation of a GrabKey or from a previous AllowEvents with mode
-/// SyncKeyboard but not from a GrabKeyboard), then the keyboard grab is released
-/// and that event is completely reprocessed, this time ignoring any passive grabs
-/// at or above (towards the root) the grab-window of the grab just released. The
-/// request has no effect if the keyboard is not grabbed by the client or if the
-/// keyboard is not frozen as the result of an event.
+///   frozen as the result of an event having been sent to the client (either from
+///   the activation of a GrabKey or from a previous AllowEvents with mode
+///   SyncKeyboard but not from a GrabKeyboard), then the keyboard grab is released
+///   and that event is completely reprocessed, this time ignoring any passive grabs
+///   at or above (towards the root) the grab-window of the grab just released. The
+///   request has no effect if the keyboard is not grabbed by the client or if the
+///   keyboard is not frozen as the result of an event.
 /// * `SyncBoth` - For SyncBoth, if both pointer and keyboard are frozen by the client, event
-/// processing (for both devices) continues normally until the next ButtonPress,
-/// ButtonRelease, KeyPress, or KeyRelease event is reported to the client for a
-/// grabbed device (button event for the pointer, key event for the keyboard), at
-/// which time the devices again appear to freeze. However, if the reported event
-/// causes the grab to be released, then the devices do not freeze (but if the
-/// other device is still grabbed, then a subsequent event for it will still cause
-/// both devices to freeze). SyncBoth has no effect unless both pointer and
-/// keyboard are frozen by the client. If the pointer or keyboard is frozen twice
-/// by the client on behalf of two separate grabs, SyncBoth thaws for both (but a
-/// subsequent freeze for SyncBoth will only freeze each device once).
+///   processing (for both devices) continues normally until the next ButtonPress,
+///   ButtonRelease, KeyPress, or KeyRelease event is reported to the client for a
+///   grabbed device (button event for the pointer, key event for the keyboard), at
+///   which time the devices again appear to freeze. However, if the reported event
+///   causes the grab to be released, then the devices do not freeze (but if the
+///   other device is still grabbed, then a subsequent event for it will still cause
+///   both devices to freeze). SyncBoth has no effect unless both pointer and
+///   keyboard are frozen by the client. If the pointer or keyboard is frozen twice
+///   by the client on behalf of two separate grabs, SyncBoth thaws for both (but a
+///   subsequent freeze for SyncBoth will only freeze each device once).
 /// * `AsyncBoth` - For AsyncBoth, if the pointer and the keyboard are frozen by the client, event
-/// processing for both devices continues normally. If a device is frozen twice by
-/// the client on behalf of two separate grabs, AsyncBoth thaws for both. AsyncBoth
-/// has no effect unless both pointer and keyboard are frozen by the client.
+///   processing for both devices continues normally. If a device is frozen twice by
+///   the client on behalf of two separate grabs, AsyncBoth thaws for both. AsyncBoth
+///   has no effect unless both pointer and keyboard are frozen by the client.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Allow(u8);
@@ -13195,8 +13195,8 @@ pub const ALLOW_EVENTS_REQUEST: u8 = 35;
 /// * `mode` -
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 ///
 /// # Errors
 ///
@@ -13372,7 +13372,7 @@ pub const QUERY_POINTER_REQUEST: u8 = 38;
 /// # Fields
 ///
 /// * `window` - A window to check if the pointer is on the same screen as `window` (see the
-/// `same_screen` field in the reply).
+///   `same_screen` field in the reply).
 ///
 /// # Errors
 ///
@@ -13438,22 +13438,22 @@ impl crate::x11_utils::ReplyRequest for QueryPointerRequest {
 /// # Fields
 ///
 /// * `same_screen` - If `same_screen` is False, then the pointer is not on the same screen as the
-/// argument window, `child` is None, and `win_x` and `win_y` are zero. If
-/// `same_screen` is True, then `win_x` and `win_y` are the pointer coordinates
-/// relative to the argument window's origin, and child is the child containing the
-/// pointer, if any.
+///   argument window, `child` is None, and `win_x` and `win_y` are zero. If
+///   `same_screen` is True, then `win_x` and `win_y` are the pointer coordinates
+///   relative to the argument window's origin, and child is the child containing the
+///   pointer, if any.
 /// * `root` - The root window the pointer is logically on.
 /// * `child` - The child window containing the pointer, if any, if `same_screen` is true. If
-/// `same_screen` is false, `XCB_NONE` is returned.
+///   `same_screen` is false, `XCB_NONE` is returned.
 /// * `root_x` - The pointer X position, relative to `root`.
 /// * `root_y` - The pointer Y position, relative to `root`.
 /// * `win_x` - The pointer X coordinate, relative to `child`, if `same_screen` is true. Zero
-/// otherwise.
+///   otherwise.
 /// * `win_y` - The pointer Y coordinate, relative to `child`, if `same_screen` is true. Zero
-/// otherwise.
+///   otherwise.
 /// * `mask` - The current logical state of the modifier keys and the buttons. Note that the
-/// logical state of a device (as seen by means of the protocol) may lag the
-/// physical state if device event processing is frozen.
+///   logical state of a device (as seen by means of the protocol) may lag the
+///   physical state if device event processing is frozen.
 #[derive(Clone, Copy, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -13916,13 +13916,13 @@ pub const WARP_POINTER_REQUEST: u8 = 41;
 /// # Fields
 ///
 /// * `src_window` - If `src_window` is not `XCB_NONE` (TODO), the move will only take place if the
-/// pointer is inside `src_window` and within the rectangle specified by (`src_x`,
-/// `src_y`, `src_width`, `src_height`). The rectangle coordinates are relative to
-/// `src_window`.
+///   pointer is inside `src_window` and within the rectangle specified by (`src_x`,
+///   `src_y`, `src_width`, `src_height`). The rectangle coordinates are relative to
+///   `src_window`.
 /// * `dst_window` - If `dst_window` is not `XCB_NONE` (TODO), the pointer will be moved to the
-/// offsets (`dst_x`, `dst_y`) relative to `dst_window`. If `dst_window` is
-/// `XCB_NONE` (TODO), the pointer will be moved by the offsets (`dst_x`, `dst_y`)
-/// relative to the current position of the pointer.
+///   offsets (`dst_x`, `dst_y`) relative to `dst_window`. If `dst_window` is
+///   `XCB_NONE` (TODO), the pointer will be moved by the offsets (`dst_x`, `dst_y`)
+///   relative to the current position of the pointer.
 ///
 /// # Errors
 ///
@@ -14036,10 +14036,10 @@ impl crate::x11_utils::VoidRequest for WarpPointerRequest {
 ///
 /// * `None` - The focus reverts to `XCB_NONE`, so no window will have the input focus.
 /// * `PointerRoot` - The focus reverts to `XCB_POINTER_ROOT` respectively. When the focus reverts,
-/// FocusIn and FocusOut events are generated, but the last-focus-change time is
-/// not changed.
+///   FocusIn and FocusOut events are generated, but the last-focus-change time is
+///   not changed.
 /// * `Parent` - The focus reverts to the parent (or closest viewable ancestor) and the new
-/// revert_to value is `XCB_INPUT_FOCUS_NONE`.
+///   revert_to value is `XCB_INPUT_FOCUS_NONE`.
 /// * `FollowKeyboard` - NOT YET DOCUMENTED. Only relevant for the xinput extension.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -14117,19 +14117,19 @@ pub const SET_INPUT_FOCUS_REQUEST: u8 = 42;
 /// # Fields
 ///
 /// * `focus` - The window to focus. All keyboard events will be reported to this window. The
-/// window must be viewable (TODO), or a `xcb_match_error_t` occurs (TODO).
+///   window must be viewable (TODO), or a `xcb_match_error_t` occurs (TODO).
 ///
-/// If `focus` is `XCB_NONE` (TODO), all keyboard events are
-/// discarded until a new focus window is set.
+///   If `focus` is `XCB_NONE` (TODO), all keyboard events are
+///   discarded until a new focus window is set.
 ///
-/// If `focus` is `XCB_POINTER_ROOT` (TODO), focus is on the root window of the
-/// screen on which the pointer is on currently.
+///   If `focus` is `XCB_POINTER_ROOT` (TODO), focus is on the root window of the
+///   screen on which the pointer is on currently.
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 /// * `revert_to` - Specifies what happens when the `focus` window becomes unviewable (if `focus`
-/// is neither `XCB_NONE` nor `XCB_POINTER_ROOT`).
+///   is neither `XCB_NONE` nor `XCB_POINTER_ROOT`).
 ///
 /// # Errors
 ///
@@ -15257,9 +15257,9 @@ pub const LIST_FONTS_REQUEST: u8 = 49;
 ///
 /// * `pattern` - A font pattern, for example "-misc-fixed-*".
 ///
-/// The asterisk (*) is a wildcard for any number of characters. The question mark
-/// (?) is a wildcard for a single character. Use of uppercase or lowercase does
-/// not matter.
+///   The asterisk (*) is a wildcard for any number of characters. The question mark
+///   (?) is a wildcard for a single character. Use of uppercase or lowercase does
+///   not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
@@ -15412,9 +15412,9 @@ pub const LIST_FONTS_WITH_INFO_REQUEST: u8 = 50;
 ///
 /// * `pattern` - A font pattern, for example "-misc-fixed-*".
 ///
-/// The asterisk (*) is a wildcard for any number of characters. The question mark
-/// (?) is a wildcard for a single character. Use of uppercase or lowercase does
-/// not matter.
+///   The asterisk (*) is a wildcard for any number of characters. The question mark
+///   (?) is a wildcard for a single character. Use of uppercase or lowercase does
+///   not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
@@ -15501,8 +15501,8 @@ impl<'input> crate::x11_utils::ReplyRequest for ListFontsWithInfoRequest<'input>
 /// * `font_ascent` - baseline to top edge of raster
 /// * `font_descent` - baseline to bottom edge of raster
 /// * `replies_hint` - An indication of how many more fonts will be returned. This is only a hint and
-/// may be larger or smaller than the number of fonts actually returned. A zero
-/// value does not guarantee that no more fonts will be returned.
+///   may be larger or smaller than the number of fonts actually returned. A zero
+///   value does not guarantee that no more fonts will be returned.
 /// * `draw_direction` -
 #[derive(Clone, Default)]
 #[cfg_attr(feature = "extra-traits", derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash))]
@@ -15825,7 +15825,7 @@ pub const CREATE_PIXMAP_REQUEST: u8 = 53;
 ///
 /// * `depth` - TODO
 /// * `pid` - The ID with which you will refer to the new pixmap, created by
-/// `xcb_generate_id`.
+///   `xcb_generate_id`.
 /// * `drawable` - Drawable to get the screen from.
 /// * `width` - The width of the new pixmap.
 /// * `height` - The height of the new pixmap.
@@ -15994,101 +15994,101 @@ impl crate::x11_utils::VoidRequest for FreePixmapRequest {
 ///
 /// * `Function` - TODO: Refer to GX
 /// * `PlaneMask` - In graphics operations, given a source and destination pixel, the result is
-/// computed bitwise on corresponding bits of the pixels; that is, a Boolean
-/// operation is performed in each bit plane. The plane-mask restricts the
-/// operation to a subset of planes, so the result is:
+///   computed bitwise on corresponding bits of the pixels; that is, a Boolean
+///   operation is performed in each bit plane. The plane-mask restricts the
+///   operation to a subset of planes, so the result is:
 ///
-/// ((src FUNC dst) AND plane-mask) OR (dst AND (NOT plane-mask))
+///   ((src FUNC dst) AND plane-mask) OR (dst AND (NOT plane-mask))
 /// * `Foreground` - Foreground colorpixel.
 /// * `Background` - Background colorpixel.
 /// * `LineWidth` - The line-width is measured in pixels and can be greater than or equal to one, a wide line, or the
-/// special value zero, a thin line.
+///   special value zero, a thin line.
 /// * `LineStyle` - The line-style defines which sections of a line are drawn:
-/// Solid                The full path of the line is drawn.
-/// DoubleDash           The full path of the line is drawn, but the even dashes are filled differently
-/// than the odd dashes (see fill-style), with Butt cap-style used where even and
-/// odd dashes meet.
-/// OnOffDash            Only the even dashes are drawn, and cap-style applies to all internal ends of
-/// the individual dashes (except NotLast is treated as Butt).
+///   Solid                The full path of the line is drawn.
+///   DoubleDash           The full path of the line is drawn, but the even dashes are filled differently
+///   than the odd dashes (see fill-style), with Butt cap-style used where even and
+///   odd dashes meet.
+///   OnOffDash            Only the even dashes are drawn, and cap-style applies to all internal ends of
+///   the individual dashes (except NotLast is treated as Butt).
 /// * `CapStyle` - The cap-style defines how the endpoints of a path are drawn:
-/// NotLast    The result is equivalent to Butt, except that for a line-width of zero the final
-/// endpoint is not drawn.
-/// Butt       The result is square at the endpoint (perpendicular to the slope of the line)
-/// with no projection beyond.
-/// Round      The result is a circular arc with its diameter equal to the line-width, centered
-/// on the endpoint; it is equivalent to Butt for line-width zero.
-/// Projecting The result is square at the end, but the path continues beyond the endpoint for
-/// a distance equal to half the line-width; it is equivalent to Butt for line-width
-/// zero.
+///   NotLast    The result is equivalent to Butt, except that for a line-width of zero the final
+///   endpoint is not drawn.
+///   Butt       The result is square at the endpoint (perpendicular to the slope of the line)
+///   with no projection beyond.
+///   Round      The result is a circular arc with its diameter equal to the line-width, centered
+///   on the endpoint; it is equivalent to Butt for line-width zero.
+///   Projecting The result is square at the end, but the path continues beyond the endpoint for
+///   a distance equal to half the line-width; it is equivalent to Butt for line-width
+///   zero.
 /// * `JoinStyle` - The join-style defines how corners are drawn for wide lines:
-/// Miter               The outer edges of the two lines extend to meet at an angle. However, if the
-/// angle is less than 11 degrees, a Bevel join-style is used instead.
-/// Round               The result is a circular arc with a diameter equal to the line-width, centered
-/// on the joinpoint.
-/// Bevel               The result is Butt endpoint styles, and then the triangular notch is filled.
+///   Miter               The outer edges of the two lines extend to meet at an angle. However, if the
+///   angle is less than 11 degrees, a Bevel join-style is used instead.
+///   Round               The result is a circular arc with a diameter equal to the line-width, centered
+///   on the joinpoint.
+///   Bevel               The result is Butt endpoint styles, and then the triangular notch is filled.
 /// * `FillStyle` - The fill-style defines the contents of the source for line, text, and fill requests. For all text and fill
-/// requests (for example, PolyText8, PolyText16, PolyFillRectangle, FillPoly, and PolyFillArc)
-/// as well as for line requests with line-style Solid, (for example, PolyLine, PolySegment,
-/// PolyRectangle, PolyArc) and for the even dashes for line requests with line-style OnOffDash
-/// or DoubleDash:
-/// Solid                     Foreground
-/// Tiled                     Tile
-/// OpaqueStippled            A tile with the same width and height as stipple but with background
-/// everywhere stipple has a zero and with foreground everywhere stipple
-/// has a one
-/// Stippled                  Foreground masked by stipple
-/// For the odd dashes for line requests with line-style DoubleDash:
-/// Solid                     Background
-/// Tiled                     Same as for even dashes
-/// OpaqueStippled            Same as for even dashes
-/// Stippled                  Background masked by stipple
+///   requests (for example, PolyText8, PolyText16, PolyFillRectangle, FillPoly, and PolyFillArc)
+///   as well as for line requests with line-style Solid, (for example, PolyLine, PolySegment,
+///   PolyRectangle, PolyArc) and for the even dashes for line requests with line-style OnOffDash
+///   or DoubleDash:
+///   Solid                     Foreground
+///   Tiled                     Tile
+///   OpaqueStippled            A tile with the same width and height as stipple but with background
+///   everywhere stipple has a zero and with foreground everywhere stipple
+///   has a one
+///   Stippled                  Foreground masked by stipple
+///   For the odd dashes for line requests with line-style DoubleDash:
+///   Solid                     Background
+///   Tiled                     Same as for even dashes
+///   OpaqueStippled            Same as for even dashes
+///   Stippled                  Background masked by stipple
 /// * `FillRule` -
 /// * `Tile` - The tile/stipple represents an infinite two-dimensional plane with the tile/stipple replicated in all
-/// dimensions. When that plane is superimposed on the drawable for use in a graphics operation,
-/// the upper-left corner of some instance of the tile/stipple is at the coordinates within the drawable
-/// specified by the tile/stipple origin. The tile/stipple and clip origins are interpreted relative to the
-/// origin of whatever destination drawable is specified in a graphics request.
-/// The tile pixmap must have the same root and depth as the gcontext (or a Match error results).
-/// The stipple pixmap must have depth one and must have the same root as the gcontext (or a
-/// Match error results). For fill-style Stippled (but not fill-style
-/// OpaqueStippled), the stipple pattern is tiled in a single plane and acts as an
-/// additional clip mask to be ANDed with the clip-mask.
-/// Any size pixmap can be used for tiling or stippling, although some sizes may be faster to use than
-/// others.
+///   dimensions. When that plane is superimposed on the drawable for use in a graphics operation,
+///   the upper-left corner of some instance of the tile/stipple is at the coordinates within the drawable
+///   specified by the tile/stipple origin. The tile/stipple and clip origins are interpreted relative to the
+///   origin of whatever destination drawable is specified in a graphics request.
+///   The tile pixmap must have the same root and depth as the gcontext (or a Match error results).
+///   The stipple pixmap must have depth one and must have the same root as the gcontext (or a
+///   Match error results). For fill-style Stippled (but not fill-style
+///   OpaqueStippled), the stipple pattern is tiled in a single plane and acts as an
+///   additional clip mask to be ANDed with the clip-mask.
+///   Any size pixmap can be used for tiling or stippling, although some sizes may be faster to use than
+///   others.
 /// * `Stipple` - The tile/stipple represents an infinite two-dimensional plane with the tile/stipple replicated in all
-/// dimensions. When that plane is superimposed on the drawable for use in a graphics operation,
-/// the upper-left corner of some instance of the tile/stipple is at the coordinates within the drawable
-/// specified by the tile/stipple origin. The tile/stipple and clip origins are interpreted relative to the
-/// origin of whatever destination drawable is specified in a graphics request.
-/// The tile pixmap must have the same root and depth as the gcontext (or a Match error results).
-/// The stipple pixmap must have depth one and must have the same root as the gcontext (or a
-/// Match error results). For fill-style Stippled (but not fill-style
-/// OpaqueStippled), the stipple pattern is tiled in a single plane and acts as an
-/// additional clip mask to be ANDed with the clip-mask.
-/// Any size pixmap can be used for tiling or stippling, although some sizes may be faster to use than
-/// others.
+///   dimensions. When that plane is superimposed on the drawable for use in a graphics operation,
+///   the upper-left corner of some instance of the tile/stipple is at the coordinates within the drawable
+///   specified by the tile/stipple origin. The tile/stipple and clip origins are interpreted relative to the
+///   origin of whatever destination drawable is specified in a graphics request.
+///   The tile pixmap must have the same root and depth as the gcontext (or a Match error results).
+///   The stipple pixmap must have depth one and must have the same root as the gcontext (or a
+///   Match error results). For fill-style Stippled (but not fill-style
+///   OpaqueStippled), the stipple pattern is tiled in a single plane and acts as an
+///   additional clip mask to be ANDed with the clip-mask.
+///   Any size pixmap can be used for tiling or stippling, although some sizes may be faster to use than
+///   others.
 /// * `TileStippleOriginX` - TODO
 /// * `TileStippleOriginY` - TODO
 /// * `Font` - Which font to use for the `ImageText8` and `ImageText16` requests.
 /// * `SubwindowMode` - For ClipByChildren, both source and destination windows are additionally
-/// clipped by all viewable InputOutput children. For IncludeInferiors, neither
-/// source nor destination window is
-/// clipped by inferiors. This will result in including subwindow contents in the source and drawing
-/// through subwindow boundaries of the destination. The use of IncludeInferiors with a source or
-/// destination window of one depth with mapped inferiors of differing depth is not illegal, but the
-/// semantics is undefined by the core protocol.
+///   clipped by all viewable InputOutput children. For IncludeInferiors, neither
+///   source nor destination window is
+///   clipped by inferiors. This will result in including subwindow contents in the source and drawing
+///   through subwindow boundaries of the destination. The use of IncludeInferiors with a source or
+///   destination window of one depth with mapped inferiors of differing depth is not illegal, but the
+///   semantics is undefined by the core protocol.
 /// * `GraphicsExposures` - Whether ExposureEvents should be generated (1) or not (0).
 ///
-/// The default is 1.
+///   The default is 1.
 /// * `ClipOriginX` - TODO
 /// * `ClipOriginY` - TODO
 /// * `ClipMask` - The clip-mask restricts writes to the destination drawable. Only pixels where the clip-mask has
-/// bits set to 1 are drawn. Pixels are not drawn outside the area covered by the clip-mask or where
-/// the clip-mask has bits set to 0. The clip-mask affects all graphics requests, but it does not clip
-/// sources. The clip-mask origin is interpreted relative to the origin of whatever destination drawable is specified in a graphics request. If a pixmap is specified as the clip-mask, it must have
-/// depth 1 and have the same root as the gcontext (or a Match error results). If clip-mask is None,
-/// then pixels are always drawn, regardless of the clip origin. The clip-mask can also be set with the
-/// SetClipRectangles request.
+///   bits set to 1 are drawn. Pixels are not drawn outside the area covered by the clip-mask or where
+///   the clip-mask has bits set to 0. The clip-mask affects all graphics requests, but it does not clip
+///   sources. The clip-mask origin is interpreted relative to the origin of whatever destination drawable is specified in a graphics request. If a pixmap is specified as the clip-mask, it must have
+///   depth 1 and have the same root as the gcontext (or a Match error results). If clip-mask is None,
+///   then pixels are always drawn, regardless of the clip origin. The clip-mask can also be set with the
+///   SetClipRectangles request.
 /// * `DashOffset` - TODO
 /// * `DashList` - TODO
 /// * `ArcMode` - TODO
@@ -17139,7 +17139,7 @@ pub const CREATE_GC_REQUEST: u8 = 55;
 /// # Fields
 ///
 /// * `cid` - The ID with which you will refer to the graphics context, created by
-/// `xcb_generate_id`.
+///   `xcb_generate_id`.
 /// * `drawable` - Drawable to get the root/depth from.
 ///
 /// # Errors
@@ -17782,8 +17782,8 @@ pub const CHANGE_GC_REQUEST: u8 = 56;
 ///
 /// * `gc` - The graphics context to change.
 /// * `value_list` - Values for each of the components specified in the bitmask `value_mask`. The
-/// order has to correspond to the order of possible `value_mask` bits. See the
-/// example.
+///   order has to correspond to the order of possible `value_mask` bits. See the
+///   example.
 ///
 /// # Errors
 ///
@@ -18981,7 +18981,7 @@ pub const POLY_SEGMENT_REQUEST: u8 = 66;
 /// * `drawable` - A drawable (Window or Pixmap) to draw on.
 /// * `gc` - The graphics context to use.
 ///
-/// TODO: document which attributes of a gc are used
+///   TODO: document which attributes of a gc are used
 /// * `segments_len` - The number of `xcb_segment_t` structures in `segments`.
 /// * `segments` - An array of `xcb_segment_t` structures.
 ///
@@ -19435,12 +19435,12 @@ pub const POLY_FILL_RECTANGLE_REQUEST: u8 = 70;
 /// * `drawable` - The drawable (Window or Pixmap) to draw on.
 /// * `gc` - The graphics context to use.
 ///
-/// The following graphics context components are used: function, plane-mask,
-/// fill-style, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+///   The following graphics context components are used: function, plane-mask,
+///   fill-style, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
 ///
-/// The following graphics context mode-dependent components are used:
-/// foreground, background, tile, stipple, tile-stipple-x-origin, and
-/// tile-stipple-y-origin.
+///   The following graphics context mode-dependent components are used:
+///   foreground, background, tile, stipple, tile-stipple-x-origin, and
+///   tile-stipple-y-origin.
 /// * `rectangles_len` - The number of `xcb_rectangle_t` structures in `rectangles`.
 /// * `rectangles` - The rectangles to fill.
 ///
@@ -20187,13 +20187,13 @@ pub const IMAGE_TEXT8_REQUEST: u8 = 76;
 ///
 /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
 /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
-/// type of `string_len`.
+///   type of `string_len`.
 /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
 /// * `y` - The y coordinate of the first character, relative to the origin of `drawable`.
 /// * `gc` - The graphics context to use.
 ///
-/// The following graphics context components are used: plane-mask, foreground,
-/// background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+///   The following graphics context components are used: plane-mask, foreground,
+///   background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
 ///
 /// # Errors
 ///
@@ -20316,14 +20316,14 @@ pub const IMAGE_TEXT16_REQUEST: u8 = 77;
 ///
 /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
 /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
-/// type of `string_len`. Every character uses 2 bytes (hence the 16 in this
-/// request's name).
+///   type of `string_len`. Every character uses 2 bytes (hence the 16 in this
+///   request's name).
 /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
 /// * `y` - The y coordinate of the first character, relative to the origin of `drawable`.
 /// * `gc` - The graphics context to use.
 ///
-/// The following graphics context components are used: plane-mask, foreground,
-/// background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+///   The following graphics context components are used: plane-mask, foreground,
+///   background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
 ///
 /// # Errors
 ///
@@ -22618,8 +22618,8 @@ pub const CREATE_GLYPH_CURSOR_REQUEST: u8 = 94;
 /// * `mask_font` - In which font to look for the mask glyph.
 /// * `source_char` - The glyph of `source_font` to use.
 /// * `mask_char` - The glyph of `mask_font` to use as a mask: Pixels which are set to 1 define
-/// which source pixels are displayed. All pixels which are set to 0 are not
-/// displayed.
+///   which source pixels are displayed. All pixels which are set to 0 are not
+///   displayed.
 /// * `fore_red` - The red value of the foreground color.
 /// * `fore_green` - The green value of the foreground color.
 /// * `fore_blue` - The blue value of the foreground color.
@@ -23137,7 +23137,7 @@ pub const QUERY_EXTENSION_REQUEST: u8 = 98;
 /// # Fields
 ///
 /// * `name` - The name of the extension to query, for example "RANDR". This is case
-/// sensitive!
+///   sensitive!
 ///
 /// # See
 ///
@@ -25526,10 +25526,10 @@ pub const KILL_CLIENT_REQUEST: u8 = 113;
 /// # Fields
 ///
 /// * `resource` - Any resource belonging to the client (for example a Window), used to identify
-/// the client connection.
+///   the client connection.
 ///
-/// The special value of `XCB_KILL_ALL_TEMPORARY`, the resources of all clients
-/// that have terminated in `RetainTemporary` (TODO) are destroyed.
+///   The special value of `XCB_KILL_ALL_TEMPORARY`, the resources of all clients
+///   that have terminated in `RetainTemporary` (TODO) are destroyed.
 ///
 /// # Errors
 ///

--- a/x11rb/examples/list_fonts.rs
+++ b/x11rb/examples/list_fonts.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (conn, _) = connect(None)?;
 
     println!("DIR  MIN  MAX EXIST DFLT PROP ASC DESC NAME");
-    for reply in conn.list_fonts_with_info(u16::max_value(), b"*")? {
+    for reply in conn.list_fonts_with_info(u16::MAX, b"*")? {
         let reply = reply?;
 
         let dir = if reply.draw_direction == FontDraw::LEFT_TO_RIGHT {

--- a/x11rb/examples/simple_window_manager.rs
+++ b/x11rb/examples/simple_window_manager.rs
@@ -209,7 +209,7 @@ impl<'a, C: Connection> WmState<'a, C> {
                 AtomEnum::WM_NAME,
                 AtomEnum::STRING,
                 0,
-                std::u32::MAX,
+                u32::MAX,
             )?
             .reply()?;
         self.conn
@@ -254,7 +254,7 @@ impl<'a, C: Connection> WmState<'a, C> {
                 // "to_ignore <= seqno". This is equivalent to "to_ignore - seqno <= 0", which is what we
                 // check instead. Since sequence numbers are unsigned, we need a trick: We decide
                 // that values from [MAX/2, MAX] count as "<= 0" and the rest doesn't.
-                if to_ignore.wrapping_sub(seqno) <= u16::max_value() / 2 {
+                if to_ignore.wrapping_sub(seqno) <= u16::MAX / 2 {
                     // If the two sequence numbers are equal, this event should be ignored.
                     should_ignore = to_ignore == seqno;
                     break;

--- a/x11rb/src/cursor/mod.rs
+++ b/x11rb/src/cursor/mod.rs
@@ -207,9 +207,9 @@ fn create_core_cursor<C: Connection>(
         0,
         0,
         // background color
-        u16::max_value(),
-        u16::max_value(),
-        u16::max_value(),
+        u16::MAX,
+        u16::MAX,
+        u16::MAX,
     )?;
     Ok(result)
 }

--- a/x11rb/src/image.rs
+++ b/x11rb/src/image.rs
@@ -752,7 +752,7 @@ impl<'a> Image<'a> {
         let mut result = Vec::with_capacity(
             (usize::from(self.height()) + lines_per_request - 1) / lines_per_request,
         );
-        let lines_per_request = lines_per_request.try_into().unwrap_or(u16::max_value());
+        let lines_per_request = lines_per_request.try_into().unwrap_or(u16::MAX);
         assert!(lines_per_request > 0);
 
         let (mut y_offset, mut byte_offset) = (0, 0);

--- a/x11rb/src/protocol/composite.rs
+++ b/x11rb/src/protocol/composite.rs
@@ -72,8 +72,8 @@ where
 ///
 /// * `window` - The root of the hierarchy to redirect to off-screen storage.
 /// * `update` - Whether contents are automatically mirrored to the parent window.  If one client
-/// already specifies an update type of Manual, any attempt by another to specify a
-/// mode of Manual so will result in an Access error.
+///   already specifies an update type of Manual, any attempt by another to specify a
+///   mode of Manual so will result in an Access error.
 pub fn redirect_window<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -99,8 +99,8 @@ where
 ///
 /// * `window` - The root of the hierarchy to redirect to off-screen storage.
 /// * `update` - Whether contents are automatically mirrored to the parent window.  If one client
-/// already specifies an update type of Manual, any attempt by another to specify a
-/// mode of Manual so will result in an Access error.
+///   already specifies an update type of Manual, any attempt by another to specify a
+///   mode of Manual so will result in an Access error.
 pub fn redirect_subwindows<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -123,9 +123,9 @@ where
 /// # Fields
 ///
 /// * `window` - The window to terminate redirection of.  Must be redirected by the
-/// current client, or a Value error results.
+///   current client, or a Value error results.
 /// * `update` - The update type passed to RedirectWindows.  If this does not match the
-/// previously requested update type, a Value error results.
+///   previously requested update type, a Value error results.
 pub fn unredirect_window<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -147,10 +147,10 @@ where
 /// # Fields
 ///
 /// * `window` - The window to terminate redirection of.  Must have previously been
-/// selected for sub-redirection by the current client, or a Value error
-/// results.
+///   selected for sub-redirection by the current client, or a Value error
+///   results.
 /// * `update` - The update type passed to RedirectSubWindows.  If this does not match
-/// the previously requested update type, a Value error results.
+///   the previously requested update type, a Value error results.
 pub fn unredirect_subwindows<Conn>(conn: &Conn, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
     Conn: RequestConnection + ?Sized,
@@ -247,8 +247,8 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `window` - The root of the hierarchy to redirect to off-screen storage.
     /// * `update` - Whether contents are automatically mirrored to the parent window.  If one client
-    /// already specifies an update type of Manual, any attempt by another to specify a
-    /// mode of Manual so will result in an Access error.
+    ///   already specifies an update type of Manual, any attempt by another to specify a
+    ///   mode of Manual so will result in an Access error.
     fn composite_redirect_window(&self, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         redirect_window(self, window, update)
@@ -264,8 +264,8 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `window` - The root of the hierarchy to redirect to off-screen storage.
     /// * `update` - Whether contents are automatically mirrored to the parent window.  If one client
-    /// already specifies an update type of Manual, any attempt by another to specify a
-    /// mode of Manual so will result in an Access error.
+    ///   already specifies an update type of Manual, any attempt by another to specify a
+    ///   mode of Manual so will result in an Access error.
     fn composite_redirect_subwindows(&self, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         redirect_subwindows(self, window, update)
@@ -278,9 +278,9 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `window` - The window to terminate redirection of.  Must be redirected by the
-    /// current client, or a Value error results.
+    ///   current client, or a Value error results.
     /// * `update` - The update type passed to RedirectWindows.  If this does not match the
-    /// previously requested update type, a Value error results.
+    ///   previously requested update type, a Value error results.
     fn composite_unredirect_window(&self, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         unredirect_window(self, window, update)
@@ -292,10 +292,10 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `window` - The window to terminate redirection of.  Must have previously been
-    /// selected for sub-redirection by the current client, or a Value error
-    /// results.
+    ///   selected for sub-redirection by the current client, or a Value error
+    ///   results.
     /// * `update` - The update type passed to RedirectSubWindows.  If this does not match
-    /// the previously requested update type, a Value error results.
+    ///   the previously requested update type, a Value error results.
     fn composite_unredirect_subwindows(&self, window: xproto::Window, update: Redirect) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {
         unredirect_subwindows(self, window, update)

--- a/x11rb/src/protocol/damage.rs
+++ b/x11rb/src/protocol/damage.rs
@@ -90,7 +90,7 @@ where
 /// # Fields
 ///
 /// * `damage` - The ID with which you will refer to the new Damage object, created by
-/// `xcb_generate_id`.
+///   `xcb_generate_id`.
 /// * `drawable` - The ID of the drawable to be monitored.
 /// * `level` - The level of detail to be provided in Damage events.
 pub fn create<Conn>(conn: &Conn, damage: Damage, drawable: xproto::Drawable, level: ReportLevel) -> Result<VoidCookie<'_, Conn>, ConnectionError>
@@ -226,7 +226,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `damage` - The ID with which you will refer to the new Damage object, created by
-    /// `xcb_generate_id`.
+    ///   `xcb_generate_id`.
     /// * `drawable` - The ID of the drawable to be monitored.
     /// * `level` - The level of detail to be provided in Damage events.
     fn damage_create(&self, damage: Damage, drawable: xproto::Drawable, level: ReportLevel) -> Result<VoidCookie<'_, Self>, ConnectionError>

--- a/x11rb/src/protocol/shm.rs
+++ b/x11rb/src/protocol/shm.rs
@@ -113,21 +113,21 @@ where
 /// * `src_x` - The source X coordinate of the sub-image to copy.
 /// * `src_y` - The source Y coordinate of the sub-image to copy.
 /// * `src_width` - The width, in source image coordinates, of the data to copy from the source.
-/// The X server will use this to determine the amount of data to copy.  The amount
-/// of the destination image that is overwritten is determined automatically.
+///   The X server will use this to determine the amount of data to copy.  The amount
+///   of the destination image that is overwritten is determined automatically.
 /// * `src_height` - The height, in source image coordinates, of the data to copy from the source.
-/// The X server will use this to determine the amount of data to copy.  The amount
-/// of the destination image that is overwritten is determined automatically.
+///   The X server will use this to determine the amount of data to copy.  The amount
+///   of the destination image that is overwritten is determined automatically.
 /// * `dst_x` - The X coordinate on the destination drawable to copy to.
 /// * `dst_y` - The Y coordinate on the destination drawable to copy to.
 /// * `depth` - The depth to use.
 /// * `format` - The format of the image being drawn.  If it is XYBitmap, depth must be 1, or a
-/// "BadMatch" error results.  The foreground pixel in the GC determines the source
-/// for the one bits in the image, and the background pixel determines the source
-/// for the zero bits.  For XYPixmap and ZPixmap, the depth must match the depth of
-/// the drawable, or a "BadMatch" error results.
+///   "BadMatch" error results.  The foreground pixel in the GC determines the source
+///   for the one bits in the image, and the background pixel determines the source
+///   for the zero bits.  For XYPixmap and ZPixmap, the depth must match the depth of
+///   the drawable, or a "BadMatch" error results.
 /// * `send_event` - True if the server should send an XCB_SHM_COMPLETION event when the blit
-/// completes.
+///   completes.
 /// * `offset` - The offset that the source image starts at.
 pub fn put_image<Conn>(conn: &Conn, drawable: xproto::Drawable, gc: xproto::Gcontext, total_width: u16, total_height: u16, src_x: u16, src_y: u16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16, depth: u8, format: u8, send_event: bool, shmseg: Seg, offset: u32) -> Result<VoidCookie<'_, Conn>, ConnectionError>
 where
@@ -335,21 +335,21 @@ pub trait ConnectionExt: RequestConnection {
     /// * `src_x` - The source X coordinate of the sub-image to copy.
     /// * `src_y` - The source Y coordinate of the sub-image to copy.
     /// * `src_width` - The width, in source image coordinates, of the data to copy from the source.
-    /// The X server will use this to determine the amount of data to copy.  The amount
-    /// of the destination image that is overwritten is determined automatically.
+    ///   The X server will use this to determine the amount of data to copy.  The amount
+    ///   of the destination image that is overwritten is determined automatically.
     /// * `src_height` - The height, in source image coordinates, of the data to copy from the source.
-    /// The X server will use this to determine the amount of data to copy.  The amount
-    /// of the destination image that is overwritten is determined automatically.
+    ///   The X server will use this to determine the amount of data to copy.  The amount
+    ///   of the destination image that is overwritten is determined automatically.
     /// * `dst_x` - The X coordinate on the destination drawable to copy to.
     /// * `dst_y` - The Y coordinate on the destination drawable to copy to.
     /// * `depth` - The depth to use.
     /// * `format` - The format of the image being drawn.  If it is XYBitmap, depth must be 1, or a
-    /// "BadMatch" error results.  The foreground pixel in the GC determines the source
-    /// for the one bits in the image, and the background pixel determines the source
-    /// for the zero bits.  For XYPixmap and ZPixmap, the depth must match the depth of
-    /// the drawable, or a "BadMatch" error results.
+    ///   "BadMatch" error results.  The foreground pixel in the GC determines the source
+    ///   for the one bits in the image, and the background pixel determines the source
+    ///   for the zero bits.  For XYPixmap and ZPixmap, the depth must match the depth of
+    ///   the drawable, or a "BadMatch" error results.
     /// * `send_event` - True if the server should send an XCB_SHM_COMPLETION event when the blit
-    /// completes.
+    ///   completes.
     /// * `offset` - The offset that the source image starts at.
     fn shm_put_image(&self, drawable: xproto::Drawable, gc: xproto::Gcontext, total_width: u16, total_height: u16, src_x: u16, src_y: u16, src_width: u16, src_height: u16, dst_x: i16, dst_y: i16, depth: u8, format: u8, send_event: bool, shmseg: Seg, offset: u32) -> Result<VoidCookie<'_, Self>, ConnectionError>
     {

--- a/x11rb/src/protocol/xproto.rs
+++ b/x11rb/src/protocol/xproto.rs
@@ -231,7 +231,7 @@ where
 /// # Errors
 ///
 /// * `Match` - You created the specified window. This does not make sense, you can only add
-/// windows created by other clients to your save set.
+///   windows created by other clients to your save set.
 /// * `Value` - You specified an invalid mode.
 /// * `Window` - The specified window does not exist.
 ///
@@ -271,12 +271,12 @@ where
 /// # Errors
 ///
 /// * `Match` - The new parent window is not on the same screen as the old parent window.
-/// 
-/// The new parent window is the specified window or an inferior of the specified window.
-/// 
-/// The new parent is InputOnly and the window is not.
-/// 
-/// The specified window has a ParentRelative background and the new parent window is not the same depth as the specified window.
+///   
+///   The new parent window is the specified window or an inferior of the specified window.
+///   
+///   The new parent is InputOnly and the window is not.
+///   
+///   The specified window has a ParentRelative background and the new parent window is not the same depth as the specified window.
 /// * `Window` - The specified window does not exist.
 ///
 /// # See
@@ -422,7 +422,7 @@ where
 /// # Errors
 ///
 /// * `Match` - You specified a Sibling without also specifying StackMode or the window is not
-/// actually a Sibling.
+///   actually a Sibling.
 /// * `Window` - The specified window does not exist. TODO: any other reason?
 /// * `Value` - TODO: reasons?
 ///
@@ -792,8 +792,8 @@ where
 /// * `Window` - The specified `window` does not exist.
 /// * `Atom` - `property` or `type` do not refer to a valid atom.
 /// * `Value` - The specified `long_offset` is beyond the actual property length (e.g. the
-/// property has a length of 3 bytes and you are setting `long_offset` to 1,
-/// resulting in a byte offset of 4).
+///   property has a length of 3 bytes and you are setting `long_offset` to 1,
+///   resulting in a byte offset of 4).
 ///
 /// # See
 ///
@@ -1255,7 +1255,7 @@ where
 /// # Errors
 ///
 /// * `Access` - Another client has already issued a GrabButton with the same button/key
-/// combination on the same window.
+///   combination on the same window.
 /// * `Value` - TODO: reasons?
 /// * `Cursor` - The specified `cursor` does not exist.
 /// * `Window` - The specified `window` does not exist.
@@ -1465,9 +1465,9 @@ where
 /// # Errors
 ///
 /// * `Access` - Another client has already issued a GrabKey with the same button/key
-/// combination on the same window.
+///   combination on the same window.
 /// * `Value` - The key is not `XCB_GRAB_ANY` and not in the range specified by `min_keycode`
-/// and `max_keycode` in the connection setup.
+///   and `max_keycode` in the connection setup.
 /// * `Window` - The specified `window` does not exist.
 ///
 /// # See
@@ -3551,7 +3551,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Match` - You created the specified window. This does not make sense, you can only add
-    /// windows created by other clients to your save set.
+    ///   windows created by other clients to your save set.
     /// * `Value` - You specified an invalid mode.
     /// * `Window` - The specified window does not exist.
     ///
@@ -3581,12 +3581,12 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Match` - The new parent window is not on the same screen as the old parent window.
-    /// 
-    /// The new parent window is the specified window or an inferior of the specified window.
-    /// 
-    /// The new parent is InputOnly and the window is not.
-    /// 
-    /// The specified window has a ParentRelative background and the new parent window is not the same depth as the specified window.
+    ///   
+    ///   The new parent window is the specified window or an inferior of the specified window.
+    ///   
+    ///   The new parent is InputOnly and the window is not.
+    ///   
+    ///   The specified window has a ParentRelative background and the new parent window is not the same depth as the specified window.
     /// * `Window` - The specified window does not exist.
     ///
     /// # See
@@ -3684,7 +3684,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Match` - You specified a Sibling without also specifying StackMode or the window is not
-    /// actually a Sibling.
+    ///   actually a Sibling.
     /// * `Window` - The specified window does not exist. TODO: any other reason?
     /// * `Value` - TODO: reasons?
     ///
@@ -3971,8 +3971,8 @@ pub trait ConnectionExt: RequestConnection {
     /// * `Window` - The specified `window` does not exist.
     /// * `Atom` - `property` or `type` do not refer to a valid atom.
     /// * `Value` - The specified `long_offset` is beyond the actual property length (e.g. the
-    /// property has a length of 3 bytes and you are setting `long_offset` to 1,
-    /// resulting in a byte offset of 4).
+    ///   property has a length of 3 bytes and you are setting `long_offset` to 1,
+    ///   resulting in a byte offset of 4).
     ///
     /// # See
     ///
@@ -4335,7 +4335,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Access` - Another client has already issued a GrabButton with the same button/key
-    /// combination on the same window.
+    ///   combination on the same window.
     /// * `Value` - TODO: reasons?
     /// * `Cursor` - The specified `cursor` does not exist.
     /// * `Window` - The specified `window` does not exist.
@@ -4482,9 +4482,9 @@ pub trait ConnectionExt: RequestConnection {
     /// # Errors
     ///
     /// * `Access` - Another client has already issued a GrabKey with the same button/key
-    /// combination on the same window.
+    ///   combination on the same window.
     /// * `Value` - The key is not `XCB_GRAB_ANY` and not in the range specified by `min_keycode`
-    /// and `max_keycode` in the connection setup.
+    ///   and `max_keycode` in the connection setup.
     /// * `Window` - The specified `window` does not exist.
     ///
     /// # See

--- a/x11rb/src/protocol/xproto.rs
+++ b/x11rb/src/protocol/xproto.rs
@@ -51,20 +51,20 @@ pub use x11rb_protocol::protocol::xproto::*;
 /// # Fields
 ///
 /// * `wid` - The ID with which you will refer to the new window, created by
-/// `xcb_generate_id`.
+///   `xcb_generate_id`.
 /// * `depth` - Specifies the new window's depth (TODO: what unit?).
 ///
-/// The special value `XCB_COPY_FROM_PARENT` means the depth is taken from the
-/// `parent` window.
+///   The special value `XCB_COPY_FROM_PARENT` means the depth is taken from the
+///   `parent` window.
 /// * `visual` - Specifies the id for the new window's visual.
 ///
-/// The special value `XCB_COPY_FROM_PARENT` means the visual is taken from the
-/// `parent` window.
+///   The special value `XCB_COPY_FROM_PARENT` means the visual is taken from the
+///   `parent` window.
 /// * `class` -
 /// * `parent` - The parent window of the new window.
 /// * `border_width` - TODO:
 ///
-/// Must be zero if the `class` is `InputOnly` or a `xcb_match_error_t` occurs.
+///   Must be zero if the `class` is `InputOnly` or a `xcb_match_error_t` occurs.
 /// * `x` - The X coordinate of the new window.
 /// * `y` - The Y coordinate of the new window.
 /// * `width` - The width of the new window.
@@ -117,8 +117,8 @@ where
 /// * `window` - The window to change.
 /// * `value_mask` -
 /// * `value_list` - Values for each of the attributes specified in the bitmask `value_mask`. The
-/// order has to correspond to the order of possible `value_mask` bits. See the
-/// example.
+///   order has to correspond to the order of possible `value_mask` bits. See the
+///   example.
 ///
 /// # Errors
 ///
@@ -417,7 +417,7 @@ where
 /// * `window` - The window to configure.
 /// * `value_mask` - Bitmask of attributes to change.
 /// * `value_list` - New values, corresponding to the attributes in value_mask. The order has to
-/// correspond to the order of possible `value_mask` bits. See the example.
+///   correspond to the order of possible `value_mask` bits. See the example.
 ///
 /// # Errors
 ///
@@ -688,8 +688,8 @@ where
 /// * `property` - The property you want to change (an atom).
 /// * `type` - The type of the property you want to change (an atom).
 /// * `format` - Specifies whether the data should be viewed as a list of 8-bit, 16-bit or
-/// 32-bit quantities. Possible values are 8, 16 and 32. This information allows
-/// the X server to correctly perform byte-swap operations as necessary.
+///   32-bit quantities. Possible values are 8, 16 and 32. This information allows
+///   the X server to correctly perform byte-swap operations as necessary.
 /// * `data_len` - Specifies the number of elements (see `format`).
 /// * `data` - The property data.
 ///
@@ -779,13 +779,13 @@ where
 ///
 /// * `window` - The window whose property you want to get.
 /// * `delete` - Whether the property should actually be deleted. For deleting a property, the
-/// specified `type` has to match the actual property type.
+///   specified `type` has to match the actual property type.
 /// * `property` - The property you want to get (an atom).
 /// * `type` - The type of the property you want to get (an atom).
 /// * `long_offset` - Specifies the offset (in 32-bit multiples) in the specified property where the
-/// data is to be retrieved.
+///   data is to be retrieved.
 /// * `long_length` - Specifies how many 32-bit multiples of data should be retrieved (e.g. if you
-/// set `long_length` to 4, you will receive 16 bytes of data).
+///   set `long_length` to 4, you will receive 16 bytes of data).
 ///
 /// # Errors
 ///
@@ -877,15 +877,15 @@ where
 /// * `selection` - The selection.
 /// * `owner` - The new owner of the selection.
 ///
-/// The special value `XCB_NONE` means that the selection will have no owner.
+///   The special value `XCB_NONE` means that the selection will have no owner.
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The selection will not be changed if `time` is earlier than the current
-/// last-change time of the `selection` or is later than the current X server time.
-/// Otherwise, the last-change time is set to the specified time.
+///   The selection will not be changed if `time` is earlier than the current
+///   last-change time of the `selection` or is later than the current X server time.
+///   Otherwise, the last-change time is set to the specified time.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 ///
 /// # Errors
 ///
@@ -977,23 +977,23 @@ where
 /// # Fields
 ///
 /// * `destination` - The window to send this event to. Every client which selects any event within
-/// `event_mask` on `destination` will get the event.
+///   `event_mask` on `destination` will get the event.
 ///
-/// The special value `XCB_SEND_EVENT_DEST_POINTER_WINDOW` refers to the window
-/// that contains the mouse pointer.
+///   The special value `XCB_SEND_EVENT_DEST_POINTER_WINDOW` refers to the window
+///   that contains the mouse pointer.
 ///
-/// The special value `XCB_SEND_EVENT_DEST_ITEM_FOCUS` refers to the window which
-/// has the keyboard focus.
+///   The special value `XCB_SEND_EVENT_DEST_ITEM_FOCUS` refers to the window which
+///   has the keyboard focus.
 /// * `event_mask` - Event_mask for determining which clients should receive the specified event.
-/// See `destination` and `propagate`.
+///   See `destination` and `propagate`.
 /// * `propagate` - If `propagate` is true and no clients have selected any event on `destination`,
-/// the destination is replaced with the closest ancestor of `destination` for
-/// which some client has selected a type in `event_mask` and for which no
-/// intervening window has that type in its do-not-propagate-mask. If no such
-/// window exists or if the window is an ancestor of the focus window and
-/// `InputFocus` was originally specified as the destination, the event is not sent
-/// to any clients. Otherwise, the event is reported to every client selecting on
-/// the final destination any of the types specified in `event_mask`.
+///   the destination is replaced with the closest ancestor of `destination` for
+///   which some client has selected a type in `event_mask` and for which no
+///   intervening window has that type in its do-not-propagate-mask. If no such
+///   window exists or if the window is an ancestor of the focus window and
+///   `InputFocus` was originally specified as the destination, the event is not sent
+///   to any clients. Otherwise, the event is reported to every client selecting on
+///   the final destination any of the types specified in `event_mask`.
 /// * `event` - The event to send to the specified `destination`.
 ///
 /// # Errors
@@ -1065,27 +1065,27 @@ where
 ///
 /// * `event_mask` - Specifies which pointer events are reported to the client.
 ///
-/// TODO: which values?
+///   TODO: which values?
 /// * `confine_to` - Specifies the window to confine the pointer in (the user will not be able to
-/// move the pointer out of that window).
+///   move the pointer out of that window).
 ///
-/// The special value `XCB_NONE` means don't confine the pointer.
+///   The special value `XCB_NONE` means don't confine the pointer.
 /// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
-/// cursor.
+///   cursor.
 /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-/// reported to the `grab_window`.
+///   reported to the `grab_window`.
 /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
 /// * `time` - The time argument allows you to avoid certain circumstances that come up if
-/// applications take a long time to respond or if there are long network delays.
-/// Consider a situation where you have two applications, both of which normally
-/// grab the pointer when clicked on. If both applications specify the timestamp
-/// from the event, the second application may wake up faster and successfully grab
-/// the pointer before the first application. The first application then will get
-/// an indication that the other application grabbed the pointer before its request
-/// was processed.
+///   applications take a long time to respond or if there are long network delays.
+///   Consider a situation where you have two applications, both of which normally
+///   grab the pointer when clicked on. If both applications specify the timestamp
+///   from the event, the second application may wake up faster and successfully grab
+///   the pointer before the first application. The first application then will get
+///   an indication that the other application grabbed the pointer before its request
+///   was processed.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 /// * `pointer_mode` -
 /// * `keyboard_mode` -
 ///
@@ -1166,8 +1166,8 @@ where
 ///
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The pointer will not be released if `time` is earlier than the
-/// last-pointer-grab time or later than the current X server time.
+///   The pointer will not be released if `time` is earlier than the
+///   last-pointer-grab time or later than the current X server time.
 /// * `name_len` - Length (in bytes) of `name`.
 /// * `name` - A pattern describing an X core font.
 ///
@@ -1233,21 +1233,21 @@ where
 /// # Fields
 ///
 /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-/// reported to the `grab_window`.
+///   reported to the `grab_window`.
 /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
 /// * `event_mask` - Specifies which pointer events are reported to the client.
 ///
-/// TODO: which values?
+///   TODO: which values?
 /// * `confine_to` - Specifies the window to confine the pointer in (the user will not be able to
-/// move the pointer out of that window).
+///   move the pointer out of that window).
 ///
-/// The special value `XCB_NONE` means don't confine the pointer.
+///   The special value `XCB_NONE` means don't confine the pointer.
 /// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
-/// cursor.
+///   cursor.
 /// * `modifiers` - The modifiers to grab.
 ///
-/// Using the special value `XCB_MOD_MASK_ANY` means grab the pointer with all
-/// possible modifier combinations.
+///   Using the special value `XCB_MOD_MASK_ANY` means grab the pointer with all
+///   possible modifier combinations.
 /// * `pointer_mode` -
 /// * `keyboard_mode` -
 /// * `button` -
@@ -1334,12 +1334,12 @@ where
 /// # Fields
 ///
 /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-/// reported to the `grab_window`.
+///   reported to the `grab_window`.
 /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 /// * `pointer_mode` -
 /// * `keyboard_mode` -
 ///
@@ -1450,15 +1450,15 @@ where
 /// # Fields
 ///
 /// * `owner_events` - If 1, the `grab_window` will still get the key events. If 0, events are not
-/// reported to the `grab_window`.
+///   reported to the `grab_window`.
 /// * `grab_window` - Specifies the window on which the key should be grabbed.
 /// * `key` - The keycode of the key to grab.
 ///
-/// The special value `XCB_GRAB_ANY` means grab any key.
+///   The special value `XCB_GRAB_ANY` means grab any key.
 /// * `modifiers` - The modifiers to grab.
 ///
-/// Using the special value `XCB_MOD_MASK_ANY` means grab the key with all
-/// possible modifier combinations.
+///   Using the special value `XCB_MOD_MASK_ANY` means grab the key with all
+///   possible modifier combinations.
 /// * `pointer_mode` -
 /// * `keyboard_mode` -
 ///
@@ -1502,12 +1502,12 @@ where
 ///
 /// * `key` - The keycode of the specified key combination.
 ///
-/// Using the special value `XCB_GRAB_ANY` means releasing all possible key codes.
+///   Using the special value `XCB_GRAB_ANY` means releasing all possible key codes.
 /// * `grab_window` - The window on which the grabbed key combination will be released.
 /// * `modifiers` - The modifiers of the specified key combination.
 ///
-/// Using the special value `XCB_MOD_MASK_ANY` means releasing the key combination
-/// with every possible modifier combination.
+///   Using the special value `XCB_MOD_MASK_ANY` means releasing the key combination
+///   with every possible modifier combination.
 ///
 /// # Errors
 ///
@@ -1547,8 +1547,8 @@ where
 /// * `mode` -
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 ///
 /// # Errors
 ///
@@ -1599,7 +1599,7 @@ where
 /// # Fields
 ///
 /// * `window` - A window to check if the pointer is on the same screen as `window` (see the
-/// `same_screen` field in the reply).
+///   `same_screen` field in the reply).
 ///
 /// # Errors
 ///
@@ -1669,13 +1669,13 @@ where
 /// # Fields
 ///
 /// * `src_window` - If `src_window` is not `XCB_NONE` (TODO), the move will only take place if the
-/// pointer is inside `src_window` and within the rectangle specified by (`src_x`,
-/// `src_y`, `src_width`, `src_height`). The rectangle coordinates are relative to
-/// `src_window`.
+///   pointer is inside `src_window` and within the rectangle specified by (`src_x`,
+///   `src_y`, `src_width`, `src_height`). The rectangle coordinates are relative to
+///   `src_window`.
 /// * `dst_window` - If `dst_window` is not `XCB_NONE` (TODO), the pointer will be moved to the
-/// offsets (`dst_x`, `dst_y`) relative to `dst_window`. If `dst_window` is
-/// `XCB_NONE` (TODO), the pointer will be moved by the offsets (`dst_x`, `dst_y`)
-/// relative to the current position of the pointer.
+///   offsets (`dst_x`, `dst_y`) relative to `dst_window`. If `dst_window` is
+///   `XCB_NONE` (TODO), the pointer will be moved by the offsets (`dst_x`, `dst_y`)
+///   relative to the current position of the pointer.
 ///
 /// # Errors
 ///
@@ -1719,19 +1719,19 @@ where
 /// # Fields
 ///
 /// * `focus` - The window to focus. All keyboard events will be reported to this window. The
-/// window must be viewable (TODO), or a `xcb_match_error_t` occurs (TODO).
+///   window must be viewable (TODO), or a `xcb_match_error_t` occurs (TODO).
 ///
-/// If `focus` is `XCB_NONE` (TODO), all keyboard events are
-/// discarded until a new focus window is set.
+///   If `focus` is `XCB_NONE` (TODO), all keyboard events are
+///   discarded until a new focus window is set.
 ///
-/// If `focus` is `XCB_POINTER_ROOT` (TODO), focus is on the root window of the
-/// screen on which the pointer is on currently.
+///   If `focus` is `XCB_POINTER_ROOT` (TODO), focus is on the root window of the
+///   screen on which the pointer is on currently.
 /// * `time` - Timestamp to avoid race conditions when running X over the network.
 ///
-/// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-/// time.
+///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+///   time.
 /// * `revert_to` - Specifies what happens when the `focus` window becomes unviewable (if `focus`
-/// is neither `XCB_NONE` nor `XCB_POINTER_ROOT`).
+///   is neither `XCB_NONE` nor `XCB_POINTER_ROOT`).
 ///
 /// # Errors
 ///
@@ -1908,9 +1908,9 @@ where
 /// * `pattern_len` - The length (in bytes) of `pattern`.
 /// * `pattern` - A font pattern, for example "-misc-fixed-*".
 ///
-/// The asterisk (*) is a wildcard for any number of characters. The question mark
-/// (?) is a wildcard for a single character. Use of uppercase or lowercase does
-/// not matter.
+///   The asterisk (*) is a wildcard for any number of characters. The question mark
+///   (?) is a wildcard for a single character. Use of uppercase or lowercase does
+///   not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
 pub fn list_fonts<'c, 'input, Conn>(conn: &'c Conn, max_names: u16, pattern: &'input [u8]) -> Result<Cookie<'c, Conn, ListFontsReply>, ConnectionError>
 where
@@ -1935,9 +1935,9 @@ where
 /// * `pattern_len` - The length (in bytes) of `pattern`.
 /// * `pattern` - A font pattern, for example "-misc-fixed-*".
 ///
-/// The asterisk (*) is a wildcard for any number of characters. The question mark
-/// (?) is a wildcard for a single character. Use of uppercase or lowercase does
-/// not matter.
+///   The asterisk (*) is a wildcard for any number of characters. The question mark
+///   (?) is a wildcard for a single character. Use of uppercase or lowercase does
+///   not matter.
 /// * `max_names` - The maximum number of fonts to be returned.
 pub fn list_fonts_with_info<'c, 'input, Conn>(conn: &'c Conn, max_names: u16, pattern: &'input [u8]) -> Result<ListFontsWithInfoCookie<'c, Conn>, ConnectionError>
 where
@@ -1986,7 +1986,7 @@ where
 ///
 /// * `depth` - TODO
 /// * `pid` - The ID with which you will refer to the new pixmap, created by
-/// `xcb_generate_id`.
+///   `xcb_generate_id`.
 /// * `drawable` - Drawable to get the screen from.
 /// * `width` - The width of the new pixmap.
 /// * `height` - The height of the new pixmap.
@@ -2050,7 +2050,7 @@ where
 /// # Fields
 ///
 /// * `cid` - The ID with which you will refer to the graphics context, created by
-/// `xcb_generate_id`.
+///   `xcb_generate_id`.
 /// * `drawable` - Drawable to get the root/depth from.
 ///
 /// # Errors
@@ -2089,8 +2089,8 @@ where
 /// * `gc` - The graphics context to change.
 /// * `value_mask` -
 /// * `value_list` - Values for each of the components specified in the bitmask `value_mask`. The
-/// order has to correspond to the order of possible `value_mask` bits. See the
-/// example.
+///   order has to correspond to the order of possible `value_mask` bits. See the
+///   example.
 ///
 /// # Errors
 ///
@@ -2380,7 +2380,7 @@ where
 /// * `drawable` - A drawable (Window or Pixmap) to draw on.
 /// * `gc` - The graphics context to use.
 ///
-/// TODO: document which attributes of a gc are used
+///   TODO: document which attributes of a gc are used
 /// * `segments_len` - The number of `xcb_segment_t` structures in `segments`.
 /// * `segments` - An array of `xcb_segment_t` structures.
 ///
@@ -2462,12 +2462,12 @@ where
 /// * `drawable` - The drawable (Window or Pixmap) to draw on.
 /// * `gc` - The graphics context to use.
 ///
-/// The following graphics context components are used: function, plane-mask,
-/// fill-style, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+///   The following graphics context components are used: function, plane-mask,
+///   fill-style, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
 ///
-/// The following graphics context mode-dependent components are used:
-/// foreground, background, tile, stipple, tile-stipple-x-origin, and
-/// tile-stipple-y-origin.
+///   The following graphics context mode-dependent components are used:
+///   foreground, background, tile, stipple, tile-stipple-x-origin, and
+///   tile-stipple-y-origin.
 /// * `rectangles_len` - The number of `xcb_rectangle_t` structures in `rectangles`.
 /// * `rectangles` - The rectangles to fill.
 ///
@@ -2596,15 +2596,15 @@ where
 ///
 /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
 /// * `string_len` - The length of the `string`. Note that this parameter limited by 255 due to
-/// using 8 bits!
+///   using 8 bits!
 /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
-/// type of `string_len`.
+///   type of `string_len`.
 /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
 /// * `y` - The y coordinate of the first character, relative to the origin of `drawable`.
 /// * `gc` - The graphics context to use.
 ///
-/// The following graphics context components are used: plane-mask, foreground,
-/// background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+///   The following graphics context components are used: plane-mask, foreground,
+///   background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
 ///
 /// # Errors
 ///
@@ -2647,16 +2647,16 @@ where
 ///
 /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
 /// * `string_len` - The length of the `string` in characters. Note that this parameter limited by
-/// 255 due to using 8 bits!
+///   255 due to using 8 bits!
 /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
-/// type of `string_len`. Every character uses 2 bytes (hence the 16 in this
-/// request's name).
+///   type of `string_len`. Every character uses 2 bytes (hence the 16 in this
+///   request's name).
 /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
 /// * `y` - The y coordinate of the first character, relative to the origin of `drawable`.
 /// * `gc` - The graphics context to use.
 ///
-/// The following graphics context components are used: plane-mask, foreground,
-/// background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+///   The following graphics context components are used: plane-mask, foreground,
+///   background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
 ///
 /// # Errors
 ///
@@ -2965,8 +2965,8 @@ where
 /// * `mask_font` - In which font to look for the mask glyph.
 /// * `source_char` - The glyph of `source_font` to use.
 /// * `mask_char` - The glyph of `mask_font` to use as a mask: Pixels which are set to 1 define
-/// which source pixels are displayed. All pixels which are set to 0 are not
-/// displayed.
+///   which source pixels are displayed. All pixels which are set to 0 are not
+///   displayed.
 /// * `fore_red` - The red value of the foreground color.
 /// * `fore_green` - The green value of the foreground color.
 /// * `fore_blue` - The blue value of the foreground color.
@@ -3080,7 +3080,7 @@ where
 ///
 /// * `name_len` - The length of `name` in bytes.
 /// * `name` - The name of the extension to query, for example "RANDR". This is case
-/// sensitive!
+///   sensitive!
 ///
 /// # See
 ///
@@ -3291,10 +3291,10 @@ where
 /// # Fields
 ///
 /// * `resource` - Any resource belonging to the client (for example a Window), used to identify
-/// the client connection.
+///   the client connection.
 ///
-/// The special value of `XCB_KILL_ALL_TEMPORARY`, the resources of all clients
-/// that have terminated in `RetainTemporary` (TODO) are destroyed.
+///   The special value of `XCB_KILL_ALL_TEMPORARY`, the resources of all clients
+///   that have terminated in `RetainTemporary` (TODO) are destroyed.
 ///
 /// # Errors
 ///
@@ -3427,20 +3427,20 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `wid` - The ID with which you will refer to the new window, created by
-    /// `xcb_generate_id`.
+    ///   `xcb_generate_id`.
     /// * `depth` - Specifies the new window's depth (TODO: what unit?).
     ///
-    /// The special value `XCB_COPY_FROM_PARENT` means the depth is taken from the
-    /// `parent` window.
+    ///   The special value `XCB_COPY_FROM_PARENT` means the depth is taken from the
+    ///   `parent` window.
     /// * `visual` - Specifies the id for the new window's visual.
     ///
-    /// The special value `XCB_COPY_FROM_PARENT` means the visual is taken from the
-    /// `parent` window.
+    ///   The special value `XCB_COPY_FROM_PARENT` means the visual is taken from the
+    ///   `parent` window.
     /// * `class` -
     /// * `parent` - The parent window of the new window.
     /// * `border_width` - TODO:
     ///
-    /// Must be zero if the `class` is `InputOnly` or a `xcb_match_error_t` occurs.
+    ///   Must be zero if the `class` is `InputOnly` or a `xcb_match_error_t` occurs.
     /// * `x` - The X coordinate of the new window.
     /// * `y` - The Y coordinate of the new window.
     /// * `width` - The width of the new window.
@@ -3474,8 +3474,8 @@ pub trait ConnectionExt: RequestConnection {
     /// * `window` - The window to change.
     /// * `value_mask` -
     /// * `value_list` - Values for each of the attributes specified in the bitmask `value_mask`. The
-    /// order has to correspond to the order of possible `value_mask` bits. See the
-    /// example.
+    ///   order has to correspond to the order of possible `value_mask` bits. See the
+    ///   example.
     ///
     /// # Errors
     ///
@@ -3679,7 +3679,7 @@ pub trait ConnectionExt: RequestConnection {
     /// * `window` - The window to configure.
     /// * `value_mask` - Bitmask of attributes to change.
     /// * `value_list` - New values, corresponding to the attributes in value_mask. The order has to
-    /// correspond to the order of possible `value_mask` bits. See the example.
+    ///   correspond to the order of possible `value_mask` bits. See the example.
     ///
     /// # Errors
     ///
@@ -3893,8 +3893,8 @@ pub trait ConnectionExt: RequestConnection {
     /// * `property` - The property you want to change (an atom).
     /// * `type` - The type of the property you want to change (an atom).
     /// * `format` - Specifies whether the data should be viewed as a list of 8-bit, 16-bit or
-    /// 32-bit quantities. Possible values are 8, 16 and 32. This information allows
-    /// the X server to correctly perform byte-swap operations as necessary.
+    ///   32-bit quantities. Possible values are 8, 16 and 32. This information allows
+    ///   the X server to correctly perform byte-swap operations as necessary.
     /// * `data_len` - Specifies the number of elements (see `format`).
     /// * `data` - The property data.
     ///
@@ -3958,13 +3958,13 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `window` - The window whose property you want to get.
     /// * `delete` - Whether the property should actually be deleted. For deleting a property, the
-    /// specified `type` has to match the actual property type.
+    ///   specified `type` has to match the actual property type.
     /// * `property` - The property you want to get (an atom).
     /// * `type` - The type of the property you want to get (an atom).
     /// * `long_offset` - Specifies the offset (in 32-bit multiples) in the specified property where the
-    /// data is to be retrieved.
+    ///   data is to be retrieved.
     /// * `long_length` - Specifies how many 32-bit multiples of data should be retrieved (e.g. if you
-    /// set `long_length` to 4, you will receive 16 bytes of data).
+    ///   set `long_length` to 4, you will receive 16 bytes of data).
     ///
     /// # Errors
     ///
@@ -4032,15 +4032,15 @@ pub trait ConnectionExt: RequestConnection {
     /// * `selection` - The selection.
     /// * `owner` - The new owner of the selection.
     ///
-    /// The special value `XCB_NONE` means that the selection will have no owner.
+    ///   The special value `XCB_NONE` means that the selection will have no owner.
     /// * `time` - Timestamp to avoid race conditions when running X over the network.
     ///
-    /// The selection will not be changed if `time` is earlier than the current
-    /// last-change time of the `selection` or is later than the current X server time.
-    /// Otherwise, the last-change time is set to the specified time.
+    ///   The selection will not be changed if `time` is earlier than the current
+    ///   last-change time of the `selection` or is later than the current X server time.
+    ///   Otherwise, the last-change time is set to the specified time.
     ///
-    /// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-    /// time.
+    ///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+    ///   time.
     ///
     /// # Errors
     ///
@@ -4097,23 +4097,23 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `destination` - The window to send this event to. Every client which selects any event within
-    /// `event_mask` on `destination` will get the event.
+    ///   `event_mask` on `destination` will get the event.
     ///
-    /// The special value `XCB_SEND_EVENT_DEST_POINTER_WINDOW` refers to the window
-    /// that contains the mouse pointer.
+    ///   The special value `XCB_SEND_EVENT_DEST_POINTER_WINDOW` refers to the window
+    ///   that contains the mouse pointer.
     ///
-    /// The special value `XCB_SEND_EVENT_DEST_ITEM_FOCUS` refers to the window which
-    /// has the keyboard focus.
+    ///   The special value `XCB_SEND_EVENT_DEST_ITEM_FOCUS` refers to the window which
+    ///   has the keyboard focus.
     /// * `event_mask` - Event_mask for determining which clients should receive the specified event.
-    /// See `destination` and `propagate`.
+    ///   See `destination` and `propagate`.
     /// * `propagate` - If `propagate` is true and no clients have selected any event on `destination`,
-    /// the destination is replaced with the closest ancestor of `destination` for
-    /// which some client has selected a type in `event_mask` and for which no
-    /// intervening window has that type in its do-not-propagate-mask. If no such
-    /// window exists or if the window is an ancestor of the focus window and
-    /// `InputFocus` was originally specified as the destination, the event is not sent
-    /// to any clients. Otherwise, the event is reported to every client selecting on
-    /// the final destination any of the types specified in `event_mask`.
+    ///   the destination is replaced with the closest ancestor of `destination` for
+    ///   which some client has selected a type in `event_mask` and for which no
+    ///   intervening window has that type in its do-not-propagate-mask. If no such
+    ///   window exists or if the window is an ancestor of the focus window and
+    ///   `InputFocus` was originally specified as the destination, the event is not sent
+    ///   to any clients. Otherwise, the event is reported to every client selecting on
+    ///   the final destination any of the types specified in `event_mask`.
     /// * `event` - The event to send to the specified `destination`.
     ///
     /// # Errors
@@ -4172,27 +4172,27 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `event_mask` - Specifies which pointer events are reported to the client.
     ///
-    /// TODO: which values?
+    ///   TODO: which values?
     /// * `confine_to` - Specifies the window to confine the pointer in (the user will not be able to
-    /// move the pointer out of that window).
+    ///   move the pointer out of that window).
     ///
-    /// The special value `XCB_NONE` means don't confine the pointer.
+    ///   The special value `XCB_NONE` means don't confine the pointer.
     /// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
-    /// cursor.
+    ///   cursor.
     /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-    /// reported to the `grab_window`.
+    ///   reported to the `grab_window`.
     /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
     /// * `time` - The time argument allows you to avoid certain circumstances that come up if
-    /// applications take a long time to respond or if there are long network delays.
-    /// Consider a situation where you have two applications, both of which normally
-    /// grab the pointer when clicked on. If both applications specify the timestamp
-    /// from the event, the second application may wake up faster and successfully grab
-    /// the pointer before the first application. The first application then will get
-    /// an indication that the other application grabbed the pointer before its request
-    /// was processed.
+    ///   applications take a long time to respond or if there are long network delays.
+    ///   Consider a situation where you have two applications, both of which normally
+    ///   grab the pointer when clicked on. If both applications specify the timestamp
+    ///   from the event, the second application may wake up faster and successfully grab
+    ///   the pointer before the first application. The first application then will get
+    ///   an indication that the other application grabbed the pointer before its request
+    ///   was processed.
     ///
-    /// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-    /// time.
+    ///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+    ///   time.
     /// * `pointer_mode` -
     /// * `keyboard_mode` -
     ///
@@ -4255,8 +4255,8 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `time` - Timestamp to avoid race conditions when running X over the network.
     ///
-    /// The pointer will not be released if `time` is earlier than the
-    /// last-pointer-grab time or later than the current X server time.
+    ///   The pointer will not be released if `time` is earlier than the
+    ///   last-pointer-grab time or later than the current X server time.
     /// * `name_len` - Length (in bytes) of `name`.
     /// * `name` - A pattern describing an X core font.
     ///
@@ -4313,21 +4313,21 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-    /// reported to the `grab_window`.
+    ///   reported to the `grab_window`.
     /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
     /// * `event_mask` - Specifies which pointer events are reported to the client.
     ///
-    /// TODO: which values?
+    ///   TODO: which values?
     /// * `confine_to` - Specifies the window to confine the pointer in (the user will not be able to
-    /// move the pointer out of that window).
+    ///   move the pointer out of that window).
     ///
-    /// The special value `XCB_NONE` means don't confine the pointer.
+    ///   The special value `XCB_NONE` means don't confine the pointer.
     /// * `cursor` - Specifies the cursor that should be displayed or `XCB_NONE` to not change the
-    /// cursor.
+    ///   cursor.
     /// * `modifiers` - The modifiers to grab.
     ///
-    /// Using the special value `XCB_MOD_MASK_ANY` means grab the pointer with all
-    /// possible modifier combinations.
+    ///   Using the special value `XCB_MOD_MASK_ANY` means grab the pointer with all
+    ///   possible modifier combinations.
     /// * `pointer_mode` -
     /// * `keyboard_mode` -
     /// * `button` -
@@ -4373,12 +4373,12 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `owner_events` - If 1, the `grab_window` will still get the pointer events. If 0, events are not
-    /// reported to the `grab_window`.
+    ///   reported to the `grab_window`.
     /// * `grab_window` - Specifies the window on which the pointer should be grabbed.
     /// * `time` - Timestamp to avoid race conditions when running X over the network.
     ///
-    /// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-    /// time.
+    ///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+    ///   time.
     /// * `pointer_mode` -
     /// * `keyboard_mode` -
     ///
@@ -4467,15 +4467,15 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `owner_events` - If 1, the `grab_window` will still get the key events. If 0, events are not
-    /// reported to the `grab_window`.
+    ///   reported to the `grab_window`.
     /// * `grab_window` - Specifies the window on which the key should be grabbed.
     /// * `key` - The keycode of the key to grab.
     ///
-    /// The special value `XCB_GRAB_ANY` means grab any key.
+    ///   The special value `XCB_GRAB_ANY` means grab any key.
     /// * `modifiers` - The modifiers to grab.
     ///
-    /// Using the special value `XCB_MOD_MASK_ANY` means grab the key with all
-    /// possible modifier combinations.
+    ///   Using the special value `XCB_MOD_MASK_ANY` means grab the key with all
+    ///   possible modifier combinations.
     /// * `pointer_mode` -
     /// * `keyboard_mode` -
     ///
@@ -4505,12 +4505,12 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `key` - The keycode of the specified key combination.
     ///
-    /// Using the special value `XCB_GRAB_ANY` means releasing all possible key codes.
+    ///   Using the special value `XCB_GRAB_ANY` means releasing all possible key codes.
     /// * `grab_window` - The window on which the grabbed key combination will be released.
     /// * `modifiers` - The modifiers of the specified key combination.
     ///
-    /// Using the special value `XCB_MOD_MASK_ANY` means releasing the key combination
-    /// with every possible modifier combination.
+    ///   Using the special value `XCB_MOD_MASK_ANY` means releasing the key combination
+    ///   with every possible modifier combination.
     ///
     /// # Errors
     ///
@@ -4539,8 +4539,8 @@ pub trait ConnectionExt: RequestConnection {
     /// * `mode` -
     /// * `time` - Timestamp to avoid race conditions when running X over the network.
     ///
-    /// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-    /// time.
+    ///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+    ///   time.
     ///
     /// # Errors
     ///
@@ -4567,7 +4567,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `window` - A window to check if the pointer is on the same screen as `window` (see the
-    /// `same_screen` field in the reply).
+    ///   `same_screen` field in the reply).
     ///
     /// # Errors
     ///
@@ -4604,13 +4604,13 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `src_window` - If `src_window` is not `XCB_NONE` (TODO), the move will only take place if the
-    /// pointer is inside `src_window` and within the rectangle specified by (`src_x`,
-    /// `src_y`, `src_width`, `src_height`). The rectangle coordinates are relative to
-    /// `src_window`.
+    ///   pointer is inside `src_window` and within the rectangle specified by (`src_x`,
+    ///   `src_y`, `src_width`, `src_height`). The rectangle coordinates are relative to
+    ///   `src_window`.
     /// * `dst_window` - If `dst_window` is not `XCB_NONE` (TODO), the pointer will be moved to the
-    /// offsets (`dst_x`, `dst_y`) relative to `dst_window`. If `dst_window` is
-    /// `XCB_NONE` (TODO), the pointer will be moved by the offsets (`dst_x`, `dst_y`)
-    /// relative to the current position of the pointer.
+    ///   offsets (`dst_x`, `dst_y`) relative to `dst_window`. If `dst_window` is
+    ///   `XCB_NONE` (TODO), the pointer will be moved by the offsets (`dst_x`, `dst_y`)
+    ///   relative to the current position of the pointer.
     ///
     /// # Errors
     ///
@@ -4637,19 +4637,19 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `focus` - The window to focus. All keyboard events will be reported to this window. The
-    /// window must be viewable (TODO), or a `xcb_match_error_t` occurs (TODO).
+    ///   window must be viewable (TODO), or a `xcb_match_error_t` occurs (TODO).
     ///
-    /// If `focus` is `XCB_NONE` (TODO), all keyboard events are
-    /// discarded until a new focus window is set.
+    ///   If `focus` is `XCB_NONE` (TODO), all keyboard events are
+    ///   discarded until a new focus window is set.
     ///
-    /// If `focus` is `XCB_POINTER_ROOT` (TODO), focus is on the root window of the
-    /// screen on which the pointer is on currently.
+    ///   If `focus` is `XCB_POINTER_ROOT` (TODO), focus is on the root window of the
+    ///   screen on which the pointer is on currently.
     /// * `time` - Timestamp to avoid race conditions when running X over the network.
     ///
-    /// The special value `XCB_CURRENT_TIME` will be replaced with the current server
-    /// time.
+    ///   The special value `XCB_CURRENT_TIME` will be replaced with the current server
+    ///   time.
     /// * `revert_to` - Specifies what happens when the `focus` window becomes unviewable (if `focus`
-    /// is neither `XCB_NONE` nor `XCB_POINTER_ROOT`).
+    ///   is neither `XCB_NONE` nor `XCB_POINTER_ROOT`).
     ///
     /// # Errors
     ///
@@ -4762,9 +4762,9 @@ pub trait ConnectionExt: RequestConnection {
     /// * `pattern_len` - The length (in bytes) of `pattern`.
     /// * `pattern` - A font pattern, for example "-misc-fixed-*".
     ///
-    /// The asterisk (*) is a wildcard for any number of characters. The question mark
-    /// (?) is a wildcard for a single character. Use of uppercase or lowercase does
-    /// not matter.
+    ///   The asterisk (*) is a wildcard for any number of characters. The question mark
+    ///   (?) is a wildcard for a single character. Use of uppercase or lowercase does
+    ///   not matter.
     /// * `max_names` - The maximum number of fonts to be returned.
     fn list_fonts<'c, 'input>(&'c self, max_names: u16, pattern: &'input [u8]) -> Result<Cookie<'c, Self, ListFontsReply>, ConnectionError>
     {
@@ -4779,9 +4779,9 @@ pub trait ConnectionExt: RequestConnection {
     /// * `pattern_len` - The length (in bytes) of `pattern`.
     /// * `pattern` - A font pattern, for example "-misc-fixed-*".
     ///
-    /// The asterisk (*) is a wildcard for any number of characters. The question mark
-    /// (?) is a wildcard for a single character. Use of uppercase or lowercase does
-    /// not matter.
+    ///   The asterisk (*) is a wildcard for any number of characters. The question mark
+    ///   (?) is a wildcard for a single character. Use of uppercase or lowercase does
+    ///   not matter.
     /// * `max_names` - The maximum number of fonts to be returned.
     fn list_fonts_with_info<'c, 'input>(&'c self, max_names: u16, pattern: &'input [u8]) -> Result<ListFontsWithInfoCookie<'c, Self>, ConnectionError>
     {
@@ -4804,7 +4804,7 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `depth` - TODO
     /// * `pid` - The ID with which you will refer to the new pixmap, created by
-    /// `xcb_generate_id`.
+    ///   `xcb_generate_id`.
     /// * `drawable` - Drawable to get the screen from.
     /// * `width` - The width of the new pixmap.
     /// * `height` - The height of the new pixmap.
@@ -4846,7 +4846,7 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `cid` - The ID with which you will refer to the graphics context, created by
-    /// `xcb_generate_id`.
+    ///   `xcb_generate_id`.
     /// * `drawable` - Drawable to get the root/depth from.
     ///
     /// # Errors
@@ -4874,8 +4874,8 @@ pub trait ConnectionExt: RequestConnection {
     /// * `gc` - The graphics context to change.
     /// * `value_mask` -
     /// * `value_list` - Values for each of the components specified in the bitmask `value_mask`. The
-    /// order has to correspond to the order of possible `value_mask` bits. See the
-    /// example.
+    ///   order has to correspond to the order of possible `value_mask` bits. See the
+    ///   example.
     ///
     /// # Errors
     ///
@@ -5038,7 +5038,7 @@ pub trait ConnectionExt: RequestConnection {
     /// * `drawable` - A drawable (Window or Pixmap) to draw on.
     /// * `gc` - The graphics context to use.
     ///
-    /// TODO: document which attributes of a gc are used
+    ///   TODO: document which attributes of a gc are used
     /// * `segments_len` - The number of `xcb_segment_t` structures in `segments`.
     /// * `segments` - An array of `xcb_segment_t` structures.
     ///
@@ -5074,12 +5074,12 @@ pub trait ConnectionExt: RequestConnection {
     /// * `drawable` - The drawable (Window or Pixmap) to draw on.
     /// * `gc` - The graphics context to use.
     ///
-    /// The following graphics context components are used: function, plane-mask,
-    /// fill-style, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+    ///   The following graphics context components are used: function, plane-mask,
+    ///   fill-style, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
     ///
-    /// The following graphics context mode-dependent components are used:
-    /// foreground, background, tile, stipple, tile-stipple-x-origin, and
-    /// tile-stipple-y-origin.
+    ///   The following graphics context mode-dependent components are used:
+    ///   foreground, background, tile, stipple, tile-stipple-x-origin, and
+    ///   tile-stipple-y-origin.
     /// * `rectangles_len` - The number of `xcb_rectangle_t` structures in `rectangles`.
     /// * `rectangles` - The rectangles to fill.
     ///
@@ -5127,15 +5127,15 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
     /// * `string_len` - The length of the `string`. Note that this parameter limited by 255 due to
-    /// using 8 bits!
+    ///   using 8 bits!
     /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
-    /// type of `string_len`.
+    ///   type of `string_len`.
     /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
     /// * `y` - The y coordinate of the first character, relative to the origin of `drawable`.
     /// * `gc` - The graphics context to use.
     ///
-    /// The following graphics context components are used: plane-mask, foreground,
-    /// background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+    ///   The following graphics context components are used: plane-mask, foreground,
+    ///   background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
     ///
     /// # Errors
     ///
@@ -5165,16 +5165,16 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `drawable` - The drawable (Window or Pixmap) to draw text on.
     /// * `string_len` - The length of the `string` in characters. Note that this parameter limited by
-    /// 255 due to using 8 bits!
+    ///   255 due to using 8 bits!
     /// * `string` - The string to draw. Only the first 255 characters are relevant due to the data
-    /// type of `string_len`. Every character uses 2 bytes (hence the 16 in this
-    /// request's name).
+    ///   type of `string_len`. Every character uses 2 bytes (hence the 16 in this
+    ///   request's name).
     /// * `x` - The x coordinate of the first character, relative to the origin of `drawable`.
     /// * `y` - The y coordinate of the first character, relative to the origin of `drawable`.
     /// * `gc` - The graphics context to use.
     ///
-    /// The following graphics context components are used: plane-mask, foreground,
-    /// background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
+    ///   The following graphics context components are used: plane-mask, foreground,
+    ///   background, font, subwindow-mode, clip-x-origin, clip-y-origin, and clip-mask.
     ///
     /// # Errors
     ///
@@ -5292,8 +5292,8 @@ pub trait ConnectionExt: RequestConnection {
     /// * `mask_font` - In which font to look for the mask glyph.
     /// * `source_char` - The glyph of `source_font` to use.
     /// * `mask_char` - The glyph of `mask_font` to use as a mask: Pixels which are set to 1 define
-    /// which source pixels are displayed. All pixels which are set to 0 are not
-    /// displayed.
+    ///   which source pixels are displayed. All pixels which are set to 0 are not
+    ///   displayed.
     /// * `fore_red` - The red value of the foreground color.
     /// * `fore_green` - The green value of the foreground color.
     /// * `fore_blue` - The blue value of the foreground color.
@@ -5352,7 +5352,7 @@ pub trait ConnectionExt: RequestConnection {
     ///
     /// * `name_len` - The length of `name` in bytes.
     /// * `name` - The name of the extension to query, for example "RANDR". This is case
-    /// sensitive!
+    ///   sensitive!
     ///
     /// # See
     ///
@@ -5425,10 +5425,10 @@ pub trait ConnectionExt: RequestConnection {
     /// # Fields
     ///
     /// * `resource` - Any resource belonging to the client (for example a Window), used to identify
-    /// the client connection.
+    ///   the client connection.
     ///
-    /// The special value of `XCB_KILL_ALL_TEMPORARY`, the resources of all clients
-    /// that have terminated in `RetainTemporary` (TODO) are destroyed.
+    ///   The special value of `XCB_KILL_ALL_TEMPORARY`, the resources of all clients
+    ///   that have terminated in `RetainTemporary` (TODO) are destroyed.
     ///
     /// # Errors
     ///

--- a/x11rb/src/rust_connection/mod.rs
+++ b/x11rb/src/rust_connection/mod.rs
@@ -723,7 +723,7 @@ impl<S: Stream> RequestConnection for RustConnection<S> {
                     .unwrap_or_else(|| self.setup.maximum_request_length.into())
                     // Turn the u32 into usize, using the max value in case of overflow
                     .try_into()
-                    .unwrap_or(usize::max_value());
+                    .unwrap_or(usize::MAX);
                 let length = length * 4;
                 *max_bytes = Known(length);
                 crate::info!("Maximum request length is {} bytes", length);

--- a/x11rb/src/rust_connection/stream.rs
+++ b/x11rb/src/rust_connection/stream.rs
@@ -427,7 +427,7 @@ impl Stream for DefaultStream {
                 match (&mut &self.inner).write(buf) {
                     Ok(n) => return Ok(n),
                     // try again
-                    Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                    Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
                     Err(e) => return Err(e),
                 }
             }
@@ -450,7 +450,7 @@ impl Stream for DefaultStream {
                 match (&mut &self.inner).write_vectored(bufs) {
                     Ok(n) => return Ok(n),
                     // try again
-                    Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                    Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
                     Err(e) => return Err(e),
                 }
             }

--- a/x11rb/src/rust_connection/stream.rs
+++ b/x11rb/src/rust_connection/stream.rs
@@ -85,7 +85,7 @@ pub trait Stream {
     /// If `Self` is `Send + Sync` and `read` is used concurrently from more than one thread:
     ///
     /// * Both the data and the file descriptors shall be read in order, but possibly
-    /// interleaved across threads.
+    ///   interleaved across threads.
     /// * Neither the data nor the file descriptors shall be duplicated.
     /// * The returned value shall always be the actual number of bytes read into `buf`.
     fn read(&self, buf: &mut [u8], fd_storage: &mut Vec<RawFdContainer>) -> Result<usize>;
@@ -112,7 +112,7 @@ pub trait Stream {
     /// If `Self` is `Send + Sync` and `write` is used concurrently from more than one thread:
     ///
     /// * Both the data and the file descriptors shall be written in order, but possibly
-    /// interleaved across threads.
+    ///   interleaved across threads.
     /// * Neither the data nor the file descriptors shall be duplicated.
     /// * The returned value shall always be the actual number of bytes written from `buf`.
     fn write(&self, buf: &[u8], fds: &mut Vec<RawFdContainer>) -> Result<usize>;

--- a/x11rb/src/xcb_ffi/mod.rs
+++ b/x11rb/src/xcb_ffi/mod.rs
@@ -573,8 +573,8 @@ impl Connection for XCBConnection {
             let id = raw_ffi::xcb_generate_id(self.conn.as_ptr());
             // XCB does not document the behaviour of `xcb_generate_id` when
             // there is an error. Looking at its source code it seems that it
-            // returns `-1` (presumably `u32::max_value()`).
-            if id == u32::max_value() {
+            // returns `-1` (presumably `u32::MAX`).
+            if id == u32::MAX {
                 Err(Self::connection_error_from_connection(self.conn.as_ptr()).into())
             } else {
                 Ok(id)
@@ -613,7 +613,7 @@ unsafe impl as_raw_xcb_connection::AsRawXcbConnection for XCBConnection {
 /// The new sequence number may be before or after the `recent` sequence number.
 fn reconstruct_full_sequence_impl(recent: SequenceNumber, value: u32) -> SequenceNumber {
     // Expand 'value' to a full sequence number. The high bits are copied from 'recent'.
-    let u32_max = SequenceNumber::from(u32::max_value());
+    let u32_max = SequenceNumber::from(u32::MAX);
     let expanded_value = SequenceNumber::from(value) | (recent & !u32_max);
 
     // The "step size" is the difference between two sequence numbers that cannot be told apart
@@ -642,7 +642,7 @@ fn reconstruct_full_sequence_impl(recent: SequenceNumber, value: u32) -> Sequenc
     .unwrap();
     // Just because: Check that the result matches the passed-in value in the low bits
     assert_eq!(
-        result & SequenceNumber::from(u32::max_value()),
+        result & SequenceNumber::from(u32::MAX),
         SequenceNumber::from(value),
     );
     result
@@ -666,10 +666,10 @@ mod test {
     #[test]
     fn reconstruct_full_sequence() {
         use super::reconstruct_full_sequence_impl;
-        let max32 = u32::max_value();
+        let max32 = u32::MAX;
         let max32_: u64 = max32.into();
         let max32_p1 = max32_ + 1;
-        let large_offset = max32_p1 * u64::from(u16::max_value());
+        let large_offset = max32_p1 * u64::from(u16::MAX);
         for &(recent, value, expected) in &[
             (0, 0, 0),
             (0, 10, 10),

--- a/xtrace-example/src/connection.rs
+++ b/xtrace-example/src/connection.rs
@@ -106,7 +106,7 @@ impl Connection {
                 if let Some(length_field) = packet.get(4..8) {
                     let length_field = u32::from_ne_bytes(length_field.try_into().unwrap());
                     let length_field = usize::try_from(length_field).unwrap();
-                    assert!(length_field <= usize::max_value() / 4);
+                    assert!(length_field <= usize::MAX / 4);
                     4 * length_field
                 } else {
                     0


### PR DESCRIPTION
I am not quite sure why, but CI started failing on windows. The previous, successful build used Rust 1.77.2 and now with 1.78.0, the build fail. I do not know whether this is really the reason, but it is my best guess.

The compiler error message looks like this:

    error: unnecessary qualification
       --> x11rb\src\rust_connection\stream.rs:430:47
        |
    430 |                     Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
        |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
    note: the lint level is defined here
       --> x11rb\src\lib.rs:129:5
        |
    129 |     unused_qualifications,
        |     ^^^^^^^^^^^^^^^^^^^^^
