### PR TITLE
Some small cursor code cleanups

### DIFF
--- a/x11rb/src/cursor/mod.rs
+++ b/x11rb/src/cursor/mod.rs
@@ -210,7 +210,6 @@ fn create_render_cursor<C: Connection>(
         )
     };
 
-    let (cursor, picture) = (conn.generate_id()?, conn.generate_id()?);
     let (width, height) = (to_u16(image.width), to_u16(image.height));
 
     // Get a pixmap of the right size and a gc for it
@@ -246,21 +245,20 @@ fn create_render_cursor<C: Connection>(
         &image.pixels_rgba,
     )?;
 
-    let _ = render::create_picture(
+    let picture = render::PictureWrapper::create_picture(
         conn,
-        picture,
         pixmap,
         handle.picture_format,
         &Default::default(),
     )?;
+    let cursor = conn.generate_id()?;
     let _ = render::create_cursor(
         conn,
         cursor,
-        picture,
+        picture.picture(),
         to_u16(image.xhot),
         to_u16(image.yhot),
     )?;
-    let _ = render::free_picture(conn, picture)?;
 
     Ok(render::Animcursorelt {
         cursor,


### PR DESCRIPTION
Two commits here. The later is just a small refactoring that does not really do anything, but might be nice anyway.

The first one fixes a resource leak where a font was not getting closed again. I think my fix actually simplifies the code a bit.

I tested this by hardcoding a "core" cursor and changing `simple_window` to use the `boat` cursor. No idea what I am looking at, but it's definitely not my default cursor. This also looks fine in `xtrace`, so this still seems to work.