### PR TITLE
Add a way to safely wrap an object that implements AsRawXCBConnection with XCBConnection

### DIFF
--- a/x11rb/src/xcb_ffi/raw_ffi/mod.rs
+++ b/x11rb/src/xcb_ffi/raw_ffi/mod.rs
@@ -28,9 +28,16 @@ pub(crate) struct xcb_connection_t {
 }
 
 #[derive(Debug)]
-pub(crate) struct XcbConnectionWrapper {
+#[doc(hidden)]
+pub struct XcbConnectionWrapper {
     ptr: NonNull<xcb_connection_t>,
     should_drop: bool,
+}
+
+unsafe impl as_raw_xcb_connection::AsRawXcbConnection for XcbConnectionWrapper {
+    fn as_raw_xcb_connection(&self) -> *mut as_raw_xcb_connection::xcb_connection_t {
+        self.ptr.as_ptr().cast()
+    }
 }
 
 // libxcb is fully thread-safe (well, except for xcb_disconnect()), so the following is


### PR DESCRIPTION
The goal here is to allow for an XCBConnection to be created safely from an object that already implements AsRawXcbConnection. This way, instead of using "from_raw_xcb_connection" and needing to use unsafe code, we can instead have it wrap aound something that already implements AsRawXcbConnection safely.

This adds a generic parameter to XCBConnection that is set to a ZST by default. If this new feature is used this parameter is replaced by the type that is being wrapped.

Similar to how owned display handles work in the winit ecosystem. The goal is to be able to safely wrap a "tiny_xlib::Display" with an XCBConnection.
