### PR TITLE
Allow using libloading 0.9.0

### DIFF
--- a/x11rb/Cargo.toml
+++ b/x11rb/Cargo.toml
@@ -20,7 +20,7 @@ mostly-unused = true
 [dependencies]
 x11rb-protocol = { version = "0.13.2", default-features = false, features = ["std"], path = "../x11rb-protocol" }
 libc = { version = "0.2", optional = true }
-libloading = { version = "0.8.0", optional = true }
+libloading = { version = ">=0.8.0, <0.10.0", optional = true }
 once_cell = { version = "1.19", optional = true }
 raw-window-handle = { version = "0.6.0", optional = true }
 as-raw-xcb-connection = { version = "1.0", optional = true }


### PR DESCRIPTION
The dl-libxcb features uses libloading to dynamically load libxcb.so. There was a new major release for version 0.9.0, but the documented breaking changes do not affect us.

In this commit, I loosen the dependency specification in Cargo.toml to also allow libloading 0.9.0 or newer, up to version 0.10.0.

libloading 0.8.* is also still allowed since we had to pin libloading 0.8.8 in the MSRV CI check.