### PR TITLE
Update to rustix 1.0

### DIFF
--- a/x11rb-async/Cargo.toml
+++ b/x11rb-async/Cargo.toml
@@ -100,7 +100,7 @@ async-executor = "1.8"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [target.'cfg(unix)'.dev-dependencies.rustix]
-version = "0.38"
+version = "1.0"
 default-features = false
 features = ["mm", "pipe"]
 

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -21,7 +21,7 @@ libloading = { version = "0.8.0", optional = true }
 once_cell = { version = "1.19", optional = true }
 as-raw-xcb-connection = { version = "1.0", optional = true }
 tracing = { version = "0.1", optional = true, default-features = false }
-rustix = { version = "0.38", default-features = false, features = ["std", "event", "fs", "net", "system"] }
+rustix = { version = "1.0", default-features = false, features = ["std", "event", "fs", "net", "system"] }
 xcursor = { version = "0.3.7", optional = true }
 
 [target.'cfg(not(unix))'.dependencies]


### PR DESCRIPTION
https://lib.rs/~psychon/dash#x11rb says we should do so.

I took a guess and how to fix the API changes
- Replacing `connect_unix` with `connect` seemed obious
- Poll with a negative timeout argument means "no timeout", so that's `None`
- The compiler asked for `MaybeUninit` and after I provided it, the compiler was happy