### PR TITLE
Depend on once_cell < 1.21

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -175,6 +175,9 @@ jobs:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@1.63.0
 
+    - name: Pin last once_cell release supporting our msrv of Rust 1.63
+      run: cargo update --package once_cell --precise 1.20.1
+
     # build
     - name: cargo check x11rb-protocol with all features
       run: cargo build --package x11rb-protocol --verbose --lib --all-features


### PR DESCRIPTION
once_cell 1.21.0 raised the MSRV to 1.70. While 1.21.1 reduced this again to 1.65, this is still higher than our MSRV of 1.63. Thus, fix the MSRV builds by avoiding that version of once_cell.