### PR TITLE
Update to gethostname 0.5

### DIFF
--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -22,12 +22,10 @@ once_cell = { version = "1.19", optional = true }
 as-raw-xcb-connection = { version = "1.0", optional = true }
 tracing = { version = "0.1", optional = true, default-features = false }
 rustix = { version = "0.38", default-features = false, features = ["std", "event", "fs", "net", "system"] }
-
-[target.'cfg(not(unix))'.dependencies]
-gethostname = "0.4"
+gethostname = "0.5"
 
 [dev-dependencies]
-gethostname = "0.4"
+gethostname = "0.5"
 polling = "3.4"
 tracing-subscriber = "0.3"
 

--- a/x11rb/src/lib.rs
+++ b/x11rb/src/lib.rs
@@ -183,7 +183,6 @@ mod test;
 
 use errors::ConnectError;
 use protocol::xproto::{Keysym, Timestamp};
-use std::ffi::OsString;
 
 /// Establish a new connection to an X11 server.
 ///
@@ -214,15 +213,3 @@ pub const CURRENT_TIME: Timestamp = 0;
 
 /// This constant can be used to fill unused entries in `Keysym` tables
 pub const NO_SYMBOL: Keysym = 0;
-
-#[cfg(not(unix))]
-fn hostname() -> OsString {
-    gethostname::gethostname()
-}
-
-#[cfg(unix)]
-fn hostname() -> OsString {
-    use std::os::unix::ffi::OsStringExt;
-
-    OsString::from_vec(rustix::system::uname().nodename().to_bytes().to_vec())
-}

--- a/x11rb/src/resource_manager/mod.rs
+++ b/x11rb/src/resource_manager/mod.rs
@@ -64,6 +64,6 @@ pub fn new_from_resource_manager(conn: &impl Connection) -> Result<Option<Databa
 pub fn new_from_default(conn: &impl Connection) -> Result<Database, ReplyError> {
     Ok(Database::new_from_default(
         &send_request(conn)?,
-        crate::hostname(),
+        gethostname::gethostname(),
     ))
 }

--- a/x11rb/src/rust_connection/stream.rs
+++ b/x11rb/src/rust_connection/stream.rs
@@ -549,7 +549,7 @@ mod peer_addr {
 
     // Get xauth information representing a local connection
     pub(super) fn local() -> PeerAddr {
-        let hostname = crate::hostname()
+        let hostname = gethostname::gethostname()
             .to_str()
             .map_or_else(Vec::new, |s| s.as_bytes().to_vec());
         (Family::LOCAL, hostname)


### PR DESCRIPTION
With version 0.5, gethostname now uses rustic on unix to determine the host name. In fact, the code is exactly to identical to what we've been doing ourselves. As such, I am dropping the unix-specific implementation of this and let this just always use gethostname.