### PR TITLE
Permanently fix msrv check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -173,32 +173,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.68.0
 
-    # cairo-example (indirectly) depends on syn v1 which causes ambiguity
-    - name: Remove cairo-example from build
-      run: sed -i -e '/cairo-example/d' Cargo.toml
+    - name: Remove non-release workspace members
+      run: sed -i -e '/example/d;/generat/d;/xcbgen/d' Cargo.toml
+    - run: cat Cargo.toml
 
-    - name: Pin last once_cell release supporting our msrv of Rust 1.68
-      run: cargo update --package once_cell --precise 1.20.1
-    - name: Pin last gethostname release supporting our msrv of Rust 1.68
-      run: cargo update --package gethostname --precise 1.0.2
-    - name: Pin last libloading release supporting our msrv of Rust 1.68
-      run: cargo update --package libloading --precise 0.8.8
-    - name: Pin last async-io release supporting our msrv of Rust 1.68
-      run: cargo update --package async-io --precise 2.5.0
-    - name: Pin last polling release supporting our msrv of Rust 1.68
-      run: cargo update --package polling --precise 3.10.0
-    - name: Pin last async-lock release supporting our msrv of Rust 1.68
-      run: cargo update --package async-lock --precise 3.4.1
-    - name: Pin last unicode-ident release supporting our msrv of Rust 1.68
-      run: cargo update --package unicode-ident --precise 1.0.22
-    - name: Pin last syn release supporting our msrv of Rust 1.68
-      run: cargo update --package syn --precise 2.0.114
-    - name: Pin last quote release supporting our msrv of Rust 1.68
-      run: cargo update --package quote --precise 1.0.44
+    # use nightly's -Z minimal-versions to set up Cargo.lock
+    - uses: dtolnay/rust-toolchain@nightly
+    - name: Generate Cargo.lock with minimal versions
+      run: cargo update -Z minimal-versions
 
     # build
+    - uses: dtolnay/rust-toolchain@1.68.0
     - name: cargo check x11rb-protocol with all features
       run: cargo build --package x11rb-protocol --verbose --lib --all-features
     - name: cargo check x11rb with all features

--- a/x11rb-protocol/Cargo.toml
+++ b/x11rb-protocol/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["xcb", "X11"]
 mostly-unused = true
 
 [dependencies]
-serde = { version = "1", features = ["derive"], optional = true }
+serde = { version = "1.0.96", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
    CI: Rewrite msrv-check
    
    The constant battle of manually using "cargo update" to pin dependencies
    in the msrv check build is annoying. It is time for another approach.
    
    In this commit, that action is rewritten using Cargo's -Z
    minimal-versions flag. That way, everything is built using its oldest
    compatible version, which in turn means that new releases of other
    crates should not influence the version selection.
    
    Additionally, I am removing the non-release workspace members from this
    build. They were not attempted to be build anyway, but their presence
    and dependencies could influence version selection.
    
    Signed-off-by: Uli Schlachter <psychon@znc.in>

------

    Bump minimum serde version
    
    Thanks to the previous commit, the msrv-check actually tries to build
    serde 1.0.0. This fails with various error messages, among them
    
        error[E0554]: `#![feature]` may not be used on the stable release
        channel
    
    In this commit, I increase the minimum serde version to 1.0.96. Why this
    version? This is the first version where the build actually passes.
    
    Serde 1.0.96 is from 2019 and since previous versions did not build for
    me with Rust 1.68 (which is from 2023), I do not think this actually
    really bumps anything.
    
    Signed-off-by: Uli Schlachter <psychon@znc.in>
