### PR TITLE
Fix clippy::precedence warning

### DIFF
--- a/xcbgen-rs/src/defs/alignment.rs
+++ b/xcbgen-rs/src/defs/alignment.rs
@@ -255,7 +255,7 @@ impl VariableSize {
             }
 
             if base_overflow {
-                incr = 1 << (incr | base | 1 << 31).trailing_zeros().min(31);
+                incr = 1 << (incr | base | (1 << 31)).trailing_zeros().min(31);
                 Self { base: 0, incr }
             } else {
                 if incr != 0 {


### PR DESCRIPTION
With Rust 1.85.0, clippy started warning:

```
error: operator precedence can trip the unwary
   --> xcbgen-rs/src/defs/alignment.rs:258:30
    |
258 |                 incr = 1 << (incr | base | 1 << 31).trailing_zeros().min(31);
    |                              ^^^^^^^^^^^^^^^^^^^^^ help: consider parenthesizing your expression: `incr | base | (1 << 31)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#precedence
    = note: `-D clippy::precedence` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::precedence)]`
```

This commit simply follows clippy's suggestion.