### PR TITLE
Add missing dependency to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,6 +46,8 @@ jobs:
   clippy-rustfmt:
      runs-on: ubuntu-latest
      steps:
+       - name: Install cairo-rs dependencies
+         run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev libcairo2-dev
        - uses: actions/checkout@v4
        - name: Install rustfmt and clippy
          uses: dtolnay/rust-toolchain@stable
@@ -85,6 +87,8 @@ jobs:
           - rust: nightly
 
     steps:
+    - name: Install cairo-rs dependencies
+      run: sudo apt-get update && sudo apt-get install -y libglib2.0-dev libcairo2-dev
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:


### PR DESCRIPTION
GitHub updated its ubuntu-latest system and the new version apparently does not provide some of the dependencies that our cairo example needs. Fix this by installing the missing system packages.