### PR TITLE
Fix cargo clippy build failure with Rust 1.82

### DIFF
--- a/x11rb-async/examples/shared_memory_async.rs
+++ b/x11rb-async/examples/shared_memory_async.rs
@@ -160,8 +160,9 @@ async fn main2(file: File) -> Result<(), Box<dyn std::error::Error>> {
         async move {
             // Spawn a task to read from the connection.
             ex.spawn(async move {
-                if let Err(e) = drive.await {
-                    tracing::error!("Error while driving the connection: {}", e);
+                match drive.await {
+                    Err(e) => tracing::error!("Error while driving the connection: {}", e),
+                    _ => unreachable!(),
                 }
             })
             .detach();

--- a/x11rb-async/examples/xclock_utc_async.rs
+++ b/x11rb-async/examples/xclock_utc_async.rs
@@ -240,8 +240,9 @@ async fn main2() -> Result<(), Box<dyn std::error::Error>> {
         async move {
             // Spawn a task to poll for events.
             let driver = ex.spawn(async move {
-                if let Err(e) = drive.await {
-                    tracing::error!("Error while driving the connection: {}", e);
+                match drive.await {
+                    Err(e) => tracing::error!("Error while driving the connection: {}", e),
+                    _ => unreachable!(),
                 }
             });
 


### PR DESCRIPTION
CI reports:
```
error: irrefutable `if let` pattern
   --> x11rb-async/examples/xclock_utc_async.rs:243:20
    |
243 |                 if let Err(e) = drive.await {
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this pattern will always match, so the `if let` is useless
    = help: consider replacing the `if let` with a `let`
```
Trying the suggested fix does not work with older rustc:
```
error[E0005]: refutable pattern in local binding
   --> x11rb-async/examples/xclock_utc_async.rs:243:21
    |
243 |                 let Err(e) = drive.await;
    |                     ^^^^^^ pattern `Ok(_)` not covered
```
So change this "if let" into a "match" that works everywhere.