### PR TITLE
Fix new clippy mismatched_lifetime_syntaxes warnings

### DIFF
--- a/x11rb/tests/regression_tests.rs
+++ b/x11rb/tests/regression_tests.rs
@@ -67,7 +67,7 @@ impl RequestConnection for FakeConnection {
         &self,
         bufs: &[IoSlice],
         fds: Vec<RawFdContainer>,
-    ) -> Result<Cookie<Self, R>, ConnectionError>
+    ) -> Result<Cookie<'_, Self, R>, ConnectionError>
     where
         R: TryParse,
     {
@@ -78,7 +78,7 @@ impl RequestConnection for FakeConnection {
         &self,
         _bufs: &[IoSlice],
         _fds: Vec<RawFdContainer>,
-    ) -> Result<CookieWithFds<Self, R>, ConnectionError>
+    ) -> Result<CookieWithFds<'_, Self, R>, ConnectionError>
     where
         R: TryParseFd,
     {
@@ -89,7 +89,7 @@ impl RequestConnection for FakeConnection {
         &self,
         bufs: &[IoSlice],
         fds: Vec<RawFdContainer>,
-    ) -> Result<VoidCookie<Self>, ConnectionError> {
+    ) -> Result<VoidCookie<'_, Self>, ConnectionError> {
         Ok(VoidCookie::new(
             self,
             self.internal_send_request(bufs, fds)?,

--- a/x11rb/tests/x11_utils.rs
+++ b/x11rb/tests/x11_utils.rs
@@ -50,7 +50,7 @@ impl RequestConnection for AtomFakeConnection {
         &self,
         bufs: &[IoSlice],
         _fds: RealVec<RawFdContainer>,
-    ) -> RealResult<Cookie<Self, R>, ConnectionError>
+    ) -> RealResult<Cookie<'_, Self, R>, ConnectionError>
     where
         R: TryParse,
     {
@@ -72,7 +72,7 @@ impl RequestConnection for AtomFakeConnection {
         &self,
         _bufs: &[IoSlice],
         _fds: RealVec<RawFdContainer>,
-    ) -> RealResult<CookieWithFds<Self, R>, ConnectionError>
+    ) -> RealResult<CookieWithFds<'_, Self, R>, ConnectionError>
     where
         R: TryParseFd,
     {
@@ -83,7 +83,7 @@ impl RequestConnection for AtomFakeConnection {
         &self,
         _bufs: &[IoSlice],
         _fds: RealVec<RawFdContainer>,
-    ) -> RealResult<VoidCookie<Self>, ConnectionError> {
+    ) -> RealResult<VoidCookie<'_, Self>, ConnectionError> {
         unimplemented!()
     }
 


### PR DESCRIPTION
Example:

```
error: hiding a lifetime that's elided elsewhere is confusing
  --> x11rb/tests/regression_tests.rs:67:9
   |
67 |         &self,
   |         ^^^^^ the lifetime is elided here
...
70 |     ) -> Result<Cookie<Self, R>, ConnectionError>
   |                 --------------- the same lifetime is hidden here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: use `'_` for type paths
   |
70 |     ) -> Result<Cookie<'_, Self, R>, ConnectionError>
   |                        +++
```