### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -179,6 +179,8 @@ jobs:
       run: cargo update --package once_cell --precise 1.20.1
     - name: Pin last gethostname release supporting our msrv of Rust 1.64
       run: cargo update --package gethostname --precise 1.0.1
+    - name: Pin last tracing-core release supporting our msrv of Rust 1.64
+      run: cargo update --package tracing-core --precise 0.1.33
 
     # build
     - name: cargo check x11rb-protocol with all features

--- a/cairo-example/src/main.rs
+++ b/cairo-example/src/main.rs
@@ -114,7 +114,7 @@ fn composite_manager_running(
     conn: &impl Connection,
     screen_num: usize,
 ) -> Result<bool, ReplyError> {
-    let atom = format!("_NET_WM_CM_S{}", screen_num);
+    let atom = format!("_NET_WM_CM_S{screen_num}");
     let atom = conn.intern_atom(false, atom.as_bytes())?.reply()?.atom;
     let owner = conn.get_selection_owner(atom)?.reply()?;
     Ok(owner.owner != x11rb::NONE)
@@ -242,15 +242,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let atoms = AtomCollection::new(&conn)?.reply()?;
     let (mut width, mut height) = (100, 100);
     let (depth, visualid) = choose_visual(&conn, screen_num)?;
-    println!("Using visual {:#x} with depth {}", visualid, depth);
+    println!("Using visual {visualid:#x} with depth {depth}");
 
     // Check if a composite manager is running. In a real application, we should also react to a
     // composite manager starting/stopping at runtime.
     let transparency = composite_manager_running(&conn, screen_num)?;
-    println!(
-        "Composite manager running / working transparency: {:?}",
-        transparency
-    );
+    println!("Composite manager running / working transparency: {transparency:?}");
 
     let window = create_window(&conn, screen, &atoms, (width, height), depth, visualid)?;
 
@@ -276,7 +273,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut event_option = Some(event);
         let mut need_redraw = false;
         while let Some(event) = event_option {
-            println!("{:?})", event);
+            println!("{event:?})");
             match event {
                 Event::Expose(_) => {
                     need_redraw = true;

--- a/extract-generated-code-doc/src/main.rs
+++ b/extract-generated-code-doc/src/main.rs
@@ -28,7 +28,7 @@ impl Sections {
             if let Some(prev) = previous {
                 // If the new entry starts with indentation, it belongs to the previous section
                 if Some(&b' ') == entry.as_bytes().first() {
-                    previous = Some(format!("{}\n\n{}", prev, entry));
+                    previous = Some(format!("{prev}\n\n{entry}"));
                 } else {
                     vec.push(prev);
                     previous = Some(entry);

--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -169,8 +169,7 @@ fn write_code_header(out: &mut Output) {
 fn camel_case_to_snake(arg: &str) -> String {
     assert!(
         arg.bytes().all(|c| c.is_ascii_alphanumeric() || c == b'_'),
-        "{:?}",
-        arg
+        "{arg:?}"
     );
 
     // Matches "[A-Z][a-z0-9]+|[A-Z]+(?![a-z0-9])|[a-z0-9]+"

--- a/generator/src/generator/namespace/async_switch.rs
+++ b/generator/src/generator/namespace/async_switch.rs
@@ -31,6 +31,6 @@ impl ImplMode {
             ),
         };
 
-        format!("{}{}{}", begin, inner, end)
+        format!("{begin}{inner}{end}")
     }
 }

--- a/generator/src/generator/namespace/expr_to_str.rs
+++ b/generator/src/generator/namespace/expr_to_str.rs
@@ -135,9 +135,9 @@ fn expr_to_str_impl(
                         true,
                     );
                     if needs_parens {
-                        format!("({} & {})", lhs_str, rhs_str)
+                        format!("({lhs_str} & {rhs_str})")
                     } else {
-                        format!("{} & {}", lhs_str, rhs_str)
+                        format!("{lhs_str} & {rhs_str}")
                     }
                 }
                 xcbdefs::BinaryOperator::Or => {
@@ -158,9 +158,9 @@ fn expr_to_str_impl(
                         true,
                     );
                     if needs_parens {
-                        format!("({} | {})", lhs_str, rhs_str)
+                        format!("({lhs_str} | {rhs_str})")
                     } else {
-                        format!("{} | {}", lhs_str, rhs_str)
+                        format!("{lhs_str} | {rhs_str}")
                     }
                 }
                 // I'm not sure know how to handle overflow here,
@@ -179,9 +179,9 @@ fn expr_to_str_impl(
                     true,
                 );
                 if needs_parens {
-                    format!("(!{})", rhs_str)
+                    format!("(!{rhs_str})")
                 } else {
-                    format!("!{}", rhs_str)
+                    format!("!{rhs_str}")
                 }
             }
         },
@@ -195,7 +195,7 @@ fn expr_to_str_impl(
                 }
             };
             if let Some(t) = cast_to_type {
-                format!("{}::from({})", t, value)
+                format!("{t}::from({value})")
             } else {
                 value
             }
@@ -203,7 +203,7 @@ fn expr_to_str_impl(
         xcbdefs::Expression::ParamRef(param_ref_expr) => {
             let rust_field_name = to_rust_variable_name(&param_ref_expr.field_name);
             if let Some(t) = cast_to_type {
-                format!("{}::from({})", t, rust_field_name)
+                format!("{t}::from({rust_field_name})")
             } else {
                 rust_field_name
             }
@@ -227,7 +227,7 @@ fn expr_to_str_impl(
                 Some("u32"),
                 true,
             );
-            format!("{}.count_ones()", arg)
+            format!("{arg}.count_ones()")
         }
         xcbdefs::Expression::SumOf(sum_of_expr) => {
             // nested sum-of not supported
@@ -272,7 +272,7 @@ fn expr_to_str_impl(
         }
         xcbdefs::Expression::ListElementRef => {
             if let Some(t) = cast_to_type {
-                format!("{}::from(*x)", t)
+                format!("{t}::from(*x)")
             } else if needs_parens {
                 "(*x)".into()
             } else {
@@ -281,11 +281,11 @@ fn expr_to_str_impl(
         }
         xcbdefs::Expression::Value(value) => {
             let value_str = format_literal_integer(*value);
-            format!("{}u32", value_str)
+            format!("{value_str}u32")
         }
         xcbdefs::Expression::Bit(bit) => {
             let value_str = format_literal_integer(1u32 << *bit);
-            format!("{}u32", value_str)
+            format!("{value_str}u32")
         }
     }
 }

--- a/generator/src/generator/namespace/helpers.rs
+++ b/generator/src/generator/namespace/helpers.rs
@@ -576,7 +576,7 @@ pub(super) fn to_rust_variable_name(name: &str) -> String {
 ///
 /// If name ends with an underscore, it will be trimmed.
 pub(super) fn prefix_var_name(name: &str, prefix: &str) -> String {
-    let mut prefixed = format!("{}_{}", prefix, name);
+    let mut prefixed = format!("{prefix}_{name}");
     if prefixed.ends_with('_') {
         prefixed.truncate(prefixed.len() - 1);
     }
@@ -589,9 +589,9 @@ pub(super) fn prefix_var_name(name: &str, prefix: &str) -> String {
 /// extra one.
 pub(super) fn postfix_var_name(name: &str, postfix: &str) -> String {
     if name.ends_with('_') {
-        format!("{}{}", name, postfix)
+        format!("{name}{postfix}")
     } else {
-        format!("{}_{}", name, postfix)
+        format!("{name}_{postfix}")
     }
 }
 

--- a/generator/src/generator/namespace/mod.rs
+++ b/generator/src/generator/namespace/mod.rs
@@ -237,7 +237,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
         };
         self.emit_event_opcode(name, number, event_full_def, out);
 
-        let full_name = format!("{}Event", name);
+        let full_name = format!("{name}Event");
 
         let fields = event_full_def.fields.borrow();
         let mut derives = Derives::all();
@@ -346,7 +346,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                         |field_name| {
                             let rust_field_name = to_rust_variable_name(field_name);
                             if !deducible_fields.contains_key(field_name) {
-                                format!("input.{}", rust_field_name)
+                                format!("input.{rust_field_name}")
                             } else {
                                 rust_field_name
                             }
@@ -536,7 +536,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                         )
                     };
                     if let Some(list_length) = list_field.length() {
-                        format!("[{}; {}]", element_type, list_length)
+                        format!("[{element_type}; {list_length}]")
                     } else {
                         unreachable!();
                     }
@@ -956,16 +956,15 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 if let xcbdefs::FieldDef::Normal(normal_field) = field {
                     let rust_type = self.field_value_type_to_rust_type(&normal_field.type_);
                     let rust_list_field_name = to_rust_variable_name(list_field_name);
-                    let msg = format!("`{}` has too many elements", rust_list_field_name);
+                    let msg = format!("`{rust_list_field_name}` has too many elements");
                     let list_len = format!("{}.len()", wrap_field_ref(&rust_list_field_name));
                     let value = match op {
                         DeducibleLengthFieldOp::None => {
-                            format!("{}::try_from({}).expect(\"{}\")", rust_type, list_len, msg)
+                            format!("{rust_type}::try_from({list_len}).expect(\"{msg}\")")
                         }
                         DeducibleLengthFieldOp::Mul(n) => format!(
-                            "{}::try_from({}).ok().and_then(|len| \
-                             len.checked_mul({})).expect(\"{}\")",
-                            rust_type, list_len, n, msg,
+                            "{rust_type}::try_from({list_len}).ok().and_then(|len| \
+                             len.checked_mul({n})).expect(\"{msg}\")"
                         ),
                         DeducibleLengthFieldOp::Div(n) => {
                             outln!(
@@ -977,10 +976,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                                 rust_list_field_name,
                                 n,
                             );
-                            format!(
-                                "{}::try_from({} / {}).expect(\"{}\")",
-                                rust_type, list_len, n, msg,
-                            )
+                            format!("{rust_type}::try_from({list_len} / {n}).expect(\"{msg}\")")
                         }
                     };
                     outln!(out, "let {} = {};", dst_var_name, value);
@@ -1123,7 +1119,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 // Prevent rustdoc interpreting many leading spaces as code examples (?)
                 for line in text.trim().split('\n') {
                     let line = line.trim();
-                    let line = format!("{} {}", prefix_char, line);
+                    let line = format!("{prefix_char} {line}");
                     prefix_char = ' ';
                     if line.trim().is_empty() {
                         outln!(out, "///");
@@ -1305,7 +1301,7 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
                 _ => None,
             };
             if let Some(ref type_) = wire_type {
-                write!(s, "{}::from(", type_).unwrap();
+                write!(s, "{type_}::from(").unwrap();
             }
             s.push_str(&wrap_name(&ext_param.name));
             if wire_type.is_some() {
@@ -1325,9 +1321,9 @@ impl<'ns, 'c> NamespaceGenerator<'ns, 'c> {
             xcbdefs::FieldDef::List(list_field) => {
                 let element_type = self.field_value_type_to_rust_type(&list_field.element_type);
                 if let Some(list_len) = list_field.length() {
-                    format!("[{}; {}]", element_type, list_len)
+                    format!("[{element_type}; {list_len}]")
                 } else {
-                    format!("Vec<{}>", element_type)
+                    format!("Vec<{element_type}>")
                 }
             }
             xcbdefs::FieldDef::Switch(switch_field) => {

--- a/generator/src/generator/namespace/parse.rs
+++ b/generator/src/generator/namespace/parse.rs
@@ -129,7 +129,7 @@ pub(super) fn emit_field_parse(
                 );
             } else if let Some(list_len) = list_field.length() {
                 for i in 0..list_len {
-                    let tmp_name = format!("{}_{}", rust_field_name, i);
+                    let tmp_name = format!("{rust_field_name}_{i}");
                     outln!(
                         out,
                         "let ({}_{}, remaining) = {};",
@@ -186,7 +186,7 @@ pub(super) fn emit_field_parse(
         xcbdefs::FieldDef::Switch(switch_field) => {
             let rust_field_name = to_rust_variable_name(&switch_field.name);
             let switch_struct_name = if let FieldContainer::Request(request_name) = container {
-                format!("{}Aux", request_name)
+                format!("{request_name}Aux")
             } else {
                 format!("{}{}", switch_prefix, to_rust_type_name(&switch_field.name))
             };

--- a/generator/src/generator/namespace/resource_wrapper.rs
+++ b/generator/src/generator/namespace/resource_wrapper.rs
@@ -211,7 +211,7 @@ fn generate_creator(
             xcbdefs::FieldDef::VirtualLen(_) => unimplemented!(),
             xcbdefs::FieldDef::Fd(fd_field) => {
                 let generic_param = format!("{}", char::from(letter_iter.next().unwrap()));
-                let where_ = format!("{}: Into<RawFdContainer>", generic_param);
+                let where_ = format!("{generic_param}: Into<RawFdContainer>");
                 generics.push(generic_param.clone());
                 wheres.push(where_);
                 (fd_field.name.clone(), generic_param)
@@ -232,7 +232,7 @@ fn generate_creator(
 
                 if use_into {
                     let generic_param = format!("{}", char::from(letter_iter.next().unwrap()));
-                    let where_ = format!("{}: Into<{}>", generic_param, rust_field_type);
+                    let where_ = format!("{generic_param}: Into<{rust_field_type}>");
                     generics.push(generic_param.clone());
                     wheres.push(where_);
                     (rust_field_name, generic_param)
@@ -245,9 +245,9 @@ fn generate_creator(
                 let element_type =
                     generator.field_value_type_to_rust_type(&list_field.element_type);
                 let field_type = if let Some(list_len) = list_field.length() {
-                    format!("&[{}; {}]", element_type, list_len)
+                    format!("&[{element_type}; {list_len}]")
                 } else {
-                    format!("&[{}]", element_type)
+                    format!("&[{element_type}]")
                 };
                 (field_name, field_type)
             }
@@ -260,7 +260,7 @@ fn generate_creator(
             .created_argument
             .eq_ignore_ascii_case(&rust_field_name)
         {
-            write!(function_args, ", {}: {}", rust_field_name, rust_field_type).ok();
+            write!(function_args, ", {rust_field_name}: {rust_field_type}").ok();
 
             forward_args_without_resource.push(rust_field_name.clone());
         }

--- a/generator/src/generator/namespace/serialize.rs
+++ b/generator/src/generator/namespace/serialize.rs
@@ -63,7 +63,7 @@ pub(super) fn emit_field_serialize(
                 );
             }
             for i in 0..field_size {
-                result_bytes.push(format!("{}[{}]", bytes_name, i));
+                result_bytes.push(format!("{bytes_name}[{i}]"));
             }
             Some(bytes_name)
         }
@@ -80,7 +80,7 @@ pub(super) fn emit_field_serialize(
                 for i in 0..list_length {
                     let src_value = format!("{}[{}]", wrap_field_ref(&list_field.name), i);
                     let rust_field_name = to_rust_variable_name(&list_field.name);
-                    let bytes_name = postfix_var_name(&rust_field_name, &format!("{}_bytes", i));
+                    let bytes_name = postfix_var_name(&rust_field_name, &format!("{i}_bytes"));
                     outln!(
                         out,
                         "let {} = {};",
@@ -93,7 +93,7 @@ pub(super) fn emit_field_serialize(
                         ),
                     );
                     for j in 0..element_size {
-                        result_bytes.push(format!("{}[{}]", bytes_name, j));
+                        result_bytes.push(format!("{bytes_name}[{j}]"));
                     }
                 }
                 None
@@ -110,7 +110,7 @@ pub(super) fn emit_field_serialize(
                 wrap_field_ref(&switch_field.name),
             );
             for i in 0..field_size {
-                result_bytes.push(format!("{}[{}]", bytes_name, i));
+                result_bytes.push(format!("{bytes_name}[{i}]"));
             }
             Some(bytes_name)
         }
@@ -145,7 +145,7 @@ pub(super) fn emit_field_serialize(
             outln!(out, "let {0} = {0}.to_ne_bytes();", bytes_name);
 
             for i in 0..4 {
-                result_bytes.push(format!("{}[{}]", bytes_name, i));
+                result_bytes.push(format!("{bytes_name}[{i}]"));
             }
 
             Some(bytes_name)
@@ -426,15 +426,12 @@ pub(super) fn emit_value_serialize(
         let current_wire_size = type_.type_.get_resolved().size().unwrap();
 
         if max_wire_size > 1 && u32::from(max_wire_size / 8) > current_wire_size {
-            format!(
-                "(u{}::from({}) as {}).serialize()",
-                max_wire_size, value, rust_wire_type,
-            )
+            format!("(u{max_wire_size}::from({value}) as {rust_wire_type}).serialize()")
         } else {
-            format!("{}::from({}).serialize()", rust_wire_type, value)
+            format!("{rust_wire_type}::from({value}).serialize()")
         }
     } else {
-        format!("{}.serialize()", value)
+        format!("{value}.serialize()")
     }
 }
 

--- a/generator/src/generator/namespace/struct_type.rs
+++ b/generator/src/generator/namespace/struct_type.rs
@@ -267,7 +267,7 @@ pub(super) fn emit_struct_type(
             let field_type = generator.field_to_rust_type(field, switch_prefix);
             let name = field.name().unwrap();
             let name = if name == "type" {
-                format!("r#{}", name)
+                format!("r#{name}")
             } else {
                 name.to_string()
             };
@@ -385,7 +385,7 @@ fn emit_fixed_size_struct_serialize(
                     |field_name| {
                         let rust_field_name = to_rust_variable_name(field_name);
                         if !deducible_fields.contains_key(field_name) {
-                            format!("self.{}", rust_field_name)
+                            format!("self.{rust_field_name}")
                         } else {
                             rust_field_name
                         }
@@ -421,7 +421,7 @@ fn emit_fixed_size_struct_serialize(
                         if !deducible_fields.contains_key(field_name)
                             && !external_params.iter().any(|param| param.name == field_name)
                         {
-                            format!("self.{}", rust_field_name)
+                            format!("self.{rust_field_name}")
                         } else {
                             rust_field_name
                         }
@@ -513,7 +513,7 @@ fn emit_variable_size_struct_serialize(
                         if !deducible_fields.contains_key(field_name)
                             && !external_params.iter().any(|param| param.name == field_name)
                         {
-                            format!("self.{}", rust_field_name)
+                            format!("self.{rust_field_name}")
                         } else {
                             rust_field_name
                         }

--- a/generator/src/generator/requests_replies.rs
+++ b/generator/src/generator/requests_replies.rs
@@ -148,12 +148,12 @@ fn generate_request_naming(out: &mut Output) {
         out.indented(|out| {
             outln!(out, "RequestInfo::Xproto(request) => request.into(),");
             outln!(out, "RequestInfo::KnownExt(ext_and_request) => ext_and_request.into(),");
-            outln!(out, "RequestInfo::UnknownRequest(None, opcode) => alloc::format!(\"xproto::opcode {{}}\", opcode).into(),");
-            outln!(out, "RequestInfo::UnknownRequest(Some(ext), opcode) => alloc::format!(\"{{}}::opcode {{}}\", ext, opcode).into(),");
+            outln!(out, "RequestInfo::UnknownRequest(None, opcode) => alloc::format!(\"xproto::opcode {{opcode}}\").into(),");
+            outln!(out, "RequestInfo::UnknownRequest(Some(ext), opcode) => alloc::format!(\"{{ext}}::opcode {{opcode}}\").into(),");
             outln!(out, "RequestInfo::UnknownExtension(major_opcode, minor_opcode) => match ext_name {{");
             out.indented(|out| {
-                outln!(out, "None => alloc::format!(\"ext {{}}::opcode {{}}\", major_opcode, minor_opcode).into(),");
-                outln!(out, "Some(ext_name) => alloc::format!(\"ext {{}}::opcode {{}}\", ext_name, minor_opcode).into(),");
+                outln!(out, "None => alloc::format!(\"ext {{major_opcode}}::opcode {{minor_opcode}}\").into(),");
+                outln!(out, "Some(ext_name) => alloc::format!(\"ext {{ext_name}}::opcode {{minor_opcode}}\").into(),");
             });
             outln!(out, "}}");
         });

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -133,7 +133,7 @@ fn main() -> Result<ExitCode, Error> {
     let module = xcbgen::defs::Module::new();
     let mut parser = xcbgen::Parser::new(module.clone());
     for file_path in xml_files.iter() {
-        println!("Loading {:?}", file_path);
+        println!("Loading {file_path:?}");
         load_namespace(file_path, &mut parser)?;
     }
 

--- a/x11rb-async/examples/shared_memory_async.rs
+++ b/x11rb-async/examples/shared_memory_async.rs
@@ -171,9 +171,7 @@ async fn main2(file: File) -> Result<(), Box<dyn std::error::Error>> {
             if let Some((major, minor)) = check_shm_version(conn).await? {
                 if major < 1 || (major == 1 && minor < 2) {
                     eprintln!(
-                        "X11 server supports version {}.{} of the SHM extension, but version 1.2 \
-                     is needed",
-                        major, minor,
+                        "X11 server supports version {major}.{minor} of the SHM extension, but version 1.2 is needed"
                     );
                     return Ok(());
                 }

--- a/x11rb-async/src/rust_connection/mod.rs
+++ b/x11rb-async/src/rust_connection/mod.rs
@@ -735,8 +735,7 @@ async fn compute_length_field<'b>(
     assert_eq!(
         length % 4,
         0,
-        "The length of X11 requests must be a multiple of 4, got {}",
-        length
+        "The length of X11 requests must be a multiple of 4, got {length}"
     );
     let wire_length = length / 4;
 

--- a/x11rb-async/src/rust_connection/nb_connect.rs
+++ b/x11rb-async/src/rust_connection/nb_connect.rs
@@ -151,7 +151,7 @@ async fn resolve_host(host: &str) -> io::Result<impl Stream<Item = IpAddr>> {
     }
 
     // Resolve the host using the threadpool.
-    let host = format!("{}:0", host);
+    let host = format!("{host}:0");
     let iter = blocking::unblock(move || {
         use std::net::ToSocketAddrs;
 

--- a/x11rb-async/tests/connection_regression_tests.rs
+++ b/x11rb-async/tests/connection_regression_tests.rs
@@ -89,7 +89,7 @@ fn connection_sends_large_request() {
     // Send a large request. This should be larger than the write buffer size, which is 16384 bytes.
     let length = 16384 * 2;
     let res = send_request_via_connection(FakeStream(Arc::clone(&data)), length, Vec::new());
-    assert!(res.is_none(), "{:?}", res);
+    assert!(res.is_none(), "{res:?}");
 
     // Check that all the data was sent
     assert_eq!(data.lock().unwrap().len(), length);
@@ -113,6 +113,6 @@ fn retry_for_left_over_fds() {
             assert_eq!(e.kind(), std::io::ErrorKind::Other);
             assert_eq!(e.to_string(), "Left over FDs after sending the request");
         }
-        e => panic!("Unexpected error: {:?}", e),
+        e => panic!("Unexpected error: {e:?}"),
     }
 }

--- a/x11rb-protocol/benches/proto_connection.rs
+++ b/x11rb-protocol/benches/proto_connection.rs
@@ -62,10 +62,7 @@ fn enqueue_packet_test(c: &mut Criterion) {
                 Many => "many",
             };
 
-            let name = format!(
-                "enqueue_packet {} with {} packets",
-                packet_ty_desc, packet_count_desc
-            );
+            let name = format!("enqueue_packet {packet_ty_desc} with {packet_count_desc} packets");
             group.bench_function(name, |b| {
                 // generate a valid packet with the given first byte and sequence number
                 let mut seqno = 0u16;
@@ -302,7 +299,7 @@ fn serialize_struct(c: &mut Criterion) {
                 Large => "large",
             };
 
-            let name = format!("serialize_struct {} {}", try_desc, size_desc);
+            let name = format!("serialize_struct {try_desc} {size_desc}");
             group.bench_function(name, |b| {
                 b.iter(|| {
                     let bytes = match struct_size {

--- a/x11rb-protocol/src/errors.rs
+++ b/x11rb-protocol/src/errors.rs
@@ -108,7 +108,7 @@ impl fmt::Display for DisplayParsingError {
                 )
             }
             DisplayParsingError::MalformedValue(dpy) => {
-                write!(f, "Failed to parse value '{}'", dpy)
+                write!(f, "Failed to parse value '{dpy}'")
             }
             DisplayParsingError::NotUnicode => {
                 write!(f, "The value of $DISPLAY is not valid unicode")
@@ -181,8 +181,8 @@ impl fmt::Display for ConnectError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn display(f: &mut fmt::Formatter<'_>, prefix: &str, value: &[u8]) -> fmt::Result {
             match core::str::from_utf8(value).ok() {
-                Some(value) => write!(f, "{}: '{}'", prefix, value),
-                None => write!(f, "{}: {:?} [message is not utf8]", prefix, value),
+                Some(value) => write!(f, "{prefix}: '{value}'"),
+                None => write!(f, "{prefix}: {value:?} [message is not utf8]"),
             }
         }
         match self {
@@ -200,8 +200,7 @@ impl fmt::Display for ConnectError {
             }
             ConnectError::Incomplete { expected, received } => write!(
                 f,
-                "Not enough data received to complete the handshake. Expected {}, received {}",
-                expected, received
+                "Not enough data received to complete the handshake. Expected {expected}, received {received}"
             ),
         }
     }

--- a/x11rb-protocol/src/packet_reader.rs
+++ b/x11rb-protocol/src/packet_reader.rs
@@ -249,16 +249,16 @@ mod tests {
         // The debug output includes the length of the packet of the packet and how much was
         // already read
         let mut reader = PacketReader::new();
-        assert_eq!(std::format!("{:?}", reader), "PacketReader(0/32)");
+        assert_eq!(std::format!("{reader:?}"), "PacketReader(0/32)");
 
         let _ = reader.advance(15);
-        assert_eq!(std::format!("{:?}", reader), "PacketReader(15/32)");
+        assert_eq!(std::format!("{reader:?}"), "PacketReader(15/32)");
 
         let _ = reader.advance(15);
-        assert_eq!(std::format!("{:?}", reader), "PacketReader(30/32)");
+        assert_eq!(std::format!("{reader:?}"), "PacketReader(30/32)");
 
         let _ = reader.advance(2);
-        assert_eq!(std::format!("{:?}", reader), "PacketReader(0/32)");
+        assert_eq!(std::format!("{reader:?}"), "PacketReader(0/32)");
     }
 
     #[test]
@@ -275,6 +275,6 @@ mod tests {
         reader.buffer()[..second_len].copy_from_slice(&packet[..second_len]);
         let _ = reader.advance(second_len);
 
-        assert_eq!(std::format!("{:?}", reader), "PacketReader(35/1200)");
+        assert_eq!(std::format!("{reader:?}"), "PacketReader(35/1200)");
     }
 }

--- a/x11rb-protocol/src/parse_display/connect_instruction.rs
+++ b/x11rb-protocol/src/parse_display/connect_instruction.rs
@@ -39,7 +39,7 @@ pub(super) fn connect_addresses(p: &ParsedDisplay) -> impl Iterator<Item = Conne
         targets.push(ConnectAddress::Hostname(host, TCP_PORT_BASE + display));
     } else {
         if protocol.is_none() || protocol.as_deref() == Some("unix") {
-            let file_name = format!("/tmp/.X11-unix/X{}", display);
+            let file_name = format!("/tmp/.X11-unix/X{display}");
             targets.push(ConnectAddress::Socket(file_name));
         }
 

--- a/x11rb-protocol/src/parse_display/mod.rs
+++ b/x11rb-protocol/src/parse_display/mod.rs
@@ -211,8 +211,7 @@ mod test {
             assert_eq!(
                 do_parse_display(input).as_ref(),
                 Ok(output),
-                "Failed parsing correctly: {}",
-                input
+                "Failed parsing correctly: {input}"
             );
         }
     }
@@ -224,8 +223,7 @@ mod test {
             Err(DisplayParsingError::MalformedValue(
                 non_existing_file.to_string().into()
             )),
-            "Unexpectedly parsed: {}",
-            non_existing_file
+            "Unexpectedly parsed: {non_existing_file}"
         );
     }
 
@@ -524,8 +522,7 @@ mod test {
             assert_eq!(
                 do_parse_display(input).as_ref(),
                 Ok(output),
-                "Failed parsing correctly: {}",
-                input
+                "Failed parsing correctly: {input}"
             );
         }
     }
@@ -563,8 +560,7 @@ mod test {
                 Err(DisplayParsingError::MalformedValue(
                     input.to_string().into()
                 )),
-                "Unexpectedly parsed: {}",
-                input
+                "Unexpectedly parsed: {input}"
             );
         }
     }

--- a/x11rb-protocol/src/protocol/mod.rs
+++ b/x11rb-protocol/src/protocol/mod.rs
@@ -1001,11 +1001,11 @@ pub fn get_request_name(
     match info {
         RequestInfo::Xproto(request) => request.into(),
         RequestInfo::KnownExt(ext_and_request) => ext_and_request.into(),
-        RequestInfo::UnknownRequest(None, opcode) => alloc::format!("xproto::opcode {}", opcode).into(),
-        RequestInfo::UnknownRequest(Some(ext), opcode) => alloc::format!("{}::opcode {}", ext, opcode).into(),
+        RequestInfo::UnknownRequest(None, opcode) => alloc::format!("xproto::opcode {opcode}").into(),
+        RequestInfo::UnknownRequest(Some(ext), opcode) => alloc::format!("{ext}::opcode {opcode}").into(),
         RequestInfo::UnknownExtension(major_opcode, minor_opcode) => match ext_name {
-            None => alloc::format!("ext {}::opcode {}", major_opcode, minor_opcode).into(),
-            Some(ext_name) => alloc::format!("ext {}::opcode {}", ext_name, minor_opcode).into(),
+            None => alloc::format!("ext {major_opcode}::opcode {minor_opcode}").into(),
+            Some(ext_name) => alloc::format!("ext {ext_name}::opcode {minor_opcode}").into(),
         }
     }
 }

--- a/x11rb-protocol/src/resource_manager/matcher.rs
+++ b/x11rb-protocol/src/resource_manager/matcher.rs
@@ -596,8 +596,7 @@ mod test {
             let result = match_entry(&entries, resource, class);
             if result != expected {
                 eprintln!(
-                    "While testing resource '{}' and class '{}' with the following input:",
-                    resource, class
+                    "While testing resource '{resource}' and class '{class}' with the following input:"
                 );
                 eprintln!("{}", print_string(data));
                 eprintln!("Expected: {:?}", expected.map(print_string));
@@ -614,6 +613,6 @@ mod test {
     fn print_string(data: &[u8]) -> String {
         std::str::from_utf8(data)
             .map(|s| s.to_string())
-            .unwrap_or_else(|_| format!("{:?}", data))
+            .unwrap_or_else(|_| format!("{data:?}"))
     }
 }

--- a/x11rb-protocol/src/resource_manager/parser.rs
+++ b/x11rb-protocol/src/resource_manager/parser.rs
@@ -296,7 +296,7 @@ mod test {
         ];
         for (data, expected) in tests.iter() {
             let result = parse_query(data);
-            assert_eq!(result.as_ref(), Some(expected), "while parsing {:?}", data);
+            assert_eq!(result.as_ref(), Some(expected), "while parsing {data:?}");
         }
     }
 
@@ -313,9 +313,7 @@ mod test {
             let result = parse_query(data);
             assert!(
                 result.is_none(),
-                "Unexpected success parsing '{:?}': {:?}",
-                data,
-                result,
+                "Unexpected success parsing '{data:?}': {result:?}"
             );
         }
     }
@@ -624,9 +622,9 @@ mod test {
             let mut result = Vec::new();
             parse_database(data, &mut result, |_, _| unreachable!());
             if &result != expected {
-                eprintln!("While testing {:?}", data);
-                eprintln!("Expected: {:?}", expected);
-                eprintln!("Got:      {:?}", result);
+                eprintln!("While testing {data:?}");
+                eprintln!("Expected: {expected:?}");
+                eprintln!("Got:      {result:?}");
                 eprintln!();
                 success = false;
             }
@@ -657,9 +655,9 @@ mod test {
             let mut calls = Vec::new();
             parse_database(data, &mut result, |file, _| calls.push(file.to_vec()));
             if &calls != expected {
-                eprintln!("While testing {:?}", data);
-                eprintln!("Expected: {:?}", expected);
-                eprintln!("Got:      {:?}", calls);
+                eprintln!("While testing {data:?}");
+                eprintln!("Expected: {expected:?}");
+                eprintln!("Got:      {calls:?}");
                 eprintln!();
                 success = false;
             }
@@ -686,17 +684,12 @@ mod test {
     fn run_entry_test(data: &[u8], resource: &[(Binding, Component)], value: &[u8]) {
         match parse_entry(data) {
             (Ok(result), remaining) => {
-                assert_eq!(remaining, b"", "failed to parse {:?}", data);
+                assert_eq!(remaining, b"", "failed to parse {data:?}");
                 assert_eq!(
                     result.components, resource,
-                    "incorrect components when parsing {:?}",
-                    data
+                    "incorrect components when parsing {data:?}",
                 );
-                assert_eq!(
-                    result.value, value,
-                    "incorrect value when parsing {:?}",
-                    data
-                );
+                assert_eq!(result.value, value, "incorrect value when parsing {data:?}");
             }
             (Err(err), _) => panic!("Failed to parse '{:?}': {:?}", data, err),
         }

--- a/x11rb-protocol/src/utils.rs
+++ b/x11rb-protocol/src/utils.rs
@@ -161,14 +161,14 @@ mod pretty_printer {
         fn test_enum() {
             let cases = [(0, "zero", "ZERO"), (42, "the answer", "ANSWER")];
             let printer = new_enum(0, &cases);
-            assert_eq!(&format!("{}", printer), "zero");
-            assert_eq!(&format!("{:#}", printer), "ZERO");
+            assert_eq!(&format!("{printer}"), "zero");
+            assert_eq!(&format!("{printer:#}"), "ZERO");
             let printer = new_enum(1, &cases);
-            assert_eq!(&format!("{}", printer), "1");
-            assert_eq!(&format!("{:#}", printer), "1");
+            assert_eq!(&format!("{printer}"), "1");
+            assert_eq!(&format!("{printer:#}"), "1");
             let printer = new_enum(42, &cases);
-            assert_eq!(&format!("{}", printer), "the answer");
-            assert_eq!(&format!("{:#}", printer), "ANSWER");
+            assert_eq!(&format!("{printer}"), "the answer");
+            assert_eq!(&format!("{printer:#}"), "ANSWER");
         }
 
         #[test]
@@ -179,17 +179,17 @@ mod pretty_printer {
                 (1 << 0, "unused", "UNUSED"),
             ];
             let printer = new_bitmask(8, &bits);
-            assert_eq!(&format!("{}", printer), "8");
-            assert_eq!(&format!("{:#}", printer), "8");
+            assert_eq!(&format!("{printer}"), "8");
+            assert_eq!(&format!("{printer:#}"), "8");
             let printer = new_bitmask(32, &bits);
-            assert_eq!(&format!("{}", printer), "b5");
-            assert_eq!(&format!("{:#}", printer), "B5");
+            assert_eq!(&format!("{printer}"), "b5");
+            assert_eq!(&format!("{printer:#}"), "B5");
             let printer = new_bitmask(34, &bits);
-            assert_eq!(&format!("{}", printer), "b5 | b1");
-            assert_eq!(&format!("{:#}", printer), "B5 | B1");
+            assert_eq!(&format!("{printer}"), "b5 | b1");
+            assert_eq!(&format!("{printer:#}"), "B5 | B1");
             let printer = new_bitmask(42, &bits);
-            assert_eq!(&format!("{}", printer), "8 | b5 | b1");
-            assert_eq!(&format!("{:#}", printer), "8 | B5 | B1");
+            assert_eq!(&format!("{printer}"), "8 | b5 | b1");
+            assert_eq!(&format!("{printer:#}"), "8 | B5 | B1");
         }
     }
 }

--- a/x11rb/examples/check_unchecked_requests.rs
+++ b/x11rb/examples/check_unchecked_requests.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // We can check for errors explicitly
     match conn.destroy_window(INVALID_WINDOW)?.check() {
         Err(ReplyError::X11Error(_)) => {}
-        e => panic!("{:?} unexpected", e),
+        e => panic!("{e:?} unexpected"),
     }
 
     // We can silently ignore the error
@@ -71,7 +71,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (event, seq2) = conn.wait_for_event_with_sequence()?;
         match event {
             Event::Error(_) => {}
-            event => panic!("Unexpectedly got {:?} instead of an X11 error", event),
+            event => panic!("Unexpectedly got {event:?} instead of an X11 error"),
         }
         assert_eq!(seq, seq2);
     }

--- a/x11rb/examples/display_ppm.rs
+++ b/x11rb/examples/display_ppm.rs
@@ -93,10 +93,7 @@ fn check_visual(screen: &Screen, id: Visualid) -> PixelLayout {
     match visual_type.class {
         VisualClass::TRUE_COLOR | VisualClass::DIRECT_COLOR => {}
         _ => {
-            eprintln!(
-                "The root visual is not true / direct color, but {:?}",
-                visual_type,
-            );
+            eprintln!("The root visual is not true / direct color, but {visual_type:?}");
             std::process::exit(1);
         }
     }
@@ -154,8 +151,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     return Ok(());
                 }
             }
-            Event::Error(err) => println!("Got an unexpected error: {:?}", err),
-            ev => println!("Got an unknown event: {:?}", ev),
+            Event::Error(err) => println!("Got an unexpected error: {err:?}"),
+            ev => println!("Got an unknown event: {ev:?}"),
         }
     }
 }
@@ -232,10 +229,7 @@ mod ppm_parser {
         let max = read_decimal(input)?;
 
         if max != 255 {
-            eprintln!(
-                "Image declares a max pixel value of {}, but I expected 255.",
-                max,
-            );
+            eprintln!("Image declares a max pixel value of {max}, but I expected 255.");
             eprintln!("Something will happen...?");
         }
 

--- a/x11rb/examples/generic_events.rs
+++ b/x11rb/examples/generic_events.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Now check that the event really is what we wanted to get
     let event = match event {
         Event::PresentConfigureNotify(event) => event,
-        other => panic!("Unexpected event {:?}", other),
+        other => panic!("Unexpected event {other:?}"),
     };
     println!(
         "Got a Present ConfigureNotify event for event ID 0x{:x} and window 0x{:x}.",

--- a/x11rb/examples/hypnomoire.rs
+++ b/x11rb/examples/hypnomoire.rs
@@ -254,7 +254,7 @@ where
                 return Ok(());
             }
             Event::Error(err) => {
-                eprintln!("Got an X11 error: {:?}", err);
+                eprintln!("Got an X11 error: {err:?}");
             }
             _ => {}
         }

--- a/x11rb/examples/integration_test_util/util.rs
+++ b/x11rb/examples/integration_test_util/util.rs
@@ -39,7 +39,7 @@ mod util {
             );
 
             if let Err(err) = conn.send_event(false, window, EventMask::NO_EVENT, event) {
-                eprintln!("Error while sending event: {:?}", err);
+                eprintln!("Error while sending event: {err:?}");
             }
             if let Err(err) = conn.send_event(
                 false,
@@ -47,7 +47,7 @@ mod util {
                 EventMask::SUBSTRUCTURE_REDIRECT,
                 event,
             ) {
-                eprintln!("Error while sending event: {:?}", err);
+                eprintln!("Error while sending event: {err:?}");
             }
             conn.flush().unwrap();
         });

--- a/x11rb/examples/record.rs
+++ b/x11rb/examples/record.rs
@@ -117,7 +117,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         } else if reply.category == START_OF_DATA {
             println!("Press Escape to exit...");
         } else {
-            println!("Got a reply with an unsupported category: {:?}", reply);
+            println!("Got a reply with an unsupported category: {reply:?}");
         }
     }
     Ok(())
@@ -129,27 +129,27 @@ fn print_reply_data(data: &[u8]) -> Result<(&[u8], bool), ParseError> {
     match data[0] {
         xproto::KEY_PRESS_EVENT => {
             let (event, remaining) = xproto::KeyPressEvent::try_parse(data)?;
-            println!("key press: {:?}", event);
+            println!("key press: {event:?}");
             Ok((remaining, false))
         }
         xproto::KEY_RELEASE_EVENT => {
             let (event, remaining) = xproto::KeyReleaseEvent::try_parse(data)?;
-            println!("key release: {:?}", event);
+            println!("key release: {event:?}");
             Ok((remaining, event.detail == 9))
         }
         xproto::BUTTON_PRESS_EVENT => {
             let (event, remaining) = xproto::ButtonPressEvent::try_parse(data)?;
-            println!("button press: {:?}", event);
+            println!("button press: {event:?}");
             Ok((remaining, false))
         }
         xproto::BUTTON_RELEASE_EVENT => {
             let (event, remaining) = xproto::ButtonReleaseEvent::try_parse(data)?;
-            println!("button release: {:?}", event);
+            println!("button release: {event:?}");
             Ok((remaining, false))
         }
         xproto::MOTION_NOTIFY_EVENT => {
             let (event, remaining) = xproto::MotionNotifyEvent::try_parse(data)?;
-            println!("motion notify: {:?}", event);
+            println!("motion notify: {event:?}");
             Ok((remaining, false))
         }
         0 => {

--- a/x11rb/examples/shared_memory.rs
+++ b/x11rb/examples/shared_memory.rs
@@ -148,15 +148,14 @@ fn receive_fd<C: Connection>(conn: &C, screen_num: usize) -> Result<(), ReplyOrI
 fn main() {
     let file = make_file().expect("Failed to create temporary file for FD passing");
     match connect(None) {
-        Err(err) => eprintln!("Failed to connect to the X11 server: {}", err),
+        Err(err) => eprintln!("Failed to connect to the X11 server: {err}"),
         Ok((conn, screen_num)) => {
             // Check for SHM 1.2 support (needed for fd passing)
             if let Some((major, minor)) = check_shm_version(&conn).unwrap() {
                 if major < 1 || (major == 1 && minor < 2) {
                     eprintln!(
-                        "X11 server supports version {}.{} of the SHM extension, but version 1.2 \
-                         is needed",
-                        major, minor,
+                        "X11 server supports version {major}.{minor} of the SHM extension, but version 1.2 \
+                         is needed"
                     );
                     return;
                 }

--- a/x11rb/examples/simple_window_manager.rs
+++ b/x11rb/examples/simple_window_manager.rs
@@ -122,7 +122,7 @@ impl<'a, C: Connection> WmState<'a, C> {
         win: Window,
         geom: &GetGeometryReply,
     ) -> Result<(), ReplyOrIdError> {
-        println!("Managing window {:?}", win);
+        println!("Managing window {win:?}");
         let screen = &self.conn.setup().roots[self.screen_num];
         assert!(self.find_window_by_id(win).is_none());
 
@@ -263,7 +263,7 @@ impl<'a, C: Connection> WmState<'a, C> {
             }
         }
 
-        println!("Got event {:?}", event);
+        println!("Got event {event:?}");
         if should_ignore {
             println!("  [ignored]");
             return Ok(());
@@ -306,7 +306,7 @@ impl<'a, C: Connection> WmState<'a, C> {
         let aux = ConfigureWindowAux::from_configure_request(&event)
             .sibling(None)
             .stack_mode(None);
-        println!("Configure: {:?}", aux);
+        println!("Configure: {aux:?}");
         self.conn.configure_window(event.window, &aux)?;
         Ok(())
     }

--- a/x11rb/examples/tutorial.rs
+++ b/x11rb/examples/tutorial.rs
@@ -209,7 +209,7 @@ fn example1() -> Result<(), Box<dyn Error>> {
     let mut atoms = [Into::<u32>::into(AtomEnum::NONE); COUNT];
 
     // Init names
-    let names = (0..COUNT).map(|i| format!("NAME{}", i)).collect::<Vec<_>>();
+    let names = (0..COUNT).map(|i| format!("NAME{i}")).collect::<Vec<_>>();
 
     // Bad use
     let start = Instant::now();
@@ -217,7 +217,7 @@ fn example1() -> Result<(), Box<dyn Error>> {
         atoms[i] = conn.intern_atom(false, names[i].as_bytes())?.reply()?.atom;
     }
     let diff = start.elapsed();
-    println!("bad use time:  {:?}", diff);
+    println!("bad use time:  {diff:?}");
 
     // Good use
     let start = Instant::now();
@@ -231,7 +231,7 @@ fn example1() -> Result<(), Box<dyn Error>> {
         atoms[i] = atom?.reply()?.atom;
     }
     let diff2 = start.elapsed();
-    println!("good use time: {:?}", diff2);
+    println!("good use time: {diff2:?}");
     println!(
         "ratio:         {:?}",
         diff.as_nanos() as f64 / diff2.as_nanos() as f64
@@ -1238,7 +1238,7 @@ pub struct RenamedKeyPressEvent {
 // those which have been described above.
 
 fn print_modifiers(mask: x11rb::protocol::xproto::KeyButMask) {
-    println!("Modifier mask: {:#?}", mask);
+    println!("Modifier mask: {mask:#?}");
 }
 
 fn example7() -> Result<(), Box<dyn Error>> {
@@ -1344,7 +1344,7 @@ fn example7() -> Result<(), Box<dyn Error>> {
             }
             _ => {
                 // Unknown event type, ignore it
-                println!("Unknown event: {:?}", event);
+                println!("Unknown event: {event:?}");
             }
         }
     }
@@ -2670,7 +2670,7 @@ fn example_get_visual2<C: Connection>(conn: &C, screen_num: usize) {
     for depth in &screen.allowed_depths {
         for visualtype in &depth.visuals {
             if visualtype.visual_id == screen.root_visual {
-                println!("Found: {:?}", visualtype);
+                println!("Found: {visualtype:?}");
             }
         }
     }

--- a/x11rb/examples/xclock_utc.rs
+++ b/x11rb/examples/xclock_utc.rs
@@ -231,7 +231,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         poll_with_timeout(&poller, conn, Duration::from_millis(1_000))?;
         while let Some(event) = conn.poll_for_event()? {
-            println!("{:?})", event);
+            println!("{event:?})");
             match event {
                 Event::ConfigureNotify(event) => {
                     width = event.width;

--- a/x11rb/examples/xeyes.rs
+++ b/x11rb/examples/xeyes.rs
@@ -323,10 +323,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
                 Event::Error(error) => {
-                    println!("Unknown error {:?}", error);
+                    println!("Unknown error {error:?}");
                 }
                 event => {
-                    println!("Unknown event {:?}", event);
+                    println!("Unknown event {event:?}");
                 }
             }
 

--- a/x11rb/src/connection/mod.rs
+++ b/x11rb/src/connection/mod.rs
@@ -547,8 +547,7 @@ pub fn compute_length_field<'b>(
     assert_eq!(
         length % 4,
         0,
-        "The length of X11 requests must be a multiple of 4, got {}",
-        length
+        "The length of X11 requests must be a multiple of 4, got {length}"
     );
     let wire_length = length / 4;
 

--- a/x11rb/src/cursor/parse_cursor.rs
+++ b/x11rb/src/cursor/parse_cursor.rs
@@ -66,7 +66,7 @@ mod test {
         let res = find_best_size(&[], 42);
         match res {
             Err(Error::NoImages) => {}
-            r => panic!("Unexpected result {:?}", r),
+            r => panic!("Unexpected result {r:?}"),
         }
     }
 

--- a/x11rb/src/errors.rs
+++ b/x11rb/src/errors.rs
@@ -21,7 +21,7 @@ impl std::fmt::Display for LibxcbLoadError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LibxcbLoadError::OpenLibError(lib_name, e) => {
-                write!(f, "failed to open library {:?}: {}", lib_name, e)
+                write!(f, "failed to open library {lib_name:?}: {e}")
             }
             LibxcbLoadError::GetSymbolError(symbol, e) => write!(
                 f,
@@ -118,8 +118,8 @@ impl std::error::Error for ReplyError {}
 impl std::fmt::Display for ReplyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ReplyError::ConnectionError(e) => write!(f, "{}", e),
-            ReplyError::X11Error(e) => write!(f, "X11 error {:?}", e),
+            ReplyError::ConnectionError(e) => write!(f, "{e}"),
+            ReplyError::X11Error(e) => write!(f, "X11 error {e:?}"),
         }
     }
 }
@@ -163,8 +163,8 @@ impl std::fmt::Display for ReplyOrIdError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ReplyOrIdError::IdsExhausted => f.write_str("X11 IDs have been exhausted"),
-            ReplyOrIdError::ConnectionError(e) => write!(f, "{}", e),
-            ReplyOrIdError::X11Error(e) => write!(f, "X11 error {:?}", e),
+            ReplyOrIdError::ConnectionError(e) => write!(f, "{e}"),
+            ReplyOrIdError::X11Error(e) => write!(f, "X11 error {e:?}"),
         }
     }
 }

--- a/x11rb/src/extension_manager.rs
+++ b/x11rb/src/extension_manager.rs
@@ -314,14 +314,14 @@ mod test {
         // Ask for an extension info. FakeConnection will return an error.
         match ext_info.extension_information(&conn, "whatever") {
             Err(ConnectionError::UnknownError) => {}
-            r => panic!("Unexpected result: {:?}", r),
+            r => panic!("Unexpected result: {r:?}"),
         }
 
         // Ask again for the extension information. ExtensionInformation should not try to get the
         // reply again, because that would just hang. Once upon a time, this caused a hang.
         match ext_info.extension_information(&conn, "whatever") {
             Err(ConnectionError::UnknownError) => {}
-            r => panic!("Unexpected result: {:?}", r),
+            r => panic!("Unexpected result: {r:?}"),
         }
     }
 

--- a/x11rb/src/image.rs
+++ b/x11rb/src/image.rs
@@ -283,7 +283,7 @@ mod test_stride {
             (41, 32, 32, 164),
         ] {
             let actual = compute_stride(width, bpp.try_into().unwrap(), pad.try_into().unwrap());
-            assert_eq!(stride, actual, "width={}, bpp={}, pad={}", width, bpp, pad);
+            assert_eq!(stride, actual, "width={width}, bpp={bpp}, pad={pad}");
         }
     }
 }
@@ -410,20 +410,17 @@ mod test_scanline_pad {
             assert_eq!(
                 pad8,
                 ScanlinePad::Pad8.round_to_multiple(value),
-                "value={} for pad8",
-                value,
+                "value={value} for pad8"
             );
             assert_eq!(
                 pad16,
                 ScanlinePad::Pad16.round_to_multiple(value),
-                "value={} for pad16",
-                value,
+                "value={value} for pad16"
             );
             assert_eq!(
                 pad32,
                 ScanlinePad::Pad32.round_to_multiple(value),
-                "value={} for pad32",
-                value,
+                "value={value} for pad32"
             );
         }
     }

--- a/x11rb/src/properties.rs
+++ b/x11rb/src/properties.rs
@@ -803,7 +803,7 @@ mod test {
         assert_eq!(wm_hints.input, Some(true));
         match wm_hints.initial_state {
             Some(WmHintsState::Normal) => {}
-            value => panic!("Expected Some(Normal), but got {:?}", value),
+            value => panic!("Expected Some(Normal), but got {value:?}"),
         }
         assert_eq!(wm_hints.icon_pixmap, None);
         assert_eq!(wm_hints.icon_window, None);

--- a/x11rb/src/rust_connection/write_buffer.rs
+++ b/x11rb/src/rust_connection/write_buffer.rs
@@ -218,7 +218,7 @@ mod test {
             Ok(0) => panic!("This looks like EOF!?"),
             Ok(_) => {}
             Err(ref e) if e.kind() == ErrorKind::WouldBlock => {}
-            Err(e) => panic!("Unexpected error: {:?}", e),
+            Err(e) => panic!("Unexpected error: {e:?}"),
         }
     }
 }

--- a/x11rb/src/xcb_ffi/mod.rs
+++ b/x11rb/src/xcb_ffi/mod.rs
@@ -688,13 +688,7 @@ fn reconstruct_full_sequence_impl(recent: SequenceNumber, value: u32) -> Sequenc
     ]
     .iter()
     .copied()
-    .min_by_key(|&value| {
-        if value > recent {
-            value - recent
-        } else {
-            recent - value
-        }
-    })
+    .min_by_key(|&value| value.abs_diff(recent))
     .unwrap();
     // Just because: Check that the result matches the passed-in value in the low bits
     assert_eq!(

--- a/x11rb/src/xcb_ffi/mod.rs
+++ b/x11rb/src/xcb_ffi/mod.rs
@@ -746,8 +746,7 @@ mod test {
             let actual = reconstruct_full_sequence_impl(recent, value);
             assert_eq!(
                 actual, expected,
-                "reconstruct({:x}, {:x}) == {:x}, but was {:x}",
-                recent, value, expected, actual,
+                "reconstruct({recent:x}, {value:x}) == {expected:x}, but was {actual:x}"
             );
         }
     }

--- a/x11rb/src/xcb_ffi/raw_ffi/ffi.rs
+++ b/x11rb/src/xcb_ffi/raw_ffi/ffi.rs
@@ -70,7 +70,7 @@ pub(crate) mod libxcb_library {
         #[cold]
         #[inline(never)]
         fn failed(e: &LibxcbLoadError) -> ! {
-            panic!("failed to load libxcb: {}", e);
+            panic!("failed to load libxcb: {e}");
         }
         match *LIBXCB_LIBRARY {
             Ok(ref library) => library,

--- a/x11rb/tests/multithread_test.rs
+++ b/x11rb/tests/multithread_test.rs
@@ -22,7 +22,7 @@ fn multithread_test() {
             cookie.reply().unwrap();
 
             if (i % 50_000) == 0 {
-                eprintln!("{}", i);
+                eprintln!("{i}");
             }
         }
         eprintln!("all replies received successfully");

--- a/x11rb/tests/regression_tests.rs
+++ b/x11rb/tests/regression_tests.rs
@@ -243,7 +243,7 @@ fn test_too_large_request() {
     let res = conn.poly_text16(drawable, gc, x, y, &big_buffer);
     match res.unwrap_err() {
         ConnectionError::MaximumRequestLengthExceeded => {}
-        err => panic!("Wrong error: {:?}", err),
+        err => panic!("Wrong error: {err:?}"),
     };
 }
 

--- a/x11rb/tests/resource_manager.rs
+++ b/x11rb/tests/resource_manager.rs
@@ -61,13 +61,12 @@ mod test {
             let result = db.get_bytes(query, "");
             if result != Some(expected) {
                 eprintln!(
-                    "Queried database for \"{}\" and expected {:?}, but got {:?}",
-                    query, expected, result
+                    "Queried database for \"{query}\" and expected {expected:?}, but got {result:?}"
                 );
                 errors += 1;
             }
         }
-        assert_eq!(errors, 0, "Had {} errors", errors);
+        assert_eq!(errors, 0, "Had {errors} errors");
     }
 
     #[test]

--- a/xkbcommon-example/src/main.rs
+++ b/xkbcommon-example/src/main.rs
@@ -25,7 +25,7 @@ fn handle_key(event: xproto::KeyPressEvent, press: bool, state: &xkbc::State) {
     let kind = if press { "  Pressed" } else { "Released" };
     let sym = state.key_get_one_sym(event.detail.into());
     let utf8 = state.key_get_utf8(event.detail.into());
-    println!("{} keysym {sym:?} for utf8 '{utf8}'", kind);
+    println!("{kind} keysym {sym:?} for utf8 '{utf8}'");
 
     // Just as an example on how this works:
     if sym == xkbc::keysyms::KEY_BackSpace.into() {

--- a/xtrace-example/src/connection_inner.rs
+++ b/xtrace-example/src/connection_inner.rs
@@ -13,11 +13,11 @@ use std::collections::VecDeque;
 fn print_parse_return<T: TryParse + std::fmt::Debug>(data: &[u8]) -> Result<T, ParseError> {
     match T::try_parse(data) {
         Err(e) => {
-            println!("Error while parsing: {:?}", e);
+            println!("Error while parsing: {e:?}");
             Err(e)
         }
         Ok((obj, _remaining)) => {
-            println!("{:?}", obj);
+            println!("{obj:?}");
             Ok(obj)
         }
     }
@@ -81,7 +81,7 @@ impl ConnectionInner {
                 }
             }
             2 => print_parse::<xproto::SetupAuthenticate>(packet),
-            _ => eprintln!("Unknown server setup response: {:?}", packet),
+            _ => eprintln!("Unknown server setup response: {packet:?}"),
         }
     }
 
@@ -93,17 +93,17 @@ impl ConnectionInner {
 
             let (header, remaining) = parse_request_header(packet, BigRequests::Enabled)?;
             let request = Request::parse(header, remaining, &mut Vec::new(), &inner.ext_info)?;
-            println!("client ({}): {:?}", seqno, request);
+            println!("client ({seqno}): {request:?}");
 
             // Is this a QueryExtension?
             let queried_extension = if let Request::QueryExtension(ref request) = request {
                 match String::from_utf8(request.name.to_vec()) {
                     Ok(name) => {
-                        println!("Extension name: {}", name);
+                        println!("Extension name: {name}");
                         Some(name)
                     }
                     Err(e) => {
-                        println!("Extension name is not utf8: {:?}", e);
+                        println!("Extension name is not utf8: {e:?}");
                         None
                     }
                 }
@@ -123,7 +123,7 @@ impl ConnectionInner {
             Ok(())
         }
         if let Err(e) = do_parse(self, packet) {
-            eprintln!("Error while parsing a client request: {:?}", e);
+            eprintln!("Error while parsing a client request: {e:?}");
         }
     }
 
@@ -142,7 +142,7 @@ impl ConnectionInner {
             Ok(())
         }
         if let Err(e) = do_parse(self, packet) {
-            eprintln!("Error while parsing an X11 error: {:?}", e);
+            eprintln!("Error while parsing an X11 error: {e:?}");
         }
     }
 
@@ -158,7 +158,7 @@ impl ConnectionInner {
             Ok(())
         }
         if let Err(e) = do_parse(self, packet) {
-            eprintln!("Error while parsing an X11 event: {:?}", e);
+            eprintln!("Error while parsing an X11 event: {e:?}");
         }
     }
 
@@ -168,7 +168,7 @@ impl ConnectionInner {
             // Figure out information about the request that is being answered.
             let request = match inner.pending_replies.pop_front() {
                 None => {
-                    println!("server: Got unexpected reply {:?}", packet);
+                    println!("server: Got unexpected reply {packet:?}");
                     return Ok(());
                 }
                 Some(request) => request,
@@ -211,7 +211,7 @@ impl ConnectionInner {
             Ok(())
         }
         if let Err(e) = do_parse(self, packet) {
-            eprintln!("Error while parsing an X11 event: {:?}", e);
+            eprintln!("Error while parsing an X11 event: {e:?}");
         }
     }
 }

--- a/xtrace-example/src/main.rs
+++ b/xtrace-example/src/main.rs
@@ -102,7 +102,7 @@ async fn handle_client(client: Async<TcpStream>) {
     match handle_client_impl(client).await {
         Ok(()) => {}
         Err(e) if e.kind() == ErrorKind::UnexpectedEof => println!("Something disconnected"),
-        Err(e) => eprintln!("Error in client forwarding: {:?}", e),
+        Err(e) => eprintln!("Error in client forwarding: {e:?}"),
     }
 }
 
@@ -114,10 +114,10 @@ fn spawn_command_line(display: &str) {
         let command = std::process::Command::new(command).args(args).spawn();
         match command {
             Ok(child) => println!("Started child process with ID {}", child.id()),
-            Err(e) => eprintln!("Error while starting child process: {}", e),
+            Err(e) => eprintln!("Error while starting child process: {e}"),
         }
     } else {
-        println!("You can now start programs with DISPLAY=\"{}\"", display);
+        println!("You can now start programs with DISPLAY=\"{display}\"");
         println!(
             "Hint: Alternatively, you could run {} [your-command]",
             std::env::args().next().unwrap(),


### PR DESCRIPTION
It's been a month and the Rust ecosystem brought new breakage. This pings `tracing-core 0.1.33` since version 0.1.34 has a higher MSRV. This also fixes some new complaints from clippy about format strings and `abs_diff`.