### PR TITLE
Fix a clippy complaint in a test

### DIFF
--- a/x11rb/src/rust_connection/packet_reader.rs
+++ b/x11rb/src/rust_connection/packet_reader.rs
@@ -139,7 +139,7 @@ mod tests {
     impl Stream for TestStream {
         fn read(&self, buf: &mut [u8], _: &mut Vec<RawFdContainer>) -> Result<usize> {
             let mut data = self.data.borrow_mut();
-            if data.len() == 0 {
+            if data.is_empty() {
                 return Err(Error::from(ErrorKind::WouldBlock));
             }
 


### PR DESCRIPTION
```
error: length comparison to zero
   --> x11rb/src/rust_connection/packet_reader.rs:142:16
    |
142 |             if data.len() == 0 {
    |                ^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `data.is_empty()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
    = note: `-D clippy::len-zero` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::len_zero)]`
```