### PR TITLE
gate tests behind the features they use

### DIFF
--- a/x11rb-protocol/src/connect.rs
+++ b/x11rb-protocol/src/connect.rs
@@ -44,6 +44,8 @@ use core::fmt;
 /// to establish an X11 connection like so:
 ///
 /// ```rust,no_run
+/// # #[cfg(feature = "std")]
+/// # {
 /// # use x11rb_protocol::connect::Connect;
 /// # use x11rb_protocol::xauth::Family;
 /// # use std::{error::Error, io::prelude::*};
@@ -85,6 +87,7 @@ use core::fmt;
 /// // get the setup used for our connection
 /// let setup = connect.into_setup()?;
 /// # Ok(())
+/// # }
 /// # }
 /// ```
 ///
@@ -262,7 +265,7 @@ impl TryFrom<Connect> for Setup {
 }
 
 #[cfg(test)]
-#[cfg(feature = "extra-traits")]
+#[cfg(all(feature = "extra-traits", feature = "std"))]
 mod tests {
     use super::Connect;
     use crate::errors::ConnectError;

--- a/x11rb-protocol/src/packet_reader.rs
+++ b/x11rb-protocol/src/packet_reader.rs
@@ -124,7 +124,7 @@ fn extra_length(buffer: &[u8]) -> usize {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     use super::PacketReader;
     use alloc::{vec, vec::Vec};

--- a/x11rb-protocol/src/parse_display/connect_instruction.rs
+++ b/x11rb-protocol/src/parse_display/connect_instruction.rs
@@ -54,7 +54,7 @@ pub(super) fn connect_addresses(p: &ParsedDisplay) -> impl Iterator<Item = Conne
     targets.into_iter()
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod tests {
     // make sure iterator properties are clean
     use super::{super::parse_display, ConnectAddress};

--- a/x11rb-protocol/src/parse_display/mod.rs
+++ b/x11rb-protocol/src/parse_display/mod.rs
@@ -141,7 +141,7 @@ fn parse_display_direct_path(
     ))
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod test {
     use super::{
         parse_display, parse_display_with_file_exists_callback, DisplayParsingError, ParsedDisplay,

--- a/x11rb-protocol/src/test.rs
+++ b/x11rb-protocol/src/test.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "std")]
 use std::borrow::Cow;
 
 use crate::protocol::{get_request_name, request_name};

--- a/x11rb-protocol/src/x11_utils.rs
+++ b/x11rb-protocol/src/x11_utils.rs
@@ -386,7 +386,7 @@ implement_serialize!(i64: 8);
 forward_float!(f32: u32);
 forward_float!(f64: u64);
 
-#[cfg(test)]
+#[cfg(all(test, feature = "std"))]
 mod float_tests {
     use super::{Serialize, TryParse};
 


### PR DESCRIPTION
this enables running 'cargo test --no-default-features'

We use a similar patch in Debian to make our CI/CD happy: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/x11rb-protocol/debian/patches/gate-tests-on-std.patch?ref_type=heads