### PR TITLE
Improve find cursor

### DIFF
--- a/x11rb/src/cursor/mod.rs
+++ b/x11rb/src/cursor/mod.rs
@@ -90,9 +90,11 @@ impl<C: Connection> Cookie<'_, '_, C> {
         } else {
             RenderSupport::None
         };
-        let theme = resource_database
-            .get_string("Xcursor.theme", "")
-            .map(|theme| theme.to_string());
+        let theme = std::env::var("XCURSOR_THEME").ok().or_else(|| {
+            resource_database
+                .get_string("Xcursor.theme", "")
+                .map(|theme| theme.to_string())
+        });
         let cursor_size = match resource_database.get_value("Xcursor.size", "") {
             Ok(Some(value)) => value,
             _ => 0,


### PR DESCRIPTION
This pr does two things. When `load_cursor` now splits the `$XCURSOR_PATH` variable on both `':'` and `' '`, on my system `$XCURSOR_PATH` is separated by spaces. Second, `cursor::Handle::new` now checks `$XCURSOR_THEME` if getting `Xcursor.theme` from the `resource_database` fails.