### PR TITLE
xtrace-example: Fix a new clippy warning

### DIFF
--- a/xtrace-example/src/connection_inner.rs
+++ b/xtrace-example/src/connection_inner.rs
@@ -185,7 +185,7 @@ impl ConnectionInner {
 
             // Actually parse the reply
             let (reply, _remaining) = (request.parser)(packet, &mut Vec::new())?;
-            println!("server ({}): {:?}", seqno, &reply);
+            println!("server ({}): {:?}", seqno, reply);
 
             // If it is a reply to a QueryExtension request and the extension is present, update
             // our state (add the extension to our ext_info).


### PR DESCRIPTION
    error: redundant reference in `println!` argument
       --> xtrace-example/src/connection_inner.rs:188:50
        |
    188 |             println!("server ({}): {:?}", seqno, &reply);
        |                                                  ^^^^^^ help: remove the redundant `&`: `reply`