### PR TITLE
x11rb: Update default cursor search path

### DIFF
--- a/x11rb/src/cursor/find_cursor.rs
+++ b/x11rb/src/cursor/find_cursor.rs
@@ -217,7 +217,7 @@ pub(crate) fn find_cursor(theme: &str, name: &str) -> Result<Cursor<File>, Error
         None => return Err(Error::NoHomeDir),
     };
     let cursor_path = var("XCURSOR_PATH").unwrap_or_else(|_| {
-        "~/.icons:/usr/share/icons:/usr/share/pixmaps:/usr/X11R6/lib/X11/icons".into()
+        "~/.local/share/icons:~/.icons:/usr/share/icons:/usr/share/pixmaps".into()
     });
     let open_cursor = |file: &Path| File::open(file);
     find_cursor_impl(


### PR DESCRIPTION
In [1], xcb-util-cursor's default search path was changed. This change was done to bring it in line with libXcursor's behaviour. In that library, in [2], ~/.local/share/icons was added to the default search path.

Additionally, /usr/X11R6/lib/X11/icons was never part of libXcursor's search path. It only searched there if you set --prefix or --datadir suitably, but in that case /usr/share/icons would disappear from the search path. This path was thus removed from xcb-util-cursor in [1].

In this commit, I bring x11rb in sync with xcb-util-cursor again.

[1]: https://gitlab.freedesktop.org/xorg/lib/libxcb-cursor/-/commit/d28a3227eb9e4bdeeb4dd93017c298808bbe62ee
[2]: https://gitlab.freedesktop.org/xorg/lib/libxcursor/-/commit/2263c196cb0d