### PR TITLE
Fix unnecessary-qualification in Rust beta

### DIFF
--- a/x11rb-protocol/src/wrapper.rs
+++ b/x11rb-protocol/src/wrapper.rs
@@ -41,7 +41,8 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let size = self.0.len() / core::mem::size_of::<T>();
+        use core::mem::size_of;
+        let size = self.0.len() / size_of::<T>();
         (size, Some(size))
     }
 }


### PR DESCRIPTION
Fix unnecessary-qualification in Rust beta

```
error: unnecessary qualification
  --> x11rb-protocol/src/wrapper.rs:44:35
   |
44 |         let size = self.0.len() / core::mem::size_of::<T>();
   |                                   ^^^^^^^^^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> x11rb-protocol/src/lib.rs:49:5
   |
49 |     unused_qualifications,
   |     ^^^^^^^^^^^^^^^^^^^^^
help: remove the unnecessary path segments
   |
44 -         let size = self.0.len() / core::mem::size_of::<T>();
44 +         let size = self.0.len() / size_of::<T>();
   |
```
This comes from https://github.com/rust-lang/rust/pull/123168

