### PR TITLE
Fix CUT_BUFFER0 atom names

### DIFF
--- a/generator/src/generator/mod.rs
+++ b/generator/src/generator/mod.rs
@@ -172,6 +172,11 @@ fn camel_case_to_snake(arg: &str) -> String {
         "{arg:?}"
     );
 
+    // Special case: No lower case letter, then pass the input through unmodified
+    if !arg.bytes().any(|c| c.is_ascii_lowercase()) {
+        return arg.to_string();
+    }
+
     // Matches "[A-Z][a-z0-9]+|[A-Z]+(?![a-z0-9])|[a-z0-9]+"
     struct Matcher<'a> {
         remaining: &'a str,
@@ -298,4 +303,18 @@ struct ResourceInfo<'a> {
     resource_name: &'a str,
     create_requests: &'a [CreateInfo<'a>],
     free_request: &'a str,
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_camel_case_to_snake() {
+        // This is what the function should actually do
+        assert_eq!("FD_From_Fence", super::camel_case_to_snake("FDFromFence"));
+
+        // Here are some special cases that should pass through unmodified
+        for input in ["WM_NAME", "CUT_BUFFER0", "Mod1"] {
+            assert_eq!(input, super::camel_case_to_snake(input));
+        }
+    }
 }

--- a/x11rb-protocol/src/protocol/xproto.rs
+++ b/x11rb-protocol/src/protocol/xproto.rs
@@ -5145,14 +5145,14 @@ impl AtomEnum {
     pub const CARDINAL: Self = Self(6);
     pub const COLORMAP: Self = Self(7);
     pub const CURSOR: Self = Self(8);
-    pub const CUT_BUFFE_R0: Self = Self(9);
-    pub const CUT_BUFFE_R1: Self = Self(10);
-    pub const CUT_BUFFE_R2: Self = Self(11);
-    pub const CUT_BUFFE_R3: Self = Self(12);
-    pub const CUT_BUFFE_R4: Self = Self(13);
-    pub const CUT_BUFFE_R5: Self = Self(14);
-    pub const CUT_BUFFE_R6: Self = Self(15);
-    pub const CUT_BUFFE_R7: Self = Self(16);
+    pub const CUT_BUFFER0: Self = Self(9);
+    pub const CUT_BUFFER1: Self = Self(10);
+    pub const CUT_BUFFER2: Self = Self(11);
+    pub const CUT_BUFFER3: Self = Self(12);
+    pub const CUT_BUFFER4: Self = Self(13);
+    pub const CUT_BUFFER5: Self = Self(14);
+    pub const CUT_BUFFER6: Self = Self(15);
+    pub const CUT_BUFFER7: Self = Self(16);
     pub const DRAWABLE: Self = Self(17);
     pub const FONT: Self = Self(18);
     pub const INTEGER: Self = Self(19);
@@ -5261,14 +5261,14 @@ impl core::fmt::Debug for AtomEnum  {
             (Self::CARDINAL.0.into(), "CARDINAL", "CARDINAL"),
             (Self::COLORMAP.0.into(), "COLORMAP", "COLORMAP"),
             (Self::CURSOR.0.into(), "CURSOR", "CURSOR"),
-            (Self::CUT_BUFFE_R0.0.into(), "CUT_BUFFE_R0", "CUT_BUFFER0"),
-            (Self::CUT_BUFFE_R1.0.into(), "CUT_BUFFE_R1", "CUT_BUFFER1"),
-            (Self::CUT_BUFFE_R2.0.into(), "CUT_BUFFE_R2", "CUT_BUFFER2"),
-            (Self::CUT_BUFFE_R3.0.into(), "CUT_BUFFE_R3", "CUT_BUFFER3"),
-            (Self::CUT_BUFFE_R4.0.into(), "CUT_BUFFE_R4", "CUT_BUFFER4"),
-            (Self::CUT_BUFFE_R5.0.into(), "CUT_BUFFE_R5", "CUT_BUFFER5"),
-            (Self::CUT_BUFFE_R6.0.into(), "CUT_BUFFE_R6", "CUT_BUFFER6"),
-            (Self::CUT_BUFFE_R7.0.into(), "CUT_BUFFE_R7", "CUT_BUFFER7"),
+            (Self::CUT_BUFFER0.0.into(), "CUT_BUFFER0", "CUT_BUFFER0"),
+            (Self::CUT_BUFFER1.0.into(), "CUT_BUFFER1", "CUT_BUFFER1"),
+            (Self::CUT_BUFFER2.0.into(), "CUT_BUFFER2", "CUT_BUFFER2"),
+            (Self::CUT_BUFFER3.0.into(), "CUT_BUFFER3", "CUT_BUFFER3"),
+            (Self::CUT_BUFFER4.0.into(), "CUT_BUFFER4", "CUT_BUFFER4"),
+            (Self::CUT_BUFFER5.0.into(), "CUT_BUFFER5", "CUT_BUFFER5"),
+            (Self::CUT_BUFFER6.0.into(), "CUT_BUFFER6", "CUT_BUFFER6"),
+            (Self::CUT_BUFFER7.0.into(), "CUT_BUFFER7", "CUT_BUFFER7"),
             (Self::DRAWABLE.0.into(), "DRAWABLE", "DRAWABLE"),
             (Self::FONT.0.into(), "FONT", "FONT"),
             (Self::INTEGER.0.into(), "INTEGER", "INTEGER"),


### PR DESCRIPTION
I stared at the code a bit. The best approach that I came up with for not having camel_case_to_snake("CUT_BUFFER0") produce "CUT_BUFFE_R0" was to treat is a special case.

In case anyone comes along and cleans this up in the future, I add a unit test that helps in understanding what this function is supposed to be doing.

Fixes: https://github.com/psychon/x11rb/issues/973