### PR TITLE
Use new `hints.mostly-unused`

### DIFF
--- a/x11rb-async/Cargo.toml
+++ b/x11rb-async/Cargo.toml
@@ -14,6 +14,9 @@ rust-version = "1.64"
 license = "MIT OR Apache-2.0"
 keywords = ["xcb", "X11", "async"]
 
+[hints]
+mostly-unused = true
+
 [dependencies]
 async-io = "2.3"
 async-lock = "3.3"

--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -14,6 +14,9 @@ rust-version = "1.64"
 license = "MIT OR Apache-2.0"
 keywords = ["xcb", "X11"]
 
+[hints]
+mostly-unused = true
+
 [dependencies]
 serde = { version = "1", features = ["derive"], optional = true }
 

--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -14,6 +14,9 @@ rust-version = "1.64"
 license = "MIT OR Apache-2.0"
 keywords = ["xcb", "X11"]
 
+[hints]
+mostly-unused = true
+
 [dependencies]
 x11rb-protocol = { version = "0.13.1", default-features = false, features = ["std"], path = "../x11rb-protocol" }
 libc = { version = "0.2", optional = true }


### PR DESCRIPTION
Most users of the `x11rb`, `x11rb-async`, or `x11rb-protocol` crates will use a fraction of their API surface area.

Nightly rustc provides an option `-Zhint-mostly-unused` to tell it to defer as much compilation as possible, which provides a substantial performance improvement if most of that compilation doesn't end up happening. Cargo plumbs this option through using the new `[hints]` table. This will cause users of these crates to default to setting `hint-mostly-unused`. (Top-level crates can override this if they wish, using a new profile option.)

Note that setting this hint does not increase the MSRV of these crates, as old versions of Cargo will ignore it. New versions of Cargo will respect it automatically (and, until we stabilize it, Cargo will do nothing unless you pass `-Zprofile-hint-mostly-unused` to cargo).

Some sample performance numbers: this takes the combined compilation time of `x11rb` and `x11rb-protocol` from ~5.3s to ~2.6s, a 51% improvement.

---

Thanks for x11rb! I'm thrilled to see that xcb-proto continues to serve as a basis for X protocol libraries a couple of decades later.
