### PR TITLE
Fix new clippy warnings

### DIFF
--- a/x11rb/examples/hypnomoire.rs
+++ b/x11rb/examples/hypnomoire.rs
@@ -242,11 +242,9 @@ where
                     eprintln!("ButtonRelease on unknown window!");
                 }
             }
-            Event::MapNotify(event) => {
-                if !first_window_mapped {
-                    first_window_mapped = true;
-                    util::start_timeout_thread(conn_arc.clone(), event.window);
-                }
+            Event::MapNotify(event) if !first_window_mapped => {
+                first_window_mapped = true;
+                util::start_timeout_thread(conn_arc.clone(), event.window);
             }
             Event::ClientMessage(_) => {
                 // We simply assume that this is a message to close. Since we are the main thread,

--- a/x11rb/examples/tutorial.rs
+++ b/x11rb/examples/tutorial.rs
@@ -1514,11 +1514,9 @@ fn example8() -> Result<(), Box<dyn Error>> {
                 text_draw(&conn, screen, window, 10, HEIGHT as i16 - 10, text)?;
                 conn.flush()?;
             }
-            Event::KeyRelease(event) => {
-                if event.detail == 9 {
-                    // ESC
-                    return Ok(());
-                }
+            Event::KeyRelease(event) if event.detail == 9 => {
+                // ESC
+                return Ok(());
             }
             _ => {} // Unknown event type, ignore it
         }
@@ -2421,11 +2419,9 @@ fn example10() -> Result<(), Box<dyn Error>> {
                 }
                 conn.flush()?;
             }
-            Event::KeyRelease(event) => {
-                if event.detail == 9 {
-                    // ESC
-                    return Ok(());
-                }
+            Event::KeyRelease(event) if event.detail == 9 => {
+                // ESC
+                return Ok(());
             }
             _ => {} // Unknown event type, ignore it
         }


### PR DESCRIPTION
clippy starting reporting new "clippy::collapsible-match" warnings: "this `if` can be collapsed into the outer `match`"