### PR TITLE
Run tests on no_std

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,9 +105,9 @@ jobs:
     - name: cargo build with all features
       run: cargo build --workspace --verbose --all-targets --all-features
 
-    # build no_std
-    - name: cargo build protocol with no default features
-      run: cargo build --manifest-path x11rb-protocol/Cargo.toml --no-default-features --features=all-extensions
+    # test no_std
+    - name: cargo test protocol with no default features
+      run: cargo test --manifest-path x11rb-protocol/Cargo.toml --no-default-features --features=all-extensions
 
     - name: Add rustflag for instrument coverage
       if: matrix.rust == 'nightly'


### PR DESCRIPTION
In commit 896ef02a52500 / PR #944 , the existing tests where fixed so that they can be run without the std feature. To ensure this keeps working, in this commit I am adding that to CI.

I tested that this new command failed before the fix.